### PR TITLE
Schedule our GHA Unit Tests to run every hour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ name: Unit Tests
     branches:
     - master
   schedule:
-  - cron: 0 7 * * *
+  - cron: 0 * * * *
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ name: Unit Tests
     branches:
     - master
   schedule:
-  - cron: 0 * * * *
+  - cron: 0 */4 * * 1-5
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -251,7 +251,7 @@ namespace :github do
             ]
           },
           'schedule' => [
-            { 'cron' => '0 7 * * *' }
+            { 'cron' => '0 * * * *' }
           ]
         },
         'concurrency' => {

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -251,7 +251,7 @@ namespace :github do
             ]
           },
           'schedule' => [
-            { 'cron' => '0 * * * *' }
+            { 'cron' => '0 */4 * * 1-5' }
           ]
         },
         'concurrency' => {


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR increases our GHA Unit Tests scheduled runs to once every 4 hour.

**Motivation:**
By increasing our scheduled runs, we will get a larger sample size of test runs on `master` -- helpful for discovering (and then addressing) flaky tests! GHA runs are free, so this should not increase CI costs.

**Change log entry**
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit Tests on GHA will run once every 4 hour.

<!-- Unsure? Have a question? Request a review! -->
