### PR TITLE
DEBUG-3498 Add exception information to the InternalErrorResponse stringification

### DIFF
--- a/lib/datadog/core/transport/response.rb
+++ b/lib/datadog/core/transport/response.rb
@@ -55,6 +55,10 @@ module Datadog
           true
         end
 
+        def to_s
+          "#{super}, error_type:#{error.class} error:#{error}"
+        end
+
         def inspect
           "#{super}, error_type:#{error.class} error:#{error}"
         end

--- a/spec/datadog/core/transport/response_spec.rb
+++ b/spec/datadog/core/transport/response_spec.rb
@@ -68,4 +68,10 @@ RSpec.describe Datadog::Core::Transport::InternalErrorResponse do
 
     it { is_expected.to be true }
   end
+
+  describe '#to_s' do
+    it 'includes the causing exception' do
+      expect(response.to_s).to match(/StandardError/)
+    end
+  end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds the causing exception information to InternalErrorResponse class that is used by Remote Config client.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
When an error happens, it is currently reported as follows:

```
E, [2025-02-11T16:00:52.781351 #24] ERROR -- datadog: [datadog] (/usr/local/bundle/gems/datadog-2.9.0/lib/datadog/core/remote/component.rb:53:in `rescue in block in initialize') remote worker error: Datadog::Core::Remote::Client::TransportError #<Datadog::Core::Transport::InternalErrorResponse:0x00007df67ff5b128> location: /usr/local/bundle/gems/datadog-2.9.0/lib/datadog/core/remote/client.rb:34:in `sync'. reseting client state
```

There is no information as to the actual issue.

With this PR, the report is as follows:
```
W, [2025-02-13T12:46:53.334734 #645]  WARN -- datadog: [datadog] (/home/w/apps/dd-trace-rb/lib/datadog/core/diagnostics/environment_logger.rb:23:in `log_error!') DATADOG ERROR - TRACING - Agent Error: {"agent_error":"#\u003cDatadog::Core::Transport::InternalErrorResponse:0x00007d68f8d1b918\u003e, error_type:Net::ReadTimeout error:Net::ReadTimeout"}
```

The reason for the error is included in the end.

**Change log entry**
Yes: improve remote configuration diagnostic output
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit test added + I tested manually
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
