### PR TITLE
Add AppSec server-side request forgery remote capability

### DIFF
--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -23,6 +23,7 @@ module Datadog
         CAP_ASM_CUSTOM_RULES              = 1 << 8   # accept custom rules
         CAP_ASM_CUSTOM_BLOCKING_RESPONSE  = 1 << 9   # supports custom http code or redirect sa blocking response
         CAP_ASM_TRUSTED_IPS               = 1 << 10  # supports trusted ip
+        CAP_ASM_RASP_SSRF                 = 1 << 23  # support for server-side request forgery exploit prevention rules
 
         # TODO: we need to dynamically add CAP_ASM_ACTIVATION once we support it
         ASM_CAPABILITIES = [
@@ -35,6 +36,7 @@ module Datadog
           CAP_ASM_CUSTOM_RULES,
           CAP_ASM_CUSTOM_BLOCKING_RESPONSE,
           CAP_ASM_TRUSTED_IPS,
+          CAP_ASM_RASP_SSRF,
         ].freeze
 
         ASM_PRODUCTS = [

--- a/sig/datadog/appsec/remote.rbs
+++ b/sig/datadog/appsec/remote.rbs
@@ -29,6 +29,8 @@ module Datadog
 
       CAP_ASM_TRUSTED_IPS: Integer
 
+      CAP_ASM_RASP_SSRF: Integer
+
       ASM_CAPABILITIES: Array[Integer]
 
       ASM_PRODUCTS: ::Array[String]

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::AppSec::Remote do
       end
 
       it 'returns capabilities' do
-        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024])
+        expect(described_class.capabilities).to eq([4, 128, 16, 32, 64, 8, 256, 512, 1024, 8_388_608])
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
This PR adds a remote capability for AppSec server-side request forgery exploit prevention.

**Motivation:**
We have instrumentation for Faraday, Excon, and RestClient to detect SSRF attacks.

**Change log entry**
None. This is internal change.

**Additional Notes:**
None.

**How to test the change?**
CI is enough.