### PR TITLE
Switch system-tests ref back to main

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,8 +24,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  # TODO: remove this change before merging to master
-  SYSTEM_TESTS_REF: enable-ip-blocking-for-ruby
+  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   build-harness:


### PR DESCRIPTION
**What does this PR do?**
It switches system-tests back to `main` ref

**Motivation:**
This PR: https://github.com/DataDog/dd-trace-rb/pull/4345

**Change log entry**
None. This is internal change.

**Additional Notes:**
None.

**How to test the change?**
CI is enough.
