### PR TITLE
[PROF-11203] Bump minimum version of `datadog-ruby_core_source` to 3.4

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'msgpack'
 
   # Used by the profiler native extension to support Ruby 2.5 and > 3.2, see NativeExtensionDesign.md for details
-  spec.add_dependency 'datadog-ruby_core_source', '~> 3.3', '>= 3.3.7'
+  spec.add_dependency 'datadog-ruby_core_source', '~> 3.4'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.18.0.0.0'


### PR DESCRIPTION
**What does this PR do?**

This PR bumps the minimum version of the `datadog-ruby_core_source` gem to 3.4

**Motivation:**

This bump ensures that any customers upgrading dd-trace-rb also pick up the latest version of `datadog-ruby_core_source`.

**Change log entry**

Yes. Bump minimum version of `datadog-ruby_core_source` to 3.4

**Additional Notes:**

N/A

**How to test the change?**

Green CI means all ok :)