### PR TITLE
rack instrumentation: continue trace from distributed trace digest only when distributed trace is present

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -43,7 +43,7 @@ module Datadog
             # so that all spans will be added to the distributed trace.
             if configuration[:distributed_tracing]
               trace_digest = Contrib::HTTP.extract(env)
-              Tracing.continue_trace!(trace_digest)
+              Tracing.continue_trace!(trace_digest) if trace_digest
             end
 
             TraceProxyMiddleware.call(env, configuration) do

--- a/spec/datadog/tracing/contrib/rack/distributed_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/distributed_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe 'Rack integration distributed tracing' do
 
   shared_examples_for 'a Rack request without distributed tracing' do
     it 'produces a non-distributed Rack trace' do
+      expect(Datadog::Tracing).not_to receive(:continue_trace!)
+
       is_expected.to be_ok
       expect(span).to_not be nil
       expect(span.name).to eq('rack.request')


### PR DESCRIPTION
**What does this PR do?**
Currently Rack always tries to continue from distributed trace when distributed tracing is enabled, even when there is no distributed trace present.

It causes Rack to always start a new trace, which causes issues with tracing during rails integration tests: controller spans are never appended to a test trace.

**Motivation:**
A bug reported by Datadog Test Optimization customer: spans from rails instrumentation are not appearing in trace view with a test like that:

```ruby
  class WelcomeControllerTest < ActionDispatch::IntegrationTest
    test "should get index" do
      get root_url
      assert_response :success
    end
  end
```

**Change log entry**
Yes. Fix: rails spans now appear in test trace view when using Datadog Test Optimization with ActionDispatch::IntegrationTest

**How to test the change?**
Tested using a reproducible case from customer: https://github.com/anmarchenko/test-datadog-ci

Before this parch:
![image](https://github.com/user-attachments/assets/c908b83b-401d-47c6-8171-e0945bd2fdb1)

After this patch:
![image](https://github.com/user-attachments/assets/c9a03157-2b79-4fdd-9c9f-af6d26a49c39)
