### PR TITLE
DEBUG-3568 DRY transport adapter registration

### DIFF
--- a/lib/datadog/core/remote/transport/http.rb
+++ b/lib/datadog/core/remote/transport/http.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-require 'uri'
-
 require_relative '../../environment/container'
 require_relative '../../environment/ext'
 require_relative '../../transport/ext'
-require_relative '../../transport/http/builder'
-require_relative '../../transport/http/adapters/net'
-require_relative '../../transport/http/adapters/unix_socket'
-require_relative '../../transport/http/adapters/test'
+require_relative '../../transport/http'
 
 # TODO: Improve negotiation to allow per endpoint selection
 #
@@ -46,7 +41,7 @@ module Datadog
 
           # Builds a new Transport::HTTP::Client
           def new(klass, &block)
-            Core::Transport::HTTP::Builder.new(
+            Core::Transport::HTTP.build(
               api_instance_class: API::Instance, &block
             ).to_transport(klass)
           end
@@ -126,20 +121,6 @@ module Datadog
           def default_adapter
             Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
           end
-
-          # Add adapters to registry
-          Core::Transport::HTTP::Builder::REGISTRY.set(
-            Datadog::Core::Transport::HTTP::Adapters::Net,
-            Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
-          )
-          Core::Transport::HTTP::Builder::REGISTRY.set(
-            Datadog::Core::Transport::HTTP::Adapters::Test,
-            Datadog::Core::Transport::Ext::Test::ADAPTER
-          )
-          Core::Transport::HTTP::Builder::REGISTRY.set(
-            Datadog::Core::Transport::HTTP::Adapters::UnixSocket,
-            Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
-          )
         end
       end
     end

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -8,6 +8,7 @@ require_relative 'http/adapters/test'
 module Datadog
   module Core
     module Transport
+      # HTTP transport
       module HTTP
         # Add adapters to registry
         Builder::REGISTRY.set(

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'http/builder'
+require_relative 'http/adapters/net'
+require_relative 'http/adapters/unix_socket'
+require_relative 'http/adapters/test'
+
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        # Helper function that delegates to Builder.new
+        # but is under HTTP namespace so that client code requires this file
+        # to get the adapters configured, and not the builder directly.
+        module_function def build(api_instance_class:, &block)
+          Builder.new(api_instance_class: api_instance_class, &block)
+        end
+
+        # Add adapters to registry
+        Builder::REGISTRY.set(
+          Transport::HTTP::Adapters::Net,
+          Core::Configuration::Ext::Agent::HTTP::ADAPTER
+        )
+        Builder::REGISTRY.set(
+          Transport::HTTP::Adapters::Test,
+          Transport::Ext::Test::ADAPTER
+        )
+        Builder::REGISTRY.set(
+          Transport::HTTP::Adapters::UnixSocket,
+          Transport::Ext::UnixSocket::ADAPTER
+        )
+      end
+    end
+  end
+end

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -9,13 +9,6 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        # Helper function that delegates to Builder.new
-        # but is under HTTP namespace so that client code requires this file
-        # to get the adapters configured, and not the builder directly.
-        module_function def build(api_instance_class:, &block)
-          Builder.new(api_instance_class: api_instance_class, &block)
-        end
-
         # Add adapters to registry
         Builder::REGISTRY.set(
           Transport::HTTP::Adapters::Net,
@@ -29,6 +22,15 @@ module Datadog
           Transport::HTTP::Adapters::UnixSocket,
           Transport::Ext::UnixSocket::ADAPTER
         )
+
+        module_function
+
+        # Helper function that delegates to Builder.new
+        # but is under HTTP namespace so that client code requires this file
+        # to get the adapters configured, and not the builder directly.
+        def build(api_instance_class:, &block)
+          Builder.new(api_instance_class: api_instance_class, &block)
+        end
       end
     end
   end

--- a/lib/datadog/di/transport/http.rb
+++ b/lib/datadog/di/transport/http.rb
@@ -5,13 +5,10 @@ require 'uri'
 require_relative '../../core/environment/container'
 require_relative '../../core/environment/ext'
 require_relative '../../core/transport/ext'
-require_relative '../../core/transport/http/adapters/net'
-require_relative '../../core/transport/http/adapters/test'
-require_relative '../../core/transport/http/adapters/unix_socket'
 require_relative 'diagnostics'
 require_relative 'input'
 require_relative 'http/api'
-require_relative '../../core/transport/http/builder'
+require_relative '../../core/transport/http'
 require_relative '../../../datadog/version'
 
 module Datadog
@@ -23,7 +20,7 @@ module Datadog
 
         # Builds a new Transport::HTTP::Client
         def new(klass, &block)
-          Core::Transport::HTTP::Builder.new(
+          Core::Transport::HTTP.build(
             api_instance_class: API::Instance, &block
           ).to_transport(klass)
         end
@@ -102,17 +99,6 @@ module Datadog
         def default_adapter
           Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
         end
-
-        # Add adapters to registry
-        Datadog::Core::Transport::HTTP::Builder::REGISTRY.set(
-          Datadog::Core::Transport::HTTP::Adapters::Net,
-          Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
-        )
-        Datadog::Core::Transport::HTTP::Builder::REGISTRY.set(Datadog::Core::Transport::HTTP::Adapters::Test, Datadog::Core::Transport::Ext::Test::ADAPTER)
-        Datadog::Core::Transport::HTTP::Builder::REGISTRY.set(
-          Datadog::Core::Transport::HTTP::Adapters::UnixSocket,
-          Datadog::Core::Transport::Ext::UnixSocket::ADAPTER
-        )
       end
     end
   end

--- a/lib/datadog/tracing/transport/http.rb
+++ b/lib/datadog/tracing/transport/http.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-require 'uri'
-
 require_relative '../../core/environment/container'
 require_relative '../../core/environment/ext'
 require_relative '../../core/transport/ext'
-require_relative '../../core/transport/http/adapters/net'
-require_relative '../../core/transport/http/adapters/test'
-require_relative '../../core/transport/http/adapters/unix_socket'
-require_relative '../../core/transport/http/builder'
+require_relative '../../core/transport/http'
 require_relative 'http/api'
 require_relative '../../../datadog/version'
 
@@ -31,7 +26,7 @@ module Datadog
 
         # Builds a new Transport::HTTP::Client
         def new(klass, &block)
-          Core::Transport::HTTP::Builder.new(
+          Core::Transport::HTTP.build(
             api_instance_class: API::Instance, &block
           ).to_transport(klass)
         end
@@ -86,20 +81,6 @@ module Datadog
         def default_adapter
           Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
         end
-
-        # Add adapters to registry
-        Core::Transport::HTTP::Builder::REGISTRY.set(
-          Datadog::Core::Transport::HTTP::Adapters::Net,
-          Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
-        )
-        Core::Transport::HTTP::Builder::REGISTRY.set(
-          Datadog::Core::Transport::HTTP::Adapters::Test,
-          Datadog::Core::Transport::Ext::Test::ADAPTER
-        )
-        Core::Transport::HTTP::Builder::REGISTRY.set(
-          Datadog::Core::Transport::HTTP::Adapters::UnixSocket,
-          Datadog::Core::Transport::Ext::UnixSocket::ADAPTER
-        )
       end
     end
   end

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        def self?.build: (api_instance_class: untyped) { (?) -> untyped } -> untyped
+        def self?.build: (api_instance_class: untyped) ?{ (untyped) -> untyped } -> HTTP::Builder
       end
     end
   end

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module Core
+    module Transport
+      module HTTP
+        def self?.build: (api_instance_class: untyped) { (?) -> untyped } -> untyped
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Moves the adapter registration code to core, since the adapters and the registry where the adapters are added to are both core components. 

As far as I can tell, in master this registration is performed 3 times (once for each component) and each of the registrations are the same exact operation.

**Motivation:**
Making the transport code smaller so that it is easier to use.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
None
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
