### PR TITLE
[PROF-11394] Graduate heap profiling from alpha to preview

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -313,7 +313,7 @@ module Datadog
 
             # Can be used to enable/disable the collection of heap profiles.
             #
-            # This feature is alpha and disabled by default
+            # This feature is in preview and disabled by default. Requires Ruby 3.1+.
             #
             # @warn To enable heap profiling you are required to also enable allocation profiling.
             #
@@ -326,12 +326,12 @@ module Datadog
 
             # Can be used to enable/disable the collection of heap size profiles.
             #
-            # This feature is alpha and enabled by default when heap profiling is enabled.
+            # This feature is in preview and by default is enabled whenever heap profiling is enabled.
             #
-            # @warn To enable heap size profiling you are required to also enable allocation and heap profiling.
+            # @warn Heap size profiling depends on allocation and heap profiling, so they must be enabled as well.
             #
-            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` environment variable as a boolean, otherwise
-            # whatever the value of DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED is.
+            # @default `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` environment variable as a boolean, otherwise it
+            # follows the value of `experimental_heap_enabled`.
             option :experimental_heap_size_enabled do |o|
               o.type :bool
               o.env 'DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED'

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -221,13 +221,14 @@ module Datadog
         end
 
         unless allocation_profiling_enabled
-          raise ArgumentError, "Heap profiling requires allocation profiling to be enabled"
+          logger.warn(
+            "Heap profiling was requested but allocation profiling is not enabled. " \
+            "Heap profiling has been disabled."
+          )
+          return false
         end
 
-        logger.warn(
-          "Enabled experimental heap profiling: heap_sample_rate=#{heap_sample_rate}. This is experimental, not " \
-          "recommended, and will increase overhead!"
-        )
+        logger.debug("Enabled heap profiling: heap_sample_rate=#{heap_sample_rate}")
 
         true
       end
@@ -236,10 +237,6 @@ module Datadog
         heap_size_profiling_enabled = settings.profiling.advanced.experimental_heap_size_enabled
 
         return false unless heap_profiling_enabled && heap_size_profiling_enabled
-
-        logger.warn(
-          "Enabled experimental heap size profiling. This is experimental, not recommended, and will increase overhead!"
-        )
 
         true
       end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -331,8 +331,14 @@ RSpec.describe Datadog::Profiling::Component do
               settings.profiling.allocation_enabled = false
             end
 
-            it "raises an ArgumentError during component initialization" do
-              expect { build_profiler_component }.to raise_error(ArgumentError, /requires allocation profiling/)
+            it "initializes StackRecorder without heap sampling support and warns" do
+              expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
+                .and_call_original
+
+              expect(logger).to receive(:warn).with(/allocation profiling is not enabled/)
+
+              build_profiler_component
             end
           end
 
@@ -350,8 +356,7 @@ RSpec.describe Datadog::Profiling::Component do
 
               expect(logger).to receive(:info).with(/Ractors.+stopping/)
               expect(logger).to receive(:debug).with(/Enabled allocation profiling/)
-              expect(logger).to receive(:warn).with(/experimental heap profiling/)
-              expect(logger).to receive(:warn).with(/experimental heap size profiling/)
+              expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 
               build_profiler_component
             end
@@ -368,8 +373,7 @@ RSpec.describe Datadog::Profiling::Component do
 
                 expect(logger).to receive(:info).with(/Ractors.+stopping/)
                 expect(logger).to receive(:debug).with(/Enabled allocation profiling/)
-                expect(logger).to receive(:warn).with(/experimental heap profiling/)
-                expect(logger).not_to receive(:warn).with(/experimental heap size profiling/)
+                expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 
                 build_profiler_component
               end


### PR DESCRIPTION
**What does this PR do?**

This PR updates the documentation and logs to mark that the heap profiling feature is no longer alpha, and is now considered a preview feature.

We still very much welcome all feedback on this feature.

**Motivation:**

Graduate feature.

**Change log entry**

Yes. Graduate heap profiling from alpha to preview

Also, here's a snippet for the release highlights:

````markdown
### Heap Profiling is now in Preview

The heap profiling feature is now in preview. With this release, we've done extensive performance improvements and improved data accuracy.

This feature requires Ruby 3.1+. You can enable it by using the `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED=true` environment variable, or via code:

```ruby
Datadog.configure do |c|
  # ... existing configuration ...
  c.profiling.advanced.experimental_heap_enabled = true
end
```

(Note that this feature requires that allocation profiling is also enabled. To do so, set `DD_PROFILING_ALLOCATION_ENABLED=true` or `c.profiling.allocation_enabled = true` via code).
````

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage.
