### PR TITLE
DEBUG-3472 send snapshot and status events together

### DIFF
--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -263,7 +263,7 @@ module Datadog
 
       def maybe_send
         rv = maybe_send_status
-        rv || maybe_send_snapshot
+        maybe_send_snapshot || rv
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes probe notifier worker to send both status and snapshot events in each iteration

**Motivation:**
When a probe executes for the first time, it emits a status event (that it is emitting) and the snapshot event (execution result). Currently these events are submitted to agent in different processing iterations, which upon reflection is not good - there was one action that caused both events to happen (probe execution), therefore both events should be submitted together.

There is also an issue in debugger-demo-ruby where the snapshot events are dropped between iterations for some reason. The root cause of this issue has not yet been identified but sending both events together works around the problem.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes: improve dynamic instrumentation event reporting 
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
I tested manually against debugger-demo-ruby. I don't think we have a CI configuration presently that can test this change.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
