### PR TITLE
[NO-TICKET] Adjust leaking thread detection for new Rails

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -159,7 +159,7 @@ RSpec.configure do |config|
           # WEBrick server thread
           t[:WEBrickSocket] ||
           # Rails connection reaper
-          backtrace.find { |b| b.include?('lib/active_record/connection_adapters/abstract/connection_pool.rb') } ||
+          backtrace.find { |b| b =~ %r{lib/active_record/connection_adapters/abstract/connection_pool(/reaper)?.rb} } ||
           # Ruby JetBrains debugger
           (t.class.name && t.class.name.include?('DebugThread')) ||
           # Categorized as a known leaky thread


### PR DESCRIPTION
**What does this PR do?**

This will fix the warning about the leaking threads in the tests for `ActiveRecord` connection reaper.

**Motivation:**

Result of the discussion with guild regarding that issue. It turns out we already was ignoring the reaper, but only for the older versions of `ActiveRecord`.

**Change log entry**

No. Internal change

**Additional Notes:**

None.

**How to test the change?**

CI