### PR TITLE
ci: upload gem from GitLab release stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,10 +6,12 @@ stages:
   - macrobenchmarks
   - microbenchmarks
   - benchmarks
+  - release
 
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
   - local: ".gitlab/benchmarks.yml"
+  - local: ".gitlab/release.yml"
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -3,11 +3,9 @@ release_ruby_gem:
   image: $DOCKER_REGISTRY/images/mirror/ruby:3.2.2  
   tags: ["arch:amd64"]
   only:
-    # v2.10.0
-    # v2.10.1
-    # v2.10.0rc0
-    # v2.10.0rc5
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # Version pattern from Rubygems: https://github.com/rubygems/rubygems/blob/969f32050f0dc024c411fef7cbe25b1aaed16983/lib/rubygems/version.rb#L158
+    # with a added `v` prefix.
+    - /^v[0-9]+(?>\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/
   before_script:
     - |
       curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.3.zip" -o "awscliv2.zip"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,0 +1,19 @@
+release_ruby_gem:
+  stage: release
+  image: $DOCKER_REGISTRY/images/mirror/ruby:3.2.2  
+  tags: ["arch:amd64"]
+  only:
+    # v2.10.0
+    # v2.10.1
+    # v2.10.0rc0
+    # v2.10.0rc5
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+  before_script:
+    - |
+      curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.3.zip" -o "awscliv2.zip"
+      echo "13ee8a87756aa61027bd87985d4da4dee7ac777a36410321b03621a943cf030e awscliv2.zip" | sha256sum --check
+      unzip awscliv2.zip
+      ./aws/install
+    - export GEM_HOST_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.${CI_PROJECT_NAME}.rubygems_datadog_token" --with-decryption --query "Parameter.Value" --out text)
+  script:
+    - gem publish pkg/datadog-*.gem


### PR DESCRIPTION
**What does this PR do?**
Automates Ruby gem publishing by uploading from GitLab pipeline.

**Motivation:**
Remove manual step of uploading the gem on release.

**Change log entry**

None.

**Additional Notes:**

This is modeled after the dd-trace-java and dd-trace-py processes which assume that a Git tag/GitHub Release are created first (that is the trigger to "do a release"). Rather than existing Ruby process which first builds/checks tests, then uploads the Gem, and then finally creates the GitHub Release. We can adjust this workflow, but wanted to give us a place to start, aligning with others was simplest.

Since this is done in a final release stage, it does mean that the GitLab pipeline needs to fully run and complete before the Gem will be uploaded. Any checks/tests added to GitLab will become a blocker to the Gem being uploaded.

This process also uses the built Gem that we already do in the pipeline and use in the OCI/lib-injection artifacts.

We have not added any additional checks on GitHub commit status, we can/should do that. I'd love to add to the one pipeline so it is implemented consistently for all repos.

I have not yet added the necessary RubyGem token to the process.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
