### PR TITLE
[PROF-11412] Support correlating profiling with otel-api 1.5+

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -18,8 +18,7 @@
     #  < 1.5 Context is kept in `Thread.current#[]`
     'opentelemetry_otlp'     => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
     # >= 1.5 Context is kept as instance variable in `Fiber.current`
-    # TODO: Disabled until profiler is fixed to work with 1.5+
-    'opentelemetry_otlp_1_5' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ❌ 3.1 / ❌ 3.2 / ❌ 3.3 / ❌ 3.4 / ❌ jruby',
+    'opentelemetry_otlp_1_5' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby',
     ''                       => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby',
   },
   'profiling:ractors' => {

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -164,6 +164,10 @@ $defs << "-DNO_INT_FIRST_LINENO" if RUBY_VERSION < "3.2"
 # On older Rubies, "pop" was not a primitive operation
 $defs << "-DNO_PRIMITIVE_POP" if RUBY_VERSION < "3.2"
 
+# We could support this for older Rubies, but since this only gets used by the OTEL context extraction, and that
+# use-case is only for 3.1+, we didn't bother supporting it farther back yet.
+$defs << "-DNO_CURRENT_FIBER_FOR" if RUBY_VERSION < "3.1"
+
 # On older Rubies, there was no tid member in the internal thread structure
 $defs << "-DNO_THREAD_TID" if RUBY_VERSION < "3.1"
 

--- a/ext/datadog_profiling_native_extension/gvl_profiling_helper.c
+++ b/ext/datadog_profiling_native_extension/gvl_profiling_helper.c
@@ -1,5 +1,7 @@
 #include <ruby.h>
 #include <ruby/thread.h>
+
+#include "datadog_ruby_common.h"
 #include "gvl_profiling_helper.h"
 
 #if !defined(NO_GVL_INSTRUMENTATION) && !defined(USE_GVL_PROFILING_3_2_WORKAROUNDS) // Ruby 3.3+

--- a/ext/datadog_profiling_native_extension/gvl_profiling_helper.h
+++ b/ext/datadog_profiling_native_extension/gvl_profiling_helper.h
@@ -39,14 +39,6 @@
 
   static inline void gvl_profiling_init(void) { }
 
-  // This header gets included in private_vm_access.c which can't include datadog_ruby_common.h so we replicate this
-  // helper here
-  #ifdef __GNUC__
-    #define DDTRACE_UNUSED  __attribute__((unused))
-  #else
-    #define DDTRACE_UNUSED
-  #endif
-
   // NOTE: This is a hack that relies on the knowledge that on Ruby 3.2 the
   // RUBY_INTERNAL_THREAD_EVENT_READY and RUBY_INTERNAL_THREAD_EVENT_RESUMED events always get called on the thread they
   // are about. Thus, we can use our thread local storage hack to get this data, even though the event doesn't include it.

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -803,3 +803,50 @@ static inline int ddtrace_imemo_type(VALUE imemo) {
 
 // Is the VM smack in the middle of raising an exception?
 bool is_raised_flag_set(VALUE thread) { return thread_struct_from_object(thread)->ec->raised_flag > 0; }
+
+#ifndef NO_CURRENT_FIBER_FOR
+  // The following three declarations are all
+  // taken from upstream cont.c at commit d97884a58be32e829fd03a80cd521f4733d65c79 (February 2025, master branch)
+  // (See the Ruby project copyright and license above)
+  // to enable building `current_fiber_for`.
+  //
+  // We needed to copy them because they aren't otherwise exposed in any VM APIs or headers.
+  // @ivoanjo: I manually checked the Ruby 3.1, 3.2, 3.3 and 3.4 branches + master, and the parts we care about in these
+  // structures have not changed in many years (in fact, last change I spotted was for 2.7).
+  enum context_type {
+      CONTINUATION_CONTEXT = 0,
+      FIBER_CONTEXT = 1
+  };
+
+  typedef struct rb_context_struct { // This declaration is incomplete -- only contains up to `self` which is the part we care about
+      enum context_type type;
+      int argc;
+      int kw_splat;
+      VALUE self;
+  } rb_context_t;
+
+  struct rb_fiber_struct { // This declaration is incomplete -- only contains the first entry which is the part we care about
+    rb_context_t cont;
+  };
+
+  VALUE current_fiber_for(VALUE thread) {
+    VALUE self = thread_struct_from_object(thread)->ec->fiber_ptr->cont.self;
+    return self == 0 ? Qnil : self;
+  }
+
+  void self_test_current_fiber_for(void) {
+    VALUE expected_current_fiber = current_fiber_for(rb_thread_current());
+    VALUE actual_current_fiber = rb_fiber_current();
+
+    if (expected_current_fiber == Qnil) {
+      // On purpose above we tried reading before calling `rb_fiber_current()` so the fiber may have not existed yet.
+      // But now it should be there.
+      expected_current_fiber = current_fiber_for(rb_thread_current());
+    }
+
+    if (expected_current_fiber != actual_current_fiber) rb_raise(rb_eRuntimeError, "current_fiber_for() self-test failed");
+  }
+#else
+  VALUE current_fiber_for(VALUE thread) { rb_raise(rb_eRuntimeError, "Not implemented for Ruby < 3.1"); }
+  void self_test_current_fiber_for(void) { } // Nothing to do
+#endif

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -40,6 +40,13 @@
   #endif
 #endif
 
+// This file can't include datadog_ruby_common.h so we replicate this here
+#ifdef __GNUC__
+  #define DDTRACE_UNUSED  __attribute__((unused))
+#else
+  #define DDTRACE_UNUSED
+#endif
+
 #define PRIVATE_VM_API_ACCESS_SKIP_RUBY_INCLUDES
 #include "private_vm_api_access.h"
 
@@ -847,6 +854,8 @@ bool is_raised_flag_set(VALUE thread) { return thread_struct_from_object(thread)
     if (expected_current_fiber != actual_current_fiber) rb_raise(rb_eRuntimeError, "current_fiber_for() self-test failed");
   }
 #else
-  VALUE current_fiber_for(VALUE thread) { rb_raise(rb_eRuntimeError, "Not implemented for Ruby < 3.1"); }
+  NORETURN(VALUE current_fiber_for(DDTRACE_UNUSED VALUE thread));
+
+  VALUE current_fiber_for(DDTRACE_UNUSED VALUE thread) { rb_raise(rb_eRuntimeError, "Not implemented for Ruby < 3.1"); }
   void self_test_current_fiber_for(void) { } // Nothing to do
 #endif

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.h
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.h
@@ -44,6 +44,7 @@ bool is_thread_alive(VALUE thread);
 VALUE thread_name_for(VALUE thread);
 
 int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *stack_buffer);
+
 // Returns true if the current thread belongs to the main Ractor or if Ruby has no Ractor support
 bool ddtrace_rb_ractor_main_p(void);
 
@@ -70,3 +71,9 @@ const char *imemo_kind(VALUE imemo);
   { if (RB_UNLIKELY(!rb_typeddata_is_kind_of(value, RTYPEDDATA_TYPE(rb_thread_current())))) raise_unexpected_type(value, ADD_QUOTES(value), "Thread", __FILE__, __LINE__, __func__); }
 
 bool is_raised_flag_set(VALUE thread);
+
+// Can be nil if `rb_fiber_current()` or similar has not been called (gets allocated lazily)
+// Only implemented for Ruby 3.1+
+VALUE current_fiber_for(VALUE thread);
+
+void self_test_current_fiber_for(void);

--- a/ext/datadog_profiling_native_extension/profiling.c
+++ b/ext/datadog_profiling_native_extension/profiling.c
@@ -86,6 +86,7 @@ void DDTRACE_EXPORT Init_datadog_profiling_native_extension(void) {
 
 static VALUE native_working_p(DDTRACE_UNUSED VALUE _self) {
   self_test_clock_id();
+  self_test_current_fiber_for();
   self_test_mn_enabled();
 
   return Qtrue;


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for correlating profiling wih otel-api 1.5+.

Context storage was moved in https://github.com/open-telemetry/opentelemetry-ruby/pull/1807 and we needed to update the profiler to account for this.

**Motivation:**

Keep profiling + otel correlation working.

**Change log entry**

Yes. Support correlating profiling with otel-api 1.5+

**Additional Notes:**

N/A

**How to test the change?**

In #4421 I had already bootstrapped the new appraisal groups needed for testing this. This PR enables them, and our existing test coverage will cover the new code path when used with otel-api 1.5+.