### PR TITLE
Un-skip spec in core environment

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
       context 'when in a Pry session' do
         it 'returns true' do
-          skip('Temporarily skipping for batched tests from Github Actions') if ENV['BATCHED_TASKS']
           Tempfile.create('test') do |f|
             f.write(repl_script)
             f.close


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR un-skips a core environment spec. 

**Motivation:**
We want to enable all tests for our migration to GHA: https://github.com/DataDog/ruby-guild/issues/214.

**Change log entry**
None.

**Additional Notes:**
This spec is known to be flaky. See this issue that was resolved for CircleCI: https://github.com/DataDog/ruby-guild/issues/185. However, we should still enable the test. If it flakes for GHA, then we will address it in another PR (or this one if it flakes now).

**How to test the change?**
Consistently green GHA Unit Tests. I tested this by running GHA Unit Tests five times.

<!-- Unsure? Have a question? Request a review! -->
