### PR TITLE
Add comment for skipped mongodb spec

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,8 +142,6 @@ services:
     environment:
       <<: *common-environment
       BUNDLE_GEMFILE: /app/ruby-3.4.gemfile
-    links:
-      - "mongodb:mongodb-secondary-host"
     stdin_open: true
     tty: true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,8 @@ services:
     environment:
       <<: *common-environment
       BUNDLE_GEMFILE: /app/ruby-3.4.gemfile
+    links:
+      - "mongodb:mongodb-secondary-host"
     stdin_open: true
     tty: true
     volumes:

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       let(:secondary_client) { Mongo::Client.new(["#{secondary_host}:#{port}"], client_options) }
       # TODO: This tests doesn't work if TEST_MONGODB_HOST is set to anything other than 127.0.0.1
       #       We should fix this... maybe do a more clever IP resolve or something?
-      let(:secondary_host) { 'localhost' }
+      let(:secondary_host) { 'host.docker.internal' }
 
       before do
         Datadog.configure do |c|

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       let(:secondary_client) { Mongo::Client.new(["#{secondary_host}:#{port}"], client_options) }
       # TODO: This tests doesn't work if TEST_MONGODB_HOST is set to anything other than 127.0.0.1
       #       We should fix this... maybe do a more clever IP resolve or something?
-      let(:secondary_host) { 'mongodb-secondary-host' }
+      let(:secondary_host) { 'localhost' }
 
       before do
         Datadog.configure do |c|
@@ -110,7 +110,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       # service, causing the test to timeout while waiting for "primary server [to be] available in cluster".
       # One solution is to pull a second MongoDB service and set the secondary client accordingly. However,
       # given the large amount of services already being pulled, this spec remains skipped on GHA for now.
-      context 'secondary client' do
+      context 'secondary client', skip: ENV['BATCHED_TASKS'] do
         around do |example|
           without_warnings do
             # Reset before and after each example; don't allow global state to linger.

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       let(:secondary_client) { Mongo::Client.new(["#{secondary_host}:#{port}"], client_options) }
       # TODO: This tests doesn't work if TEST_MONGODB_HOST is set to anything other than 127.0.0.1
       #       We should fix this... maybe do a more clever IP resolve or something?
-      let(:secondary_host) { 'localhost' }
+      let(:secondary_host) { 'mongodb-secondary-host' }
 
       before do
         Datadog.configure do |c|
@@ -110,7 +110,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       # service, causing the test to timeout while waiting for "primary server [to be] available in cluster".
       # One solution is to pull a second MongoDB service and set the secondary client accordingly. However,
       # given the large amount of services already being pulled, this spec remains skipped on GHA for now.
-      context 'secondary client', skip: ENV['BATCHED_TASKS'] do
+      context 'secondary client' do
         around do |example|
           without_warnings do
             # Reset before and after each example; don't allow global state to linger.

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         end
       end
 
-      context 'secondary client', skip: ENV['BATCHED_TASKS'] do
+      context 'secondary client' do
         around do |example|
           without_warnings do
             # Reset before and after each example; don't allow global state to linger.

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe 'Mongo::Client instrumentation' do
         end
       end
 
+      # Our GHA Unit Tests run in docker containers, where "localhost" refers to the container itself.
+      # As a result, the secondary client (with host "localhost") cannot connect to the primary MongoDB
+      # service, causing the test to timeout while waiting for "primary server [to be] available in cluster".
+      # One solution is to pull a second MongoDB service and set the secondary client accordingly. However,
+      # given the large amount of services already being pulled, this spec remains skipped on GHA for now.
       context 'secondary client', skip: ENV['BATCHED_TASKS'] do
         around do |example|
           without_warnings do

--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
       let(:secondary_client) { Mongo::Client.new(["#{secondary_host}:#{port}"], client_options) }
       # TODO: This tests doesn't work if TEST_MONGODB_HOST is set to anything other than 127.0.0.1
       #       We should fix this... maybe do a more clever IP resolve or something?
-      let(:secondary_host) { 'host.docker.internal' }
+      let(:secondary_host) { 'localhost' }
 
       before do
         Datadog.configure do |c|
@@ -105,7 +105,7 @@ RSpec.describe 'Mongo::Client instrumentation' do
         end
       end
 
-      context 'secondary client' do
+      context 'secondary client', skip: ENV['BATCHED_TASKS'] do
         around do |example|
           without_warnings do
             # Reset before and after each example; don't allow global state to linger.


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds a comment for why the mongodb spec is still skipped for GHA.

**Motivation:**
Tried to un-skip this spec, but resolving the underlying issue noted in the comment without a better solution would increase overhead by too much for this one spec. The goal is to eventually unskip this spec! We want to enable all tests for our migration to GHA: https://github.com/DataDog/ruby-guild/issues/214.

**Change log entry**
None.

**Additional Notes:**
Issue: https://github.com/DataDog/ruby-guild/issues/216.

**How to test the change?**
The PR change itself is just adding a comment. However, for the spec that is being skipped, it fails when running in a docker container (like for our GHA workflow) but passes when running locally.

<!-- Unsure? Have a question? Request a review! -->
