### PR TITLE
[PROF-11151] Fix test-memory-leaks flaky behavior

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ruby/setup-ruby@8388f20e6a9c43cd241131b678469a9f89579f37 # v1.216.0
+      - uses: ruby/setup-ruby@04c2e2b8e83fbca87e4c7ea9c16e82a1c029c074 # Adds 3.4-asan builds
         with:
-          ruby-version: asan
+          ruby-version: 3.4-asan
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
           cache-version: v2 # bump this to invalidate cache


### PR DESCRIPTION
**What does this PR do?**

This PR will hopefully fix almost [all of the the
flakiness](https://github.com/DataDog/dd-trace-rb/pulls?q=is%3Apr+asan) we've seen from the test-memory-leaks GitHub workflow.

The previous "asan" builds we were using were built from ruby-head, which means that any instability or early breakage in ruby-head would make test-memory-leaks fail.

To fix this, I've worked with upstream to create these 3.4-asan builds: these are Ruby builds that are built **from the latest 3.4 stable Ruby** with asan. Thus any breakages we see in them, should also exist in regular 3.4 builds.

**Motivation:**

With this change, the test-memory-leaks workflow becomes a lot more valuable, since it's now never expected to fail.

Thus, any failures we see in it are worth investigating.

**Change log entry**

None.

**Additional Notes:**

For context, asan (or ASan) is the "AddressSanitizer" tool, see https://github.com/google/sanitizers/wiki/AddressSanitizer for more details.

**How to test the change?**

Validate that the updated workflow is running on ruby-3.4.2 and that it still has the diagnostic output from asan.
