### PR TITLE
[APPSEC-57032] Add `usr.login` to Kit::AppSec::Events

### DIFF
--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -9,11 +9,13 @@ module Datadog
 
         # Gateway User argument
         class User < Argument
-          attr_reader :id
+          attr_reader :id, :login
 
-          def initialize(id)
+          def initialize(id, login)
             super()
+
             @id = id
+            @login = login
           end
         end
       end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -19,9 +19,8 @@ module Datadog
               gateway.watch('identity.set_user', :appsec) do |stack, user|
                 context = Datadog::AppSec.active_context
 
-                persistent_data = {
-                  'usr.id' => user.id
-                }
+                persistent_data = { 'usr.id' => user.id }
+                persistent_data['usr.login'] = user.login if user.login
 
                 result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -30,11 +30,14 @@ module Datadog
             set_trace_and_span_context('track_login_success', trace, span) do |active_trace, active_span|
               user_options = user.dup
               user_id = user_options.delete(:id)
+              user_login = user_options[:login] || others[:'usr.login'] || user_id
 
               raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
+              others[:'usr.login'] = user_login
               track(LOGIN_SUCCESS_EVENT, active_trace, active_span, **others)
 
+              user_options[:login] = user_login
               Kit::Identity.set_user(active_trace, active_span, id: user_id, **user_options)
             end
           end
@@ -55,6 +58,7 @@ module Datadog
           #   event information to attach to the trace.
           def track_login_failure(trace = nil, span = nil, user_exists:, user_id: nil, **others)
             set_trace_and_span_context('track_login_failure', trace, span) do |active_trace, active_span|
+              others[:'usr.login'] = user_id if user_id && !others.key?(:'usr.login')
               track(LOGIN_FAILURE_EVENT, active_trace, active_span, **others)
 
               active_span.set_tag('appsec.events.users.login.failure.usr.id', user_id) if user_id
@@ -80,11 +84,14 @@ module Datadog
             set_trace_and_span_context('track_signup', trace, span) do |active_trace, active_span|
               user_options = user.dup
               user_id = user_options.delete(:id)
+              user_login = user_options[:login] || others[:'usr.login'] || user_id
 
               raise ArgumentError, 'missing required key: :user => { :id }' if user_id.nil?
 
+              others[:'usr.login'] = user_login
               track(SIGNUP_EVENT, active_trace, active_span, **others)
 
+              user_options[:login] = user_login
               Kit::Identity.set_user(trace, id: user_id, **user_options)
             end
           end

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -33,6 +33,7 @@ module Datadog
         # @param others [Hash<Symbol, String>] Additional free-form
         #   user information to attach to the trace.
         #
+        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         def set_user(
@@ -67,13 +68,14 @@ module Datadog
             end
 
             if Datadog::AppSec.active_context
-              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(id)
+              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(id, others[:login])
               ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
             end
           end
         end
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/sig/datadog/appsec/instrumentation/gateway/argument.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway/argument.rbs
@@ -7,9 +7,15 @@ module Datadog
         end
 
         class User < Argument
+          @id: String
+
+          @login: String?
+
           attr_reader id: String
 
-          def initialize: (String id) -> void
+          attr_reader login: String?
+
+          def initialize: (String id, String? login) -> void
         end
       end
     end

--- a/spec/datadog/kit/appsec/events_spec.rb
+++ b/spec/datadog/kit/appsec/events_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
-require 'time'
+require 'spec_helper'
 
 require 'datadog/tracing/trace_operation'
 require 'datadog/kit/appsec/events'
@@ -49,11 +49,57 @@ RSpec.describe Datadog::Kit::AppSec::Events do
   end
 
   describe '#track_login_success' do
+    it 'sets additional user login data based on user id as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_success(trace_op, user: { id: '42' }) }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => '42',
+            'appsec.events.users.login.success.usr.login' => '42'
+          )
+      end
+    end
+
+    it 'sets additional user login data from other keys as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_success(trace_op, user: { id: '42' }, 'usr.login': 'hey') }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.login.success.usr.login' => 'hey'
+          )
+      end
+    end
+
+    it 'sets additional user login data as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_success(trace_op, user: { id: '42', login: 'hey' }) }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.login.success.usr.login' => 'hey'
+          )
+      end
+    end
+
+    it 'sets additional user login data as tags with user data priority' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_success(trace_op, user: { id: '42', login: 'hey' }, 'usr.login': 'extra') }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.login.success.usr.login' => 'hey'
+          )
+      end
+    end
+
     it 'sets event tracking key on trace' do
-      trace_op.measure('root') do |span, _trace|
-        described_class.track_login_success(trace_op, user: { id: '42' })
-        expect(span.tags).to include('appsec.events.users.login.success.track' => 'true')
-        expect(span.tags).to include('_dd.appsec.events.users.login.success.sdk' => 'true')
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_success(trace_op, user: { id: '42' }) }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.success.track' => 'true',
+            '_dd.appsec.events.users.login.success.sdk' => 'true'
+          )
       end
     end
 
@@ -99,6 +145,20 @@ RSpec.describe Datadog::Kit::AppSec::Events do
   end
 
   describe '#track_login_failure' do
+    it 'sets additional user login data based on user id as tags' do
+      trace_op.measure('root') do |span, _trace|
+        expect { described_class.track_login_failure(trace_op, user_id: '42', user_exists: true) }
+          .to change { span.tags }.to include('appsec.events.users.login.failure.usr.login' => '42')
+      end
+    end
+
+    it 'sets additional user login data from other keys as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_login_failure(trace_op, user_id: '42', user_exists: true, 'usr.login': 'hey') }
+          .to change { span.tags }.to include('appsec.events.users.login.failure.usr.login' => 'hey')
+      end
+    end
+
     it 'sets event tracking key on trace' do
       trace_op.measure('root') do |span, _trace|
         described_class.track_login_failure(trace_op, user_id: '42', user_exists: true)
@@ -155,11 +215,57 @@ RSpec.describe Datadog::Kit::AppSec::Events do
   end
 
   describe '#track_signup' do
+    it 'sets additional user login data based on user id as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_signup(trace_op, user: { id: '42' }) }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => '42',
+            'appsec.events.users.signup.usr.login' => '42'
+          )
+      end
+    end
+
+    it 'sets additional user login data as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_signup(trace_op, user: { id: '42', login: 'hey' }) }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.signup.usr.login' => 'hey'
+          )
+      end
+    end
+
+    it 'sets additional user login data from other keys as tags' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_signup(trace_op, user: { id: '42' }, 'usr.login': 'hey') }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.signup.usr.login' => 'hey'
+          )
+      end
+    end
+
+    it 'sets additional user login data as tags with user data priority' do
+      trace_op.measure('root') do |span, _|
+        expect { described_class.track_signup(trace_op, user: { id: '42', login: 'hey' }, 'usr.login': 'extra') }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'usr.login' => 'hey',
+            'appsec.events.users.signup.usr.login' => 'hey'
+          )
+      end
+    end
+
     it 'sets event tracking key on trace' do
       trace_op.measure('root') do |span, _trace|
-        described_class.track_signup(trace_op, user: { id: '42' })
-        expect(span.tags).to include('appsec.events.users.signup.track' => 'true')
-        expect(span.tags).to include('_dd.appsec.events.users.signup.sdk' => 'true')
+        expect { described_class.track_signup(trace_op, user: { id: '42' }) }
+          .to change { span.tags }.to include(
+            'appsec.events.users.signup.track' => 'true',
+            '_dd.appsec.events.users.signup.sdk' => 'true'
+          )
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

1. Always set AppSec tag `appsec.events.<event>.usr.login` with a fallback value as `usr.id`
2. Pass `usr.login` when available to `libddwaf`

**Motivation:**

This is an intermediate step to comply with v3 ATO behavior in which it is expected (by the backend) that we alway pass login data `appsec.events.<event>.usr.login` and in addition we pass `usr.login` to `libddwaf` when available.

**Change log entry**

No. Announcement will be done as a part of #4433 

**Additional Notes:**

Unfortunately, in the current state the `Kit::AppSec::Events` and `Kit::Identity` are coupled, which led to some questionable areas.

**How to test the change?**

CI should be fine