### PR TITLE
DEBUG-3457 hack probe notifier worker starting

### DIFF
--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -95,7 +95,7 @@ module Datadog
         # presently starts the remote config worker.
         #
         # DI is hacked into that middleware the same way.
-        #probe_notifier_worker.start
+        # probe_notifier_worker.start
       end
 
       attr_reader :settings

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -39,6 +39,10 @@ module Datadog
 
             boot = Datadog::Core::Remote::Tie.boot
 
+            if defined?(Datadog::DI)
+              Datadog::DI.current_component&.probe_notifier_worker&.start
+            end
+
             # Extract distributed tracing context before creating any spans,
             # so that all spans will be added to the distributed trace.
             if configuration[:distributed_tracing]

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -40,7 +40,7 @@ module Datadog
             boot = Datadog::Core::Remote::Tie.boot
 
             if defined?(Datadog::DI.current_component)
-              # TODO when would Datadog::DI be defined but
+              # TODO: when would Datadog::DI be defined but
               # Datadog::DI.current_component not be defined?
               Datadog::DI.current_component&.probe_notifier_worker&.start
             end

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -39,7 +39,9 @@ module Datadog
 
             boot = Datadog::Core::Remote::Tie.boot
 
-            if defined?(Datadog::DI)
+            if defined?(Datadog::DI.current_component)
+              # TODO when would Datadog::DI be defined but
+              # Datadog::DI.current_component not be defined?
               Datadog::DI.current_component&.probe_notifier_worker&.start
             end
 

--- a/spec/datadog/di/integration/everything_from_remote_config_spec.rb
+++ b/spec/datadog/di/integration/everything_from_remote_config_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe 'DI integration from remote config' do
 
   before do
     expect(Datadog::DI).to receive(:component).at_least(:once).and_return(component)
+
+    # This is done by tracing Rack middleware in actual applications
+    component.probe_notifier_worker.start
   end
 
   let(:mock_response) do

--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -107,6 +107,9 @@ RSpec.describe 'Instrumentation integration' do
       allow(agent_settings).to receive(:ssl)
 
       allow(Datadog::DI).to receive(:current_component).and_return(component)
+
+      # This is done by tracing Rack middleware in actual applications
+      component.probe_notifier_worker.start
     end
 
     context 'method probe' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Moves the call to start probe notifier worker (i.e. the background thread) to tracing Rack middleware, which also starts remote config worker.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
On forking web servers like puma the probe notifier worker is currently started in the parent (supervisor) process rather than in the worker processes, causing DI to not send any events to the agent.

**Change log entry**
Yes: fix dynamic instrumentation event sending on forking web servers
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
A proper solution would, in my opinion, not invoke DI (or remote config, which is a prerequisite for DI) from tracing, however in practice all DI customers should have tracing enabled therefore the solution in this PR should work for them.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
I manually verified it against debugger-demo-ruby.
Current CI does not appear to have a configuration that reproduces debugger-demo-ruby environment (since without this PR everything works in CI but does not work in debugger-demo-ruby).
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
