### PR TITLE
Split parametric tests away

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -1,0 +1,49 @@
+name: Parametric Tests
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".circleci/**"
+      - ".gitlab/**"
+      - "appraisal/**"
+      - "benchmarks/**"
+      - "docs/**"
+      - "gemfiles/**"
+      - "integration/**"
+      - "sig/**"
+      - "spec/**"
+      - "suppressions/**"
+      - "tools/**"
+      - "vendor/**"
+  workflow_dispatch: {}
+  schedule:
+    - cron: "00 04 * * 2-6"
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    steps:
+      - run: mkdir binaries/
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: binaries/dd-trace-rb/
+      - name: Upload artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: system_tests_binaries
+          path: binaries/
+
+  parametric:
+    needs:
+      - build-artifacts
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
+    secrets: inherit
+    with:
+      library: ruby
+      binaries_artifact: system_tests_binaries
+      job_count: 8
+      job_matrix: "[1,2,3,4,5,6,7,8]"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -457,29 +457,3 @@ jobs:
           package-name: "system-tests/${{ matrix.image }}"
           package-type: "container"
         continue-on-error: true
-
-  build-artifacts:
-    runs-on: ubuntu-22.04
-    permissions:
-      packages: write
-    steps:
-      - run: mkdir binaries/
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: binaries/dd-trace-rb/
-      - name: Upload artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: system_tests_binaries
-          path: binaries/
-
-  parametric:
-    needs:
-      - build-artifacts
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
-    secrets: inherit
-    with:
-      library: ruby
-      binaries_artifact: system_tests_binaries
-      job_count: 8
-      job_matrix: "[1,2,3,4,5,6,7,8]"


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Split parametric tests away

**Motivation:**

Parametric tests are independent from System Tests in many ways, notably they have an entirely different run profile, both in runners used and time spent.

Instead of blocking system tests workflow final result visibility we split parametric tests away to their own workflow.

This also allows for better trackability of CI costs.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Post-merge, `Parametric Tests` should be made required in GitHub settings.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should still pass.

<!-- Unsure? Have a question? Request a review! -->
