### PR TITLE
Update lograge/patcher.rb so that the correct logger is checked

### DIFF
--- a/lib/datadog/tracing/contrib/lograge/patcher.rb
+++ b/lib/datadog/tracing/contrib/lograge/patcher.rb
@@ -20,10 +20,12 @@ module Datadog
 
           # patch applies our patch
           def patch
+            # First check Lograge logger directly for when keep_original_rails_log option is used
+            used_logger = ::Lograge.logger || ::Lograge::LogSubscribers::ActionController.logger
+
             # ActiveSupport::TaggedLogging is the default Rails logger since Rails 5
             if defined?(::ActiveSupport::TaggedLogging::Formatter) &&
-                ::Lograge::LogSubscribers::ActionController
-                    .logger&.formatter.is_a?(::ActiveSupport::TaggedLogging::Formatter)
+                used_logger&.formatter.is_a?(::ActiveSupport::TaggedLogging::Formatter)
               Datadog.logger.warn(
                 'Lograge and ActiveSupport::TaggedLogging (the default Rails log formatter) are not compatible: ' \
                   'Lograge does not account for Rails log tags, creating polluted logs and breaking log formatting. ' \


### PR DESCRIPTION
**What does this PR do?**
In this PR I make sure that when the Lograge logger is present, it is checked instead of the Rails logger for showing a warning about tagged logging. 

**Motivation:**
When the lograge `keep_original_rails_log` option is used, the lograge logger cannot be found in `::Lograge::LogSubscribers::ActionController`, as the existing actioncontroller log subscriber is never removed. Therefore the warning in `lograge/patcher.rb` is shown even when lograge does use a plain logger.

**Change log entry**
Hide the warning about tagged logging when Lograge uses a plain logger and `keep_original_rails_log` is enabled.
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
The change should be covered by the tests. If you want to test it manually, enable the Lograge `keep_original_rails_log` config option, keep the default Rails logger but use a plain logger in the lograge config. Now there should no longer be an error about tagged logging.

