### PR TITLE
Add ignored files to GHA steep summary.

### DIFF
--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -73,26 +73,13 @@ namespace :steep do
         File.readlines(steepfile_path).each do |line|
           if line.strip.start_with?('ignore')
             file = line.strip.match(/^ignore\s+'([^']+)'/)
-            ignored_files << file[1]
+            ignored_files << file[1] if file
           end
         end
       end
 
       ignored_files.each do |file|
-        $stdout.write('|')
-        $stdout.write('datadog') # header: Target
-        $stdout.write('|')
-        $stdout.write(file) # header: File
-        $stdout.write('|')
-        $stdout.write('ignored') # header: Status
-        $stdout.write('|')
-        $stdout.write('|')
-        $stdout.write('0') # header: Untyped calls
-        $stdout.write('|')
-        $stdout.write('|')
-        $stdout.write('0') # header: Typed %
-        $stdout.write('|')
-        $stdout.write("\n")
+        $stdout.write("|N/A|#{file}|ignored|N/A|N/A|N/A|N/A|\n")
       end
     else
       sh "steep stats --format=#{format}"

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -67,20 +67,10 @@ namespace :steep do
 
       # Append ignored files from Steepfile to the end of the steep/typecheck summary
       steepfile_path = 'Steepfile'
-      ignored_files = []
-
-      if File.exist?(steepfile_path)
-        File.readlines(steepfile_path).each do |line|
-          if line.strip.start_with?('ignore')
-            file = line.strip.match(/^ignore\s+'([^']+)'/)
-            ignored_files << file[1] if file
-          end
-        end
-      end
-
-      ignored_files.each do |file|
-        $stdout.write("|N/A|#{file}|ignored|N/A|N/A|N/A|N/A|\n")
-      end
+      File
+        .foreach(steepfile_path)
+        .with_object([]) { |line, ignored_files| line =~ /^\s*ignore\s+(["'])(.*?(?:\\?.)*?)\1/ && ignored_files << $2 }
+        .each { |file| $stdout.write("|N/A|#{file}|ignored|N/A|N/A|N/A|N/A|\n") }
     else
       sh "steep stats --format=#{format}"
     end

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -65,7 +65,7 @@ namespace :steep do
         $stdout.write("\n")
       end
 
-      # append ignored files from Steepfile
+      # Append ignored files from Steepfile to the end of the steep/typecheck summary
       steepfile_path = 'Steepfile'
       ignored_files = []
 
@@ -80,17 +80,17 @@ namespace :steep do
 
       ignored_files.each do |file|
         $stdout.write('|')
-        $stdout.write('datadog')
+        $stdout.write('datadog') # header: Target
         $stdout.write('|')
-        $stdout.write(file)
+        $stdout.write(file) # header: File
         $stdout.write('|')
-        $stdout.write('ignored')
-        $stdout.write('|')
-        $stdout.write('|')
-        $stdout.write('0')
+        $stdout.write('ignored') # header: Status
         $stdout.write('|')
         $stdout.write('|')
-        $stdout.write('0')
+        $stdout.write('0') # header: Untyped calls
+        $stdout.write('|')
+        $stdout.write('|')
+        $stdout.write('0') # header: Typed %
         $stdout.write('|')
         $stdout.write("\n")
       end

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -64,6 +64,34 @@ namespace :steep do
         $stdout.write('|')
         $stdout.write("\n")
       end
+
+      # append ignored files from Steepfile
+      steepfile_path = 'Steepfile'
+      ignored_files = []
+
+      if File.exist?(steepfile_path)
+        File.readlines(steepfile_path).each do |line|
+          if line.strip.start_with?('ignore')
+            ignored_files << line.strip.sub('/^ignore /', '')
+          end
+        end
+      end
+
+      ignored_files.each do |file|
+        $stdout.write('|')
+        $stdout.write('|')
+        $stdout.write(file)
+        $stdout.write('|')
+        $stdout.write('ignored')
+        $stdout.write('|')
+        $stdout.write('|')
+        $stdout.write('0')
+        $stdout.write('|')
+        $stdout.write('|')
+        $stdout.write('0')
+        $stdout.write('|')
+        $stdout.write("\n")
+      end
     else
       sh "steep stats --format=#{format}"
     end

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -70,7 +70,7 @@ namespace :steep do
       File
         .foreach(steepfile_path)
         .with_object([]) { |line, ignored_files| line =~ /^\s*ignore\s+(["'])(.*?(?:\\?.)*?)\1/ && ignored_files << $2 }
-        .each { |file| $stdout.write("|N/A|#{file}|ignored|N/A|N/A|N/A|N/A|\n") }
+        .each { |file| $stdout.write("|datadog|#{file}|ignored|N/A|N/A|N/A|0|\n") }
     else
       sh "steep stats --format=#{format}"
     end

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -69,7 +69,13 @@ namespace :steep do
       File
         .foreach('Steepfile')
         .with_object([]) { |line, ignored_files| line =~ /^\s*ignore\s+(["'])(.*?(?:\\?.)*?)\1/ && ignored_files << $2 }
-        .each { |file| $stdout.write("|datadog|#{file}|ignored|N/A|N/A|N/A|0|\n") }
+        .each do |file|
+          if File.exist?(file)
+            $stdout.write("|datadog|#{file}|ignored|N/A|N/A|N/A|0|\n")
+          else
+            warn "Ignored file '#{file}' does not exist. Please remove it from the Steepfile."
+          end
+        end
     else
       sh "steep stats --format=#{format}"
     end

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -72,13 +72,15 @@ namespace :steep do
       if File.exist?(steepfile_path)
         File.readlines(steepfile_path).each do |line|
           if line.strip.start_with?('ignore')
-            ignored_files << line.strip.sub('/^ignore /', '')
+            file = line.strip.match(/^ignore\s+'([^']+)'/)
+            ignored_files << file[1]
           end
         end
       end
 
       ignored_files.each do |file|
         $stdout.write('|')
+        $stdout.write('datadog')
         $stdout.write('|')
         $stdout.write(file)
         $stdout.write('|')

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -66,9 +66,8 @@ namespace :steep do
       end
 
       # Append ignored files from Steepfile to the end of the steep/typecheck summary
-      steepfile_path = 'Steepfile'
       File
-        .foreach(steepfile_path)
+        .foreach('Steepfile')
         .with_object([]) { |line, ignored_files| line =~ /^\s*ignore\s+(["'])(.*?(?:\\?.)*?)\1/ && ignored_files << $2 }
         .each { |file| $stdout.write("|datadog|#{file}|ignored|N/A|N/A|N/A|0|\n") }
     else


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add ignored files from `Steepfile` into our GHA steep/typecheck summary. Here is an example of a [steep/typecheck summary](https://github.com/DataDog/dd-trace-rb/actions/runs/13544586301#summary-37853098486).

**Motivation:**
We have a lot of files that are ignored by steep type-checking, so this will provide visibility in our summary of which files are ignored.

**Change log entry**
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
See the ignored files in the GHA `steep/typecheck summary` for this PR.

<!-- Unsure? Have a question? Request a review! -->
