### PR TITLE
Patch `ActionController::Base` and `API` instead of `Metal`

### DIFF
--- a/lib/datadog/tracing/contrib/action_pack/action_controller/patcher.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/patcher.rb
@@ -19,7 +19,8 @@ module Datadog
             end
 
             def patch
-              ::ActionController::Metal.prepend(ActionController::Instrumentation::Metal)
+              ::ActionController::Base.prepend(ActionController::Instrumentation::Metal)
+              ::ActionController::API.prepend(ActionController::Instrumentation::Metal)
             end
           end
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Makes a small adjustment to _where_ the patch for `rails.action_controller` is applied. Originally it `prepend`ed `ActionController::Metal`, but this PR proposes to move it earlier to `ActionController::Base` and `ActionController::API`.


**Motivation:**
<!-- What inspired you to submit this pull request? -->
In Rails, you will commonly see something like

```ruby
class MyController < ApplicationController
  # Rescue and gracefully handle error response
  rescue_from MyError, with: :render_error_response

  def index
    # ...
    fail MyError if no_good # On some condition, raise an error
  end
end
```

These are exceptions that are being handled gracefully, but Datadog will tag the `rails.action_controller` with errors. This causes APM to report errors on these controller actions, which can also cause alerts via the error tracking feature. The problem here is that this is reporting on something that is in fact being handled correctly by the code, but the tracer simply isn't aware of it.

This is happening because `datadog` is patching `ActionController::Metal`, which adds the [exception to the payload](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb#L117-L121) before the `ActionController` has a chance to [run the rescue handler](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/rescue.rb#L26-L31).

There is a workaround, but it requires you to configure [`action_dispatch.rescue_responses` ](https://guides.rubyonrails.org/configuring.html#config-action-dispatch-rescue-responses); `datadog` will [check this](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/action_pack/utils.rb#L15) to determine whether or not this is an expected exception. But this isn't really tenable; that configuration is largely intended for Rails' `ShowExceptions` to handled raised exceptions, so you wouldn't typically configure these with exceptions that you are already handling in the controller.

By simply moving the patch, the entirety of `process_action` is traced, which gives Rails a chance to run the rescue handlers.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

This may address a few existing issues:
- https://github.com/DataDog/dd-trace-rb/issues/3482: This one seems to be reporting that the `rack.request` resource is not correctly set when a `before_action` raises an exception. This is because with the original patch, the action callbacks ran _before_ the trace; now they will run _under_ the trace. This will allow the patch to now set the `rack.request` resource before any `before_action`s run.
- https://github.com/DataDog/dd-trace-rb/issues/2100: Reports that the action callbacks are not included in the trace (ie. they happen before the `rails.action_controller` span). This will no longer be the case. This is worth mentioning because there appears to be some differing opinions around whether or not this should be included as part of the `rails.action_controller` span. I personally think it should, because it _is_ part of the `process_action` call.

With the proposed change, it means more work is being traced. Given that the `rails.action_controller` span is intended to measure the controller action, I do think that this is more representative of what is happening in the controller.

I have chosen to also patch `ActionController::API` to support Rails' `api_mode`. Unsure if this needs to be smarter by first checking if the module exists before attempting to apply the patch. I can make that change if need be.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

I did follow the guide in https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md, and it does appear that the existing suite is still green. I may not have done it right, though. The change seems pretty superficial to me, but if there are any tests that I should add or modify, please let me know. I'm really not sure what to do here, my apologies.

I have applied this patch manually in our own API application, and everything is working as expected as far as I can tell. I don't expect "just trust me!" to be super convincing, though 😆.

<!-- Unsure? Have a question? Request a review! -->
