### PR TITLE
[PROF-11412] Add new otel appraisal variant for profiling

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -14,9 +14,13 @@
     '' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby'
   },
   'profiling:main' => {
-    'opentelemetry'      => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
-    'opentelemetry_otlp' => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
-    ''                   => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
+    'opentelemetry'          => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
+    #  < 1.5 Context is kept in `Thread.current#[]`
+    'opentelemetry_otlp'     => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
+    # >= 1.5 Context is kept as instance variable in `Fiber.current`
+    # TODO: Disabled until profiler is fixed to work with 1.5+
+    'opentelemetry_otlp_1_5' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ❌ 3.1 / ❌ 3.2 / ❌ 3.3 / ❌ 3.4 / ❌ jruby',
+    ''                       => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
   },
   'profiling:ractors' => {
     '' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby'

--- a/appraisal/ruby-2.6.rb
+++ b/appraisal/ruby-2.6.rb
@@ -244,6 +244,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-2.7.rb
+++ b/appraisal/ruby-2.7.rb
@@ -247,6 +247,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-3.0.rb
+++ b/appraisal/ruby-3.0.rb
@@ -168,6 +168,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-3.1.rb
+++ b/appraisal/ruby-3.1.rb
@@ -168,6 +168,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-3.2.rb
+++ b/appraisal/ruby-3.2.rb
@@ -168,6 +168,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-3.3.rb
+++ b/appraisal/ruby-3.3.rb
@@ -168,6 +168,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end

--- a/appraisal/ruby-3.4.rb
+++ b/appraisal/ruby-3.4.rb
@@ -180,6 +180,13 @@ appraise 'opentelemetry' do
 end
 
 appraise 'opentelemetry_otlp' do
+  gem 'opentelemetry-api', '< 1.5' # Context is kept in `Thread.current#[]`
+  gem 'opentelemetry-sdk', '~> 1.1'
+  gem 'opentelemetry-exporter-otlp'
+end
+
+appraise 'opentelemetry_otlp_1_5' do
+  gem 'opentelemetry-api', '>= 1.5' # Context is kept as instance variable in `Fiber.current`
   gem 'opentelemetry-sdk', '~> 1.1'
   gem 'opentelemetry-exporter-otlp'
 end


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new otel appraisal variant for profiling that uses `opentelemetry-api` >= 1.5 .

This is because 1.5 includes
https://github.com/open-telemetry/opentelemetry-ruby/pull/1807 and we'll need to add special support for it.

**Motivation:**

I'm adding already the appraisal version (disabled for now) to avoid any future conflicts with changes to the `Matrixfile`.

**Change log entry**

None

**Additional Notes:**

N/A

**How to test the change?**

This new group is not yet used -- green CI is enough for this PR.