### PR TITLE
Fix AppSec faraday instrumentation type signatures

### DIFF
--- a/sig/datadog/appsec/contrib/faraday/patcher.rbs
+++ b/sig/datadog/appsec/contrib/faraday/patcher.rbs
@@ -9,9 +9,7 @@ module Datadog
 
           def self?.patch: () -> bool
 
-          def self?.register_middleware!: () -> void
-
-          def self?.add_default_middleware!: () -> void
+          def self?.configure_default_faraday_connection: () -> void
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
It fixes type signatures for `Datadog::AppSec::Contrib::Faraday::Patcher`.

**Motivation:**
Follow up for [PR #4391](https://github.com/DataDog/dd-trace-rb/pull/4391).

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
CI is enough