### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,7 @@ jobs:
       - rubygems-release
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
       GEM_VERSION: ${{ needs.verify-checks.outputs.version }}
     permissions:
       contents: write
@@ -153,6 +154,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@8388f20e6a9c43cd241131b678469a9f89579f37 # v1.216.0
+        with:
+          ruby-version: '3.3.7'
       - run: bundle install
       - id: next_version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -269,11 +269,16 @@ jobs:
         with:
           fetch-depth: 0
       - run: |
-          JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}"
+          JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEMP_BRANCH="update-document-v${GEM_VERSION}"
+
+          # Create and checkout a new branch from the tag
+          git checkout -b "${TEMP_BRANCH}" "v${GEM_VERSION}"
+          git push origin "${TEMP_BRANCH}"
 
           gh pr create \
             --base release \
-            --head master \
+            --head "${TEMP_BRANCH}" \
             --title "Update document v${GEM_VERSION}" \
             --body "This is an auto-generated PR to update documentation from [here](${JOB_URL}). Please merge (with a merge commit) when ready." \
             --label "docs"


### PR DESCRIPTION
**What does this PR do?**

https://github.com/DataDog/dd-trace-rb/actions/runs/13496397564

Fix error from releasing 2.11.0

1. Fix `github-release` job with the repo information
2. Fix `update-gem-version` job with ruby installed
3. Fix `update-release-branch` job with the correct url and branch

**Change log entry**
None