### PR TITLE
Use non-large arm runner

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,7 +25,7 @@ jobs:
             base: ubuntu-24.04 # always x86_64-linux-gnu
           - os: linux
             cpu: aarch64
-            base: arm-4core-linux-ubuntu24.04 # always aarch64-linux-gnu
+            base: ubuntu-24.04-arm # always aarch64-linux-gnu
         nix:
           - 24.05
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Use `ubuntu-24.04-arm`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

As visible in repo `Insights` `Actions Usage Metrics` the `arm-4core-linux-ubuntu24.04` variant is a `hosted-larger` which may not be free.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Parametric tests would be the last one using a `hosted-larged` runner type:

https://github.com/DataDog/system-tests/blob/abb550d5ea74ff1cc4c9f455bb18dc0fa085e1d4/.github/workflows/run-parametric.yml#L46-L48

To get control over `runs-on:` it would need a change like:

```
on:
  workflow_call:
    inputs:
      runs_on:
        description: "How many job should be spawned for the parametric test"
        default: '{ "group": ""APM Larger Runners"" }'
        required: false
        type: string

jobs:
  parametric:
    runs-on: ${{ fromJson( inputs.runs_on ) }}
```

Then a change here:

https://github.com/DataDog/dd-trace-rb/blob/917747bbbe26399f059d3d017b177ce087f96557/.github/workflows/parametric-tests.yml#L56-L67

to:

```
  parametric:
    with:
      library: ruby
      binaries_artifact: system_tests_binaries
      job_count: 2
      job_matrix: "[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]"
      runs_on: "ubuntu-24.04"
```


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

- CI should pass
- Insights should report `hosted` instead of `hosted-larger`.

<!-- Unsure? Have a question? Request a review! -->
