### PR TITLE
DEBUG-3568 remove agent settings defaulting hack

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -22,7 +22,7 @@ module Datadog
           transport_options[:agent_settings] = agent_settings if agent_settings
 
           negotiation = Negotiation.new(settings, agent_settings)
-          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(**transport_options)
+          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(**transport_options) # steep:ignore
 
           @barrier = Barrier.new(settings.remote.boot_timeout_seconds)
 

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -22,7 +22,7 @@ module Datadog
           transport_options[:agent_settings] = agent_settings if agent_settings
 
           negotiation = Negotiation.new(settings, agent_settings)
-          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(**transport_options.dup)
+          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(**transport_options)
 
           @barrier = Barrier.new(settings.remote.boot_timeout_seconds)
 

--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -11,7 +11,7 @@ module Datadog
           transport_options = {}
           transport_options[:agent_settings] = agent_settings if agent_settings
 
-          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(**transport_options.dup)
+          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(**transport_options)
           @logged = suppress_logging
         end
 

--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -11,7 +11,7 @@ module Datadog
           transport_options = {}
           transport_options[:agent_settings] = agent_settings if agent_settings
 
-          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(**transport_options)
+          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(**transport_options) # steep:ignore
           @logged = suppress_logging
         end
 

--- a/lib/datadog/core/remote/transport/http.rb
+++ b/lib/datadog/core/remote/transport/http.rb
@@ -32,16 +32,6 @@ module Datadog
       module Transport
         # Namespace for HTTP transport components
         module HTTP
-          # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
-          # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
-          # represents only settings specified via environment variables + the usual defaults.
-          #
-          # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
-          DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS = Datadog::Core::Configuration::AgentSettingsResolver.call(
-            Datadog::Core::Configuration::Settings.new,
-            logger: nil,
-          )
-
           module_function
 
           # Builds a new Transport::HTTP::Client
@@ -54,7 +44,7 @@ module Datadog
           # Builds a new Transport::HTTP::Client with default settings
           # Pass a block to override any settings.
           def root(
-            agent_settings: DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS,
+            agent_settings:,
             **options
           )
             new(Core::Remote::Transport::Negotiation::Transport) do |transport|
@@ -79,7 +69,7 @@ module Datadog
           # Builds a new Transport::HTTP::Client with default settings
           # Pass a block to override any settings.
           def v7(
-            agent_settings: DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS,
+            agent_settings:,
             **options
           )
             new(Core::Remote::Transport::Config::Transport) do |transport|

--- a/lib/datadog/tracing/sync_writer.rb
+++ b/lib/datadog/tracing/sync_writer.rb
@@ -19,7 +19,8 @@ module Datadog
       attr_reader \
         :logger,
         :events,
-        :transport
+        :transport,
+        :agent_settings
 
       # @param [Datadog::Tracing::Transport::Traces::Transport] transport a custom transport instance.
       #   If provided, overrides `transport_options` and `agent_settings`.
@@ -28,9 +29,12 @@ module Datadog
       #   the default transport instance.
       def initialize(transport: nil, transport_options: {}, agent_settings: nil, logger: Datadog.logger)
         @logger = logger
+        @agent_settings = agent_settings
 
         @transport = transport || begin
-          transport_options[:agent_settings] = agent_settings if agent_settings
+          if agent_settings
+            transport_options = transport_options.merge(agent_settings: agent_settings)
+          end
           Transport::HTTP.default(**transport_options)
         end
 

--- a/lib/datadog/tracing/sync_writer.rb
+++ b/lib/datadog/tracing/sync_writer.rb
@@ -32,9 +32,7 @@ module Datadog
         @agent_settings = agent_settings
 
         @transport = transport || begin
-          if agent_settings
-            transport_options = transport_options.merge(agent_settings: agent_settings)
-          end
+          transport_options = transport_options.merge(agent_settings: agent_settings) if agent_settings
           Transport::HTTP.default(**transport_options)
         end
 

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -49,6 +49,8 @@ module Datadog
       # @param tags [Hash] default tags added to all spans
       # @param writer [Datadog::Tracing::Writer] consumes traces returned by the provided +trace_flush+
       def initialize(
+        # rubocop:disable Style/KeywordParametersOrder
+        # https://github.com/rubocop/rubocop/issues/13933
         trace_flush: Flush::Finished.new,
         context_provider: DefaultContextProvider.new,
         default_service: Core::Environment::Ext::FALLBACK_SERVICE_NAME,
@@ -63,6 +65,7 @@ module Datadog
         # writer is not defaulted because creating it requires agent_settings,
         # which we do not have here and otherwise do not need.
         writer:
+        # rubocop:enable Style/KeywordParametersOrder
       )
         @trace_flush = trace_flush
         @default_service = default_service

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -60,7 +60,9 @@ module Datadog
         ),
         span_sampler: Sampling::Span::Sampler.new,
         tags: {},
-        writer: Writer.new(logger: logger)
+        # writer is not defaulted because creating it requires agent_settings,
+        # which we do not have here and otherwise do not need.
+        writer:
       )
         @trace_flush = trace_flush
         @default_service = default_service

--- a/lib/datadog/tracing/transport/http.rb
+++ b/lib/datadog/tracing/transport/http.rb
@@ -17,16 +17,6 @@ module Datadog
     module Transport
       # Namespace for HTTP transport components
       module HTTP
-        # NOTE: Due to... legacy reasons... This class likes having a default `AgentSettings` instance to fall back to.
-        # Because we generate this instance with an empty instance of `Settings`, the resulting `AgentSettings` below
-        # represents only settings specified via environment variables + the usual defaults.
-        #
-        # DO NOT USE THIS IN NEW CODE, as it ignores any settings specified by users via `Datadog.configure`.
-        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS = Datadog::Core::Configuration::AgentSettingsResolver.call(
-          Datadog::Core::Configuration::Settings.new,
-          logger: nil,
-        )
-
         module_function
 
         # Builds a new Transport::HTTP::Client
@@ -39,7 +29,7 @@ module Datadog
         # Builds a new Transport::HTTP::Client with default settings
         # Pass a block to override any settings.
         def default(
-          agent_settings: DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS,
+          agent_settings:,
           **options
         )
           new(Transport::Traces::Transport) do |transport|

--- a/lib/datadog/tracing/workers/trace_writer.rb
+++ b/lib/datadog/tracing/workers/trace_writer.rb
@@ -18,7 +18,8 @@ module Datadog
       class TraceWriter < Core::Worker
         attr_reader \
           :logger,
-          :transport
+          :transport,
+          :agent_settings
 
         # rubocop:disable Lint/MissingSuper
         def initialize(options = {})
@@ -26,7 +27,10 @@ module Datadog
 
           transport_options = options.fetch(:transport_options, {})
 
-          transport_options[:agent_settings] = options[:agent_settings] if options.key?(:agent_settings)
+          if options.key?(:agent_settings)
+            @agent_settings = options[:agent_settings]
+            transport_options = transport_options.merge(agent_settings: @agent_settings)
+          end
 
           @transport = options.fetch(:transport) do
             Datadog::Tracing::Transport::HTTP.default(**transport_options)

--- a/lib/datadog/tracing/writer.rb
+++ b/lib/datadog/tracing/writer.rb
@@ -16,7 +16,8 @@ module Datadog
         :logger,
         :transport,
         :worker,
-        :events
+        :events,
+        :agent_settings
 
       def initialize(options = {})
         @logger = options[:logger] || Datadog.logger
@@ -26,7 +27,10 @@ module Datadog
         @flush_interval = options.fetch(:flush_interval, Workers::AsyncTransport::DEFAULT_FLUSH_INTERVAL)
         transport_options = options.fetch(:transport_options, {})
 
-        transport_options[:agent_settings] = options[:agent_settings] if options.key?(:agent_settings)
+        if options.key?(:agent_settings)
+          @agent_settings = options[:agent_settings]
+          transport_options = transport_options.merge(agent_settings: @agent_settings)
+        end
 
         # transport and buffers
         @transport = options.fetch(:transport) do

--- a/sig/datadog/core/remote/transport/http.rbs
+++ b/sig/datadog/core/remote/transport/http.rbs
@@ -3,23 +3,13 @@ module Datadog
     module Remote
       module Transport
         module HTTP
-          DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
-
-          def self?.new: (untyped klass) ?{ (untyped) -> untyped } -> untyped
-
-          def self?.root: (?agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
-
-          def self?.v7: (?agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
+          def self?.new: (untyped klass) { (?) -> untyped } -> untyped
+          def self?.root: (agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
+          def self?.v7: (agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
 
           def self?.default_headers: () -> untyped
 
           def self?.default_adapter: () -> untyped
-
-          def self?.default_hostname: (?logger: untyped) -> untyped
-
-          def self?.default_port: (?logger: untyped) -> untyped
-
-          def self?.default_url: (?logger: untyped) -> nil
         end
       end
     end

--- a/sig/datadog/di/transport/http.rbs
+++ b/sig/datadog/di/transport/http.rbs
@@ -2,7 +2,6 @@ module Datadog
   module DI
     module Transport
       module HTTP
-        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
         def self?.new: (untyped klass) { (?) -> untyped } -> untyped
         def self?.diagnostics: (agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
         def self?.input: (agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped

--- a/sig/datadog/tracing/transport/http.rbs
+++ b/sig/datadog/tracing/transport/http.rbs
@@ -2,21 +2,12 @@ module Datadog
   module Tracing
     module Transport
       module HTTP
-        DO_NOT_USE_ENVIRONMENT_AGENT_SETTINGS: untyped
-
-        def self?.new: () ?{ () -> untyped } -> untyped
-
-        def self?.default: (?agent_settings: untyped, **untyped options) { (untyped) -> untyped } -> untyped
+        def self?.new: (untyped klass) { (?) -> untyped } -> untyped
+        def self?.default: (agent_settings: untyped, **untyped options) ?{ (untyped) -> untyped } -> untyped
 
         def self?.default_headers: () -> untyped
 
         def self?.default_adapter: () -> untyped
-
-        def self?.default_hostname: (?logger: untyped) -> untyped
-
-        def self?.default_port: (?logger: untyped) -> untyped
-
-        def self?.default_url: (?logger: untyped) -> nil
       end
     end
   end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Rack integration tests' do
   # In the future, it might be a good idea to use the traces that the mocked agent
   # receives in the tests/shared examples
   let(:agent_http_client) do
-    Datadog::Tracing::Transport::HTTP.default do |t|
+    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
       t.adapter agent_http_adapter
     end
   end

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Rails integration tests' do
   # In the future, it might be a good idea to use the traces that the mocked agent
   # receives in the tests/shared examples
   let(:agent_http_client) do
-    Datadog::Tracing::Transport::HTTP.default do |t|
+    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
       t.adapter agent_http_adapter
     end
   end

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Sinatra integration tests' do
   # In the future, it might be a good idea to use the traces that the mocked agent
   # receives in the tests/shared examples
   let(:agent_http_client) do
-    Datadog::Tracing::Transport::HTTP.default do |t|
+    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
       t.adapter agent_http_adapter
     end
   end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -533,7 +533,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new tracer' do
         let(:tracer) { instance_double(Datadog::Tracing::Tracer) }
-        let(:writer) { Datadog::Tracing::Writer.new }
+        let(:writer) { Datadog::Tracing::Writer.new(agent_settings: test_agent_settings) }
         let(:trace_flush) { be_a(Datadog::Tracing::Flush::Finished) }
         let(:sampler) do
           if defined?(super)
@@ -852,7 +852,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
             context 'and :async' do
               context 'is set' do
-                let(:writer) { Datadog::Tracing::Writer.new }
+                let(:writer) { Datadog::Tracing::Writer.new(agent_settings: test_agent_settings) }
                 let(:writer_options) { { transport_options: :bar } }
                 let(:writer_options_test_mode) { { transport_options: :baz } }
 
@@ -878,7 +878,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
               end
 
               context 'is not set' do
-                let(:sync_writer) { Datadog::Tracing::SyncWriter.new }
+                let(:sync_writer) { Datadog::Tracing::SyncWriter.new(agent_settings: test_agent_settings) }
 
                 before do
                   expect(Datadog::Tracing::SyncWriter)
@@ -986,7 +986,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         context 'that publishes events' do
           it_behaves_like 'new tracer' do
             let(:options) { { writer: writer } }
-            let(:writer) { Datadog::Tracing::Writer.new }
+            let(:writer) { Datadog::Tracing::Writer.new(agent_settings: test_agent_settings) }
             after { writer.stop }
 
             it_behaves_like 'event publishing writer and priority sampler'

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -9,6 +9,7 @@ require 'datadog/tracing/tracer'
 RSpec.describe Datadog::Core::Configuration do
   let(:default_log_level) { ::Logger::INFO }
   let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+  let(:writer) { instance_double(Datadog::Tracing::Writer) }
 
   before do
     allow(telemetry).to receive(:stop!)
@@ -269,8 +270,8 @@ RSpec.describe Datadog::Core::Configuration do
 
       context 'when the tracer' do
         context 'is replaced' do
-          let(:old_tracer) { Datadog::Tracing::Tracer.new }
-          let(:new_tracer) { Datadog::Tracing::Tracer.new }
+          let(:old_tracer) { Datadog::Tracing::Tracer.new(writer: writer) }
+          let(:new_tracer) { Datadog::Tracing::Tracer.new(writer: writer) }
 
           before do
             expect(old_tracer).to receive(:shutdown!)
@@ -285,7 +286,7 @@ RSpec.describe Datadog::Core::Configuration do
         end
 
         context 'is reused' do
-          let(:tracer) { Datadog::Tracing::Tracer.new }
+          let(:tracer) { Datadog::Tracing::Tracer.new(writer: writer) }
 
           before do
             expect(tracer).to_not receive(:shutdown!)
@@ -300,7 +301,7 @@ RSpec.describe Datadog::Core::Configuration do
         end
 
         context 'is not changed' do
-          let(:tracer) { Datadog::Tracing::Tracer.new }
+          let(:tracer) { Datadog::Tracing::Tracer.new(writer: writer) }
 
           before do
             expect(tracer).to_not receive(:shutdown!)

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Datadog::Core::Remote::Client do
   end
 
   let(:http_connection) { instance_double(::Net::HTTP) }
-  let(:transport) { Datadog::Core::Remote::Transport::HTTP.v7(&proc { |_client| }) }
+  let(:transport) { Datadog::Core::Remote::Transport::HTTP.v7(agent_settings: test_agent_settings, &proc { |_client| }) }
   let(:roots) do
     [
       {

--- a/spec/datadog/core/remote/transport/http_spec.rb
+++ b/spec/datadog/core/remote/transport/http_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   let(:http_connection) { instance_double(::Net::HTTP) }
 
   describe '.root' do
-    subject(:transport) { described_class.root(&client_options) }
+    subject(:transport) { described_class.root(agent_settings: test_agent_settings, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -83,7 +83,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   end
 
   describe '.v7' do
-    subject(:transport) { described_class.v7(&client_options) }
+    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 

--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   skip_unless_integration_testing_enabled
 
   describe '.root' do
-    subject(:transport) { described_class.root(&client_options) }
+    subject(:transport) { described_class.root(agent_settings: test_agent_settings, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -33,7 +33,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   describe '.v7' do
     before { skip 'TODO: needs remote config on api key+agent+backend' if ENV['TEST_DATADOG_INTEGRATION'] }
 
-    subject(:transport) { described_class.v7(&client_options) }
+    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 

--- a/spec/datadog/tracing/benchmark/transport_benchmark_spec.rb
+++ b/spec/datadog/tracing/benchmark/transport_benchmark_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Microbenchmark Transport' do
       # in a single method call. This would translate to
       # up to 1000 spans per second in a real application.
       let(:steps) { [1, 10, 100, 1000] }
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default }
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
 
       include_examples 'benchmark'
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'net/http requests' do
     end
 
     describe 'integration' do
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default }
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
 
       it 'does not create a span for the transport request' do
         expect(Datadog::Tracing).to_not receive(:trace)

--- a/spec/datadog/tracing/contrib/suite/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/transport_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe 'transport with integrations' do
     end
 
     context 'given the default transport' do
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default }
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
 
       it_behaves_like 'an uninstrumented transport'
     end
 
     context 'given an Unix socket transport' do
       let(:transport) do
-        Datadog::Tracing::Transport::HTTP.default do |t|
+        Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
           t.adapter :unix, '/tmp/ddagent/trace.sock'
         end
       end

--- a/spec/datadog/tracing/contrib/support/tracer_helpers.rb
+++ b/spec/datadog/tracing/contrib/support/tracer_helpers.rb
@@ -103,16 +103,10 @@ module Contrib
         unless traces.empty?
           if tracer.respond_to?(:writer) && tracer.writer.transport.client.api.adapter.respond_to?(:hostname) && # rubocop:disable Style/SoleNestedConditional
               tracer.writer.transport.client.api.adapter.hostname == agent_host
-            transport_options = {
-              adapter: :net_http,
-              hostname: agent_host,
-              port: agent_port,
-              timeout: 30
-            }
             traces.each do |trace|
               # write traces after the test to the agent in order to not mess up assertions
               # remake syncwriter instance for each flush to prevent headers from being overrwritten
-              sync_writer = Datadog::Tracing::SyncWriter.new(transport_options: transport_options)
+              sync_writer = Datadog::Tracing::SyncWriter.new(agent_settings: tracer.writer.agent_settings)
               sync_writer.transport.client.api.headers['X-Datadog-Trace-Env-Variables'] = parse_tracer_config
               sync_writer.write(trace)
             end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -1007,7 +1007,7 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     let(:writer) { Datadog::Tracing::Writer.new(transport: transport) }
-    let(:transport) { Datadog::Tracing::Transport::HTTP.default }
+    let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
 
     before do
       Datadog.configure do |c|

--- a/spec/datadog/tracing/sync_writer_spec.rb
+++ b/spec/datadog/tracing/sync_writer_spec.rb
@@ -14,7 +14,7 @@ require 'datadog/tracing/transport/traces'
 RSpec.describe Datadog::Tracing::SyncWriter do
   subject(:sync_writer) { described_class.new(transport: transport) }
 
-  let(:transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :test, buffer } }
+  let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) { |t| t.adapter :test, buffer } }
   let(:buffer) { [] }
 
   describe '::new' do

--- a/spec/datadog/tracing/sync_writer_spec.rb
+++ b/spec/datadog/tracing/sync_writer_spec.rb
@@ -14,7 +14,11 @@ require 'datadog/tracing/transport/traces'
 RSpec.describe Datadog::Tracing::SyncWriter do
   subject(:sync_writer) { described_class.new(transport: transport) }
 
-  let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) { |t| t.adapter :test, buffer } }
+  let(:transport) do
+    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      t.adapter :test, buffer
+    end
+  end
   let(:buffer) { [] }
 
   describe '::new' do

--- a/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Adapters::Net tracing integration tests' do
     include_context 'HTTP server'
 
     let(:client) do
-      Datadog::Tracing::Transport::HTTP.default do |t|
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
         t.adapter adapter
       end
     end

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
     include_context 'Unix socket server'
 
     let(:client) do
-      Datadog::Tracing::Transport::HTTP.default do |t|
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
         t.adapter adapter
       end
     end

--- a/spec/datadog/tracing/transport/http/integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
   skip_unless_integration_testing_enabled
 
   describe 'HTTP#default' do
-    subject(:transport) { Datadog::Tracing::Transport::HTTP.default(&client_options) }
+    subject(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -35,7 +35,7 @@ RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
     subject(:writer) { described_class.new(writer_options) }
 
     let(:writer_options) { { transport: client } }
-    let(:client) { Datadog::Tracing::Transport::HTTP.default(&client_options) }
+    let(:client) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, &client_options) }
     let(:client_options) { proc { |_client| } }
 
     describe '#send_spans' do

--- a/spec/datadog/tracing/workers/trace_writer_spec.rb
+++ b/spec/datadog/tracing/workers/trace_writer_spec.rb
@@ -12,7 +12,7 @@ require 'datadog/core/transport/http/response'
 require 'datadog/core/transport/response'
 
 RSpec.describe Datadog::Tracing::Workers::TraceWriter do
-  subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
+  subject(:writer) { described_class.new({ agent_settings: test_agent_settings }.update(options)) }
 
   let(:options) { {} }
 
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 end
 
 RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
-  subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
+  subject(:writer) { described_class.new({ agent_settings: test_agent_settings }.update(options)) }
 
   let(:options) { {} }
 
@@ -559,7 +559,11 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
 
   describe 'integration tests' do
     let(:options) { { transport: transport, fork_policy: fork_policy } }
-    let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) { |t| t.adapter :test, output } }
+    let(:transport) do
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+        t.adapter :test, output
+      end
+    end
     let(:output) { [] }
 
     describe 'forking' do

--- a/spec/datadog/tracing/workers/trace_writer_spec.rb
+++ b/spec/datadog/tracing/workers/trace_writer_spec.rb
@@ -12,7 +12,7 @@ require 'datadog/core/transport/http/response'
 require 'datadog/core/transport/response'
 
 RSpec.describe Datadog::Tracing::Workers::TraceWriter do
-  subject(:writer) { described_class.new(options) }
+  subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
 
   let(:options) { {} }
 
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 
       before do
         expect(Datadog::Tracing::Transport::HTTP).to receive(:default)
-          .with(transport_options)
+          .with(transport_options.merge(agent_settings: test_agent_settings))
           .and_return(transport)
       end
 
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 end
 
 RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
-  subject(:writer) { described_class.new(options) }
+  subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
 
   let(:options) { {} }
 
@@ -559,7 +559,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
 
   describe 'integration tests' do
     let(:options) { { transport: transport, fork_policy: fork_policy } }
-    let(:transport) { Datadog::Tracing::Transport::HTTP.default { |t| t.adapter :test, output } }
+    let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) { |t| t.adapter :test, output } }
     let(:output) { [] }
 
     describe 'forking' do

--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
 
   let(:hostname) { 'http://127.0.0.1' }
   let(:writer) do
-    Datadog::Tracing::Writer.new.tap do |w|
+    Datadog::Tracing::Writer.new(agent_settings: test_agent_settings).tap do |w|
       # write some stuff to trigger a #start
       w.write(Datadog::Tracing::TraceSegment.new([]))
 

--- a/spec/datadog/tracing/writer_spec.rb
+++ b/spec/datadog/tracing/writer_spec.rb
@@ -16,7 +16,7 @@ require 'datadog/tracing/transport/traces'
 
 RSpec.describe Datadog::Tracing::Writer do
   describe 'instance' do
-    subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
+    subject(:writer) { described_class.new({ agent_settings: test_agent_settings }.update(options)) }
 
     let(:options) { { transport: transport } }
     let(:transport) { instance_double(Datadog::Tracing::Transport::Traces::Transport) }

--- a/spec/datadog/tracing/writer_spec.rb
+++ b/spec/datadog/tracing/writer_spec.rb
@@ -16,7 +16,7 @@ require 'datadog/tracing/transport/traces'
 
 RSpec.describe Datadog::Tracing::Writer do
   describe 'instance' do
-    subject(:writer) { described_class.new(options) }
+    subject(:writer) { described_class.new({agent_settings: test_agent_settings}.update(options)) }
 
     let(:options) { { transport: transport } }
     let(:transport) { instance_double(Datadog::Tracing::Transport::Traces::Transport) }
@@ -29,7 +29,7 @@ RSpec.describe Datadog::Tracing::Writer do
         context 'and default transport options' do
           it do
             expect(Datadog::Tracing::Transport::HTTP).to receive(:default) do |**options|
-              expect(options).to be_empty
+              expect(options).to eq(agent_settings: test_agent_settings)
             end
 
             writer

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -8,9 +8,14 @@ module TracerHelpers
     @tracer ||= new_tracer
   end
 
+  def test_agent_settings
+    settings = Datadog::Core::Configuration::Settings.new
+    Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
+  end
+
   def new_tracer(options = {})
     writer = FauxWriter.new(
-      transport: Datadog::Tracing::Transport::HTTP.default do |t|
+      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
         t.adapter :test
       end
     )
@@ -21,7 +26,7 @@ module TracerHelpers
 
   def get_test_writer(options = {})
     options = {
-      transport: Datadog::Tracing::Transport::HTTP.default do |t|
+      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
         t.adapter :test
       end
     }.merge(options)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Removes the agent settings defaulting hack from the codebase. Agent settings should be passed down from component construction into transports in order to respect user configuration.

**Motivation:**
Continued DRY refactoring of transport code to support dynamic instrumentation
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
I *think* this PR does not affect customers but not entirely sure.

I would like to remove `transport_options` in a subsequent PR.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
