### PR TITLE
Provide git metadata for junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ orbs:
 
                 datadog-ci version
 
-                DD_ENV=ci DATADOG_API_KEY=$JUNIT_UPLOAD_API_KEY DATADOG_SITE=datadoghq.com datadog-ci junit upload --verbose --service dd-trace-rb tmp/rspec/
+                DD_ENV=ci DATADOG_API_KEY=$JUNIT_UPLOAD_API_KEY DATADOG_SITE=datadoghq.com datadog-ci junit upload --dry-run --verbose --service dd-trace-rb tmp/rspec/
           - store_test_results:
               path: tmp/rspec
           - persist_to_workspace:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1620,12 +1620,17 @@ jobs:
     name: upload/junit
     if: "!cancelled()"
     runs-on: ubuntu-24.04
-    env:
-      DD_APP_KEY: "${{ secrets.DD_APP_KEY }}"
-      DD_API_KEY: "${{ secrets.DD_API_KEY }}"
-      DD_ENV: ci
-      DATADOG_SITE: datadoghq.com
-      DD_SERVICE: dd-trace-rb
+    container:
+      image: datadog/ci
+      credentials:
+        username: "${{ secrets.DOCKERHUB_USERNAME }}"
+        password: "${{ secrets.DOCKERHUB_TOKEN }}"
+      env:
+        DD_API_KEY: "${{ secrets.DD_API_KEY }}"
+        DD_ENV: ci
+        DATADOG_SITE: datadoghq.com
+        DD_SERVICE: dd-trace-rb
+        DD_GIT_REPOSITORY_URL: "${{ github.repositoryUrl }}"
     needs:
     - build-test-ruby-34
     - build-test-ruby-33
@@ -1639,10 +1644,6 @@ jobs:
     - build-test-jruby-93
     - build-test-jruby-92
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - run: |
-        curl -L --fail --retry 5 https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 --output /usr/local/bin/datadog-ci
-        chmod +x /usr/local/bin/datadog-ci
     - run: mkdir -p tmp/rspec && datadog-ci version
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
@@ -1650,7 +1651,12 @@ jobs:
         pattern: junit-*
         merge-multiple: true
     - run: sed -i 's;file="./;file=";g' tmp/rspec/*.xml
-    - run: datadog-ci junit upload --verbose --dry-run tmp/rspec/
+    - if: github.event_name == 'pull_request'
+      run: echo "DD_GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+    - if: github.event_name != 'pull_request'
+      run: echo "DD_GIT_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+    - run: echo $DD_GIT_COMMIT_SHA
+    - run: datadog-ci junit upload --verbose tmp/rspec/
   coverage:
     name: upload/coverage
     runs-on: ubuntu-24.04

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -289,36 +289,22 @@ namespace :github do
             'name' => 'upload/junit',
             'if' => '!cancelled()',
             'runs-on' => ubuntu,
-            'env' => {
-              'DD_APP_KEY' => '${{ secrets.DD_APP_KEY }}',
-              'DD_API_KEY' => '${{ secrets.DD_API_KEY }}',
-              'DD_ENV' => 'ci',
-              'DATADOG_SITE' => 'datadoghq.com',
-              'DD_SERVICE' => 'dd-trace-rb',
+            'container' => {
+              'image' => 'datadog/ci',
+              'credentials' => {
+                'username' => '${{ secrets.DOCKERHUB_USERNAME }}',
+                'password' => '${{ secrets.DOCKERHUB_TOKEN }}'
+              },
+              'env' => {
+                'DD_API_KEY' => '${{ secrets.DD_API_KEY }}',
+                'DD_ENV' => 'ci',
+                'DATADOG_SITE' => 'datadoghq.com',
+                'DD_SERVICE' => 'dd-trace-rb',
+                'DD_GIT_REPOSITORY_URL' => '${{ github.repositoryUrl }}',
+              }
             },
-            # 'container' => {
-            #   'image' => 'datadog/ci',
-            #   'credentials' => {
-            #     'username' => '${{ secrets.DOCKERHUB_USERNAME }}',
-            #     'password' => '${{ secrets.DOCKERHUB_TOKEN }}'
-            #   },
-            #   'env' => {
-            #     'DD_APP_KEY' => '${{ secrets.DD_APP_KEY }}',
-            #     'DD_API_KEY' => '${{ secrets.DD_API_KEY }}',
-            #     'DD_ENV' => 'ci',
-            #     'DATADOG_SITE' => 'datadoghq.com',
-            #     'DD_SERVICE' => 'dd-trace-rb',
-            #   }
-            # },
             'needs' => runtimes.map(&:build_test_id),
             'steps' => [
-              { 'uses' => 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' },
-              {
-                'run' => <<~BASH
-                  curl -L --fail --retry 5 https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 --output /usr/local/bin/datadog-ci
-                  chmod +x /usr/local/bin/datadog-ci
-                BASH
-              },
               { 'run' => 'mkdir -p tmp/rspec && datadog-ci version' },
               {
                 'uses' => 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16',
@@ -329,7 +315,16 @@ namespace :github do
                 }
               },
               { 'run' => "sed -i 's;file=\"\.\/;file=\";g' tmp/rspec/*.xml" },
-              { 'run' => 'datadog-ci junit upload --verbose --dry-run tmp/rspec/' },
+              {
+                'if' => "github.event_name == 'pull_request'",
+                'run' => 'echo "DD_GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV'
+              },
+              {
+                'if' => "github.event_name != 'pull_request'",
+                'run' => 'echo "DD_GIT_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV'
+              },
+              { 'run' => 'echo $DD_GIT_COMMIT_SHA' },
+              { 'run' => 'datadog-ci junit upload --verbose tmp/rspec/' },
             ]
           },
           'coverage' => {


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

1. Use the docker image instead of install the binaries
2. Clear git metadata by avoid checking out of the repo
3. Manually provide git metadata with the commit sha for the pull request event 

**Change log entry**
None