### PR TITLE
Add notification channel for build pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby
   REPO_LANG: ruby # ruby is used rather that "rb"
   BUILD_JOB_NAME: save_versions
+  REPO_NOTIFICATION_CHANNEL: "#guild-dd-ruby"
 
 default:
   tags: ["runner:main", "size:large"]


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds a notification channel for the build pipeline

**Motivation:**
One-pipeline added notification messages for failed releases. More notifications may be added in the future

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

<!-- Unsure? Have a question? Request a review! -->
