### PR TITLE
DEBUG-3457 start DI probe notifier worker on every event submission

### DIFF
--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -36,6 +36,7 @@ module Datadog
         @sleep_remaining = nil
         @wake_scheduled = false
         @thread = nil
+        @pid = nil
         @flush = 0
       end
 
@@ -44,7 +45,7 @@ module Datadog
       attr_reader :telemetry
 
       def start
-        return if @thread
+        return if @thread && @pid == Process.pid
         @thread = Thread.new do
           loop do
             # TODO If stop is requested, we stop immediately without
@@ -86,6 +87,7 @@ module Datadog
             wake.wait(more ? min_send_interval : nil)
           end
         end
+        @pid = Process.pid
       end
 
       # Stops the background thread.
@@ -200,6 +202,10 @@ module Datadog
               wake.signal
             end
           end
+
+          # Worker could be not running if the process forked - check and
+          # start it again in this case.
+          start
         end
 
         # Determine how much longer the worker thread should sleep


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Alternative implementation to https://github.com/DataDog/dd-trace-rb/pull/4358, this PR checks if the probe notifier worker is running on every event submission and starts it if the process forked.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
DI is not submitting events to backend in some forked server configurations.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes: fix dynamic instrumentation event submission on forked servers
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tested manually against debugger-demo-ruby
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
