### PR TITLE
DEBUG-3439 DEBUG-3440 remove prefixes from probe paths when path matching

### DIFF
--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -155,7 +155,7 @@ module Datadog
               return inexact.first
             end
             return nil unless suffix.include?('/')
-            suffix.sub!(%r,.*/+,, '')
+            suffix.sub!(%r{.*/+}, '')
           end
         end
       end

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -140,16 +140,23 @@ module Datadog
           exact = registry[suffix]
           return [suffix, exact] if exact
 
-          inexact = []
-          registry.each do |path, iseq|
-            if Utils.path_matches_suffix?(path, suffix)
-              inexact << [path, iseq]
+          suffix = suffix.dup
+          loop do
+            inexact = []
+            registry.each do |path, iseq|
+              if Utils.path_matches_suffix?(path, suffix)
+                inexact << [path, iseq]
+              end
             end
+            if inexact.length > 1
+              raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix"
+            end
+            if inexact.any?
+              return inexact.first
+            end
+            return nil unless suffix.include?('/')
+            suffix.sub!(%r,.*/+,, '')
           end
-          if inexact.length > 1
-            raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix"
-          end
-          inexact.first
         end
       end
 

--- a/lib/datadog/di/probe.rb
+++ b/lib/datadog/di/probe.rb
@@ -155,11 +155,8 @@ module Datadog
       # Returns whether the provided +path+ matches the user-designated
       # file (of a line probe).
       #
-      # If file is an absolute path (i.e., it starts with a slash), the file
-      # must be identical to path to match.
-      #
-      # If file is not an absolute path, the path matches if the file is its suffix,
-      # at a path component boundary.
+      # Delegates to Utils.path_can_match_spec? which performs fuzzy
+      # matching. See the comments in utils.rb for details.
       def file_matches?(path)
         if path.nil?
           raise ArgumentError, "Cannot match against a nil path"
@@ -167,7 +164,7 @@ module Datadog
         unless file
           raise ArgumentError, "Probe does not have a file to match against"
         end
-        Utils.path_matches_suffix?(path, file)
+        Utils.path_can_match_spec?(path, file)
       end
 
       # Instrumentation module for method probes.

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -4,7 +4,77 @@ module Datadog
   module DI
     module Utils
       # Returns whether the provided +path+ matches the user-designated
-      # file suffix (of a line probe).
+      # file suffix or path (of a line probe).
+      #
+      # The following use cases must be supported:
+      # 1. The "probe path" is relative path to the file from source code
+      #    repository root. The project is deployed from the repository root,
+      #    such that that same relative path exists at runtime from the
+      #    root of the application.
+      # 2. The "probe path" is a relative path to the file in a monorepo
+      #    where the project being deployed is in a subdirectory.
+      #    This the "probe path" contains additional directory components
+      #    in the beginning that do not exist in the runtime environment.
+      # 3. The "probe path" is an absolute path to the file on the customer's
+      #    development system. As specified this path definitely does not
+      #    exist at runtime, and can start with a prefix that is unknown
+      #    to any both UI and tracer code.
+      # 4. Same as (3), but the customer is using a Windows computer for
+      #    development and has the path specified in the wrong case
+      #    (which works fine on their development machine).
+      # 5. The "probe path" is the basename or any suffix of the path to
+      #    the desired file, typed manually by the customer into the UI.
+      #
+      # A related concern is that if multiple runtime paths match the path
+      # specification in the probe, the tracer must return an error to the
+      # backend/UI rather than instrumenting any of the matching paths.
+      #
+      # The logic for path matching is therefore, generally, as follows:
+      # 1. If the "probe path" is absolute, see if it exists at runtime.
+      #    If so, take it as the desired path and finish.
+      # 2. Attempt to identify the application root, by checking if the current
+      #    working directory contains a file called Gemfile. If yes, assume
+      #    the current working directory is the application root, otherwise
+      #    consider the application root to be unknown.
+      # 3. If the application root is known and the "probe path" is relative,
+      #    concatenate the "probe path" to the application root and check
+      #    if the resulting path exists at runtime. If so, take it as the
+      #    desired path and finish.
+      # 4. If the "probe path" is relative, go through the known file paths,
+      #    filter these paths down to those whose suffix is the "probe path",
+      #    and check how many we are left with. If exactly one, assume this
+      #    is the desired path and finish. If more than one, return an error
+      #    "multiple matching paths".
+      # 5. If the application root is known, for each suffix of the "probe path",
+      #    see if that relative paths concatenated to the application root
+      #    results in a known file. If a known file is found, assume this
+      #    is the wanted file and finish.
+      # 6. For each suffix of the "probe path", filter the set of known paths
+      #    down to those that end in the suffix. If exactly one path remains
+      #    for a given suffix, assume this is the wanted path and finish.
+      #    If more than one path remains for a given suffix, return the error
+      #    "multiple matching paths".
+      # 7. Repeat step 5 but perform case-insensitive comparison.
+      # 8. Repeat step 6 but perform case-insensitive comparison.
+      #
+      # Note that we do not look for "probe paths" under the current working
+      # directory at runtime if the current working directory does not contain
+      # a Gemfile, to avoid finding files from potentially undesired bases.
+      #
+      # What "known file"/"known path" means also differs based on the
+      # operation being performed:
+      # - If the operation is "install a probe", "known file/path" can
+      #   include files on the filesystem that have not been loaded as
+      #   well as paths from the code tracker.
+      # - If the operation is "check if any pending probes match the file
+      #   that was just loaded", we would only consider the path that was
+      #   just loaded and not check the filesystem.
+      #
+      # Filesystem inquiries are obviously quite expensive and should be
+      # cached. For the vast majority of applications it should be safe to
+      # indefinitely cache whether a particular filesystem paths exists
+      # in both positive and negative.
+      #
       #
       # If suffix is an absolute path (i.e., it starts with a slash), the path
       # must be identical for it to match.

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -128,7 +128,7 @@ module Datadog
         spec = spec.dup
         loop do
           return false unless spec.include?('/')
-          spec.sub!(%r,.*/+,, '')
+          spec.sub!(%r{.*/+}, '')
           return true if path_matches_suffix?(path, spec)
         end
       end

--- a/sig/datadog/di/utils.rbs
+++ b/sig/datadog/di/utils.rbs
@@ -2,6 +2,7 @@ module Datadog
   module DI
     module Utils
       def self?.path_matches_suffix?: (String path, String suffix) -> bool
+      def self?.path_can_match_spec?: (String path, String suffix) -> bool
     end
   end
 end

--- a/spec/datadog/di/utils_spec.rb
+++ b/spec/datadog/di/utils_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Datadog::DI::Utils do
   di_test
 
   describe '.path_matches_suffix?' do
+    # NB; when updating this list also add to the list in
+    # path_can_match_spec? test below.
     [
       ['exact match - absolute path', '/foo/bar.rb', '/foo/bar.rb', true],
       # Suffix matching is only applicable to relative paths.
@@ -15,7 +17,7 @@ RSpec.describe Datadog::DI::Utils do
       ['extra leading slash in file', '//foo/bar.rb', '/foo/bar.rb', false],
       ['extra slash in the middle of file', 'foo//bar.rb', '/foo/bar.rb', false],
       ['nothing in common', 'blah.rb', '/foo/bar.rb', false],
-      ['path is a suffix of file', '/a/foo/bar.rbr', '/foo/bar.rb', false],
+      ['path is a suffix of file', '/a/foo/bar.rb', '/foo/bar.rb', false],
 
       # We expect path to always be an absolute path.
       ['path is relative', 'bar.rb', 'bar.rb', false],
@@ -25,6 +27,38 @@ RSpec.describe Datadog::DI::Utils do
       context name do
         it "is #{result}" do
           expect(described_class.path_matches_suffix?(path, suffix)).to be result
+        end
+      end
+    end
+  end
+
+  describe '.path_can_match_spec?' do
+    # NB; when updating this list also add to the list in
+    # path_matches_suffix? test above.
+    [
+      ['exact match - absolute path', '/foo/bar.rb', '/foo/bar.rb', true],
+      # Prefixes of suffix are removed until there is a match
+      ['absolute path is a suffix', '/bar.rb', '/foo/bar.rb', true],
+      # ... but not if basename does not match
+      ['absolute path is a suffix', '/bar.rb', '/foo/bar1.rb', false],
+      ['suffix - multiple path components', 'foo/bar.rb', '/foo/bar.rb', true],
+      ['suffix - at basename', 'bar.rb', '/foo/bar.rb', true],
+      ['suffix - not at path component boundary', 'ar.rb', '/foo/bar.rb', false],
+      # Extra leading slashes are removed
+      ['extra leading slash in file', '//foo/bar.rb', '/foo/bar.rb', true],
+      # Extra slashes in the middle are also removed
+      ['extra slash in the middle of file', 'foo//bar.rb', '/foo/bar.rb', true],
+      ['nothing in common', 'blah.rb', '/foo/bar.rb', false],
+      ['path is a suffix of file', '/a/foo/bar.rb', '/foo/bar.rb', true],
+
+      # We expect path to always be an absolute path.
+      ['path is relative', 'bar.rb', 'bar.rb', false],
+    ].each do |name, suffix_, path_, result_|
+      suffix, path, result = suffix_, path_, result_
+
+      context name do
+        it "is #{result}" do
+          expect(described_class.path_can_match_spec?(path, suffix)).to be result
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Loosens the restrictions on path matching to also try to match prefixes of probe paths to the paths that exist at runtime.

For example, suppose at runtime we have:
`/app/app/controllers/hello_controller.rb`

Previously, either exact full path or suffixes of the path were accepted:
- `/app/app/controllers/hello_controller.rb`
- `app/controllers/hello_controller.rb`
- `hello_controller.rb`
Now, paths that have extra subdirectories in front will also be accepted:
 - `local/hello_controller.rb`
 - `local/controllers/hello_controller.rb`

**Motivation:**
For projects that are stored in subdirectories in their source code repositories (e.g. monorepos), source code integration is providing a full path that has extra prefixes from the application's standpoint (and also runtime standpoint). These prefixes previously made such paths not instrumentable. With this PR, the extra prefixes will be removed to try to find a matching file.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes: loosen path matching in dynamic instrumentation 
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
This change can cause potentially incorrect files to match if the desired file is not yet loaded.

In order to properly implement matching accounting for these extra prefixes, much more work is needed. The ideal (in my present opinion) matching algorithm is described in a comment in this diff. This PR only implements a quick fix to get Ruby DI out to customers as soon as possible.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit tests and integration test are added.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
