### PR TITLE
DEBUG-3568 Inject logger into transport code

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -74,6 +74,9 @@ target :datadog do
   ignore 'lib/datadog/core/metrics/options.rb'
   # steep fails in this file due to https://github.com/soutaro/steep/issues/1231
   ignore 'lib/datadog/core/remote/tie.rb'
+  # steep gets lost in module inclusions
+  ignore 'lib/datadog/core/remote/transport/http/config.rb'
+  ignore 'lib/datadog/core/remote/transport/http/negotiation.rb'
   ignore 'lib/datadog/core/runtime/ext.rb'
   ignore 'lib/datadog/core/runtime/metrics.rb'
   ignore 'lib/datadog/core/transport/http/adapters/net.rb'

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -102,7 +102,7 @@ module Datadog
           agent_settings = AgentSettingsResolver.call(settings, logger: @logger)
 
           # Exposes agent capability information for detection by any components
-          @agent_info = Core::Environment::AgentInfo.new(agent_settings)
+          @agent_info = Core::Environment::AgentInfo.new(agent_settings, logger: @logger)
 
           @telemetry = self.class.build_telemetry(settings, agent_settings, @logger)
 

--- a/lib/datadog/core/environment/agent_info.rb
+++ b/lib/datadog/core/environment/agent_info.rb
@@ -51,11 +51,12 @@ module Datadog
       #
       # @see https://github.com/DataDog/datadog-agent/blob/f07df0a3c1fca0c83b5a15f553bd994091b0c8ac/pkg/trace/api/info.go#L20
       class AgentInfo
-        attr_reader :agent_settings
+        attr_reader :agent_settings, :logger
 
-        def initialize(agent_settings)
+        def initialize(agent_settings, logger:)
           @agent_settings = agent_settings
-          @client = Remote::Transport::HTTP.root(agent_settings: agent_settings)
+          @logger = logger
+          @client = Remote::Transport::HTTP.root(agent_settings: agent_settings, logger: logger)
         end
 
         # Fetches the information from the agent.

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -18,8 +18,8 @@ module Datadog
         def initialize(settings, capabilities, agent_settings, logger:)
           @logger = logger
 
-          negotiation = Negotiation.new(settings, agent_settings)
-          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(agent_settings: agent_settings)
+          negotiation = Negotiation.new(settings, agent_settings, logger: logger)
+          transport_v7 = Datadog::Core::Remote::Transport::HTTP.v7(agent_settings: agent_settings, logger: logger)
 
           @barrier = Barrier.new(settings.remote.boot_timeout_seconds)
 
@@ -46,7 +46,7 @@ module Datadog
               # In case of unexpected errors, reset the negotiation object
               # given external conditions have changed and the negotiation
               # negotiation object stores error logging state that should be reset.
-              negotiation = Negotiation.new(settings, agent_settings)
+              negotiation = Negotiation.new(settings, agent_settings, logger: logger)
 
               # Transient errors due to network or agent. Logged the error but not via telemetry
               logger.error do

--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -7,8 +7,11 @@ module Datadog
     module Remote
       # Endpoint negotiation
       class Negotiation
-        def initialize(_settings, agent_settings, suppress_logging: {})
-          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(agent_settings: agent_settings)
+        attr_reader :logger
+
+        def initialize(_settings, agent_settings, logger:, suppress_logging: {})
+          @logger = logger
+          @transport_root = Datadog::Core::Remote::Transport::HTTP.root(agent_settings: agent_settings, logger: logger)
           @logged = suppress_logging
         end
 
@@ -17,7 +20,7 @@ module Datadog
 
           if res.internal_error? && network_error?(res.error)
             unless @logged[:agent_unreachable]
-              Datadog.logger.warn { "agent unreachable: cannot negotiate #{path}" }
+              logger.warn { "agent unreachable: cannot negotiate #{path}" }
               @logged[:agent_unreachable] = true
             end
 
@@ -26,7 +29,7 @@ module Datadog
 
           if res.not_found?
             unless @logged[:no_info_endpoint]
-              Datadog.logger.warn { "agent reachable but has no /info endpoint: cannot negotiate #{path}" }
+              logger.warn { "agent reachable but has no /info endpoint: cannot negotiate #{path}" }
               @logged[:no_info_endpoint] = true
             end
 
@@ -35,7 +38,7 @@ module Datadog
 
           unless res.ok?
             unless @logged[:unexpected_response]
-              Datadog.logger.warn { "agent reachable but unexpected response: cannot negotiate #{path}" }
+              logger.warn { "agent reachable but unexpected response: cannot negotiate #{path}" }
               @logged[:unexpected_response] = true
             end
 
@@ -44,14 +47,14 @@ module Datadog
 
           unless res.endpoints.include?(path)
             unless @logged[:no_config_endpoint]
-              Datadog.logger.warn { "agent reachable but does not report #{path}" }
+              logger.warn { "agent reachable but does not report #{path}" }
               @logged[:no_config_endpoint] = true
             end
 
             return false
           end
 
-          Datadog.logger.debug { "agent reachable and reports #{path}" }
+          logger.debug { "agent reachable and reports #{path}" }
 
           true
         end

--- a/lib/datadog/core/remote/transport/config.rb
+++ b/lib/datadog/core/remote/transport/config.rb
@@ -32,12 +32,13 @@ module Datadog
 
           # Config transport
           class Transport
-            attr_reader :client, :apis, :default_api, :current_api_id
+            attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-            def initialize(apis, default_api)
+            def initialize(apis, default_api, logger)
               @apis = apis
+              @logger = logger
 
-              @client = HTTP::Client.new(current_api)
+              @client = HTTP::Client.new(current_api, logger)
             end
 
             ##### there is only one transport! it's negotiation!

--- a/lib/datadog/core/remote/transport/http.rb
+++ b/lib/datadog/core/remote/transport/http.rb
@@ -33,12 +33,14 @@ module Datadog
           # Pass a block to override any settings.
           def root(
             agent_settings:,
+            logger:,
             api_version: nil,
             headers: nil
           )
             Core::Transport::HTTP.build(
               api_instance_class: API::Instance,
               agent_settings: agent_settings,
+              logger: logger,
               api_version: api_version,
               headers: headers
             ) do |transport|
@@ -55,12 +57,14 @@ module Datadog
           # Pass a block to override any settings.
           def v7(
             agent_settings:,
+            logger:,
             api_version: nil,
             headers: nil
           )
             Core::Transport::HTTP.build(
               api_instance_class: API::Instance,
               agent_settings: agent_settings,
+              logger: logger,
               api_version: api_version,
               headers: headers
             ) do |transport|

--- a/lib/datadog/core/remote/transport/http/client.rb
+++ b/lib/datadog/core/remote/transport/http/client.rb
@@ -15,10 +15,11 @@ module Datadog
         module HTTP
           # Routes, encodes, and sends tracer data to the trace agent via HTTP.
           class Client
-            attr_reader :api
+            attr_reader :api, :logger
 
-            def initialize(api)
+            def initialize(api, logger)
               @api = api
+              @logger = logger
             end
 
             def send_request(request, &block)
@@ -32,7 +33,7 @@ module Datadog
                 "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
                   "Location: #{Array(e.backtrace).first}"
 
-              Datadog.logger.debug(message)
+              logger.debug(message)
 
               Datadog::Core::Transport::InternalErrorResponse.new(e)
             end

--- a/lib/datadog/core/remote/transport/negotiation.rb
+++ b/lib/datadog/core/remote/transport/negotiation.rb
@@ -49,12 +49,13 @@ module Datadog
 
           # Negotiation transport
           class Transport
-            attr_reader :client, :apis, :default_api, :current_api_id
+            attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-            def initialize(apis, default_api)
+            def initialize(apis, default_api, logger)
               @apis = apis
+              @logger = logger
 
-              @client = HTTP::Client.new(current_api)
+              @client = HTTP::Client.new(current_api, logger)
             end
 
             def send_info

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -29,8 +29,8 @@ module Datadog
         # Helper function that delegates to Builder.new
         # but is under HTTP namespace so that client code requires this file
         # to get the adapters configured, and not the builder directly.
-        def build(api_instance_class:, agent_settings:, api_version: nil, headers: nil, &block)
-          Builder.new(api_instance_class: api_instance_class) do |transport|
+        def build(api_instance_class:, agent_settings:, logger:, api_version: nil, headers: nil, &block)
+          Builder.new(api_instance_class: api_instance_class, logger: logger) do |transport|
             transport.adapter(agent_settings)
             transport.headers(default_headers)
 

--- a/lib/datadog/core/transport/http/builder.rb
+++ b/lib/datadog/core/transport/http/builder.rb
@@ -18,9 +18,10 @@ module Datadog
             :api_options,
             :default_adapter,
             :default_api,
-            :default_headers
+            :default_headers,
+            :logger
 
-          def initialize(api_instance_class:)
+          def initialize(api_instance_class:, logger:)
             # Global settings
             @default_adapter = nil
             @default_headers = {}
@@ -33,6 +34,7 @@ module Datadog
             @api_options = {}
 
             @api_instance_class = api_instance_class
+            @logger = logger
 
             yield(self) if block_given?
           end
@@ -86,7 +88,7 @@ module Datadog
           def to_transport(klass)
             raise NoDefaultApiError if @default_api.nil?
 
-            klass.new(to_api_instances, @default_api)
+            klass.new(to_api_instances, @default_api, logger)
           end
 
           def to_api_instances

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -171,7 +171,7 @@ module Datadog
       attr_reader :last_sent
 
       def status_transport
-        @status_transport ||= DI::Transport::HTTP.diagnostics(agent_settings: agent_settings)
+        @status_transport ||= DI::Transport::HTTP.diagnostics(agent_settings: agent_settings, logger: logger)
       end
 
       def do_send_status(batch)
@@ -179,7 +179,7 @@ module Datadog
       end
 
       def snapshot_transport
-        @snapshot_transport ||= DI::Transport::HTTP.input(agent_settings: agent_settings)
+        @snapshot_transport ||= DI::Transport::HTTP.input(agent_settings: agent_settings, logger: logger)
       end
 
       def do_send_snapshot(batch)

--- a/lib/datadog/di/transport/diagnostics.rb
+++ b/lib/datadog/di/transport/diagnostics.rb
@@ -15,12 +15,13 @@ module Datadog
         end
 
         class Transport
-          attr_reader :client, :apis, :default_api, :current_api_id
+          attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-          def initialize(apis, default_api)
+          def initialize(apis, default_api, logger)
             @apis = apis
+            @logger = logger
 
-            @client = HTTP::Client.new(current_api)
+            @client = HTTP::Client.new(current_api, logger)
           end
 
           def current_api

--- a/lib/datadog/di/transport/http.rb
+++ b/lib/datadog/di/transport/http.rb
@@ -22,10 +22,12 @@ module Datadog
         # Pass a block to override any settings.
         def diagnostics(
           agent_settings:,
+          logger:,
           api_version: nil,
           headers: nil
         )
           Core::Transport::HTTP.build(api_instance_class: Diagnostics::API::Instance,
+            logger: logger,
             agent_settings: agent_settings, api_version: api_version, headers: headers) do |transport|
             apis = API.defaults
 
@@ -40,10 +42,12 @@ module Datadog
         # Pass a block to override any settings.
         def input(
           agent_settings:,
+          logger:,
           api_version: nil,
           headers: nil
         )
           Core::Transport::HTTP.build(api_instance_class: Input::API::Instance,
+            logger: logger,
             agent_settings: agent_settings, api_version: api_version, headers: headers) do |transport|
             apis = API.defaults
 

--- a/lib/datadog/di/transport/http/client.rb
+++ b/lib/datadog/di/transport/http/client.rb
@@ -14,10 +14,11 @@ module Datadog
       module HTTP
         # Routes, encodes, and sends DI data to the trace agent via HTTP.
         class Client
-          attr_reader :api
+          attr_reader :api, :logger
 
-          def initialize(api)
+          def initialize(api, logger)
             @api = api
+            @logger = logger
           end
 
           def send_request(request, &block)
@@ -31,7 +32,7 @@ module Datadog
               "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
                 "Location: #{Array(e.backtrace).first}"
 
-            Datadog.logger.debug(message)
+            logger.debug(message)
 
             Datadog::Core::Transport::InternalErrorResponse.new(e)
           end

--- a/lib/datadog/di/transport/input.rb
+++ b/lib/datadog/di/transport/input.rb
@@ -15,12 +15,13 @@ module Datadog
         end
 
         class Transport
-          attr_reader :client, :apis, :default_api, :current_api_id
+          attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-          def initialize(apis, default_api)
+          def initialize(apis, default_api, logger)
             @apis = apis
+            @logger = logger
 
-            @client = HTTP::Client.new(current_api)
+            @client = HTTP::Client.new(current_api, logger)
           end
 
           def current_api

--- a/lib/datadog/tracing/sync_writer.rb
+++ b/lib/datadog/tracing/sync_writer.rb
@@ -32,7 +32,7 @@ module Datadog
         @agent_settings = agent_settings
 
         @transport = transport || begin
-          Transport::HTTP.default(agent_settings: agent_settings, **transport_options)
+          Transport::HTTP.default(agent_settings: agent_settings, logger: logger, **transport_options)
         end
 
         @events = Writer::Events.new

--- a/lib/datadog/tracing/transport/http.rb
+++ b/lib/datadog/tracing/transport/http.rb
@@ -18,12 +18,14 @@ module Datadog
         # Pass a block to override any settings.
         def default(
           agent_settings:,
+          logger:,
           api_version: nil,
           headers: nil
         )
           Core::Transport::HTTP.build(
             api_instance_class: Traces::API::Instance,
             agent_settings: agent_settings,
+            logger: logger,
             api_version: api_version,
             headers: headers
           ) do |transport|

--- a/lib/datadog/tracing/transport/http/client.rb
+++ b/lib/datadog/tracing/transport/http/client.rb
@@ -12,10 +12,11 @@ module Datadog
         class Client
           include Datadog::Tracing::Transport::HTTP::Statistics
 
-          attr_reader :api
+          attr_reader :api, :logger
 
-          def initialize(api)
+          def initialize(api, logger)
             @api = api
+            @logger = logger
           end
 
           def send_request(request, &block)
@@ -36,10 +37,10 @@ module Datadog
 
             # Log error
             if stats.consecutive_errors > 0
-              Datadog.logger.debug(message)
+              logger.debug(message)
             else
               # Not to report telemetry logs
-              Datadog.logger.error(message)
+              logger.error(message)
             end
 
             # Update statistics

--- a/lib/datadog/tracing/transport/traces.rb
+++ b/lib/datadog/tracing/transport/traces.rb
@@ -43,15 +43,17 @@ module Datadog
           # We set the value to a conservative 5 MiB, in case network speed is slow.
           DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
 
-          attr_reader :encoder, :max_size
+          attr_reader :encoder, :max_size, :logger
 
           #
           # Single traces larger than +max_size+ will be discarded.
           #
           # @param encoder [Datadog::Core::Encoding::Encoder]
+          # @param logger [Datadog::Core::Logger]
           # @param max_size [String] maximum acceptable payload size
-          def initialize(encoder, native_events_supported:, max_size: DEFAULT_MAX_PAYLOAD_SIZE)
+          def initialize(encoder, logger, native_events_supported:, max_size: DEFAULT_MAX_PAYLOAD_SIZE)
             @encoder = encoder
+            @logger = logger
             @native_events_supported = native_events_supported
             @max_size = max_size
           end
@@ -78,11 +80,11 @@ module Datadog
           private
 
           def encode_one(trace)
-            encoded = Encoder.encode_trace(encoder, trace, native_events_supported: @native_events_supported)
+            encoded = Encoder.encode_trace(encoder, trace, logger, native_events_supported: @native_events_supported)
 
             if encoded.size > max_size
               # This single trace is too large, we can't flush it
-              Datadog.logger.debug { "Dropping trace. Payload too large: '#{trace.inspect}'" }
+              logger.debug { "Dropping trace. Payload too large: '#{trace.inspect}'" }
               Datadog.health_metrics.transport_trace_too_large(1)
 
               return nil
@@ -96,7 +98,7 @@ module Datadog
         module Encoder
           module_function
 
-          def encode_trace(encoder, trace, native_events_supported:)
+          def encode_trace(encoder, trace, logger, native_events_supported:)
             # Format the trace for transport
             TraceFormatter.format!(trace)
 
@@ -106,7 +108,7 @@ module Datadog
             # Encode the trace
             encoder.encode(serializable_trace).tap do |encoded|
               # Print the actual serialized trace, since the encoder can change make non-trivial changes
-              Datadog.logger.debug { "Flushing trace: #{encoder.decode(encoded)}" }
+              logger.debug { "Flushing trace: #{encoder.decode(encoded)}" }
             end
           end
         end
@@ -117,11 +119,12 @@ module Datadog
         # batches of traces into smaller chunks and handles
         # API version downgrade handshake.
         class Transport
-          attr_reader :client, :apis, :default_api, :current_api_id
+          attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-          def initialize(apis, default_api)
+          def initialize(apis, default_api, logger)
             @apis = apis
             @default_api = default_api
+            @logger = logger
 
             change_api!(default_api)
           end
@@ -130,6 +133,7 @@ module Datadog
             encoder = current_api.encoder
             chunker = Datadog::Tracing::Transport::Traces::Chunker.new(
               encoder,
+              logger,
               native_events_supported: native_events_supported?
             )
 
@@ -190,7 +194,7 @@ module Datadog
             raise UnknownApiVersionError, api_id unless apis.key?(api_id)
 
             @current_api_id = api_id
-            @client = HTTP::Client.new(current_api)
+            @client = HTTP::Client.new(current_api, logger)
           end
 
           # Queries the agent for native span events serialization support.

--- a/lib/datadog/tracing/workers/trace_writer.rb
+++ b/lib/datadog/tracing/workers/trace_writer.rb
@@ -29,7 +29,7 @@ module Datadog
           @agent_settings = options[:agent_settings]
 
           @transport = options.fetch(:transport) do
-            Datadog::Tracing::Transport::HTTP.default(agent_settings: agent_settings, **transport_options)
+            Datadog::Tracing::Transport::HTTP.default(agent_settings: agent_settings, logger: logger, **transport_options)
           end
         end
         # rubocop:enable Lint/MissingSuper

--- a/lib/datadog/tracing/writer.rb
+++ b/lib/datadog/tracing/writer.rb
@@ -30,7 +30,7 @@ module Datadog
 
         # transport and buffers
         @transport = options.fetch(:transport) do
-          Transport::HTTP.default(agent_settings: agent_settings, **transport_options)
+          Transport::HTTP.default(agent_settings: agent_settings, logger: logger, **transport_options)
         end
 
         @shutdown_timeout = options.fetch(:shutdown_timeout, Workers::AsyncTransport::DEFAULT_SHUTDOWN_TIMEOUT)

--- a/sig/datadog/core/environment/agent_info.rbs
+++ b/sig/datadog/core/environment/agent_info.rbs
@@ -4,7 +4,7 @@ module Datadog
       class AgentInfo
         attr_reader agent_settings: Configuration::AgentSettingsResolver::AgentSettings
 
-        def initialize: (Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
+        def initialize: (Configuration::AgentSettingsResolver::AgentSettings agent_settings, logger: Core::Logger) -> void
 
         def fetch: -> Remote::Transport::HTTP::Negotiation::Response?
       end

--- a/sig/datadog/core/remote/negotiation.rbs
+++ b/sig/datadog/core/remote/negotiation.rbs
@@ -4,8 +4,10 @@ module Datadog
       class Negotiation
         @transport_root: Datadog::Core::Remote::Transport::Negotiation::Transport
         @logged: ::Hash[::Symbol, bool]
+	
+	attr_reader logger: Core::Logger
 
-        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
+        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings, logger: Core::Logger, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
 
         def endpoint?: (::String path) -> bool
 

--- a/sig/datadog/core/remote/transport/config.rbs
+++ b/sig/datadog/core/remote/transport/config.rbs
@@ -31,6 +31,12 @@ module Datadog
 
           # Config transport
           class Transport
+            @apis: untyped
+
+            @logger: untyped
+
+            @client: untyped
+
             attr_reader client: untyped
 
             attr_reader apis: untyped
@@ -39,9 +45,9 @@ module Datadog
 
             attr_reader current_api_id: untyped
 
-            def initialize: (untyped apis, untyped default_api) -> void
+            attr_reader logger: untyped
 
-            # ### there is only one transport! it's negotiation!
+            def initialize: (untyped apis, untyped default_api, untyped logger) -> void
             def send_config: (untyped payload) -> untyped
 
             def current_api: () -> untyped

--- a/sig/datadog/core/remote/transport/http.rbs
+++ b/sig/datadog/core/remote/transport/http.rbs
@@ -3,8 +3,8 @@ module Datadog
     module Remote
       module Transport
         module HTTP
-          def self?.root: (agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
-          def self?.v7: (agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
+          def self?.root: (agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
+          def self?.v7: (agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
         end
       end
     end

--- a/sig/datadog/core/remote/transport/http/api.rbs
+++ b/sig/datadog/core/remote/transport/http/api.rbs
@@ -5,14 +5,21 @@ module Datadog
         module HTTP
           module API
             ROOT: "root"
+
             V7: "v0.7"
 
             def self?.defaults: () -> untyped
 
-            class Instance < Datadog::Core::Transport::HTTP::API::Instance
+            class Instance < Core::Transport::HTTP::API::Instance
+              include Config::API::Instance
+
+              include Negotiation::API::Instance
             end
 
-            class Spec < Datadog::Core::Transport::HTTP::API::Spec
+            class Spec < Core::Transport::HTTP::API::Spec
+              include Config::API::Spec
+
+              include Negotiation::API::Spec
             end
           end
         end

--- a/sig/datadog/core/remote/transport/http/client.rbs
+++ b/sig/datadog/core/remote/transport/http/client.rbs
@@ -4,9 +4,15 @@ module Datadog
       module Transport
         module HTTP
           class Client
+            @api: untyped
+
+            @logger: untyped
+
             attr_reader api: untyped
 
-            def initialize: (untyped api) -> void
+            attr_reader logger: untyped
+
+            def initialize: (untyped api, untyped logger) -> void
 
             def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
 

--- a/sig/datadog/core/remote/transport/http/config.rbs
+++ b/sig/datadog/core/remote/transport/http/config.rbs
@@ -7,28 +7,32 @@ module Datadog
           module Config
             # Response from HTTP transport for remote configuration
             class Response
+              @empty: untyped
+
+              @roots: untyped
+
+              @targets: untyped
+
+              @target_files: untyped
+
+              @client_configs: untyped
+
               include Datadog::Core::Transport::HTTP::Response
 
               include Core::Remote::Transport::Config::Response
 
               def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
 
-              # When an expected key is missing
+              def inspect: () -> ::String
               class KeyError < StandardError
                 def initialize: (untyped key) -> void
               end
-
-              # When an expected value type is incorrect
               class TypeError < StandardError
-                def initialize: (untyped `type`, untyped value) -> void
+                def initialize: (untyped type, untyped value) -> void
               end
-
-              # When value decoding fails
               class DecodeError < StandardError
                 def initialize: (untyped key, untyped value) -> void
               end
-
-              # When value parsing fails
               class ParseError < StandardError
                 def initialize: (untyped key, untyped value) -> void
               end
@@ -42,27 +46,31 @@ module Datadog
             module API
               # Extensions for HTTP API Spec
               module Spec
+                @config: untyped
+
                 attr_reader config: untyped
 
                 def config=: (untyped endpoint) -> untyped
 
-                def send_config: (untyped env) ?{ () -> untyped } -> untyped
+                def send_config: (untyped env) { (?) -> untyped } -> untyped
               end
 
               # Extensions for HTTP API Instance
-              module Instance : HTTP::API::Instance
+              module Instance
                 def send_config: (untyped env) -> untyped
               end
 
               # Endpoint for remote configuration
               class Endpoint < Datadog::Core::Transport::HTTP::API::Endpoint
+                @encoder: untyped
+
                 HEADER_CONTENT_TYPE: "Content-Type"
 
                 attr_reader encoder: untyped
 
                 def initialize: (untyped path, untyped encoder) -> void
 
-                def call: (untyped env) { (untyped) -> untyped } -> untyped
+                def call: (untyped env) { (?) -> untyped } -> untyped
               end
             end
           end

--- a/sig/datadog/core/remote/transport/http/negotiation.rbs
+++ b/sig/datadog/core/remote/transport/http/negotiation.rbs
@@ -5,9 +5,17 @@ module Datadog
         module HTTP
           module Negotiation
             class Response
+              @version: untyped
+
+              @endpoints: untyped
+
+              @config: untyped
+
+              @span_events: untyped
+
               include Datadog::Core::Transport::HTTP::Response
 
-              include Datadog::Core::Remote::Transport::Negotiation::Response
+              include Core::Remote::Transport::Negotiation::Response
 
               def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
             end
@@ -18,21 +26,23 @@ module Datadog
 
             module API
               module Spec
+                @info: untyped
+
                 attr_reader info: untyped
 
                 def info=: (untyped endpoint) -> untyped
 
-                def send_info: (untyped env) ?{ () -> untyped } -> untyped
+                def send_info: (untyped env) { (?) -> untyped } -> untyped
               end
 
-              module Instance : Remote::Transport::HTTP::API::Instance
+              module Instance
                 def send_info: (untyped env) -> untyped
               end
 
               class Endpoint < Datadog::Core::Transport::HTTP::API::Endpoint
                 def initialize: (untyped path) -> void
 
-                def call: (untyped env) { (untyped) -> untyped } -> untyped
+                def call: (untyped env) { (?) -> untyped } -> untyped
               end
             end
           end

--- a/sig/datadog/core/remote/transport/negotiation.rbs
+++ b/sig/datadog/core/remote/transport/negotiation.rbs
@@ -25,7 +25,9 @@ module Datadog
 
             attr_reader current_api_id: untyped
 
-            def initialize: (untyped apis, untyped default_api) -> void
+            attr_reader logger: untyped
+
+            def initialize: (untyped apis, untyped default_api, untyped logger) -> void
 
             type send_info_return = HTTP::Negotiation::Response & Core::Transport::InternalErrorResponse
 

--- a/sig/datadog/core/transport/http.rbs
+++ b/sig/datadog/core/transport/http.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Transport
       module HTTP
-        def self?.build: (api_instance_class: untyped, agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) { (untyped) -> untyped } -> HTTP::Builder
+        def self?.build: (api_instance_class: untyped, agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) { (untyped) -> untyped } -> HTTP::Builder
 
         def self?.default_headers: () -> untyped
       end

--- a/sig/datadog/core/transport/http/adapters/net.rbs
+++ b/sig/datadog/core/transport/http/adapters/net.rbs
@@ -4,6 +4,14 @@ module Datadog
       module HTTP
         module Adapters
           class Net
+            @hostname: untyped
+
+            @port: untyped
+
+            @timeout: untyped
+
+            @ssl: untyped
+
             attr_reader hostname: untyped
 
             attr_reader port: untyped
@@ -12,13 +20,11 @@ module Datadog
 
             attr_reader ssl: untyped
 
-            DEFAULT_TIMEOUT: 30
-
-            def initialize: (?untyped? hostname, ?untyped? port, **untyped options) -> void
+            def initialize: (untyped agent_settings) -> void
 
             def self.build: (untyped agent_settings) -> untyped
 
-            def open: () ?{ () -> untyped } -> untyped
+            def open: () { (?) -> untyped } -> untyped
 
             def call: (untyped env) -> untyped
 
@@ -37,7 +43,9 @@ module Datadog
             end
 
             class Response
-              include Transport::Response
+              @http_response: untyped
+
+              include Datadog::Core::Transport::Response
 
               attr_reader http_response: untyped
 

--- a/sig/datadog/core/transport/http/adapters/registry.rbs
+++ b/sig/datadog/core/transport/http/adapters/registry.rbs
@@ -10,6 +10,8 @@ module Datadog
           end
 
           class Registry
+            @adapters: untyped
+
             def initialize: () -> void
 
             def get: (untyped name) -> _Class

--- a/sig/datadog/core/transport/http/adapters/test.rbs
+++ b/sig/datadog/core/transport/http/adapters/test.rbs
@@ -4,10 +4,15 @@ module Datadog
       module HTTP
         module Adapters
           class Test
+            @buffer: untyped
+
+            @mutex: untyped
+
+            @status: untyped
+
             attr_reader buffer: untyped
 
             attr_reader status: untyped
-
             def initialize: (?untyped? buffer, **untyped options) -> void
 
             def call: (untyped env) -> untyped
@@ -19,8 +24,11 @@ module Datadog
             def set_status!: (untyped status) -> untyped
 
             def url: () -> nil
-
             class Response
+              @code: untyped
+
+              @body: untyped
+
               include Datadog::Core::Transport::Response
 
               attr_reader body: untyped

--- a/sig/datadog/core/transport/http/adapters/unix_socket.rbs
+++ b/sig/datadog/core/transport/http/adapters/unix_socket.rbs
@@ -4,22 +4,36 @@ module Datadog
       module HTTP
         module Adapters
           class UnixSocket < Adapters::Net
+            @filepath: untyped
+
+            @timeout: untyped
+
             attr_reader filepath: untyped
 
             attr_reader timeout: untyped
 
             alias uds_path filepath
-
             def initialize: (?untyped? uds_path, **untyped options) -> void
 
             def self.build: (untyped agent_settings) -> untyped
 
-            def open: () ?{ () -> untyped } -> untyped
+            def open: () { (?) -> untyped } -> untyped
 
             def url: () -> ::String
-
             class HTTP < ::Net::HTTP
-              DEFAULT_TIMEOUT: 1
+              @filepath: untyped
+
+              @read_timeout: untyped
+
+              @continue_timeout: untyped
+
+              @debug_output: untyped
+
+              @unix_socket: untyped
+
+              @socket: untyped
+
+              DEFAULT_TIMEOUT: 30
 
               attr_reader filepath: untyped
 

--- a/sig/datadog/core/transport/http/api/endpoint.rbs
+++ b/sig/datadog/core/transport/http/api/endpoint.rbs
@@ -4,6 +4,10 @@ module Datadog
       module HTTP
         module API
           class Endpoint
+            @verb: untyped
+
+            @path: untyped
+
             attr_reader verb: untyped
 
             attr_reader path: untyped

--- a/sig/datadog/core/transport/http/api/fallbacks.rbs
+++ b/sig/datadog/core/transport/http/api/fallbacks.rbs
@@ -4,6 +4,8 @@ module Datadog
       module HTTP
         module API
           module Fallbacks
+            @fallbacks: untyped
+
             def fallbacks: () -> untyped
 
             def with_fallbacks: (untyped fallbacks) -> untyped

--- a/sig/datadog/core/transport/http/api/instance.rbs
+++ b/sig/datadog/core/transport/http/api/instance.rbs
@@ -9,7 +9,6 @@ module Datadog
             @adapter: untyped
 
             @headers: untyped
-
             class EndpointNotSupportedError < StandardError
               @spec: untyped
 

--- a/sig/datadog/core/transport/http/builder.rbs
+++ b/sig/datadog/core/transport/http/builder.rbs
@@ -14,8 +14,12 @@ module Datadog
           attr_reader default_api: untyped
 
           attr_reader default_headers: untyped
+	  
+	  attr_reader logger: Core::Logger
+	  
+	  attr_reader api_instance_class: untyped
 
-          def initialize: (api_instance_class: untyped) ?{ (untyped) -> untyped } -> void
+          def initialize: (api_instance_class: untyped, logger: Core::Logger) ?{ (untyped) -> untyped } -> void
 
           def adapter: (untyped config, *untyped args, **untyped kwargs) -> untyped
 
@@ -28,37 +32,36 @@ module Datadog
           def to_transport: (untyped klass) -> untyped
 
           def to_api_instances: () -> untyped
-
-          def api_instance_class: () -> untyped
-
           class UnknownApiError < StandardError
+            @key: untyped
+
             attr_reader key: untyped
 
             def initialize: (untyped key) -> void
 
             def message: () -> ::String
           end
-
           class UnknownAdapterError < StandardError
+            @type: untyped
+
             attr_reader type: untyped
 
-            def initialize: (untyped `type`) -> void
+            def initialize: (untyped type) -> void
 
             def message: () -> ::String
           end
-
           class NoAdapterForApiError < StandardError
+            @key: untyped
+
             attr_reader key: untyped
 
             def initialize: (untyped key) -> void
 
             def message: () -> ::String
           end
-
           class NoApisError < StandardError
             def message: () -> "No APIs configured for transport!"
           end
-
           class NoDefaultApiError < StandardError
             def message: () -> "No default API configured for transport!"
           end

--- a/sig/datadog/core/transport/http/response.rbs
+++ b/sig/datadog/core/transport/http/response.rbs
@@ -3,20 +3,15 @@ module Datadog
     module Transport
       module HTTP
         module Response
+          @http_response: untyped
+
           def initialize: (untyped http_response) -> void
-
           def payload: () -> untyped
-
           def internal_error?: () -> untyped
-
           def unsupported?: () -> untyped
-
           def ok?: () -> untyped
-
           def not_found?: () -> untyped
-
           def client_error?: () -> untyped
-
           def server_error?: () -> untyped
 
           def code: () -> (untyped | nil)

--- a/sig/datadog/core/transport/parcel.rbs
+++ b/sig/datadog/core/transport/parcel.rbs
@@ -2,6 +2,8 @@ module Datadog
   module Core
     module Transport
       module Parcel
+        @data: untyped
+
         attr_reader data: untyped
 
         def initialize: (untyped data) -> void

--- a/sig/datadog/core/transport/request.rbs
+++ b/sig/datadog/core/transport/request.rbs
@@ -2,6 +2,8 @@ module Datadog
   module Core
     module Transport
       class Request
+        @parcel: untyped
+
         attr_reader parcel: untyped
 
         def initialize: (?untyped? parcel) -> void

--- a/sig/datadog/core/transport/response.rbs
+++ b/sig/datadog/core/transport/response.rbs
@@ -20,6 +20,8 @@ module Datadog
       end
 
       class InternalErrorResponse
+        @error: untyped
+
         include Response
 
         attr_reader error: Exception
@@ -27,6 +29,8 @@ module Datadog
         def initialize: (untyped error) -> void
 
         def internal_error?: () -> true
+
+        def to_s: () -> ::String
 
         def inspect: () -> ::String
       end

--- a/sig/datadog/di/transport/diagnostics.rbs
+++ b/sig/datadog/di/transport/diagnostics.rbs
@@ -12,6 +12,8 @@ module Datadog
         class Transport
           @apis: untyped
 
+          @logger: untyped
+
           @client: untyped
 
           attr_reader client: untyped
@@ -22,7 +24,9 @@ module Datadog
 
           attr_reader current_api_id: untyped
 
-          def initialize: (untyped apis, untyped default_api) -> void
+          attr_reader logger: untyped
+
+          def initialize: (untyped apis, untyped default_api, untyped logger) -> void
 
           def current_api: () -> untyped
 

--- a/sig/datadog/di/transport/http.rbs
+++ b/sig/datadog/di/transport/http.rbs
@@ -2,8 +2,8 @@ module Datadog
   module DI
     module Transport
       module HTTP
-        def self?.diagnostics: (agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
-        def self?.input: (agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
+        def self?.diagnostics: (agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
+        def self?.input: (agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
       end
     end
   end

--- a/sig/datadog/di/transport/http/api.rbs
+++ b/sig/datadog/di/transport/http/api.rbs
@@ -8,18 +8,6 @@ module Datadog
           INPUT: "input"
 
           def self?.defaults: () -> untyped
-
-          class Instance < Core::Transport::HTTP::API::Instance
-            include Diagnostics::API::Instance
-
-            include Input::API::Instance
-          end
-
-          class Spec < Core::Transport::HTTP::API::Spec
-            include Diagnostics::API::Spec
-
-            include Input::API::Spec
-          end
         end
       end
     end

--- a/sig/datadog/di/transport/http/client.rbs
+++ b/sig/datadog/di/transport/http/client.rbs
@@ -5,9 +5,13 @@ module Datadog
         class Client
           @api: untyped
 
+          @logger: untyped
+
           attr_reader api: untyped
 
-          def initialize: (untyped api) -> void
+          attr_reader logger: untyped
+
+          def initialize: (untyped api, untyped logger) -> void
 
           def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
 

--- a/sig/datadog/di/transport/http/diagnostics.rbs
+++ b/sig/datadog/di/transport/http/diagnostics.rbs
@@ -8,11 +8,11 @@ module Datadog
           end
 
           module API
-            module Instance
+            class Instance < Core::Transport::HTTP::API::Instance
               def send_diagnostics: (untyped env) -> untyped
             end
 
-            module Spec
+            class Spec < Core::Transport::HTTP::API::Spec
               attr_accessor diagnostics: untyped
 
               def send_diagnostics: (untyped env) { (?) -> untyped } -> untyped

--- a/sig/datadog/di/transport/http/input.rbs
+++ b/sig/datadog/di/transport/http/input.rbs
@@ -8,11 +8,11 @@ module Datadog
           end
 
           module API
-            module Instance
+            class Instance < Core::Transport::HTTP::API::Instance
               def send_input: (untyped env) -> untyped
             end
 
-            module Spec
+            class Spec < Core::Transport::HTTP::API::Spec
               attr_accessor input: untyped
 
               def send_input: (untyped env) { (?) -> untyped } -> untyped

--- a/sig/datadog/di/transport/input.rbs
+++ b/sig/datadog/di/transport/input.rbs
@@ -12,6 +12,8 @@ module Datadog
         class Transport
           @apis: untyped
 
+          @logger: untyped
+
           @client: untyped
 
           attr_reader client: untyped
@@ -22,7 +24,9 @@ module Datadog
 
           attr_reader current_api_id: untyped
 
-          def initialize: (untyped apis, untyped default_api) -> void
+          attr_reader logger: untyped
+
+          def initialize: (untyped apis, untyped default_api, untyped logger) -> void
 
           def current_api: () -> untyped
 

--- a/sig/datadog/tracing/transport/http.rbs
+++ b/sig/datadog/tracing/transport/http.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Tracing
     module Transport
       module HTTP
-        def self?.default: (agent_settings: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
+        def self?.default: (agent_settings: untyped, logger: untyped, ?api_version: untyped?, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
       end
     end
   end

--- a/sig/datadog/tracing/transport/http/api.rbs
+++ b/sig/datadog/tracing/transport/http/api.rbs
@@ -8,12 +8,6 @@ module Datadog
           V3: "v0.3"
 
           def self?.defaults: () -> untyped
-          
-	  class Instance < Datadog::Core::Transport::HTTP::API::Instance
-	  end
-	  
-          class Instance < Datadog::Core::Transport::HTTP::API::Instance
-          end
         end
       end
     end

--- a/sig/datadog/tracing/transport/http/client.rbs
+++ b/sig/datadog/tracing/transport/http/client.rbs
@@ -3,11 +3,17 @@ module Datadog
     module Transport
       module HTTP
         class Client
-          include Transport::HTTP::Statistics
+          @api: untyped
+
+          @logger: untyped
+
+          include Datadog::Tracing::Transport::HTTP::Statistics
 
           attr_reader api: untyped
 
-          def initialize: (untyped api) -> void
+          attr_reader logger: untyped
+
+          def initialize: (untyped api, untyped logger) -> void
 
           def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
 

--- a/sig/datadog/tracing/transport/http/statistics.rbs
+++ b/sig/datadog/tracing/transport/http/statistics.rbs
@@ -4,12 +4,10 @@ module Datadog
       module HTTP
         module Statistics
           def self.included: (untyped base) -> untyped
-
           module InstanceMethods
             def metrics_for_response: (untyped response) -> untyped
 
             private
-
             STATUS_CODE_200: "status_code:200"
 
             def metrics_tag_value: (untyped status_code) -> (untyped | ::String)

--- a/sig/datadog/tracing/transport/http/traces.rbs
+++ b/sig/datadog/tracing/transport/http/traces.rbs
@@ -4,33 +4,36 @@ module Datadog
       module HTTP
         module Traces
           class Response
-            include Core::Transport::HTTP::Response
+            @service_rates: untyped
 
-            include Tracing::Transport::Traces::Response
+            @trace_count: untyped
+
+            include Datadog::Core::Transport::HTTP::Response
+
+            include Datadog::Tracing::Transport::Traces::Response
 
             def initialize: (untyped http_response, ?::Hash[untyped, untyped] options) -> void
           end
-
           module Client
             def send_traces_payload: (untyped request) -> untyped
           end
 
           module API
-            module Spec
-              attr_reader traces: untyped
+            class Spec < Core::Transport::HTTP::API::Spec
+              attr_accessor traces: untyped
 
-              def traces=: (untyped endpoint) -> untyped
-
-              def send_traces: (untyped env) ?{ () -> untyped } -> untyped
+              def send_traces: (untyped env) { (?) -> untyped } -> untyped
 
               def encoder: () -> untyped
             end
-
-            module Instance
+            class Instance < Core::Transport::HTTP::API::Instance
               def send_traces: (untyped env) -> untyped
             end
+            class Endpoint < Datadog::Core::Transport::HTTP::API::Endpoint
+              @encoder: untyped
 
-            class Endpoint < Core::Transport::HTTP::API::Endpoint
+              @service_rates: untyped
+
               HEADER_CONTENT_TYPE: "Content-Type"
 
               HEADER_TRACE_COUNT: "X-Datadog-Trace-Count"
@@ -43,7 +46,7 @@ module Datadog
 
               def service_rates?: () -> untyped
 
-              def call: (untyped env) ?{ () -> untyped } -> untyped
+              def call: (untyped env) { (?) -> untyped } -> untyped
             end
           end
         end

--- a/sig/datadog/tracing/transport/io.rbs
+++ b/sig/datadog/tracing/transport/io.rbs
@@ -2,8 +2,7 @@ module Datadog
   module Tracing
     module Transport
       module IO
-        def self?.new: (untyped `out`, untyped encoder) -> untyped
-
+        def self?.new: (untyped out, untyped encoder) -> untyped
         def self?.default: (?::Hash[untyped, untyped] options) -> untyped
       end
     end

--- a/sig/datadog/tracing/transport/io/client.rbs
+++ b/sig/datadog/tracing/transport/io/client.rbs
@@ -3,25 +3,37 @@ module Datadog
     module Transport
       module IO
         class Client
+          @out: untyped
+
+          @encoder: untyped
+
+          @request_block: untyped
+
+          @encode_block: untyped
+
+          @write_block: untyped
+
+          @response_block: untyped
+
           include Transport::Statistics
 
           attr_reader encoder: untyped
 
           attr_reader out: untyped
 
-          def initialize: (untyped `out`, untyped encoder, ?::Hash[untyped, untyped] options) -> void
+          def initialize: (untyped out, untyped encoder, ?::Hash[untyped, untyped] options) -> void
 
-          def send_request: (untyped request) { (untyped, untyped) -> untyped } -> untyped
+          def send_request: (untyped request) ?{ (untyped, untyped) -> untyped } -> untyped
 
           def encode_data: (untyped encoder, untyped request) -> untyped
 
-          def write_data: (untyped `out`, untyped data) -> untyped
+          def write_data: (untyped out, untyped data) -> untyped
 
           def build_response: (untyped _request, untyped _data, untyped result) -> untyped
 
           private
 
-          def send_default_request: (untyped `out`, untyped request) -> untyped
+          def send_default_request: (untyped out, untyped request) -> untyped
         end
       end
     end

--- a/sig/datadog/tracing/transport/io/response.rbs
+++ b/sig/datadog/tracing/transport/io/response.rbs
@@ -3,6 +3,8 @@ module Datadog
     module Transport
       module IO
         class Response
+          @result: untyped
+
           include Datadog::Core::Transport::Response
 
           attr_reader result: untyped

--- a/sig/datadog/tracing/transport/io/traces.rbs
+++ b/sig/datadog/tracing/transport/io/traces.rbs
@@ -4,25 +4,23 @@ module Datadog
       module IO
         module Traces
           class Response < IO::Response
+            @trace_count: untyped
+
             include Transport::Traces::Response
 
             def initialize: (untyped result, ?::Integer trace_count) -> void
           end
-
           module Client
-            def send_traces: (untyped traces) { (untyped, untyped) -> untyped } -> ::Array[untyped]
+            def send_traces: (untyped traces) ?{ (untyped, untyped) -> untyped } -> ::Array[untyped]
           end
-
           module Encoder
             ENCODED_IDS: ::Array[:trace_id | :span_id | :parent_id]
-
             def encode_traces: (untyped encoder, untyped traces) -> untyped
 
             private
 
             def encode_trace: (untyped trace) -> untyped
           end
-
           class Parcel
             include Datadog::Core::Transport::Parcel
 

--- a/sig/datadog/tracing/transport/statistics.rbs
+++ b/sig/datadog/tracing/transport/statistics.rbs
@@ -2,6 +2,8 @@ module Datadog
   module Tracing
     module Transport
       module Statistics
+        @stats: untyped
+
         def stats: () -> untyped
 
         def update_stats_from_response!: (untyped response) -> untyped
@@ -11,8 +13,17 @@ module Datadog
         def update_stats_from_exception!: (untyped exception) -> untyped
 
         def metrics_for_exception: (untyped _exception) -> { api_errors: untyped }
-
         class Counts
+          @success: untyped
+
+          @client_error: untyped
+
+          @server_error: untyped
+
+          @internal_error: untyped
+
+          @consecutive_errors: untyped
+
           attr_accessor success: untyped
 
           attr_accessor client_error: untyped

--- a/sig/datadog/tracing/transport/trace_formatter.rbs
+++ b/sig/datadog/tracing/transport/trace_formatter.rbs
@@ -2,6 +2,13 @@ module Datadog
   module Tracing
     module Transport
       class TraceFormatter
+        @trace: untyped
+
+        @root_span: untyped
+        @first_span: untyped
+
+        @found_root_span: untyped
+
         attr_reader root_span: untyped
 
         attr_reader first_span: untyped
@@ -11,7 +18,6 @@ module Datadog
         def self.format!: (untyped trace) -> untyped
 
         def initialize: (untyped trace) -> void
-
         def format!: () -> (nil | untyped)
 
         def set_resource!: () -> (nil | untyped)
@@ -41,6 +47,8 @@ module Datadog
         def tag_sampling_priority!: () -> (nil | untyped)
 
         def tag_high_order_trace_id!: () -> (nil | untyped)
+
+        def tag_profiling_enabled!: () -> (nil | untyped)
 
         def tag_git_repository_url!: () -> (nil | untyped)
 

--- a/sig/datadog/tracing/transport/traces.rbs
+++ b/sig/datadog/tracing/transport/traces.rbs
@@ -3,7 +3,9 @@ module Datadog
     module Transport
       module Traces
         class EncodedParcel
-          include Core::Transport::Parcel
+          @trace_count: untyped
+
+          include Datadog::Core::Transport::Parcel
 
           attr_reader trace_count: untyped
 
@@ -11,37 +13,49 @@ module Datadog
 
           def count: () -> untyped
         end
-
-        class Request < Core::Transport::Request
+        class Request < Datadog::Core::Transport::Request
         end
-
         module Response
           attr_reader service_rates: untyped
 
           attr_reader trace_count: untyped
         end
-
         class Chunker
+          @encoder: untyped
+
+          @logger: untyped
+
+          @native_events_supported: bool
+
+          @max_size: untyped
           DEFAULT_MAX_PAYLOAD_SIZE: untyped
 
           attr_reader encoder: untyped
 
           attr_reader max_size: untyped
 
-          def initialize: (untyped encoder, native_events_supported: bool, ?max_size: untyped) -> void
-
+          attr_reader logger: untyped
+          def initialize: (untyped encoder, untyped logger, native_events_supported: bool, ?max_size: untyped) -> void
           def encode_in_chunks: (untyped traces) -> untyped
 
           private
 
           def encode_one: (untyped trace) -> (nil | untyped)
         end
-
         module Encoder
-          def self?.encode_trace: (untyped encoder, untyped trace, native_events_supported: bool) -> untyped
+          def self?.encode_trace: (untyped encoder, untyped trace, untyped logger, native_events_supported: bool) -> untyped
         end
-
         class Transport
+          @apis: untyped
+
+          @default_api: untyped
+
+          @logger: untyped
+
+          @current_api_id: untyped
+
+          @client: untyped
+
           @native_events_supported: bool
 
           attr_reader client: untyped
@@ -52,7 +66,9 @@ module Datadog
 
           attr_reader current_api_id: untyped
 
-          def initialize: (untyped apis, untyped default_api) -> void
+          attr_reader logger: untyped
+
+          def initialize: (untyped apis, untyped default_api, untyped logger) -> void
 
           def send_traces: (Array[Tracing::TraceOperation] traces) -> untyped
 
@@ -67,24 +83,25 @@ module Datadog
           def downgrade!: () -> untyped
 
           def change_api!: (untyped api_id) -> untyped
-
+          def native_events_supported?: () -> bool
           class UnknownApiVersionError < StandardError
+            @version: untyped
+
             attr_reader version: untyped
 
             def initialize: (untyped version) -> void
 
             def message: () -> ::String
           end
-
           class NoDowngradeAvailableError < StandardError
+            @version: untyped
+
             attr_reader version: untyped
 
             def initialize: (untyped version) -> void
 
             def message: () -> ::String
           end
-
-          def native_events_supported?: -> bool
         end
       end
     end

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe 'Rack integration tests' do
             allow(negotiation).to receive(:endpoint?).and_return(true)
             allow(worker).to receive(:call).and_call_original
             allow(client).to receive(:sync).and_raise(exception, 'test')
-            allow(Datadog.logger).to receive(:error).and_return(nil)
+            allow(logger).to receive(:error).and_return(nil)
           end
 
           it 'has boot tags' do

--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -517,7 +517,6 @@ RSpec.describe 'Rack integration tests' do
             allow(negotiation).to receive(:endpoint?).and_return(true)
             allow(worker).to receive(:call).and_call_original
             allow(client).to receive(:sync).and_raise(exception, 'test')
-            allow(logger).to receive(:error).and_return(nil)
           end
 
           it 'has boot tags' do

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   let(:logger) { instance_double(Datadog::Core::Logger) }
   let(:settings) { Datadog::Core::Configuration::Settings.new }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
-  let(:agent_info) { Datadog::Core::Environment::AgentInfo.new(agent_settings) }
+  let(:agent_info) { Datadog::Core::Environment::AgentInfo.new(agent_settings, logger: logger) }
 
   let(:profiler_setup_task) { Datadog::Profiling.supported? ? instance_double(Datadog::Profiling::Tasks::Setup) : nil }
   let(:remote) { instance_double(Datadog::Core::Remote::Component, start: nil, shutdown!: nil) }

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -38,7 +38,14 @@ RSpec.describe Datadog::Core::Remote::Client do
   end
 
   let(:http_connection) { instance_double(::Net::HTTP) }
-  let(:transport) { Datadog::Core::Remote::Transport::HTTP.v7(agent_settings: test_agent_settings, &proc { |_client| }) }
+  let(:logger) { logger_allowing_debug }
+  let(:transport) do
+    Datadog::Core::Remote::Transport::HTTP.v7(
+      agent_settings: test_agent_settings, logger: logger,
+      &proc { |_client|
+      }
+    )
+  end
   let(:roots) do
     [
       {
@@ -247,8 +254,6 @@ RSpec.describe Datadog::Core::Remote::Client do
 
     capabilities
   end
-
-  let(:logger) { logger_allowing_debug }
 
   subject(:client) { described_class.new(transport, capabilities, repository: repository, logger: logger) }
 

--- a/spec/datadog/core/remote/negotiation_spec.rb
+++ b/spec/datadog/core/remote/negotiation_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
   end
 
   let(:settings) { Datadog::Core::Configuration::Settings.new }
+  let(:logger) { logger_allowing_debug }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
 
   describe '#endpoint?' do
@@ -36,7 +37,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
 
     subject(:endpoint?) { negotiation.endpoint?('/foo') }
     let(:suppress_logging) { {} }
-    let(:negotiation) { described_class.new(settings, agent_settings, suppress_logging: suppress_logging) }
+    let(:negotiation) { described_class.new(settings, agent_settings, logger: logger, suppress_logging: suppress_logging) }
 
     context 'when /info exists' do
       let(:response_code) { 200 }
@@ -50,13 +51,13 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       end
 
       it do
-        expect(Datadog.logger).to_not receive(:warn)
+        expect(logger).to_not receive(:warn)
 
         expect(endpoint?).to be true
       end
 
       it do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
 
         expect(negotiation.endpoint?('/bar')).to be false
       end
@@ -65,7 +66,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
         let(:suppress_logging) { { no_config_endpoint: true } }
 
         it 'does not log an error' do
-          expect(Datadog.logger).to_not receive(:warn)
+          expect(logger).to_not receive(:warn)
 
           expect(negotiation.endpoint?('/bar')).to be false
         end
@@ -77,7 +78,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       let(:response_body) { '404 page not found' }
 
       before do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
       end
 
       it { expect(endpoint?).to be false }
@@ -95,7 +96,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       let(:response_body) { '400 bad request' }
 
       before do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
       end
 
       it { expect(endpoint?).to be false }
@@ -113,7 +114,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       let(:response_body) { '500 internal server error' }
 
       before do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
       end
 
       it { expect(endpoint?).to be false }
@@ -133,7 +134,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       end
 
       before do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
       end
 
       it { expect(endpoint?).to be false }
@@ -150,7 +151,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       let(:request_exception) { Errno::ECONNREFUSED.new }
 
       before do
-        expect(Datadog.logger).to receive(:warn)
+        expect(logger).to receive(:warn)
       end
 
       it { expect(endpoint?).to be false }

--- a/spec/datadog/core/remote/transport/http_spec.rb
+++ b/spec/datadog/core/remote/transport/http_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   end
 
   let(:http_connection) { instance_double(::Net::HTTP) }
+  let(:logger) { logger_allowing_debug }
 
   describe '.root' do
-    subject(:transport) { described_class.root(agent_settings: test_agent_settings, &client_options) }
+    subject(:transport) { described_class.root(agent_settings: test_agent_settings, logger: logger, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -83,7 +84,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   end
 
   describe '.v7' do
-    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, &client_options) }
+    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, logger: logger, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -223,7 +224,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
         it 'raises a transport error' do
           expect(http_connection).to receive(:request).and_raise(IOError)
 
-          expect(Datadog.logger).to receive(:debug).with(/IOError/)
+          expect(logger).to receive(:debug).with(/IOError/)
 
           expect(response).to have_attributes(internal_error?: true)
         end

--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -11,8 +11,10 @@ require 'datadog/core/remote/transport/negotiation'
 RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   skip_unless_integration_testing_enabled
 
+  let(:logger) { logger_allowing_debug }
+
   describe '.root' do
-    subject(:transport) { described_class.root(agent_settings: test_agent_settings, &client_options) }
+    subject(:transport) { described_class.root(agent_settings: test_agent_settings, logger: logger, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 
@@ -33,7 +35,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
   describe '.v7' do
     before { skip 'TODO: needs remote config on api key+agent+backend' if ENV['TEST_DATADOG_INTEGRATION'] }
 
-    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, &client_options) }
+    subject(:transport) { described_class.v7(agent_settings: test_agent_settings, logger: logger, &client_options) }
 
     let(:client_options) { proc { |_client| } }
 

--- a/spec/datadog/core/transport/http/builder_spec.rb
+++ b/spec/datadog/core/transport/http/builder_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 require 'datadog/core/transport/http/builder'
 
 RSpec.describe Datadog::Core::Transport::HTTP::Builder do
-  subject(:builder) { described_class.new(api_instance_class: Datadog::Tracing::Transport::HTTP::Traces::API::Instance) }
+  let(:logger) { logger_allowing_debug }
+  subject(:builder) do
+    described_class.new(api_instance_class: Datadog::Tracing::Transport::HTTP::Traces::API::Instance, logger: logger)
+  end
 
   describe '#initialize' do
     context 'given a block' do
@@ -11,6 +14,7 @@ RSpec.describe Datadog::Core::Transport::HTTP::Builder do
         expect do |b|
           described_class.new(
             api_instance_class: Datadog::Tracing::Transport::HTTP::Traces::API::Instance,
+            logger: logger,
             &b
           )
         end.to yield_with_args(kind_of(described_class))

--- a/spec/datadog/opentelemetry_spec.rb
+++ b/spec/datadog/opentelemetry_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Datadog::OpenTelemetry do
     let(:writer) { get_test_writer }
     let(:tracer) { Datadog::Tracing.send(:tracer) }
     let(:otel_root_parent) { OpenTelemetry::Trace::INVALID_SPAN_ID }
+    let(:logger) { logger_allowing_debug }
 
     let(:span_options) { {} }
 

--- a/spec/datadog/tracing/benchmark/transport_benchmark_spec.rb
+++ b/spec/datadog/tracing/benchmark/transport_benchmark_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Microbenchmark Transport' do
       # in a single method call. This would translate to
       # up to 1000 spans per second in a real application.
       let(:steps) { [1, 10, 100, 1000] }
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) }
+      let(:logger) { logger_allowing_debug }
 
       include_examples 'benchmark'
 

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -228,7 +228,9 @@ RSpec.describe 'net/http requests' do
     end
 
     describe 'integration' do
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
+      let(:logger) { logger_allowing_debug }
+
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) }
 
       it 'does not create a span for the transport request' do
         expect(Datadog::Tracing).to_not receive(:trace)

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Rack integration tests' do
   let(:instrument_http) { false }
   let(:remote_enabled) { false }
   let(:apm_tracing_enabled) { true }
+  let(:logger) { logger_allowing_debug }
 
   # We send the trace to a mocked agent to verify that the trace includes the headers that we want
   # In the future, it might be a good idea to use the traces that the mocked agent
@@ -319,7 +320,7 @@ RSpec.describe 'Rack integration tests' do
             allow(negotiation).to receive(:endpoint?).and_return(true)
             allow(worker).to receive(:call).and_call_original
             allow(client).to receive(:sync).and_raise(exception, 'test')
-            allow(Datadog.logger).to receive(:error).and_return(nil)
+            allow(logger).to receive(:error).and_return(nil)
           end
 
           it 'has boot tags' do
@@ -701,7 +702,7 @@ RSpec.describe 'Rack integration tests' do
               timeout_seconds: 30
             )
             agent_http_adapter = Datadog::Core::Transport::HTTP::Adapters::Net.new(agent_settings)
-            agent_http_client = Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+            agent_http_client = Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
               t.adapter agent_http_adapter
             end
             agent_return = agent_http_client.send_traces(traces)

--- a/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/integration_test_spec.rb
@@ -702,7 +702,10 @@ RSpec.describe 'Rack integration tests' do
               timeout_seconds: 30
             )
             agent_http_adapter = Datadog::Core::Transport::HTTP::Adapters::Net.new(agent_settings)
-            agent_http_client = Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
+            agent_http_client = Datadog::Tracing::Transport::HTTP.default(
+              agent_settings: test_agent_settings,
+              logger: logger
+            ) do |t|
               t.adapter agent_http_adapter
             end
             agent_return = agent_http_client.send_traces(traces)

--- a/spec/datadog/tracing/contrib/suite/transport_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/transport_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'transport with integrations' do
 
       # Requests may produce an error (because the transport cannot connect)
       # but ignore this... we just need requests, not a successful response.
-      allow(Datadog.logger).to receive(:error)
+      allow(logger).to receive(:error)
     end
 
     shared_examples_for 'an uninstrumented transport' do
@@ -59,15 +59,17 @@ RSpec.describe 'transport with integrations' do
       end
     end
 
+    let(:logger) { logger_allowing_debug }
+
     context 'given the default transport' do
-      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
+      let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) }
 
       it_behaves_like 'an uninstrumented transport'
     end
 
     context 'given an Unix socket transport' do
       let(:transport) do
-        Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+        Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
           t.adapter :unix, '/tmp/ddagent/trace.sock'
         end
       end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -1007,7 +1007,8 @@ RSpec.describe 'Tracer integration tests' do
     include_context 'agent-based test'
 
     let(:writer) { Datadog::Tracing::Writer.new(transport: transport) }
-    let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) }
+    let(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) }
+    let(:logger) { logger_allowing_debug }
 
     before do
       Datadog.configure do |c|

--- a/spec/datadog/tracing/sync_writer_spec.rb
+++ b/spec/datadog/tracing/sync_writer_spec.rb
@@ -13,9 +13,10 @@ require 'datadog/tracing/transport/traces'
 
 RSpec.describe Datadog::Tracing::SyncWriter do
   subject(:sync_writer) { described_class.new(transport: transport) }
+  let(:logger) { logger_allowing_debug }
 
   let(:transport) do
-    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+    Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
       t.adapter :test, buffer
     end
   end
@@ -25,7 +26,7 @@ RSpec.describe Datadog::Tracing::SyncWriter do
     subject(:sync_writer) { described_class.new(**options) }
 
     context 'given :agent_settings' do
-      let(:options) { { agent_settings: agent_settings } }
+      let(:options) { { agent_settings: agent_settings, logger: logger } }
       let(:agent_settings) { instance_double(Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings) }
       let(:transport) { instance_double(Datadog::Tracing::Transport::Traces::Transport) }
 

--- a/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
@@ -67,8 +67,10 @@ RSpec.describe 'Adapters::Net tracing integration tests' do
   describe 'when sending traces through Net::HTTP adapter' do
     include_context 'HTTP server'
 
+    let(:logger) { logger_allowing_debug }
+
     let(:client) do
-      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
         t.adapter adapter
       end
     end

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -78,8 +78,10 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
   describe 'when sending traces through Unix socket client' do
     include_context 'Unix socket server'
 
+    let(:logger) { logger_allowing_debug }
+
     let(:client) do
-      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
         t.adapter adapter
       end
     end

--- a/spec/datadog/tracing/transport/http/client_spec.rb
+++ b/spec/datadog/tracing/transport/http/client_spec.rb
@@ -4,9 +4,9 @@ require 'datadog'
 require 'datadog/tracing/transport/http/client'
 
 RSpec.describe Datadog::Tracing::Transport::HTTP::Client do
-  subject(:client) { described_class.new(api) }
-
+  let(:logger) { logger_allowing_debug }
   let(:api) { instance_double(Datadog::Tracing::Transport::HTTP::Traces::API::Instance) }
+  subject(:client) { described_class.new(api, logger) }
 
   describe '#initialize' do
     it { is_expected.to be_a_kind_of(Datadog::Tracing::Transport::HTTP::Statistics) }

--- a/spec/datadog/tracing/transport/http/integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/integration_spec.rb
@@ -8,8 +8,12 @@ require 'datadog/tracing/transport/traces'
 RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
   skip_unless_integration_testing_enabled
 
+  let(:logger) { logger_allowing_debug }
+
   describe 'HTTP#default' do
-    subject(:transport) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, &client_options) }
+    subject(:transport) do
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger, &client_options)
+    end
 
     let(:client_options) { proc { |_client| } }
 
@@ -35,7 +39,9 @@ RSpec.describe 'Datadog::Tracing::Transport::HTTP integration tests' do
     subject(:writer) { described_class.new(writer_options) }
 
     let(:writer_options) { { transport: client } }
-    let(:client) { Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, &client_options) }
+    let(:client) do
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger, &client_options)
+    end
     let(:client_options) { proc { |_client| } }
 
     describe '#send_spans' do

--- a/spec/datadog/tracing/transport/http/traces_spec.rb
+++ b/spec/datadog/tracing/transport/http/traces_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe Datadog::Tracing::Transport::HTTP::Traces::Response do
 end
 
 RSpec.describe Datadog::Tracing::Transport::HTTP::Client do
-  subject(:client) { described_class.new(api) }
-
+  let(:logger) { logger_allowing_debug }
   let(:api) { instance_double(Datadog::Tracing::Transport::HTTP::Traces::API::Instance) }
+
+  subject(:client) { described_class.new(api, logger) }
 
   describe '#send_traces_payload' do
     subject(:send_traces_payload) { client.send_traces_payload(request) }

--- a/spec/datadog/tracing/transport/http_spec.rb
+++ b/spec/datadog/tracing/transport/http_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 require 'datadog/tracing/transport/http'
 
 RSpec.describe Datadog::Tracing::Transport::HTTP do
+  let(:logger) { logger_allowing_debug }
+
   describe '.default' do
-    subject(:default) { described_class.default(agent_settings: default_agent_settings) }
+    subject(:default) { described_class.default(agent_settings: default_agent_settings, logger: logger) }
     let(:default_agent_settings) do
       Datadog::Core::Configuration::AgentSettingsResolver.call(
         Datadog::Core::Configuration::Settings.new,
@@ -46,7 +48,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
     end
 
     context 'when given an agent_settings' do
-      subject(:default) { described_class.default(agent_settings: agent_settings, **options) }
+      subject(:default) { described_class.default(agent_settings: agent_settings, logger: logger, **options) }
 
       let(:options) { {} }
 
@@ -87,7 +89,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
     end
 
     context 'when given options' do
-      subject(:default) { described_class.default(agent_settings: default_agent_settings, **options) }
+      subject(:default) { described_class.default(agent_settings: default_agent_settings, logger: logger, **options) }
 
       context 'that specify an API version' do
         let(:options) { { api_version: api_version } }
@@ -120,7 +122,9 @@ RSpec.describe Datadog::Tracing::Transport::HTTP do
 
     context 'when given a block' do
       it do
-        expect { |b| described_class.default(agent_settings: default_agent_settings, &b) }.to yield_with_args(
+        expect do |b|
+          described_class.default(agent_settings: default_agent_settings, logger: logger, &b)
+        end.to yield_with_args(
           kind_of(Datadog::Core::Transport::HTTP::Builder)
         )
       end

--- a/spec/datadog/tracing/workers/trace_writer_spec.rb
+++ b/spec/datadog/tracing/workers/trace_writer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 
       before do
         expect(Datadog::Tracing::Transport::HTTP).to receive(:default)
-          .with(transport_options.merge(agent_settings: test_agent_settings))
+          .with(transport_options.merge(agent_settings: test_agent_settings, logger: Datadog.logger))
           .and_return(transport)
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 
       it 'configures a transport with the agent_settings' do
         expect(Datadog::Tracing::Transport::HTTP).to receive(:default)
-          .with(agent_settings: agent_settings)
+          .with(agent_settings: agent_settings, logger: Datadog.logger)
           .and_return(transport)
 
         expect(writer.transport).to be transport
@@ -58,7 +58,7 @@ RSpec.describe Datadog::Tracing::Workers::TraceWriter do
 
         before do
           expect(Datadog::Tracing::Transport::HTTP).to receive(:default)
-            .with(agent_settings: agent_settings, api_version: 42)
+            .with(agent_settings: agent_settings, logger: Datadog.logger, api_version: 42)
             .and_return(transport)
         end
 
@@ -560,7 +560,7 @@ RSpec.describe Datadog::Tracing::Workers::AsyncTraceWriter do
   describe 'integration tests' do
     let(:options) { { transport: transport, fork_policy: fork_policy } }
     let(:transport) do
-      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: Datadog.logger) do |t|
         t.adapter :test, output
       end
     end

--- a/spec/datadog/tracing/workers_integration_spec.rb
+++ b/spec/datadog/tracing/workers_integration_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Datadog::Workers::AsyncTransport integration tests' do
   end
   # Use SpyTransport instead of shared context because
   # worker threads sometimes call test objects after test finishes.
-  let(:transport) { SpyTransport.new }
+  let(:transport) { SpyTransport.new(logger: logger) }
   let(:stats) { writer.stats }
   let(:dump) { transport.dump }
   let(:port) { 1234 }

--- a/spec/datadog/tracing/writer_spec.rb
+++ b/spec/datadog/tracing/writer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Datadog::Tracing::Writer do
         context 'and default transport options' do
           it do
             expect(Datadog::Tracing::Transport::HTTP).to receive(:default) do |**options|
-              expect(options).to eq(agent_settings: test_agent_settings)
+              expect(options).to eq(agent_settings: test_agent_settings, logger: logger)
             end
 
             writer
@@ -55,7 +55,10 @@ RSpec.describe Datadog::Tracing::Writer do
           let(:options) { { agent_settings: agent_settings } }
 
           it 'configures the transport using the agent_settings' do
-            expect(Datadog::Tracing::Transport::HTTP).to receive(:default).with(agent_settings: agent_settings)
+            expect(Datadog::Tracing::Transport::HTTP).to receive(:default).with(
+              agent_settings: agent_settings,
+              logger: logger
+            )
 
             writer
           end
@@ -253,7 +256,7 @@ RSpec.describe Datadog::Tracing::Writer do
 
             # Ensure clean output, as failing to start the
             # worker in this situation is not an error.
-            expect(Datadog.logger).to_not receive(:debug)
+            expect(logger).to_not receive(:debug)
 
             write
           end

--- a/spec/support/spy_transport.rb
+++ b/spec/support/spy_transport.rb
@@ -34,7 +34,8 @@ end
 class SpyTransport < Datadog::Tracing::Transport::HTTP::Client
   attr_reader :helper_sent
 
-  def initialize(*)
+  def initialize(logger:)
+    @logger = logger
     @helper_sent = { 200 => {}, 500 => {} }
     @helper_mutex = Mutex.new
     @helper_error_mode = false
@@ -47,6 +48,7 @@ class SpyTransport < Datadog::Tracing::Transport::HTTP::Client
         [Datadog::Tracing::Transport::Traces::Encoder.encode_trace(
           @helper_encoder,
           trace,
+          logger,
           native_events_supported: true
         )]
       )

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -14,8 +14,9 @@ module TracerHelpers
   end
 
   def new_tracer(options = {})
+    logger = options[:logger] || Datadog.logger
     writer = FauxWriter.new(
-      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
         t.adapter :test
       end
     )
@@ -26,7 +27,7 @@ module TracerHelpers
 
   def get_test_writer(options = {})
     options = {
-      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings) do |t|
+      transport: Datadog::Tracing::Transport::HTTP.default(agent_settings: test_agent_settings, logger: logger) do |t|
         t.adapter :test
       end
     }.merge(options)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Injects `logger` into transport code instead of referencing `Datadog.logger`

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Ability in the future to define different loggers for different dd-trace-rb components

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
N/A

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
