### PR TITLE
Fix handling of AppSec actions passed with Remote Config

### DIFF
--- a/lib/datadog/appsec/processor/rule_merger.rb
+++ b/lib/datadog/appsec/processor/rule_merger.rb
@@ -22,7 +22,7 @@ module Datadog
           # TODO: `processors` and `scanners` are not provided by the caller, consider removing them
           def merge(
             telemetry:,
-            rules:, data: [], overrides: [], exclusions: [], custom_rules: [],
+            rules:, actions: [], data: [], overrides: [], exclusions: [], custom_rules: [],
             processors: nil, scanners: nil
           )
             processors ||= begin
@@ -54,6 +54,7 @@ module Datadog
             combined_exclusions = combine_exclusions(exclusions) if exclusions.any?
             combined_custom_rules = combine_custom_rules(custom_rules) if custom_rules.any?
 
+            combined_rules['actions'] = actions if actions.any?
             combined_rules['rules_data'] = combined_data if combined_data
             combined_rules['rules_override'] = combined_overrides if combined_overrides
             combined_rules['exclusions'] = combined_exclusions if combined_exclusions

--- a/sig/datadog/appsec/processor/rule_merger.rbs
+++ b/sig/datadog/appsec/processor/rule_merger.rbs
@@ -8,6 +8,7 @@ module Datadog
 
         type rules = ::Hash[::String, untyped]
         type data = ::Array[::Hash[::String, untyped]]
+        type actions = ::Array[::Hash[::String, untyped]]
         type overrides = ::Array[::Array[::Hash[::String, untyped]]]
         type exclusions = ::Array[::Array[::Hash[::String, untyped]]]
         type custom_rules = ::Array[::Array[::Hash[::String, untyped]]]
@@ -18,6 +19,7 @@ module Datadog
           telemetry: Datadog::Core::Telemetry::Component,
           rules: ::Array[rules],
           ?data: ::Array[data],
+          ?actions: actions,
           ?overrides: overrides,
           ?exclusions: exclusions,
           ?custom_rules: custom_rules,

--- a/spec/datadog/appsec/processor/rule_merger_spec.rb
+++ b/spec/datadog/appsec/processor/rule_merger_spec.rb
@@ -700,6 +700,19 @@ RSpec.describe Datadog::AppSec::Processor::RuleMerger do
     end
   end
 
+  context 'actions' do
+    it 'overwrites actions with new actions' do
+      actions = [{
+        'id' => 'block',
+        'parameters' => { 'location' => 'https://datadoghq.com', 'status_code' => 302 },
+        'type' => 'redirect_request'
+      }]
+
+      result = described_class.merge(rules: rules, actions: actions, telemetry: telemetry)
+      expect(result).to include('actions' => actions)
+    end
+  end
+
   context 'processors' do
     it 'merges default processors' do
       result = described_class.merge(rules: rules, telemetry: telemetry)

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -304,6 +304,40 @@ RSpec.describe Datadog::AppSec::Remote do
               expect(content.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::ACKNOWLEDGED)
             end
 
+            context 'actions' do
+              let(:actions) do
+                [
+                  {
+                    'id' => 'block',
+                    'parameters' => {
+                      'location' => 'https://datadoghq.com',
+                      'status_code' => 302
+                    },
+                    'type' => 'redirect_request'
+                  }
+                ]
+              end
+
+              let(:data) do
+                { 'actions' => actions }
+              end
+
+              it 'pass the right values to RuleMerger' do
+                expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
+                  rules: default_ruleset,
+                  data: [],
+                  actions: actions,
+                  overrides: [],
+                  exclusions: [],
+                  custom_rules: [],
+                  telemetry: telemetry
+                )
+
+                changes = transaction
+                receiver.call(repository, changes)
+              end
+            end
+
             context 'overrides' do
               let(:data) do
                 {
@@ -315,6 +349,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [rules_override],
                   exclusions: [],
                   custom_rules: [],
@@ -337,6 +372,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [],
                   exclusions: [exclusions],
                   custom_rules: [],
@@ -359,6 +395,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [],
                   exclusions: [],
                   custom_rules: [custom_rules],
@@ -382,6 +419,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [rules_override],
                   exclusions: [exclusions],
                   custom_rules: [],
@@ -404,6 +442,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [],
                   exclusions: [],
                   custom_rules: [],
@@ -437,6 +476,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [rules_data],
+                  actions: [],
                   overrides: [],
                   exclusions: [],
                   custom_rules: [],
@@ -459,6 +499,7 @@ RSpec.describe Datadog::AppSec::Remote do
                 expect(Datadog::AppSec::Processor::RuleMerger).to receive(:merge).with(
                   rules: default_ruleset,
                   data: [],
+                  actions: [],
                   overrides: [],
                   exclusions: [],
                   custom_rules: [],


### PR DESCRIPTION
**What does this PR do?**
This PR fixes parsing of actions that were passed via Remote Config for `ASM` product.

**Motivation:**
Custom configuration for blocking response done in Datadog UI was not parsed by our library.

**Change log entry**
Yes. AppSec: Fixed: Custom In-App WAF blocking response that was configured in the UI is now applied correctly.

**Additional Notes:**
None.

**How to test the change?**
CI and manual testing with app generator.
