### PR TITLE
Remove loading `psych` gem early to fix cucumber spec

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -170,26 +170,12 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
         let(:script) do
           <<-'RUBY'
-            # Under Ruby 3.0 through 3.2 there is a weird error that occurs
-            # in CI where two copies of psych get loaded in the same process,
-            # and even more strangely the first version is a newer one from
-            # gem and the second one is the older one from Ruby standard
-            # library. Try to work around this situation by forcing psych
-            # to be loaded from (some) gem.
-            # We still don't know exactly what is causing the original issue.
-            gem 'psych'
-
             require 'bundler/inline'
 
             gemfile(true) do
               source 'https://rubygems.org'
-              if RUBY_VERSION >= '3.4'
-                # Cucumber is broken on Ruby 3.4, requires the fix in
-                # https://github.com/cucumber/cucumber-ruby/pull/1757
-                gem 'cucumber', '>= 3', git: 'https://github.com/cucumber/cucumber-ruby'
-              else
-                gem 'cucumber', '>= 3'
-              end
+
+              gem 'cucumber', '>= 3', '<= 9.2.1'
             end
 
             load Gem.bin_path('cucumber', 'cucumber')


### PR DESCRIPTION
**What does this PR do?**

Cucumber release 9.2.1 that break our CircleCI Ruby 3.3 tests

https://app.circleci.com/pipelines/github/DataDog/dd-trace-rb/19242/workflows/95bce82e-302e-463f-96f2-eb8fbbfe8e30

1. Remove loading `psych` first to mitigate the failure (This solves the broken spec but not sure if this is inviting problems from 3.0 - 3.2 )
3. Remove fetching from master branch since it is included in 9.2.1

**Change log entry**
None