### PR TITLE
Increase curl retries to attempt to fix transient network failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,8 @@ orbs:
               command: |
                 DOCKERIZE_URL="https://github.com/powerman/dockerize/releases/download/v0.17.0/dockerize-$(uname -s | tr '[:upper:]' '[:lower:]')-$(arch | sed 's/aarch64/arm64/')"
                 DOCKERIZE_URL: $DOCKERIZE_URL
-                curl --silent --show-error --location --fail --retry 3 --output /usr/local/bin/dockerize $DOCKERIZE_URL
+                set -e
+                curl --silent --show-error --location --fail --retry 5 --output /usr/local/bin/dockerize $DOCKERIZE_URL
                 chmod +x /usr/local/bin/dockerize
                 dockerize --version
           # Wait for containers to start
@@ -275,11 +276,13 @@ orbs:
               name: Upload JUnit reports to Datadog
               when: always
               command: |
+                set -e
+                
                 sed -i 's/file="\.\//file="/g' tmp/rspec/*.xml
                 
                 ls -l tmp/rspec/*.xml
 
-                curl -L --fail --retry 3 "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+                curl -L --fail --retry 5 "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 
                 datadog-ci version
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Increases number of curl retries from 3 to 5, and also adds `-e` flag to the shell scripts to make them stop when a command fails

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Looking at this failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/18427/workflows/74c5b5dd-981f-40ad-ac8b-476decd6c636/jobs/648546
- datadog-ci was attempted to be run even though it wasn't downloaded
- There was a network failure which happened 3 times
When curl retries, it waits 1 second before the first retry and doubles the waiting time before each subsequent retry. For 3 retries that is a total of 7 seconds between the first and the last attempt (1+2+4). Perhaps 7 seconds is not enough for the network to fix itself - this PR proposes increasing the number of retries to 5 which increases the total waiting time from 7 to 31 seconds, with the last two attempts 16 seconds apart. If this makes the operation succeed I think adding 30 seconds to the build runtime is a small price to pay.

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
