### PR TITLE
lock steep to 1.9.x

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -95,6 +95,10 @@ target :datadog do
   ignore 'lib/datadog/di/transport/http/api.rb'
   ignore 'lib/datadog/di/transport/http/diagnostics.rb'
   ignore 'lib/datadog/di/transport/http/input.rb'
+  # steep thinks the type of the class is 'self', whatever that is,
+  # and then complains that this type doesn't have any methods including
+  # language basics like 'send' and 'raise'.
+  ignore 'lib/datadog/di/probe_notifier_worker.rb'
   ignore 'lib/datadog/kit/appsec/events.rb' # disabled because of https://github.com/soutaro/steep/issues/701
   ignore 'lib/datadog/kit/identity.rb'      # disabled because of https://github.com/soutaro/steep/issues/701
   ignore 'lib/datadog/opentelemetry.rb'

--- a/ruby-3.1.gemfile
+++ b/ruby-3.1.gemfile
@@ -46,7 +46,8 @@ gem 'webrick', '>= 1.7.0'
 
 group :check do
   gem 'rbs', '~> 3.7', require: false
-  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  # steep 1.10 produces additional errors
+  gem 'steep', '~> 1.9.1', require: false
   gem 'standard', require: false
 
   # Rubocop version must be pinned to major.minor because its demanded

--- a/ruby-3.2.gemfile
+++ b/ruby-3.2.gemfile
@@ -45,7 +45,8 @@ gem 'webrick', '>= 1.7.0'
 
 group :check do
   gem 'rbs', '~> 3.7', require: false
-  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  # steep 1.10 produces additional errors
+  gem 'steep', '~> 1.9.1', require: false
   gem 'standard', require: false
 
   # Rubocop version must be pinned to major.minor because its demanded

--- a/ruby-3.3.gemfile
+++ b/ruby-3.3.gemfile
@@ -45,7 +45,8 @@ gem 'webrick', '>= 1.7.0'
 
 group :check do
   gem 'rbs', '~> 3.7', require: false
-  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  # steep 1.10 produces additional errors
+  gem 'steep', '~> 1.9.1', require: false
   gem 'standard', require: false
 
   # Rubocop version must be pinned to major.minor because its demanded

--- a/ruby-3.4.gemfile
+++ b/ruby-3.4.gemfile
@@ -48,7 +48,8 @@ gem 'webrick', '>= 1.8.2'
 
 group :check do
   gem 'rbs', '~> 3.7', require: false
-  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  # steep 1.10 produces additional errors
+  gem 'steep', '~> 1.9.1', require: false
   gem 'ruby_memcheck', '>= 3'
   gem 'standard', require: false
 

--- a/ruby-3.5.gemfile
+++ b/ruby-3.5.gemfile
@@ -49,7 +49,8 @@ gem 'webrick', '>= 1.8.2'
 
 group :check do
   gem 'rbs', '~> 3.7', require: false
-  gem 'steep', '~> 1', '>= 1.9.1', require: false
+  # steep 1.10 produces additional errors
+  gem 'steep', '~> 1.9.1', require: false
   gem 'ruby_memcheck', '>= 3'
   gem 'standard', require: false
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Locks steep to version 1.9

Also skip type checking of probe_notifier_worker.rb  because it is failing with the following errors that look like a steep bug:

```
Error: adog/di/probe_notifier_worker.rb:205:20: [error] Type `self` does not have method `send`
│ Diagnostic ID: Ruby::NoMethod
│
└             queue = send("#{event_type}_queue")
                      ~~~~

Error: adog/di/probe_notifier_worker.rb:[20](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:21)6:30: [error] Type `self` does not have method `settings`
│ Diagnostic ID: Ruby::NoMethod
│
└             if queue.length > settings.dynamic_instrumentation.internal.snapshot_queue_capacity
                                ~~~~~~~~

Error: adog/di/probe_notifier_worker.rb:207:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.debug { "di: #{self.class.name}: dropping #{event_type} event because queue is full" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:207:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.debug { "di: #{self.class.name}: dropping #{event_type} event because queue is full" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:207:41: [error] Type `self` does not have method `class`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.debug { "di: #{self.class.name}: dropping #{event_type} event because queue is full" }
                                           ~~~~~

Error: adog/di/probe_notifier_worker.rb:209:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.trace { "di: #{self.class.name}: queueing #{event_type} event" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:209:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.trace { "di: #{self.class.name}: queueing #{event_type} event" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:209:41: [error] Type `self` does not have method `class`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.trace { "di: #{self.class.name}: queueing #{event_type} event" }
                                           ~~~~~

Error: adog/di/probe_notifier_worker.rb:220:14: [error] Type `self` does not have method `set_sleep_remaining`
│ Diagnostic ID: Ruby::NoMethod
│
└               set_sleep_remaining
                ~~~~~~~~~~~~~~~~~~~

Error: adog/di/probe_notifier_worker.rb:2[21](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:22):14: [error] Type `self` does not have method `wake`
│ Diagnostic ID: Ruby::NoMethod
│
└               wake.signal
                ~~~~

Error: adog/di/probe_notifier_worker.rb:[22](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:23)7:10: [error] Type `self` does not have method `start`
│ Diagnostic ID: Ruby::NoMethod
│
└           start
            ~~~~~

Error: adog/di/probe_notifier_worker.rb:256:20: [error] Type `self` does not have method `instance_variable_get`
│ Diagnostic ID: Ruby::NoMethod
│
└             batch = instance_variable_get("@#{event_type}_queue")
                      ~~~~~~~~~~~~~~~~~~~~~

Error: adog/di/probe_notifier_worker.rb:257:12: [error] Type `self` does not have method `instance_variable_set`
│ Diagnostic ID: Ruby::NoMethod
│
└             instance_variable_set("@#{event_type}_queue", [])
              ~~~~~~~~~~~~~~~~~~~~~

Error: adog/di/probe_notifier_worker.rb:264:14: [error] Type `self` does not have method `send`
│ Diagnostic ID: Ruby::NoMethod
│
└               send("do_send_#{event_type}", batch)
                ~~~~

Error: adog/di/probe_notifier_worker.rb:270:[23](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:24): [error] Type `self` does not have method `settings`
│ Diagnostic ID: Ruby::NoMethod
│
└               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
                         ~~~~~~~~

Error: adog/di/probe_notifier_worker.rb:[27](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:28)0:14: [error] Type `self` does not have method `raise`
│ Diagnostic ID: Ruby::NoMethod
│
└               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
                ~~~~~

Error: adog/di/probe_notifier_worker.rb:271:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc} (at #{exc.backtrace.first})" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:271:14: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└               logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc} (at #{exc.backtrace.first})" }
                ~~~~~~

Error: adog/di/probe_notifier_worker.rb:[28](https://github.com/DataDog/dd-trace-rb/actions/runs/13927375143/job/38975462509?pr=4510#step:7:29)2:10: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└           logger.debug { "di: unexpected #{event_name} queue underflow - consumed elsewhere?" }
            ~~~~~~

Error: adog/di/probe_notifier_worker.rb:282:10: [error] Type `self` does not have method `logger`
│ Diagnostic ID: Ruby::NoMethod
│
└           logger.debug { "di: unexpected #{event_name} queue underflow - consumed elsewhere?" }
            ~~~~~~

Error: adog/di/probe_notifier_worker.rb:283:10: [error] Type `self` does not have method `telemetry`
│ Diagnostic ID: Ruby::NoMethod
│
└           telemetry&.report(exc, description: "Unexpected #{event_name} queue underflow")
            ~~~~~~~~~

Detected 21 problems from 1 file
          +------------------------------------------------------------------------------+
          |  **Hello there, fellow contributor who just triggered a Steep type error**   |
          |                                                                              |
          | We're still experimenting with Steep on this codebase. If possible, take a   |
          | stab at getting it to work; you'll find a guide for how to use it here:      |
          |                                                                              |
          |   less docs/StaticTypingGuide.md                                             |
          |                                                                              |
          | Feel free to unblock yourself by adding a line per file that triggered       |
          | errors to the `Steepfile`:                                                   |
          |                                                                              |
          |   ignore 'lib/path/to/failing/file.rb'                                       |
          |                                                                              |
          | Also, if this is too annoying for you -- let us know! We definitely are      |
          | still improving how we use the tool.                                         |
          +------------------------------------------------------------------------------+
Error: Process completed with exit code 1.
```

These failures do not happen locally (now on the same exact version of steep as in CI, 1.9.4) and I don't know what `Type `self`` even means. In the above list of errors is a complaint about a `raise` method not existing which also does not make sense - `raise` is a keyword not a method.

**Motivation:**
Red CI on master and in all branches
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing CI
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
