### PR TITLE
Improve cache clean summary and trigger event

### DIFF
--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -10,7 +10,10 @@ on:
         default: true
   push:
     branches:
-      - "**"
+    - master
+  pull_request:
+    branches:
+    - master
 
 env:
   GEM_HOST: 'https://rubygems.pkg.github.com/DataDog'

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
 
           echo "[DEBUG] Fetching cache list..."
           # Get full cache details
-          CACHE_LIST=$(gh cache list --ref $BRANCH --limit 100 --json key,sizeInBytes,createdAt,id)
+          CACHE_LIST=$(gh cache list --ref $BRANCH --limit 100 --json key,sizeInBytes,id)
 
           if [ -z "$CACHE_LIST" ] || [ "$CACHE_LIST" = "[]" ]; then
             echo "[DEBUG] No caches found"
@@ -30,11 +30,11 @@ jobs:
           fi
 
           # Create table header
-          echo "| Cache ID | Cache Key | Size | Created At | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-----------|------|------------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache ID | Cache Key | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-----------|------|" >> $GITHUB_STEP_SUMMARY
 
           # Extract IDs and process deletions
-          echo "$CACHE_LIST" | jq -r '.[] | [.id, .key, .sizeInBytes, .createdAt] | @tsv' | while IFS=$'\t' read -r id key size created; do
+          echo "$CACHE_LIST" | jq -r '.[] | [.id, .key, .sizeInBytes] | @tsv' | while IFS=$'\t' read -r id key size; do
             # Convert size to human readable format
             if [ $size -ge 1048576 ]; then
               readable_size=$(echo "scale=2; $size/1048576" | bc)"MB"
@@ -43,16 +43,11 @@ jobs:
             fi
 
             echo "[DELETE] Processing cache ID: $id"
-            if gh cache delete $id > /dev/null 2>&1; then
-              status="✅ Deleted"
-              echo "[SUCCESS] Cache $id deleted"
-            else
-              status="❌ Failed"
-              echo "[ERROR] Failed to delete cache $id"
-            fi
+            gh cache delete $id
+            echo "[INFO] Processed cache $id"
 
             # Add row to summary table
-            echo "| \`$id\` | \`$key\` | $readable_size | $created | $status |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`$id\` | \`$key\` | $readable_size |" >> $GITHUB_STEP_SUMMARY
           done
 
           # Add completion timestamp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,11 @@
 name: Static Analysis
 on:
   push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -2,7 +2,6 @@ name: "Generate Supported Versions"
 
 on:
   workflow_dispatch:
-  
 
 concurrency:
   group: ${{ github.workflow }}
@@ -20,7 +19,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@8388f20e6a9c43cd241131b678469a9f89579f37 # v1.216.0
         with:
-          bundler-cache: true # runs bundle install
           ruby-version: "3.3"
 
       - name: Update latest
@@ -45,6 +43,6 @@ jobs:
             as defined from the `gemfile.lock` gem declarations.
 
             Workflow run: [Generate Supported Versions](https://github.com/DataDog/dd-trace-rb/actions/workflows/generate-supported-versions.yml)
-            
+
             This should be tied to tracer releases, or triggered manually.
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,7 +3,10 @@ name: Test Nix
 on:
   push:
     branches:
-      - "**"
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   test:

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -2,10 +2,10 @@ name: Test macOS
 on:
   push:
     branches:
-      - "**"
+    - master
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+    - master
 jobs:
   test-macos:
     strategy:

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -1,5 +1,11 @@
 name: Test for memory leaks
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   test-memcheck:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -1,5 +1,11 @@
 name: Test YJIT
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   test-yjit:
     strategy:


### PR DESCRIPTION
**Motivation:**

From this previous run for cleaning cache: https://github.com/DataDog/dd-trace-rb/actions/runs/13317290722

I learn that:

1. The cache clean summary is not accurate with the status
2. The cache clean does not fetch all the caches associate with the branch because the trigger event is PR closed. 

**What does this PR do?**

1. Remove status and createdAt field from the summary since they are less useful. 
2. Since cache size is limited (10Gb), modify jobs what are using caches to be triggered only with PR context instead of just branch pushes. 

**Change log entry**
None
