### PR TITLE
Add AppSec RASP SQLI remote capability

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: ruby-enable-sql-injection-tests # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: ruby-enable-sql-injection-tests # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   changes:

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -24,6 +24,7 @@ module Datadog
         CAP_ASM_CUSTOM_BLOCKING_RESPONSE  = 1 << 9   # supports custom http code or redirect sa blocking response
         CAP_ASM_TRUSTED_IPS               = 1 << 10  # supports trusted ip
         CAP_ASM_RASP_SSRF                 = 1 << 23  # support for server-side request forgery exploit prevention rules
+        CAP_ASM_RASP_SQLI                 = 1 << 21  # support for SQL injection exploit prevention rules
 
         # TODO: we need to dynamically add CAP_ASM_ACTIVATION once we support it
         ASM_CAPABILITIES = [
@@ -37,6 +38,7 @@ module Datadog
           CAP_ASM_CUSTOM_BLOCKING_RESPONSE,
           CAP_ASM_TRUSTED_IPS,
           CAP_ASM_RASP_SSRF,
+          CAP_ASM_RASP_SQLI,
         ].freeze
 
         ASM_PRODUCTS = [

--- a/sig/datadog/appsec/remote.rbs
+++ b/sig/datadog/appsec/remote.rbs
@@ -31,6 +31,8 @@ module Datadog
 
       CAP_ASM_RASP_SSRF: Integer
 
+      CAP_ASM_RASP_SQLI: Integer
+
       ASM_CAPABILITIES: Array[Integer]
 
       ASM_PRODUCTS: ::Array[String]

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::AppSec::Remote do
       end
 
       it 'returns capabilities' do
-        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024, 2_097_152, 8_388_608])
+        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024, 8_388_608, 2_097_152])
       end
     end
   end

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::AppSec::Remote do
       end
 
       it 'returns capabilities' do
-        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024, 8_388_608])
+        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024, 2_097_152, 8_388_608])
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
This PR adds a remote capability for AppSec SQL injection exploit prevention.

**Motivation:**
We have instrumentation for ActiveRecord to detect SQL injection.

**Change log entry**
None. This is internal change.

**Additional Notes:**
**Don't merge before #4269**

**How to test the change?**
CI is enough.