### PR TITLE
Test sidekiq specs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,6 +301,7 @@ services:
       - "127.0.0.1:${TEST_PRESTO_PORT}:8080"
   redis:
     image: redis:6.2
+    command: ["redis-server", "--bind", "redis", "--port", "6379"]
     expose:
       - "6379"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,6 +301,8 @@ services:
       - "127.0.0.1:${TEST_PRESTO_PORT}:8080"
   redis:
     image: redis:6.2
+    # Explicitly bind server to the hostname "redis" instead of localhost.
+    # This prevents connection issues inside Docker by connecting to redis at `redis:6379` instead of `127.0.0.1:6379`.
     command: ["redis-server", "--bind", "redis", "--port", "6379"]
     expose:
       - "6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       TEST_POSTGRES_HOST: postgres
       TEST_PRESTO_HOST: presto
       TEST_REDIS_HOST: redis
+      # Ensure use of the hostname "redis" instead of the default "localhost" inside Docker.
       REDIS_URL: redis://redis:6379/0
       DATADOG_GEM_CI: 'true'
     stdin_open: true
@@ -302,8 +303,8 @@ services:
       - "127.0.0.1:${TEST_PRESTO_PORT}:8080"
   redis:
     image: redis:6.2
-    # Explicitly bind server to the hostname "redis" instead of localhost.
-    # This prevents connection issues inside Docker by connecting to redis at `redis:6379` instead of `127.0.0.1:6379`.
+    # Explicitly bind server to the hostname "redis" instead of the default "localhost".
+    # This prevents connection issues inside Docker by connecting at `redis:6379` instead of `127.0.0.1:6379`.
     command: ["redis-server", "--bind", "redis", "--port", "6379"]
     expose:
       - "6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       TEST_POSTGRES_HOST: postgres
       TEST_PRESTO_HOST: presto
       TEST_REDIS_HOST: redis
+      REDIS_URL: redis://redis:6379/0
       DATADOG_GEM_CI: 'true'
     stdin_open: true
     tty: true

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/heartbeat_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer heartbeat', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer heartbeat' do
   include SidekiqServerExpectations
 
   before do

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/job_fetch_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
 
   before do

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/redis_info_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/redis_info_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
   before do
     unless Datadog::Tracing::Contrib::Sidekiq::Integration.compatible_with_server_internal_tracing?

--- a/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_poller_spec.rb
+++ b/spec/datadog/tracing/contrib/sidekiq/server_internal_tracer/scheduled_poller_spec.rb
@@ -1,7 +1,7 @@
 require 'datadog/tracing/contrib/support/spec_helper'
 require_relative '../support/helper'
 
-RSpec.describe 'Server internal tracer', skip: ENV['BATCHED_TASKS'] do
+RSpec.describe 'Server internal tracer' do
   include SidekiqServerExpectations
 
   before do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Attempt to address the flaky `sidekiq` tests that fail with `Connection refused - connect(2) for 127.0.0.1:6379 (Errno::ECONNREFUSED)` by forcing a `redis` host over `localhost`. Did not work though.

**Motivation:**
Reduce CI flakiness, and re-enable our GHA specs ([issue](https://github.com/DataDog/ruby-guild/issues/214))!

**Change log entry**
None.

**Additional Notes:**
Issue: https://github.com/DataDog/ruby-guild/issues/51.

**How to test the change?**
Consistently green CI.

<!-- Unsure? Have a question? Request a review! -->
