### PR TITLE
[PROF-11405] Revert "Temporary disable benchmark to make CI happy", second try

### DIFF
--- a/benchmarks/profiling_string_storage_intern.rb
+++ b/benchmarks/profiling_string_storage_intern.rb
@@ -7,11 +7,6 @@ require_relative 'benchmarks_helper'
 
 # This benchmark measures the performance of string storage-related APIs
 
-# Temporary hack to make CI happy. Our CI tries to compare benchmarks between master and branches, and if benchmarks
-# are not backwards-compatible between them (e.g. a new API was added...) it breaks. As a workaround, I'm disabling this
-# benchmark so we can merge it to master, and then I'll follow up with a micro-PR to re-enable it.
-TEMPORARY_DISABLE_BENCHMARK = true
-
 class ProfilerStringStorageIntern
   def initialize
     @recorder = Datadog::Profiling::StackRecorder.for_testing(heap_samples_enabled: true)
@@ -24,7 +19,7 @@ class ProfilerStringStorageIntern
         **benchmark_time,
       )
       x.report('intern_all 1000 repeated strings') do
-        Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(@recorder, "hello, world!", 1000, true) unless TEMPORARY_DISABLE_BENCHMARK
+        Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(@recorder, "hello, world!", 1000, true)
       end
 
       x.save! "#{File.basename(__FILE__)}-1-results.json" unless VALIDATE_BENCHMARK_MODE
@@ -45,11 +40,11 @@ class ProfilerStringStorageIntern
         new_strings = strings_to_intern - existing_strings
 
         new_strings.times do |i|
-          Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(recorder, ("%010d" % i), 1, false) unless TEMPORARY_DISABLE_BENCHMARK
+          Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(recorder, ("%010d" % i), 1, false)
         end
 
         existing_strings.times do |i|
-          Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(recorder, "hello, world!", 1, false) unless TEMPORARY_DISABLE_BENCHMARK
+          Datadog::Profiling::StackRecorder::Testing._native_benchmark_intern(recorder, "hello, world!", 1, false)
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

This reverts commit 569bf568b80e9615027a8d0c41a8a941deeb9981.

We had previously reverted that commit in
https://github.com/DataDog/dd-trace-rb/pull/4376 but due to a bug had to undo all the heap profiling-related changes in https://github.com/DataDog/dd-trace-rb/pull/4409 .

After https://github.com/DataDog/dd-trace-rb/pull/4460 gets merged, we can finally enable this benchmark again.

**Motivation:**

The benchmark was disabled for the reason mentioned in the comment.

**Change log entry**
None.

**Additional Notes:**

I'm going to open this PR stacked on top of
https://github.com/DataDog/dd-trace-rb/pull/4460, but this PR should only be merged after that other PR is merged to master.

**How to test the change?**

Validate this benchmark is now running in the benchmarking platform results page.