### PR TITLE
Fix update latest deps job

### DIFF
--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: true
+          persist-credentials: true # `persist-credentials: true` is required for `git` operations
 
       - name: Download artifacts for all runtimes
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -51,16 +51,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-
-      - name: Output Ruby version
-        run: ruby -v
-
       - name: Bundle
         run: bundle install
-
       - name: Update latest
         run: bundle exec rake edge:gemspec edge:update
-
       - name: Upload artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
@@ -75,7 +69,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Download artifacts for all runtimes
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
@@ -83,8 +77,6 @@ jobs:
           path: gemfiles
           pattern: gha${{ github.run_id }}-datadog-gem-*
           merge-multiple: true
-
-      - run: git diff
 
       - name: Create Pull Request
         id: cpr

--- a/tasks/edge.rake
+++ b/tasks/edge.rake
@@ -35,6 +35,10 @@ namespace :edge do
 
   desc 'Update groups with targeted dependencies'
   task :update do |_t, args|
+    # Naming convention:
+    #
+    # Key: integration name, the same as the name of spec task in Rakefile and MatrixFile
+    # Value: gem name
     allowlist = {
       'stripe' => 'stripe',
       'elasticsearch' => 'elasticsearch',
@@ -42,7 +46,7 @@ namespace :edge do
       'rack' => 'rack',
       'faraday' => 'faraday',
       'excon' => 'excon',
-      'rest-client' => 'rest-client',
+      'rest_client' => 'rest-client',
       'mongodb' => 'mongo',
       'dalli' => 'dalli',
       'redis' => 'redis',


### PR DESCRIPTION
**What does this PR do?**

Failure: https://github.com/DataDog/dd-trace-rb/actions/runs/13742684776

Fix the broken update latest deps job

```
rake aborted!
KeyError: key not found: "rest-client"
Did you mean?  "rest_client"
/__w/dd-trace-rb/dd-trace-rb/tasks/edge.rake:55:in `fetch'
```

`persist-credentials: false` was introduced in https://github.com/DataDog/dd-trace-rb/pull/4456 to improve our Github Actions security posture. However, this job actually depends on git operations, hence persisted credential is needed.

The fix can be verified with: https://github.com/DataDog/dd-trace-rb/pull/4490

**Change log entry**
None