### PR TITLE
Fix remote config handling for AppSec

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,9 +24,8 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  # Broken system-test: https://github.com/DataDog/system-tests/pull/3904
-  SYSTEM_TESTS_REF: 239c3eba6de0473817d3d88ebbc025c9d0c9574b
-  # SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
+  # TODO: remove this change before merging to master
+  SYSTEM_TESTS_REF: enable-ip-blocking-for-ruby
 
 jobs:
   build-harness:

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -74,15 +74,12 @@ module Datadog
               case content.path.product
               when 'ASM_DD'
                 rules << parsed_content
-                content.applied
               when 'ASM_DATA'
                 data << parsed_content['rules_data'] if parsed_content['rules_data']
-                content.applied
               when 'ASM'
                 overrides << parsed_content['rules_override'] if parsed_content['rules_override']
                 exclusions << parsed_content['exclusions'] if parsed_content['exclusions']
                 custom_rules << parsed_content['custom_rules'] if parsed_content['custom_rules']
-                content.applied
               end
             end
 
@@ -107,6 +104,10 @@ module Datadog
             )
 
             Datadog::AppSec.reconfigure(ruleset: ruleset, telemetry: telemetry)
+
+            repository.contents.each do |content|
+              content.applied if ASM_PRODUCTS.include?(content.path.product)
+            end
           end
 
           [receiver]

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -74,12 +74,15 @@ module Datadog
               case content.path.product
               when 'ASM_DD'
                 rules << parsed_content
+                content.applied
               when 'ASM_DATA'
                 data << parsed_content['rules_data'] if parsed_content['rules_data']
+                content.applied
               when 'ASM'
                 overrides << parsed_content['rules_override'] if parsed_content['rules_override']
                 exclusions << parsed_content['exclusions'] if parsed_content['exclusions']
                 custom_rules << parsed_content['custom_rules'] if parsed_content['custom_rules']
+                content.applied
               end
             end
 

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -173,6 +173,12 @@ RSpec.describe Datadog::AppSec::Remote do
           receiver.call(repository, changes)
         end
 
+        it 'sets apply_state to ACKNOWLEDGED on content' do
+          receiver.call(repository, transaction)
+
+          expect(content.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::ACKNOWLEDGED)
+        end
+
         context 'content product' do
           before do
             # Stub the reconfigure method, so we do not trigger background reconfiguration
@@ -290,6 +296,13 @@ RSpec.describe Datadog::AppSec::Remote do
 
           context 'ASM' do
             let(:path) { 'datadog/603646/ASM/whatevername/config' }
+            let(:data) { {} }
+
+            it 'sets apply_state to ACKNOWLEDGED on content' do
+              receiver.call(repository, transaction)
+
+              expect(content.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::ACKNOWLEDGED)
+            end
 
             context 'overrides' do
               let(:data) do
@@ -405,6 +418,13 @@ RSpec.describe Datadog::AppSec::Remote do
 
           context 'ASM_DATA' do
             let(:path) { 'datadog/603646/ASM_DATA/whatevername/config' }
+            let(:data) { {} }
+
+            it 'sets apply_state to ACKNOWLEDGED on content' do
+              receiver.call(repository, transaction)
+
+              expect(content.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::ACKNOWLEDGED)
+            end
 
             context 'with rules_data information' do
               let(:data) do


### PR DESCRIPTION
Before we were not setting `apply_state` to ACKNOWLEDGED on remote config content, which caused some system tests to fail.

**What does this PR do?**
This PR adds setting of `apply_state` on remote config content to `ACKNOWLEDGED` after successful processing.

**Motivation:**
Failing system tests for full denylist blocking: https://github.com/DataDog/system-tests/pull/3937

**Change log entry**
None, this is internal change. Changes via remote config were applied before too, it's just the status that wasn't set correctly.

**Additional Notes:**
None.

**How to test the change?**
CI should be enough.