### PR TITLE
Uncomment skips for sidekiq, crashtracking, and telemetry specs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ name: Unit Tests
   push:
     branches:
     - master
+    - sarahchen6/*
   pull_request:
     branches:
     - master

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
       let(:agent_base_url) { "http://#{hostname}:#{port}" }
 
       [:fiddle, :signal].each do |trigger|
-        it "reports crashes via http when app crashes with #{trigger}", skip: ENV['BATCHED_TASKS'] do
+        it "reports crashes via http when app crashes with #{trigger}" do
           fork_expectations = proc do |status:, stdout:, stderr:|
             expect(Signal.signame(status.termsig)).to eq('SEGV').or eq('ABRT')
             expect(stderr).to include('[BUG] Segmentation fault')
@@ -269,7 +269,7 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
           # Do nothing, it's ok
         end
 
-        it 'reports crashes via uds when app crashes with fiddle', skip: ENV['BATCHED_TASKS'] do
+        it 'reports crashes via uds when app crashes with fiddle' do
           fork_expectations = proc do |status:, stdout:, stderr:|
             expect(Signal.signame(status.termsig)).to eq('SEGV').or eq('ABRT')
             expect(stderr).to include('[BUG] Segmentation fault')

--- a/spec/datadog/core/telemetry/component_spec.rb
+++ b/spec/datadog/core/telemetry/component_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       end
     end
 
-    context 'when in fork', skip: ENV['BATCHED_TASKS'] do
+    context 'when in fork' do
       before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       it do
@@ -169,7 +169,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       end
     end
 
-    context 'when in fork', skip: ENV['BATCHED_TASKS'] do
+    context 'when in fork' do
       before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       it do
@@ -209,7 +209,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       end
     end
 
-    context 'when in fork', skip: ENV['BATCHED_TASKS'] do
+    context 'when in fork' do
       before { skip 'Fork not supported on current platform' unless Process.respond_to?(:fork) }
 
       it do
@@ -245,7 +245,7 @@ RSpec.describe Datadog::Core::Telemetry::Component do
         expect(worker).to have_received(:enqueue).with(event)
       end
 
-      context 'when in fork', skip: !Process.respond_to?(:fork) || ENV['BATCHED_TASKS'] do
+      context 'when in fork', skip: !Process.respond_to?(:fork) do
         it do
           telemetry
           expect_in_fork do

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer heartbeat', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer heartbeat' do
   include SidekiqServerExpectations
 
   before do

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
 
   before do

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/redis_info_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/redis_info_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
   before do
     unless Datadog::Tracing::Contrib::Sidekiq::Integration.compatible_with_server_internal_tracing?

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_poller_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_poller_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
 
   before do

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -247,6 +247,7 @@ namespace :github do
           'push' => {
             'branches' => [
               'master',
+              'sarahchen6/*'
             ]
           },
           'pull_request' => {
@@ -340,11 +341,13 @@ namespace :github do
     matrix = eval(File.read('Matrixfile')).freeze # rubocop:disable Security/Eval
 
     exceptions = [
-      # 'sidekiq', # Connection refused - connect(2) for 127.0.0.1:6379 (RedisClient::CannotConnectError)
+      'sidekiq',
+      'crashtracking',
+      'main'
     ]
 
-    # candidates = exceptions
-    candidates = matrix.keys - exceptions
+    candidates = exceptions
+    # candidates = matrix.keys - exceptions
 
     raise 'No candidates.' if candidates.empty?
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Un-skip specs for sidekiq, crashtracking, and telemetry.

**Motivation:**
These specs are known flaky. Let's see what happens when we re-enable them!

We want to enable all tests for our migration to GHA: https://github.com/DataDog/ruby-guild/issues/214.

**Change log entry**
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Consistently green GHA Unit Tests. I'll test this by running GHA Unit Tests multiple times.

<!-- Unsure? Have a question? Request a review! -->
