### PR TITLE
Add action handling to AppSec ActiveRecord instrumentation

### DIFF
--- a/lib/datadog/appsec/contrib/active_record/instrumentation.rb
+++ b/lib/datadog/appsec/contrib/active_record/instrumentation.rb
@@ -39,7 +39,7 @@ module Datadog
               }
               context.events << event
 
-              Datadog::AppSec::ActionsHandler.handle(result.actions)
+              ActionsHandler.handle(result.actions)
             end
           end
 

--- a/lib/datadog/appsec/contrib/active_record/instrumentation.rb
+++ b/lib/datadog/appsec/contrib/active_record/instrumentation.rb
@@ -38,6 +38,8 @@ module Datadog
                 actions: result.actions
               }
               context.events << event
+
+              Datadog::AppSec::ActionsHandler.handle(result.actions)
             end
           end
 

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -135,10 +135,8 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds an event to processor context if waf result is a match' do
-        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
-
-        User.where(name: 'Bob').to_a
+      it 'adds and event to context events' do
+        expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
 
       it 'calls ActionsHandler with result actions if waf result is a match' do

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -138,12 +138,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
       it 'adds and event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
-
-      it 'calls ActionsHandler with result actions if waf result is a match' do
-        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
-
-        User.where(name: 'Bob').to_a
-      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -119,15 +119,33 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
       User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
     end
 
-    it 'adds an event to processor context if waf result is a match' do
-      result = Datadog::AppSec::SecurityEngine::Result::Match.new(
-        events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
-      )
+    context 'when waf result is a match' do
+      let(:result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [],
+          actions: { 'generate_stack' => { 'stack_id' => 'some-id' } },
+          derivatives: {},
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
 
-      expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
-      expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+      before do
+        allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
+      end
 
-      User.where(name: 'Bob').to_a
+      it 'adds an event to processor context if waf result is a match' do
+        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+
+        User.where(name: 'Bob').to_a
+      end
+
+      it 'calls ActionsHandler with result actions if waf result is a match' do
+        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
+
+        User.where(name: 'Bob').to_a
+      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/mysql2_adapter_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'AppSec ActiveRecord integration for Mysql2 adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds and event to context events' do
+      it 'adds an event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
     end

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -145,12 +145,6 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
       it 'adds and event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
-
-      it 'calls ActionsHandler with result actions if waf result is a match' do
-        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
-
-        User.where(name: 'Bob').to_a
-      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds and event to context events' do
+      it 'adds an event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
     end

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -142,10 +142,8 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds an event to processor context if waf result is a match' do
-        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
-
-        User.where(name: 'Bob').to_a
+      it 'adds and event to context events' do
+        expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
 
       it 'calls ActionsHandler with result actions if waf result is a match' do

--- a/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/postgresql_adapter_spec.rb
@@ -126,15 +126,33 @@ RSpec.describe 'AppSec ActiveRecord integration for Postgresql adapter' do
       User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
     end
 
-    it 'adds an event to processor context if waf result is a match' do
-      result = Datadog::AppSec::SecurityEngine::Result::Match.new(
-        events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
-      )
+    context 'when waf result is a match' do
+      let(:result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [],
+          actions: { 'generate_stack' => { 'stack_id' => 'some-id' } },
+          derivatives: {},
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
 
-      expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
-      expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+      before do
+        allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
+      end
 
-      User.where(name: 'Bob').to_a
+      it 'adds an event to processor context if waf result is a match' do
+        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+
+        User.where(name: 'Bob').to_a
+      end
+
+      it 'calls ActionsHandler with result actions if waf result is a match' do
+        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
+
+        User.where(name: 'Bob').to_a
+      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
@@ -129,10 +129,8 @@ RSpec.describe 'AppSec ActiveRecord integration for SQLite3 adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds an event to processor context if waf result is a match' do
-        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
-
-        User.where(name: 'Bob').to_a
+      it 'adds and event to context events' do
+        expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
 
       it 'calls ActionsHandler with result actions if waf result is a match' do

--- a/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
@@ -113,15 +113,33 @@ RSpec.describe 'AppSec ActiveRecord integration for SQLite3 adapter' do
       User.find_by_sql("SELECT * FROM users WHERE name = 'Bob'").to_a
     end
 
-    it 'adds an event to processor context if waf result is a match' do
-      result = Datadog::AppSec::SecurityEngine::Result::Match.new(
-        events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
-      )
+    context 'when waf result is a match' do
+      let(:result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [],
+          actions: { 'generate_stack' => { 'stack_id' => 'some-id' } },
+          derivatives: {},
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
 
-      expect(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
-      expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+      before do
+        allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
+      end
 
-      User.where(name: 'Bob').to_a
+      it 'adds an event to processor context if waf result is a match' do
+        expect(Datadog::AppSec.active_context.events).to receive(:<<).and_call_original
+
+        User.where(name: 'Bob').to_a
+      end
+
+      it 'calls ActionsHandler with result actions if waf result is a match' do
+        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
+
+        User.where(name: 'Bob').to_a
+      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
@@ -132,12 +132,6 @@ RSpec.describe 'AppSec ActiveRecord integration for SQLite3 adapter' do
       it 'adds and event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
-
-      it 'calls ActionsHandler with result actions if waf result is a match' do
-        expect(Datadog::AppSec::ActionsHandler).to receive(:handle).with(result.actions)
-
-        User.where(name: 'Bob').to_a
-      end
     end
   end
 end

--- a/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
+++ b/spec/datadog/appsec/contrib/active_record/sqlite3_adapter_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'AppSec ActiveRecord integration for SQLite3 adapter' do
         allow(Datadog::AppSec.active_context).to receive(:run_rasp).and_return(result)
       end
 
-      it 'adds and event to context events' do
+      it 'adds an event to context events' do
         expect { User.where(name: 'Bob').to_a }.to change(Datadog::AppSec.active_context.events, :size).by(1)
       end
     end

--- a/spec/datadog/appsec/contrib/integration/active_record_sql_injection_spec.rb
+++ b/spec/datadog/appsec/contrib/integration/active_record_sql_injection_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/appsec/spec_helper'
+require 'rack/test'
+
+require 'sqlite3'
+require 'active_record'
+require 'datadog/tracing'
+require 'datadog/appsec'
+
+RSpec.describe 'ActiveRecord SQL Injection' do
+  include Rack::Test::Methods
+
+  before do
+    stub_const('User', Class.new(ActiveRecord::Base)).tap do |klass|
+      klass.establish_connection({ adapter: 'sqlite3', database: ':memory:' })
+
+      klass.connection.create_table 'users', force: :cascade do |t|
+        t.string :name, null: false
+      end
+
+      # prevent internal sql requests from showing up
+      klass.count
+    end
+
+    Datadog.configure do |c|
+      c.tracing.enabled = true
+      c.tracing.instrument :rack
+      c.tracing.instrument :http
+
+      c.appsec.enabled = true
+      c.appsec.instrument :rack
+      c.appsec.instrument :active_record
+
+      c.appsec.ruleset = {
+        rules: [
+          {
+            id: 'rasp-003-001',
+            name: 'SQL Injection',
+            tags: {
+              type: 'sql_injection',
+              category: 'exploit',
+              module: 'rasp'
+            },
+            conditions: [
+              {
+                operator: 'sqli_detector',
+                parameters: {
+                  resource: [{ address: 'server.db.statement' }],
+                  params: [{ address: 'server.request.query' }],
+                  db_type: [{ address: 'server.db.system' }]
+                }
+              }
+            ],
+            on_match: ['block']
+          }
+        ]
+      }
+
+      c.remote.enabled = false
+    end
+
+    allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
+  end
+
+  after do
+    Datadog.configuration.reset!
+    Datadog.registry[:rack].reset_configuration!
+  end
+
+  let(:app) do
+    stack = Rack::Builder.new do
+      use Datadog::Tracing::Contrib::Rack::TraceMiddleware
+      use Datadog::AppSec::Contrib::Rack::RequestMiddleware
+
+      map '/rasp' do
+        run(
+          lambda do |env|
+            request = Rack::Request.new(env)
+            users = User.find_by_sql(
+              "SELECT * FROM users WHERE name = '#{request.params['name']}'"
+            )
+
+            [200, { 'Content-Type' => 'application/json' }, [users.to_json]]
+          end
+        )
+      end
+    end
+
+    stack.to_app
+  end
+
+  let(:http_service_entry_span) do
+    Datadog::Tracing::Transport::TraceFormatter.format!(trace)
+    spans.find { |s| s.name == 'rack.request' }
+  end
+
+  context 'when RASP check triggered for database query' do
+    before do
+      get('/rasp', { 'name' => "Bob'; OR 1=1" }, { 'REMOTE_ADDR' => '127.0.0.1' })
+    end
+
+    it { expect(last_response).to be_forbidden }
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
This PR adds action handling to AppSec `ActiveRecord` instrumentation.

**Motivation:**
Currently we are only monitoring WAF events for SQLi.

**Change log entry**
Yes. AppSec: Add reporting of stack trace when SQL Injection attack is detected.

**Additional Notes:**
None.

**How to test the change?**
CI and app generator.