### PR TITLE
Update dependabot for composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       gh-actions-packages:
         patterns:


### PR DESCRIPTION
**What does this PR do?**

Currently, dependabot only updating `.github/workflows` , however, there are some composite actions should be subject to updated as well.

**Change log entry**
None.