### PR TITLE
Add a new experimental flag DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED flag

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2690,6 +2690,11 @@ Datadog.configure do |c|
   # You can also set DD_RUNTIME_METRICS_ENABLED=true to configure this.
   c.runtime_metrics.enabled = true
 
+  # Optionally, you can configure runtime metrics to generate an additional `runtime-id` tag
+  # on the generated metrics, which allows you to filter metrics at the individual process level.
+  # You can also set DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED=true to configure this.
+  c.runtime_metrics.experimental_runtime_id_enabled = true
+
   # Optionally, you can configure the Statsd instance used for sending runtime metrics.
   # Statsd is automatically configured with default settings if `dogstatsd-ruby` is available.
   # You can configure with host and port of Datadog Agent; defaults to 'localhost:8125'.

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -45,6 +45,7 @@ module Datadog
             options = { enabled: settings.runtime_metrics.enabled }
             options[:statsd] = settings.runtime_metrics.statsd unless settings.runtime_metrics.statsd.nil?
             options[:services] = [settings.service] unless settings.service.nil?
+            options[:experimental_runtime_id_enabled] = settings.runtime_metrics.experimental_runtime_id_enabled
 
             Core::Runtime::Metrics.new(logger: logger, **options)
           end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -570,6 +570,12 @@ module Datadog
             o.type :bool
           end
 
+          option :experimental_runtime_id_enabled do |o|
+            o.type :bool
+            o.env 'DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED'
+            o.default false
+          end
+
           option :opts, default: {}, type: :hash
           option :statsd
         end

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -21,6 +21,9 @@ module Datadog
           @services = Set.new(options.fetch(:services, []))
           @service_tags = nil
           compile_service_tags!
+
+          # Initialize the collection of runtime-id
+          @runtime_id_enabled = options.fetch(:experimental_runtime_id_enabled, false)
         end
 
         # Associate service with runtime metrics
@@ -105,6 +108,9 @@ module Datadog
 
             # Add services dynamically because they might change during runtime.
             options[:tags].concat(service_tags) unless service_tags.nil?
+
+            # Add runtime-id dynamically because it might change during runtime.
+            options[:tags].concat(["runtime-id:#{Core::Environment::Identity.id}"]) if @runtime_id_enabled
           end
         end
 
@@ -112,7 +118,8 @@ module Datadog
 
         attr_reader \
           :service_tags,
-          :services
+          :services,
+          :runtime_id_enabled
 
         def compile_service_tags!
           @service_tags = services.to_a.collect do |service|

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new runtime metrics' do
         let(:runtime_metrics) { instance_double(Datadog::Core::Runtime::Metrics) }
-        let(:default_options) { { enabled: settings.runtime_metrics.enabled, services: [settings.service] } }
+        let(:default_options) { { enabled: settings.runtime_metrics.enabled, services: [settings.service], experimental_runtime_id_enabled: settings.runtime_metrics.experimental_runtime_id_enabled } }
         let(:options) { {} }
 
         before do
@@ -446,6 +446,20 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         it_behaves_like 'new runtime metrics' do
           let(:options) { { statsd: statsd } }
+        end
+      end
+
+      context 'with :experimental_runtime_id_enabled' do
+        let(:experimental_runtime_id_enabled) { double('experimental_runtime_id_enabled') }
+
+        before do
+          allow(settings.runtime_metrics)
+            .to receive(:experimental_runtime_id_enabled)
+            .and_return(experimental_runtime_id_enabled)
+        end
+
+        it_behaves_like 'new runtime metrics' do
+          let(:options) { { experimental_runtime_id_enabled: experimental_runtime_id_enabled } }
         end
       end
     end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -391,7 +391,11 @@ RSpec.describe Datadog::Core::Configuration::Components do
     context 'given settings' do
       shared_examples_for 'new runtime metrics' do
         let(:runtime_metrics) { instance_double(Datadog::Core::Runtime::Metrics) }
-        let(:default_options) { { enabled: settings.runtime_metrics.enabled, services: [settings.service], experimental_runtime_id_enabled: settings.runtime_metrics.experimental_runtime_id_enabled } }
+        let(:default_options) do
+          { enabled: settings.runtime_metrics.enabled,
+            services: [settings.service],
+            experimental_runtime_id_enabled: settings.runtime_metrics.experimental_runtime_id_enabled, }
+        end
         let(:options) { {} }
 
         before do

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
       context 'given :experimental_runtime_id_enabled' do
         let(:options) { super().merge(experimental_runtime_id_enabled: runtime_id_enabled) }
         let(:runtime_id_enabled) { true }
-  
+
         it do
           is_expected.to include(*Datadog::Core::Metrics::Client.default_metric_options[:tags])
           is_expected.to include('language:ruby')

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -306,10 +306,22 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
     describe ':tags' do
       subject(:default_tags) { default_metric_options[:tags] }
 
+      context 'given :experimental_runtime_id_enabled' do
+        let(:options) { super().merge(experimental_runtime_id_enabled: runtime_id_enabled) }
+        let(:runtime_id_enabled) { true }
+  
+        it do
+          is_expected.to include(*Datadog::Core::Metrics::Client.default_metric_options[:tags])
+          is_expected.to include('language:ruby')
+          is_expected.to include(/\Aruntime-id:/o)
+        end
+      end
+
       context 'when no services have been registered' do
         it do
           is_expected.to include(*Datadog::Core::Metrics::Client.default_metric_options[:tags])
           is_expected.to include('language:ruby')
+          is_expected.to_not include(/\Aruntime-id:/o)
         end
       end
 
@@ -322,6 +334,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
           is_expected.to include(*Datadog::Core::Metrics::Client.default_metric_options[:tags])
           is_expected.to include('language:ruby')
           is_expected.to include(*services.collect { |service| "service:#{service}" })
+          is_expected.to_not include(/\Aruntime-id:/o)
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
Adds a new flag `DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED` to enable runtime ID collection for runtime metrics. This flag is disabled by default.

**Motivation:**
We ultimately want to collect the `runtime-id` tag by default, so this will allow us to collect these tags on an opt-in basis and give us better data to evaluate its impact on metrics collection.

**Change log entry**
Since this adds a feature flag, <!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
This avoids adding the name `DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED` to a const because this flag may not be necessary if we determine we can enable this by default. If that's an issue, I can change that.

[APMAPI-1225]

**How to test the change?**
This PR contains unit tests to assert that the `runtime-id` tag is included in the set of default tags from the `Datadog::Core::Runtime::Metrics` instance. Since I'm new to the dd-trace-rb repo, I'm not sure what other tests you'd like to see. Feedback is welcome!


[APMAPI-1225]: https://datadoghq.atlassian.net/browse/APMAPI-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ