### PR TITLE
[PROF-11385] Enable GVL profiling by default on Ruby 3.2+

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -104,14 +104,6 @@ only-profiling-heap:
     DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED: "true"
     ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
 
-only-profiling-gvl:
-  extends: .benchmarks
-  variables:
-    DD_BENCHMARKS_CONFIGURATION: only-profiling
-    DD_PROFILING_ENABLED: "true"
-    DD_PROFILING_PREVIEW_GVL_ENABLED: "true"
-    ADD_TO_GEMFILE: "gem 'datadog', github: 'datadog/dd-trace-rb', ref: '$CI_COMMIT_SHA'"
-
 profiling-and-tracing:
   extends: .benchmarks
   variables:

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -463,15 +463,31 @@ module Datadog
               end
             end
 
-            # Enables GVL profiling. This will show when threads are waiting for GVL in the timeline view.
-            #
-            # This is a preview feature and disabled by default. It requires Ruby 3.2+.
-            #
-            # @default `DD_PROFILING_PREVIEW_GVL_ENABLED` environment variable as a boolean, otherwise `false`
+            # @deprecated Use {:gvl_enabled} instead.
             option :preview_gvl_enabled do |o|
               o.type :bool
-              o.env 'DD_PROFILING_PREVIEW_GVL_ENABLED'
               o.default false
+              o.after_set do |_, _, precedence|
+                unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
+                  Datadog.logger.warn(
+                    'The profiling.advanced.preview_gvl_enabled setting has been deprecated for removal and ' \
+                    'no longer does anything. Please remove it from your Datadog.configure block. ' \
+                    'GVL profiling is now controlled by the profiling.advanced.gvl_enabled setting instead.'
+                  )
+                end
+              end
+            end
+
+            # Controls GVL profiling. This will show when threads are waiting for GVL in the timeline view.
+            #
+            # This feature requires Ruby 3.2+.
+            #
+            # @default `DD_PROFILING_GVL_ENABLED` environment variable as a boolean, otherwise `true`
+            option :gvl_enabled do |o|
+              o.type :bool
+              o.deprecated_env 'DD_PROFILING_PREVIEW_GVL_ENABLED'
+              o.env 'DD_PROFILING_GVL_ENABLED'
+              o.default true
             end
 
             # Controls the smallest time period the profiler will report a thread waiting for the GVL.

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -432,17 +432,11 @@ module Datadog
       end
 
       private_class_method def self.enable_gvl_profiling?(settings, logger)
-        if RUBY_VERSION < "3.2"
-          if settings.profiling.advanced.preview_gvl_enabled
-            logger.warn("GVL profiling is currently not supported in Ruby < 3.2 and will not be enabled.")
-          end
-
-          return false
-        end
+        return false if RUBY_VERSION < "3.2"
 
         # GVL profiling only makes sense in the context of timeline. We could emit a warning here, but not sure how
         # useful it is -- if a customer disables timeline, there's nowhere to look for GVL profiling anyway!
-        settings.profiling.advanced.timeline_enabled && settings.profiling.advanced.preview_gvl_enabled
+        settings.profiling.advanced.timeline_enabled && settings.profiling.advanced.gvl_enabled
       end
     end
   end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -636,7 +636,7 @@ RSpec.describe Datadog::Profiling::Component do
 
       context "when GVL profiling is requested" do
         before do
-          settings.profiling.advanced.preview_gvl_enabled = true
+          settings.profiling.advanced.gvl_enabled = true
           # This triggers a warning in some Rubies so it's easier for testing to disable it
           settings.profiling.advanced.gc_enabled = false
         end
@@ -645,16 +645,8 @@ RSpec.describe Datadog::Profiling::Component do
           before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.2." }
 
           it "does not enable GVL profiling" do
-            allow(logger).to receive(:warn)
-
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
               .to receive(:new).with(hash_including(gvl_profiling_enabled: false))
-
-            build_profiler_component
-          end
-
-          it "logs a warning" do
-            expect(logger).to receive(:warn).with(/GVL profiling is currently not supported/)
 
             build_profiler_component
           end
@@ -683,6 +675,23 @@ RSpec.describe Datadog::Profiling::Component do
 
               build_profiler_component
             end
+          end
+        end
+      end
+
+      context "when GVL profiling is disabled" do
+        before do
+          settings.profiling.advanced.gvl_enabled = false
+        end
+
+        context "on Ruby >= 3.2" do
+          before { skip "On Ruby < 3.2 you can't enable the feature, it's always disabled" if RUBY_VERSION < "3.2." }
+
+          it "disables GVL profiling" do
+            expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
+              .to receive(:new).with(hash_including(gvl_profiling_enabled: false))
+
+            build_profiler_component
           end
         end
       end


### PR DESCRIPTION
**What does this PR do?**

This PR graduates the GVL profiling feature from preview to GA, and turns it on by default.

This means the old `preview_gvl_enabled` setting and its corresponding `DD_PROFILING_PREVIEW_GVL_ENABLED` environment variable are now deprecated.

**Motivation:**

Roll out this cool feature to customers ;)

**Change log entry**

Yes. Enable GVL profiling by default on Ruby 3.2+

Also, here's a snippet for the release highlights:

```markdown
### GVL Profiling is now enabled by default on Ruby 3.2+

GVL profiling means the profiler gathers information from threads waiting to acquire the Ruby "Global VM Lock" (GVL).

This waiting can be a big a source of latency for Ruby applications: a thread "Waiting on the GVL" is a thread that's ready to make progress, but can't start because Ruby is busy doing something else.

For more details on why GVL profiling is relevant, check out [How the Ruby Global VM Lock impacts app performance](https://www.youtube.com/watch?v=MmKhsvvyiCw) and https://github.com/DataDog/dd-trace-rb/pull/3929.
```

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage.