### PR TITLE
Fix cross-repo race condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,8 @@ default:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"
       changes:
-        - .gitlab/Dockerfile-*
-      when: manual
+        - .gitlab/Dockerfile-*   # these are direct dependencies
+        - .gitlab-ci.yml         # list of images is here so it is a dependency too
       allow_failure: true
   image: $DOCKER_REGISTRY/docker:20.10.13
   parallel:
@@ -54,7 +54,13 @@ build-image-arm64:
 
 promote-image:
   stage: manual-images
-  when: manual
+  rules:                         # same as build-image
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"
+      changes:
+        - .gitlab/Dockerfile-*   # these are direct dependencies
+        - .gitlab-ci.yml         # list of images is here so it is a dependency too
+      when: manual               # this one is manual, but it means that install-dependencies may be hitting the wrong <base>:current til this is run
+      allow_failure: true
   tags: ["runner:docker"]
   image: $DOCKER_REGISTRY/docker:20.10.13
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,4 +180,4 @@ vaccine:
   stage: vaccine
   needs: [create-multiarch-lib-injection-image]
   script: |
-    .gitlab/scripts/vaccine.sh
+    .gitlab/scripts/vaccine.sh master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,4 +175,4 @@ vaccine:
   stage: vaccine
   needs: [create-multiarch-lib-injection-image]
   script: |
-    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition "${CI_COMMIT_SHA}" "glci:${CI_PIPELINE_ID}"
+    .gitlab/scripts/vaccine.sh master "${CI_COMMIT_SHA}" "glci:${CI_PIPELINE_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,4 +180,4 @@ vaccine:
   stage: vaccine
   needs: [create-multiarch-lib-injection-image]
   script: |
-    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition
+    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition "${CI_COMMIT_SHA}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,16 +168,11 @@ deploy_to_reliability_env:
 # Due to the constraints of Github workflow dispatch endpoint, it does not return the workflow run id.
 # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
 #
-# We fetch the latest workflow run from vaccine after 5 seconds of the dispatch event.
-# False positive/negative result can happen when multiple requests are made within the same window.
-#
-# TODO:
-# Replace polling implementation with reporting status to Github with Github App. This will allow us
-# to get a deterministic result without mismatched workflow run id.
+# We fetch the latest workflow runs from vaccine then match against the run name, polling until we find it.
 vaccine:
   image: $DOCKER_REGISTRY/docker:20.10.13
   tags: [ "arch:amd64" ]
   stage: vaccine
   needs: [create-multiarch-lib-injection-image]
   script: |
-    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition "${CI_COMMIT_SHA}"
+    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition "${CI_COMMIT_SHA}" "glci:${CI_PIPELINE_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,4 +180,4 @@ vaccine:
   stage: vaccine
   needs: [create-multiarch-lib-injection-image]
   script: |
-    .gitlab/scripts/vaccine.sh master
+    .gitlab/scripts/vaccine.sh lloeki/fix-cross-repo-race-condition

--- a/.gitlab/scripts/vaccine.sh
+++ b/.gitlab/scripts/vaccine.sh
@@ -1,91 +1,355 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-GH_VACCINE_PAT=$(vault kv get -field=vaccine-token kv/k8s/gitlab-runner/dd-trace-rb/github-token)
-REPO="Datadog/vaccine"
-POLL_INTERVAL=60  # seconds
+### Secret redaction utilities
 
-REF="${1:-master}"
-SHA="${2:-"$(git rev-parse HEAD)"}"
+__SECRETS=()
 
-# Trigger workflow
-echo "Triggering workflow..."
-TRIGGER_RESPONSE=$(curl -X POST \
-  -H "Accept: application/vnd.github.v3+json" \
-  -H "Authorization: token $GH_VACCINE_PAT" \
-  -w "\n%{http_code}" \
-  "https://api.github.com/repos/$REPO/actions/workflows/vaccine.yml/dispatches" \
-  -d '{"ref":"'${REF}'", "inputs": {"commit_sha": "'$CI_COMMIT_SHA'"}}' 2>&1)
+# add secret(s) to known secrets
+secret_add() {
+    __SECRETS+=("$@")
+}
 
-HTTP_STATUS=$(echo "$TRIGGER_RESPONSE" | tail -n1)
-if [ "$HTTP_STATUS" -ne 204 ]; then
-  echo "Error: Workflow trigger failed with status $HTTP_STATUS"
-  echo "Response: $(echo "$TRIGGER_RESPONSE" | sed '$ d')"
-  exit 1
-fi
+# redact all known secrets
+# shellcheck disable=SC2120
+secret_redact() {
+    local redact="${1:-REDACTED}"
+    local args=()
 
-echo "Successfully triggered workflow. Waiting for workflow to start..."
-sleep 5  # Give GitHub a moment to create the workflow run
+    local redact_escaped
+    redact_escaped="$(printf '%s\n' "${redact}" | sed -e 's/[\/&]/\\&/g')"
 
-# Get the most recent workflow run
-echo "Fetching most recent workflow run..."
-RUNS_RESPONSE=$(curl -s \
-  -H "Accept: application/vnd.github.v3+json" \
-  -H "Authorization: token $GH_VACCINE_PAT" \
-  -w "\n%{http_code}" \
-  "https://api.github.com/repos/$REPO/actions/runs?event=workflow_dispatch&per_page=1" 2>&1)
+    for secret in "${__SECRETS[@]}"; do
+        # escape sed pattern characters
+        local secret_escaped
+        secret_escaped="$(printf '%s\n' "${secret}" | sed -e 's/[]\/$*.^[]/\\&/g')"
 
-HTTP_STATUS=$(echo "$RUNS_RESPONSE" | tail -n1)
-RESPONSE_BODY=$(echo "$RUNS_RESPONSE" | sed '$ d')
+        # build sed arg list
+        args+=(-e "s^${secret_escaped}^${redact_escaped}^gi")
+    done
 
-if [ "$HTTP_STATUS" -ne 200 ]; then
-  echo "Error: Fetching runs failed with status $HTTP_STATUS"
-  echo "Response: $RESPONSE_BODY"
-  exit 1
-fi
+    # perform replacement
+    sed "${args[@]}"
+}
 
-# Get the most recent run ID
-WORKFLOW_ID=$(echo "$RESPONSE_BODY" | jq -r '.workflow_runs[0].id')
+# redirect whole script output to be redacted
+# must be used only after all secrets are known
+secret_redir_redact() {
+    exec > >(secret_redact) 2> >(secret_redact 1>&2)
+}
 
-if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" = "null" ]; then
-  echo "Error: Could not find recent workflow run"
-  exit 1
-fi
+# log safely
+log() {
+    printf "%s\n" "$*" | secret_redact 1>&2
+}
 
-echo "Found workflow run ID: $WORKFLOW_ID"
+# run safely
+run() {
+    "$@" > >(secret_redact) 2> >(secret_redact 1>&2)
+}
 
-# Poll workflow status
-while true; do
-  RUN_RESPONSE=$(curl -s \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token $GH_VACCINE_PAT" \
-    -w "\n%{http_code}" \
-    "https://api.github.com/repos/$REPO/actions/runs/$WORKFLOW_ID" 2>&1)
+# run command with safe logging
+log_and_run() {
+    local cmd=( "$@" )
 
-  HTTP_STATUS=$(echo "$RUN_RESPONSE" | tail -n1)
-  RESPONSE_BODY=$(echo "$RUN_RESPONSE" | sed '$ d')
+    (
+      printf '* Command:'
+      for e in "${cmd[@]}"; do
+        printf " "
+        printf -v quoted "%q" "${e}"
+        if [[ "${quoted}" == "${e}" ]]; then
+            printf "%s" "${e}"
+        else
+            printf "%s" "'${e//'/\"'\"}'"
+        fi
+      done
+      printf "\n"
+    ) | secret_redact 1>&2
 
-  if [ "$HTTP_STATUS" -ne 200 ]; then
-    echo "Error: Fetching run status failed with status $HTTP_STATUS"
-    echo "Response: $RESPONSE_BODY"
-    exit 1
-  fi
+    run "${cmd[@]}"
+}
 
-  STATUS=$(echo "$RESPONSE_BODY" | jq -r .status)
-  CONCLUSION=$(echo "$RESPONSE_BODY" | jq -r .conclusion)
+# obtain GitHub vaccine token from vault
+get_vaccine_token() {
+    vault kv get -field=vaccine-token kv/k8s/gitlab-runner/dd-trace-rb/github-token
+}
 
-  if [ "$STATUS" = "completed" ]; then
-    if [ "$CONCLUSION" = "success" ]; then
-      echo "✅ Workflow completed successfully!"
-      exit 0
-    else
-      echo "❌ Workflow failed with conclusion: $CONCLUSION"
-      echo "See details: https://github.com/$REPO/actions/runs/$WORKFLOW_ID"
-      exit 1
+# get current commit SHA
+head_commit_sha() {
+    git rev-parse HEAD
+}
+
+# perform a GET request on GitHub REST API
+#
+# status is emitted as last line
+github_api_get() {
+    local token="$1"
+    local repo="$2"
+    local endpoint="$3"
+    shift 3
+    local params=("$@")
+
+    local cmd=(
+      curl
+      -s
+      -H "Accept: application/vnd.github.v3+json"
+      -H "Authorization: token ${token}"
+      -w "\n%{http_code}\n"
+    )
+
+    if [[ "${#params[@]}" -gt 0 ]]; then
+        cmd+=(-G)
     fi
-  fi
 
-  echo "Current status: $STATUS (Checking again in ${POLL_INTERVAL}s)"
-  sleep $POLL_INTERVAL
-done
+    for param in "${params[@]}"; do
+        cmd+=(-d "${param}")
+    done
+
+    cmd+=(
+      "https://api.github.com/repos/${repo}/${endpoint}"
+    )
+
+    log_and_run "${cmd[@]}"
+}
+
+# perform a POST request on GitHub REST API
+#
+# status is emitted as last line
+github_api_post() {
+    local token="$1"
+    local repo="$2"
+    local endpoint="$3"
+    local body="$4"
+
+    local cmd=(
+      curl
+      -s
+      -X POST
+      -H "Accept: application/vnd.github.v3+json"
+      -H "Authorization: token ${token}"
+      -w "\n%{http_code}\n"
+    )
+    cmd+=(
+      -d "${body}"
+    )
+    cmd+=(
+
+      "https://api.github.com/repos/${repo}/${endpoint}"
+    )
+
+    log_and_run "${cmd[@]}"
+}
+
+# dispatch a workflow
+github_workflow_dispatch() {
+    local token="$1"
+    local repo="$2"
+    local ref="$3"
+    local workflow="$4"
+    local inputs="$5"
+
+    github_api_post "${token}" "${repo}" \
+        "actions/workflows/${workflow}/dispatches" \
+        '{"ref":"'"${ref}"'", "inputs": '"${inputs}"'}'
+}
+
+# list workflow runs
+github_workflow_runs() {
+    local token="$1"
+    local repo="$2"
+    local ref="$3"
+    local workflow="$4"
+    shift 4
+    local params=("$@")
+
+    github_api_get "${token}" "${repo}" \
+        "actions/workflows/${workflow}/runs" \
+        "${params[@]}"
+}
+
+# query a workflow run
+github_workflow_run() {
+    local token="$1"
+    local repo="$2"
+    local id="$3"
+    shift 3
+    local params=("$@")
+
+    github_api_get "${token}" "${repo}" \
+        "actions/runs/${id}" \
+        "${params[@]}"
+}
+
+# check request status
+#
+# - check last line as being expected status
+# - pass response body (without status) only if condition is satisfied
+check_status() {
+    local status="$1"
+
+    local body
+    local res
+    body="$(cat)"
+    res="$(printf "%s" "${body}" | tail -n1)"
+
+    if [[ "${res}" == "${status}" ]]; then
+        printf "%s" "${body}" | sed -e '$d'
+    else
+        log "*** Error: unexpected status ${res}"
+        log "*** BODY START"
+        log "${body}"
+        log "*** BODY END"
+    fi
+}
+
+# dispatch vaccine workflow
+dispatch_workflow() {
+    local vaccine_github_token="$1"
+    local vaccine_ref="$2"
+    local ddtrace_commit_sha="$3"
+    local trigger_id="${4:-}"
+
+    local vaccine_repo='DataDog/vaccine'
+    local vaccine_workflow='vaccine.yml'
+
+    log "*** Trigger workflow ${vaccine_workflow} at ${vaccine_repo}@${vaccine_ref} for dd-trace-rb@${ddtrace_commit_sha}${trigger_id+ "triggered by ${trigger_id}"}"
+    github_workflow_dispatch "${vaccine_github_token}" "${vaccine_repo}" "${vaccine_ref}" "${vaccine_workflow}" '{"dd-lib-ruby-init-tag": "'"${ddtrace_commit_sha}"'", "trigger-id": "'"${trigger_id}"'"}' | check_status 204
+}
+
+# search for vaccine workflow run
+search_workflow_run() {
+    local vaccine_github_token="$1"
+    local vaccine_ref="$2"
+    local ddtrace_commit_sha="$3"
+    local trigger_id="${4:-}"
+
+    local vaccine_repo='DataDog/vaccine'
+    local vaccine_workflow='vaccine.yml'
+    local name="dd-lib-ruby-init:${ddtrace_commit_sha}${trigger_id+" ${trigger_id}"}"
+
+    log "*** Search runs for workflow ${vaccine_workflow} at ${vaccine_repo}@${vaccine_ref} for dd-trace-rb@${ddtrace_commit_sha}${trigger_id+ "triggered by ${trigger_id}"}"
+    github_workflow_runs "${vaccine_github_token}" "${vaccine_repo}" "${vaccine_ref}" "${vaccine_workflow}" 'event=workflow_dispatch' 'per_page=10' \
+        | check_status 200 \
+        | workflow_runs \
+        | select_by name "${name}" \
+        | useful_run_keys \
+        | workflow_run_id \
+        | head -1
+}
+
+# extract workflow runs
+workflow_runs() {
+    jq '.workflow_runs[]'
+}
+
+# filter by key + value
+select_by() {
+    local key="$1"
+    local value="$2"
+
+    jq 'select(.'"${key}"'=="'"${value}"'")'
+}
+
+# reduce output to useful keys
+useful_run_keys() {
+    jq '{id: .id, workflow_id: .workflow_id, event: .event, name: .name, display_title: .display_title, run_number: .run_number, run_attempt: .run_attempt, url: .url, html_url: .html_url, created_at: .created_at, status: .status, conclusion: .conclusion}'
+}
+
+# get workflow id
+workflow_run_id() {
+    jq -r '.id'
+}
+
+# query workflow run with a command
+poll_workflow_run() {
+    local vaccine_github_token="$1"
+    local vaccine_poll_interval="$2"
+    local workflow_run_id="$3"
+    shift 3
+    local cmd=("$@")
+
+    local vaccine_repo='DataDog/vaccine'
+
+    github_workflow_run "${vaccine_github_token}" "${vaccine_repo}" "${workflow_run_id}" \
+        | check_status 200 \
+        | useful_run_keys \
+        | "${cmd[@]}"
+}
+
+# select completed workflows
+workflow_completed() {
+    jq 'select(.status == "completed")'
+}
+
+# test if workflow is successful
+workflow_successful() {
+    jq -e 'select(.status == "completed" and .conclusion == "success")'
+}
+
+# main entrypoint
+main() {
+    local vaccine_repo
+    local vaccine_ref
+    local vaccine_workflow
+    local vaccine_github_token
+    local vaccine_poll_interval
+    local ddtrace_commit_sha
+    local trigger_id
+
+    vaccine_repo='DataDog/vaccine'
+    vaccine_ref="${1:-master}"
+    ddtrace_commit_sha="${2:-"${CI_COMMIT_SHA:-"$(head_commit_sha)"}"}"
+    trigger_id="${3:-}"
+    vaccine_poll_interval="10" # seconds
+
+    vaccine_github_token="$(get_vaccine_token)"
+    secret_add "${vaccine_github_token}"
+
+  # secret_redir_redact
+
+    dispatch_workflow "${vaccine_github_token}" "${vaccine_ref}" "${ddtrace_commit_sha}" "${trigger_id}"
+
+    while true; do
+        log "*** Waiting ${vaccine_poll_interval}s"
+        sleep ${vaccine_poll_interval}
+
+        local run_id
+        run_id="$(search_workflow_run "${vaccine_github_token}" "${vaccine_ref}" "${ddtrace_commit_sha}" "${trigger_id}")"
+
+        if [[ -z "${run_id}" ]]; then
+            continue
+        fi
+
+        log "*** Found workflow run id ${run_id}"
+        log "*** See: https://github.com/${vaccine_repo}/actions/runs/${run_id}"
+
+        while true; do
+            completed="$(poll_workflow_run "${vaccine_github_token}" "${vaccine_poll_interval}" "${run_id}" workflow_completed)"
+
+            if [[ -n "${completed}" ]]; then
+                if printf "%s\n" "${completed}" | workflow_successful; then
+                    log "*** Workflow run successful"
+                    log "*** See: https://github.com/${vaccine_repo}/actions/runs/${run_id}"
+                    exit 0
+                else
+                    log "*** Workflow run failed"
+                    log "*** WORKFLOW RUN START"
+                    log "${completed}"
+                    log "*** WORKFLOW RUN END"
+                    log "*** See: https://github.com/${vaccine_repo}/actions/runs/${run_id}"
+                    exit 1
+                fi
+            fi
+
+            log "*** Waiting ${vaccine_poll_interval}s to poll again"
+            sleep "${vaccine_poll_interval}"
+        done
+    done
+
+}
+
+# call main only if directly executed
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/.gitlab/scripts/vaccine.sh
+++ b/.gitlab/scripts/vaccine.sh
@@ -7,6 +7,7 @@ REPO="Datadog/vaccine"
 POLL_INTERVAL=60  # seconds
 
 REF="${1:-master}"
+SHA="${2:-"$(git rev-parse HEAD)"}"
 
 # Trigger workflow
 echo "Triggering workflow..."

--- a/.gitlab/scripts/vaccine.sh
+++ b/.gitlab/scripts/vaccine.sh
@@ -6,6 +6,8 @@ GH_VACCINE_PAT=$(vault kv get -field=vaccine-token kv/k8s/gitlab-runner/dd-trace
 REPO="Datadog/vaccine"
 POLL_INTERVAL=60  # seconds
 
+REF="${1:-master}"
+
 # Trigger workflow
 echo "Triggering workflow..."
 TRIGGER_RESPONSE=$(curl -X POST \
@@ -13,7 +15,7 @@ TRIGGER_RESPONSE=$(curl -X POST \
   -H "Authorization: token $GH_VACCINE_PAT" \
   -w "\n%{http_code}" \
   "https://api.github.com/repos/$REPO/actions/workflows/vaccine.yml/dispatches" \
-  -d '{"ref":"master", "inputs": {"commit_sha": "'$CI_COMMIT_SHA'"}}' 2>&1)
+  -d '{"ref":"'${REF}'", "inputs": {"commit_sha": "'$CI_COMMIT_SHA'"}}' 2>&1)
 
 HTTP_STATUS=$(echo "$TRIGGER_RESPONSE" | tail -n1)
 if [ "$HTTP_STATUS" -ne 204 ]; then


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

- Pass pipeline information
- Select workflow by run name and properly identify it with absolute certainty
- Fix a lot of corner cases
- Enhance logging feedback for debugging
- Prevent token leaks

**Motivation:**

Given that we run across repos and across CIs, there was a significant probability to pick incorrect workflows, that would be entirely unrelated to the `dd-trace-rb` item that triggered a workflow here.

On the `vaccine` side this is addressed by:

- allowing an additional `trigger-id` input
- reflecting that `trigger-id` in the workflow run name

As a bonus this allows direct identification of `vaccine` workflow runs straight from GitHub Actions UI.

The image is pulled by `vaccine` by tag containing only the commit SHA and so remains vulnerable to race conditions.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

None.

**Additional Notes:**

- Depends on: https://github.com/DataDog/vaccine/pull/17
  [Use lloeki/fix-cross-repo-race-condition branch temporarily](https://github.com/DataDog/dd-trace-rb/commit/e216ea99429281a6ed394df503a0073877402e1c) must be reverted once that sister PR is merged on `DataDog/vaccine`.
- Shell script is `shellcheck`ed locally, but this linting should probably be enforced in CI.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should pick the proper things throughout. Check `Vaccine` job logs in GitLab pipeline, e.g https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/jobs/813418074 and https://github.com/DataDog/vaccine/actions/runs/13409446292

<!-- Unsure? Have a question? Request a review! -->
