### PR TITLE
Remove linting rule for list first/last

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,6 +1,10 @@
 schema-version: v1
 rulesets:
-  - ruby-code-style
+  - ruby-code-style:
+    rules:
+      first-and-last:
+        ignore:
+          - "**"
   - ruby-security
   - ruby-best-practices:
     rules:


### PR DESCRIPTION
This rule has been mostly ignored, since it doesn't always provide idiomatic Ruby.

**Change log entry**
No.
