### PR TITLE
ci: pin all GitHub Actions by SHA and update via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout code
         # Checks out the branch that the pull request is merged into
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get project milestones
         id: milestones
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Update Pull Request
         # Update the merged pull request with the milestone starts with the major version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -27,8 +27,8 @@ jobs:
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: '3.2'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -60,7 +60,7 @@ jobs:
         run: |
           find pkg
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
           path: 'pkg/*.gem'
@@ -77,14 +77,14 @@ jobs:
       - build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
           path: 'pkg'
       - name: List gem
         run: |
           find pkg
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: '3.2'
       - name: Install gem
@@ -103,7 +103,7 @@ jobs:
     if: ${{ inputs.push }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
           path: 'pkg'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-24.04
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: bundle lock
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         id: lockfile
         with:
           name: 'check-lockfile-${{ github.sha }}-${{ github.run_id }}'
@@ -27,8 +27,8 @@ jobs:
     needs: ['build']
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - run: bundle install
       - run: bundle exec rake rubocop
 
@@ -38,8 +38,8 @@ jobs:
     needs: ['build']
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Install dependencies
         run: bundle install
       - run: bundle exec rake standard
@@ -50,8 +50,8 @@ jobs:
     needs: ['build']
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: Install dependencies
         run: bundle install
       - name: Check for stale signature files
@@ -71,8 +71,8 @@ jobs:
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4 # requires the lockfile
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8 # requires the lockfile
       - uses: DataDog/datadog-sca-github-action@main
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -84,7 +84,7 @@ jobs:
     name: dd/static-analysis
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: DataDog/datadog-static-analyzer-github-action@v1
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-24.04
     container: semgrep/semgrep # PENDING: Possible to be rate limited.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           semgrep ci \
           --include=bin/* \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,7 +40,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8

--- a/.github/workflows/ensure-changelog-entry.yml
+++ b/.github/workflows/ensure-changelog-entry.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check membership
         id: membership
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -35,7 +35,7 @@ jobs:
 
       - name: Find existing comment
         id: comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Check change log entry
         id: condition
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -70,7 +70,7 @@ jobs:
             return isWriteComment
 
       - name: Write comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -15,10 +15,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           bundler-cache: true # runs bundle install
           ruby-version: "3.3"
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: ${{ secrets.GHA_PAT }}
           branch: auto-generate/update-supported-versions

--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -31,7 +31,7 @@ jobs:
       pr_base_ref: ${{ steps.pr.outputs.pr.base.ref }}
     steps:
       # Limitation with pull_request trigger: https://github.com/8BitJonny/gh-get-current-pr/tree/3.0.0/?tab=readme-ov-file#limitations
-      - uses: 8BitJonny/gh-get-current-pr@3.0.0
+      - uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # v3.0.0
         id: pr
         with:
           filterOutClosed: true # Don't trigger on commits with closed PRs, including merges into `master`.
@@ -44,8 +44,8 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.dependencies }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           # This is the best effort to get the diff comparison.
@@ -92,7 +92,7 @@ jobs:
       env:
         BUNDLE_WITHOUT: check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           ruby -v
           gem -v
@@ -100,7 +100,7 @@ jobs:
       - run: bundle install
       - run: bundle exec rake dependency:generate
       - run: bundle exec rake dependency:lock
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: lock-dependency-${{ github.run_id }}-${{ matrix.engine.name }}-${{ matrix.engine.version }}
           path: gemfiles/${{ matrix.engine.name }}_${{ matrix.engine.version }}*
@@ -113,15 +113,15 @@ jobs:
     needs: lock
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GHA_PAT }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: gemfiles
           pattern: lock-dependency-${{ github.run_id }}-*
           merge-multiple: true
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
         with:
           file_pattern: 'gemfiles/*'
           commit_message: "[🤖] Lock Dependency: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Check CPU arch
         run: |
           test "$(uname -m)" = "${{ matrix.platform.cpu }}"
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: DeterminateSystems/nix-installer-action@dea7810afd9d4c98556c8ec68cf361bd5b648eaa # main
       - name: Print ruby version
         run: |
           nix develop --command which ruby

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: '3.3.7'
 
@@ -40,7 +40,7 @@ jobs:
       # Check if the commit has passed all Github checks
       # API: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
       - name: Verify check runs
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const checkRuns = await github.paginate(github.rest.checks.listForRef, {
@@ -64,7 +64,7 @@ jobs:
       # Check if the commit has passed external CI checks
       # API: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference
       - name: Verify commit status
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data: status } = await github.rest.repos.getCombinedStatusForRef({
@@ -108,12 +108,12 @@ jobs:
     env:
       SKIP_SIMPLECOV: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: '3.3.7'
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
         with:
           attestations: false # PENDING decision for attestations
 

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -44,13 +44,13 @@ jobs:
     name: Build (${{ matrix.image.name }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -130,13 +130,13 @@ jobs:
       FORCED_TESTS_LIST: ${{steps.read_forced_tests_list.outputs.FORCED_TESTS_LIST}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Checkout ${{ matrix.library.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "${{ matrix.library.repository }}"
           path: "binaries/${{ matrix.library.path }}"
@@ -149,7 +149,7 @@ jobs:
           echo "$(cat binaries/dd-trace-rb/.github/forced-tests-list.json)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -311,13 +311,13 @@ jobs:
     name: Test (${{ matrix.app }}, ${{ matrix.scenario }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -353,7 +353,7 @@ jobs:
           SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY: ${{ secrets.SYSTEM_TESTS_IDM_AWS_SECRET_ACCESS_KEY }}
           FORCED_TESTS_LIST: ${{ needs.build-apps.outputs.FORCED_TESTS_LIST }}
       - name: Archive logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: ${{ always() }}
         with:
           name: system-tests-${{ matrix.library }}-${{ matrix.app }}-${{ matrix.scenario }}-logs-gha${{ github.run_id }}-g${{ github.sha }}
@@ -395,17 +395,17 @@ jobs:
     name: Aggregate (${{ matrix.app }})
     steps:
       - name: Setup python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "DataDog/system-tests"
           ref: ${{ env.SYSTEM_TESTS_REF }}
           persist-credentials: false
       - name: Retrieve logs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: system-tests-${{ matrix.library }}-${{ matrix.app }}-*-logs-gha${{ github.run_id }}-g${{ github.sha }}
           merge-multiple: true
@@ -451,7 +451,7 @@ jobs:
       - name: Log in to the Container registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-version-ids: "gha${{ github.run_id }}-g${{ github.sha }}"
           package-name: "system-tests/${{ matrix.image }}"
@@ -464,11 +464,11 @@ jobs:
       packages: write
     steps:
       - run: mkdir binaries/
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: binaries/dd-trace-rb/
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: system_tests_binaries
           path: binaries/

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -30,13 +30,13 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies
       - if: ${{ matrix.ruby == 'head' }}
         run: sed -i~ -e '/spec\.required_ruby_version/d' datadog.gemspec
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: ${{ matrix.ruby }}
           rubygems: 3.3.26

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -4,8 +4,8 @@ jobs:
   test-memcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: 3.4.1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -17,8 +17,8 @@ jobs:
   test-asan:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: asan
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -30,13 +30,13 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # bundler appears to match both prerelease and release rubies when we
       # want the former only. relax the constraint to allow any version for
       # head rubies
       - if: ${{ matrix.ruby == 'head' }}
         run: sed -i~ -e '/spec\.required_ruby_version/d' datadog.gemspec
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@2654679fe7f7c29875c669398a8ec0791b8a64a1 # v1.215.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:3.4
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-34-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-34-${{ hashFiles('*.lock') }}
@@ -37,7 +37,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -125,13 +125,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-34-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-34.outputs.cache-key }}"
@@ -140,7 +140,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-33:
@@ -151,13 +151,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:3.3
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-33-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-33-${{ hashFiles('*.lock') }}
@@ -165,7 +165,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -253,13 +253,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-33-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-33.outputs.cache-key }}"
@@ -268,7 +268,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-32:
@@ -279,13 +279,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:3.2
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-32-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-32-${{ hashFiles('*.lock') }}
@@ -293,7 +293,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -381,13 +381,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-32-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-32.outputs.cache-key }}"
@@ -396,7 +396,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-31:
@@ -407,13 +407,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:3.1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-31-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-31-${{ hashFiles('*.lock') }}
@@ -421,7 +421,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -509,13 +509,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-31-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-31.outputs.cache-key }}"
@@ -524,7 +524,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-30:
@@ -535,13 +535,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:3.0
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-30-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-30-${{ hashFiles('*.lock') }}
@@ -549,7 +549,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -637,13 +637,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-30-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-30.outputs.cache-key }}"
@@ -652,7 +652,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-27:
@@ -663,13 +663,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:2.7
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-27-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-27-${{ hashFiles('*.lock') }}
@@ -677,7 +677,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -765,13 +765,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-27-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-27.outputs.cache-key }}"
@@ -780,7 +780,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-26:
@@ -791,13 +791,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:2.6
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-26-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-26-${{ hashFiles('*.lock') }}
@@ -805,7 +805,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -893,13 +893,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-26-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-26.outputs.cache-key }}"
@@ -908,7 +908,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-ruby-25:
@@ -919,13 +919,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/ruby:2.5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-ruby-25-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-ruby-25-${{ hashFiles('*.lock') }}
@@ -933,7 +933,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -1021,13 +1021,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-ruby-25-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-ruby-25.outputs.cache-key }}"
@@ -1036,7 +1036,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-jruby-94:
@@ -1047,13 +1047,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/jruby:9.4
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-jruby-94-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-jruby-94-${{ hashFiles('*.lock') }}
@@ -1061,7 +1061,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -1149,13 +1149,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-jruby-94-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-jruby-94.outputs.cache-key }}"
@@ -1164,7 +1164,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-jruby-93:
@@ -1175,13 +1175,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/jruby:9.3
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-jruby-93-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-jruby-93-${{ hashFiles('*.lock') }}
@@ -1189,7 +1189,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -1277,13 +1277,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-jruby-93-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-jruby-93.outputs.cache-key }}"
@@ -1292,7 +1292,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   batch-jruby-92:
@@ -1303,13 +1303,13 @@ jobs:
       cache-key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
     container: ghcr.io/datadog/images-rb/engines/jruby:9.2
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle lock
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: lockfile-jruby-92-${{ github.run_id }}
         path: "*.lock"
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: bundle-${{ runner.os }}-${{ runner.arch }}-jruby-92-${{ hashFiles('*.lock') }}
@@ -1317,7 +1317,7 @@ jobs:
     - if: steps.restore-cache.outputs.cache-hit != 'true'
       run: bundle install
     - if: steps.restore-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         key: "${{ steps.restore-cache.outputs.cache-primary-key }}"
         path: "/usr/local/bundle"
@@ -1405,13 +1405,13 @@ jobs:
           DD_DISABLE_ERROR_RESPONSES: 'true'
           ENABLED_CHECKS: trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: lockfile-jruby-92-${{ github.run_id }}
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: restore-cache
       with:
         key: "${{ needs.batch-jruby-92.outputs.cache-key }}"
@@ -1420,7 +1420,7 @@ jobs:
     - run: bundle exec rake github:run_batch_build
     - run: bundle exec rake github:run_batch_tests
     - if: "${{ failure() && env.RUNNER_DEBUG == '1' }}"
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19.0
       with:
         limit-access-to-actor: true
   unit-tests:

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -45,7 +45,7 @@ jobs:
       image: "ghcr.io/datadog/images-rb/engines/${{ matrix.engine.name }}:${{ matrix.engine.version }}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Output Ruby version
         run: ruby -v
@@ -57,7 +57,7 @@ jobs:
         run: bundle exec rake edge:gemspec edge:update
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: 'gha${{ github.run_id }}-datadog-gem-${{ matrix.engine.name }}-${{ matrix.engine.version }}'
           path: gemfiles/${{ matrix.engine.name }}_${{ matrix.engine.version }}_*
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download artifacts for all runtimes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: gemfiles
           pattern: gha${{ github.run_id }}-datadog-gem-*
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: ${{ secrets.GHA_PAT }}
           branch: auto-generate/update-latest-dependencies
@@ -97,7 +97,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
           token: ${{ secrets.GHA_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -31,19 +31,19 @@ jobs:
         BUNDLE_GEMFILE: tools/yard.gemfile
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: ls -al
       - name: Bundle
         run: bundle install
       - name: Generate YARD documentation
         run: bundle exec rake docs --rakefile=tasks/yard.rake
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           # Upload generated YARD directory
           path: 'doc/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
- **Add dependabot for github actions**
- **Pin actions by hash**

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Pinning 3rd-party GitHub Actions by commit SHA makes them less vulnerable to compromise of the 3rd party. To avoid outdating and non-verbosity, versions are commented after the SHA and updating via dependabot is introduced that will automatically update the commented version tag as well.

In case of a false commit SHA, this change could break the corresponding workflow. Typically, this does not cause major interruptions, but it can for example affect a release pipeline and require restart causing delays.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
