### PR TITLE
Add Stack Trace reporting for AppSec actions

### DIFF
--- a/lib/datadog/appsec/actions_handler.rb
+++ b/lib/datadog/appsec/actions_handler.rb
@@ -30,8 +30,8 @@ module Datadog
         active_span = AppSec.active_context&.span
         return unless active_span
 
-        event_category = Datadog::AppSec::Ext::EXPLOIT_PREVENTION_EVENT_CATEGORY
-        tag_key = Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE
+        event_category = Ext::EXPLOIT_PREVENTION_EVENT_CATEGORY
+        tag_key = Ext::TAG_METASTRUCT_STACK_TRACE
 
         existing_stack_data = active_span.get_metastruct_tag(tag_key).dup || { event_category => [] }
         max_stack_traces = Datadog.configuration.appsec.stack_trace.max_stack_traces

--- a/lib/datadog/appsec/actions_handler.rb
+++ b/lib/datadog/appsec/actions_handler.rb
@@ -37,7 +37,6 @@ module Datadog
         return if existing_stack_data[event_category].count >= Datadog.configuration.appsec.stack_trace.max_stack_traces
 
         backtrace = SerializableBacktrace.new(locations: Array(caller_locations), stack_id: stack_id)
-
         existing_stack_data[event_category] << backtrace
         active_span.set_metastruct_tag(tag_key, existing_stack_data)
       end

--- a/lib/datadog/appsec/actions_handler.rb
+++ b/lib/datadog/appsec/actions_handler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'actions_handler/serializable_backtrace'
+
 module Datadog
   module AppSec
     # this module encapsulates functions for handling actions that libddawf returns
@@ -19,7 +21,16 @@ module Datadog
         throw(Datadog::AppSec::Ext::INTERRUPT, action_params)
       end
 
-      def generate_stack(_action_params); end
+      def generate_stack(action_params)
+        # TODO: check how many stack traces we already collected
+
+        stack_id = action_params['stack_id']
+        return unless stack_id
+
+        _backtrace = SerializableBacktrace.new(locations: caller_locations, stack_id: stack_id)
+
+        # TODO: add stack frames to span metastruct
+      end
 
       def generate_schema(_action_params); end
     end

--- a/lib/datadog/appsec/actions_handler.rb
+++ b/lib/datadog/appsec/actions_handler.rb
@@ -29,7 +29,7 @@ module Datadog
         stack_id = action_params['stack_id']
         return unless stack_id
 
-        _backtrace = SerializableBacktrace.new(locations: caller_locations, stack_id: stack_id)
+        _backtrace = SerializableBacktrace.new(locations: Array(caller_locations), stack_id: stack_id)
 
         # TODO: add stack frames to span metastruct
       end

--- a/lib/datadog/appsec/actions_handler.rb
+++ b/lib/datadog/appsec/actions_handler.rb
@@ -22,6 +22,8 @@ module Datadog
       end
 
       def generate_stack(action_params)
+        return unless Datadog.configuration.appsec.stack_trace.enabled
+
         # TODO: check how many stack traces we already collected
 
         stack_id = action_params['stack_id']

--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -27,7 +27,7 @@ module Datadog
 
             frame_idx += 1
 
-            next if frame_idx >= drop_from_idx && frame_idx < drop_until_idx
+            next if max_depth != 0 && frame_idx >= drop_from_idx && frame_idx < drop_until_idx
 
             map[frame_idx] = location
           end

--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module ActionsHandler
+      # This module serves encapsulates MessagePack serialization for caller locations.
+      #
+      # It serializes part of the stack:
+      # up to 32 frames (configurable)
+      # keeping frames from top and bottom of the stack (75% to 25%, configurable).
+      #
+      # It represents the stack trace that is added to span metastruct field.
+      class SerializableBacktrace
+        def initialize(locations:, stack_id:)
+          @stack_id = stack_id
+
+          max_depth = 32
+          top_percent = 75
+
+          drop_from_idx = max_depth * top_percent / 100
+          drop_until_idx = locations.size - (max_depth - drop_from_idx)
+
+          frame_idx = -1
+          @serializable_locations_map = locations.each_with_object({}) do |location, map|
+            # we are dropping frames from library code without increasing frame index
+            next if location.path.include?('lib/datadog')
+
+            frame_idx += 1
+
+            next if frame_idx >= drop_from_idx && frame_idx < drop_until_idx
+
+            map[frame_idx] = location
+          end
+        end
+
+        def to_msgpack(packer = nil)
+          # JRuby doesn't pass the packer
+          packer ||= MessagePack::Packer.new
+
+          packer.write_map_header(3)
+
+          packer.write('stack_id')
+          packer.write(@stack_id)
+
+          packer.write('language')
+          packer.write('ruby')
+
+          packer.write('frames')
+          packer.write_array_header(@serializable_locations_map.size)
+
+          @serializable_locations_map.each do |frame_id, location|
+            packer.write_map_header(6)
+
+            packer.write('id')
+            packer.write(frame_id)
+
+            packer.write('text')
+            packer.write(location.to_s)
+
+            packer.write('file')
+            packer.write(location.path)
+
+            packer.write('line')
+            packer.write(location.lineno)
+
+            class_name, function_name = location.label.match(/\b([\w+:{2}]*\w+)?[#|.]?\b(\w+)\z/)&.captures
+
+            packer.write('class_name')
+            packer.write(class_name)
+
+            packer.write('function')
+            packer.write(function_name)
+          end
+
+          packer
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -14,8 +14,8 @@ module Datadog
         def initialize(locations:, stack_id:)
           @stack_id = stack_id
 
-          max_depth = 32
-          top_percent = 75
+          max_depth = Datadog.configuration.appsec.stack_trace.max_depth
+          top_percent = Datadog.configuration.appsec.stack_trace.top_percentage
 
           drop_from_idx = max_depth * top_percent / 100
           drop_until_idx = locations.size - (max_depth - drop_from_idx)

--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -39,11 +39,11 @@ module Datadog
 
           packer.write_map_header(3)
 
-          packer.write('stack_id')
-          packer.write(@stack_id)
+          packer.write('id')
+          packer.write(@stack_id.encode('UTF-8'))
 
           packer.write('language')
-          packer.write('ruby')
+          packer.write('ruby'.encode('UTF-8'))
 
           packer.write('frames')
           packer.write_array_header(@serializable_locations_map.size)
@@ -55,10 +55,10 @@ module Datadog
             packer.write(frame_id)
 
             packer.write('text')
-            packer.write(location.to_s)
+            packer.write(location.to_s.encode('UTF-8'))
 
             packer.write('file')
-            packer.write(location.path)
+            packer.write(location.path&.encode('UTF-8'))
 
             packer.write('line')
             packer.write(location.lineno)
@@ -66,10 +66,10 @@ module Datadog
             class_name, function_name = location.label.match(/\b([\w+:{2}]*\w+)?[#|.]?\b(\w+)\z/)&.captures
 
             packer.write('class_name')
-            packer.write(class_name)
+            packer.write(class_name&.encode('UTF-8'))
 
             packer.write('function')
-            packer.write(function_name)
+            packer.write(function_name&.encode('UTF-8'))
           end
 
           packer

--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -23,7 +23,7 @@ module Datadog
           frame_idx = -1
           @serializable_locations_map = locations.each_with_object({}) do |location, map|
             # we are dropping frames from library code without increasing frame index
-            next if location.path.include?('lib/datadog')
+            next if location.path&.include?('lib/datadog')
 
             frame_idx += 1
 

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -165,6 +165,12 @@ module Datadog
               end
 
               settings :stack_trace do
+                option :enabled do |o|
+                  o.type :bool
+                  o.env 'DD_APPSEC_STACK_TRACE_ENABLED'
+                  o.default true
+                end
+
                 # The maximum number of stack trace frames to collect for each stack trace.
                 #
                 # If the stack trace exceeds this limit, the frames are dropped from the middle of the stack trace:

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -205,6 +205,20 @@ module Datadog
                     value
                   end
                 end
+
+                # Maximum number of stack traces to collect per span.
+                #
+                # Default value is 2
+                option :max_stack_traces do |o|
+                  o.type :int
+                  o.env 'DD_APPSEC_MAX_STACK_TRACES'
+                  o.default 2
+
+                  o.setter do |value|
+                    value = 1 if value < 1
+                    value
+                  end
+                end
               end
 
               settings :auto_user_instrumentation do

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -164,6 +164,43 @@ module Datadog
                 end
               end
 
+              settings :stack_trace do
+                # The maximum number of stack trace frames to collect for each stack trace.
+                #
+                # If the stack trace exceeds this limit, the frames are dropped from the middle of the stack trace:
+                # 75% of the frames are kept from the top of the stack trace and 25% from the bottom
+                # (this percentage is also configurable).
+                #
+                # Minimum value is 10.
+                #
+                # Default value is 32
+                option :max_depth do |o|
+                  o.type :int
+                  o.env 'DD_APPSEC_MAX_STACK_TRACE_DEPTH'
+                  o.default 32
+
+                  o.setter do |value|
+                    value = 10 if value < 10
+                    value
+                  end
+                end
+
+                # The percentage of frames to keep from the top of the stack trace.
+                #
+                # Default value is 75
+                option :top_percentage do |o|
+                  o.type :int
+                  o.env 'DD_APPSEC_MAX_STACK_TRACE_DEPTH_TOP_PERCENT'
+                  o.default 75
+
+                  o.setter do |value|
+                    value = 100 if value > 100
+                    value = 0 if value.negative?
+                    value
+                  end
+                end
+              end
+
               settings :auto_user_instrumentation do
                 define_method(:enabled?) { get_option(:mode) != DISABLED_AUTO_USER_INSTRUMENTATION_MODE }
 

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -178,6 +178,7 @@ module Datadog
                 # (this percentage is also configurable).
                 #
                 # Minimum value is 10.
+                # Set to zero if you don't want any frames to be dropped.
                 #
                 # Default value is 32
                 option :max_depth do |o|
@@ -186,7 +187,7 @@ module Datadog
                   o.default 32
 
                   o.setter do |value|
-                    value = 10 if value < 10
+                    value = 0 if value < 0
                     value
                   end
                 end
@@ -208,6 +209,8 @@ module Datadog
 
                 # Maximum number of stack traces to collect per span.
                 #
+                # Set to zero if you want to collect all stack traces.
+                #
                 # Default value is 2
                 option :max_stack_traces do |o|
                   o.type :int
@@ -215,7 +218,7 @@ module Datadog
                   o.default 2
 
                   o.setter do |value|
-                    value = 1 if value < 1
+                    value = 0 if value < 0
                     value
                   end
                 end

--- a/lib/datadog/appsec/ext.rb
+++ b/lib/datadog/appsec/ext.rb
@@ -10,10 +10,12 @@ module Datadog
       INTERRUPT = :datadog_appsec_interrupt
       CONTEXT_KEY = 'datadog.appsec.context'
       ACTIVE_CONTEXT_KEY = :datadog_appsec_active_context
+      EXPLOIT_PREVENTION_EVENT_CATEGORY = 'exploit'
 
       TAG_APPSEC_ENABLED = '_dd.appsec.enabled'
       TAG_APM_ENABLED = '_dd.apm.enabled'
       TAG_DISTRIBUTED_APPSEC_EVENT = '_dd.p.appsec'
+      TAG_METASTRUCT_STACK_TRACE = '_dd.stack'
 
       TELEMETRY_METRICS_NAMESPACE = 'appsec'
     end

--- a/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
+++ b/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
@@ -2,7 +2,7 @@ module Datadog
   module AppSec
     module ActionsHandler
       class SerializableBacktrace
-        def initialize: (locations: ::Array[::Thread::Backtrace::Location], stack_id: String | Symbol | Integer) -> void
+        def initialize: (locations: ::Array[::Thread::Backtrace::Location], stack_id: String) -> void
         def to_msgpack: (?untyped? packer) -> void
       end
     end

--- a/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
+++ b/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
@@ -2,8 +2,12 @@ module Datadog
   module AppSec
     module ActionsHandler
       class SerializableBacktrace
+        CLASS_AND_FUNCTION_NAME_REGEX: ::Regexp
+
         def initialize: (locations: ::Array[::Thread::Backtrace::Location], stack_id: String) -> void
         def to_msgpack: (?untyped? packer) -> void
+
+        private def build_serializable_locations_map: -> ::Hash[Integer, ::Thread::Backtrace::Location]
       end
     end
   end

--- a/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
+++ b/sig/datadog/appsec/actions_handler/serializable_backtrace.rbs
@@ -1,0 +1,10 @@
+module Datadog
+  module AppSec
+    module ActionsHandler
+      class SerializableBacktrace
+        def initialize: (locations: ::Array[::Thread::Backtrace::Location], stack_id: String | Symbol | Integer) -> void
+        def to_msgpack: (?untyped? packer) -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/ext.rbs
+++ b/sig/datadog/appsec/ext.rbs
@@ -15,11 +15,15 @@ module Datadog
 
       ACTIVE_CONTEXT_KEY: ::Symbol
 
+      EXPLOIT_PREVENTION_EVENT_CATEGORY: ::String
+
       TAG_APPSEC_ENABLED: ::String
 
       TAG_APM_ENABLED: ::String
 
       TAG_DISTRIBUTED_APPSEC_EVENT: ::String
+
+      TAG_METASTRUCT_STACK_TRACE: ::String
 
       TELEMETRY_METRICS_NAMESPACE: ::String
     end

--- a/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
+++ b/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
     end
 
     it 'correctly serializes stack attributes' do
-      result = pack_and_unpack(described_class.new(locations: [], stack_id: 1))
+      result = pack_and_unpack(described_class.new(locations: [], stack_id: 'some-id'))
 
-      expect(result.fetch('stack_id')).to eq(1)
+      expect(result.fetch('id')).to eq('some-id')
       expect(result.fetch('language')).to eq('ruby')
     end
 
     it 'correctly serializes stack frames' do
       location = location_struct.new('path/to/file.rb', 15, 'SomeModule::SomeClass#some_method')
 
-      result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+      result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
       frames = result.fetch('frames')
 
       expect(frames.size).to eq(1)
@@ -51,7 +51,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       location_2 = location_struct.new('lib/datadog/file.rb', 25, 'Datadog::SomeClass.some_method')
       location_3 = location_struct.new('path/to/another/file.rb', 30, 'AnotherModule.another_method')
 
-      result = pack_and_unpack(described_class.new(locations: [location_1, location_2, location_3], stack_id: 1))
+      result = pack_and_unpack(described_class.new(locations: [location_1, location_2, location_3], stack_id: 'some-id'))
       frames = result.fetch('frames')
 
       expect(frames.size).to eq(2)
@@ -68,7 +68,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
         location_struct.new("path/to/file_#{i}.rb", 10, "SomeModule::SomeClass#some_method_#{i}")
       end
 
-      result = pack_and_unpack(described_class.new(locations: locations, stack_id: 1))
+      result = pack_and_unpack(described_class.new(locations: locations, stack_id: 'some-id'))
       frames = result.fetch('frames')
 
       expect(frames.size).to eq(40)
@@ -92,7 +92,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       it 'parses labels with plain function names' do
         location = location_struct.new('path/to/file.rb', 15, 'some_method')
 
-        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
         frame = result.fetch('frames')[0]
 
         aggregate_failures('frame attributes') do
@@ -104,7 +104,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       it 'parses instance function names' do
         location = location_struct.new('path/to/file.rb', 15, 'SomeClass#some_method')
 
-        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
         frame = result.fetch('frames')[0]
 
         aggregate_failures('frame attributes') do
@@ -116,7 +116,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       it 'parses class function names' do
         location = location_struct.new('path/to/file.rb', 15, 'SomeClass.some_class_method')
 
-        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
         frame = result.fetch('frames')[0]
 
         aggregate_failures('frame attributes') do
@@ -128,7 +128,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       it 'parses namespaced class names' do
         location = location_struct.new('path/to/file.rb', 15, 'SomeModule::SomeClass#some_method')
 
-        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
         frame = result.fetch('frames')[0]
 
         aggregate_failures('frame attributes') do
@@ -141,7 +141,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
         location_one = location_struct.new('path/to/file.rb', 15, 'block in some_method')
         location_two = location_struct.new('path/to/file.rb', 15, 'block (2 levels) in SomeClass.some_method')
 
-        result = pack_and_unpack(described_class.new(locations: [location_one, location_two], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location_one, location_two], stack_id: 'some-id'))
         frames = result.fetch('frames')
 
         aggregate_failures('for first level blocks') do
@@ -158,7 +158,7 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       it 'parses labels for top scope' do
         location = location_struct.new('path/to/file.rb', 15, 'block (3 levels) in <top (required)>')
 
-        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 'some-id'))
         frame = result.fetch('frames')[0]
 
         aggregate_failures('frame attributes') do

--- a/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
+++ b/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
   end
 
   describe '#to_msgpack' do
+    before do
+      Datadog.configuration.appsec.stack_trace.max_depth = 40
+      Datadog.configuration.appsec.stack_trace.top_percentage = 75
+    end
+
+    after do
+      Datadog.configuration.appsec.reset!
+    end
+
     it 'correctly serializes stack attributes' do
       result = pack_and_unpack(described_class.new(locations: [], stack_id: 1))
 
@@ -62,17 +71,17 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       result = pack_and_unpack(described_class.new(locations: locations, stack_id: 1))
       frames = result.fetch('frames')
 
-      expect(frames.size).to eq(32)
+      expect(frames.size).to eq(40)
 
       aggregate_failures('top frames') do
-        0.upto(23) do |i|
+        0.upto(29) do |i|
           expect(frames[i].fetch('id')).to eq(i)
           expect(frames[i].fetch('file')).to eq(locations[i].path)
         end
       end
 
       aggregate_failures('bottom frames') do
-        1.upto(8) do |i|
+        1.upto(10) do |i|
           expect(frames[-i].fetch('id')).to eq(50 - i)
           expect(frames[-i].fetch('file')).to eq(locations[50 - i].path)
         end

--- a/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
+++ b/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
       end
     end
 
+    it 'does not drop frames when appsec.stack_trace.max_depth is set to 0' do
+      Datadog.configuration.appsec.stack_trace.max_depth = 0
+
+      locations = 0.upto(49).map do |i|
+        location_struct.new("path/to/file_#{i}.rb", 10, "SomeModule::SomeClass#some_method_#{i}")
+      end
+
+      result = pack_and_unpack(described_class.new(locations: locations, stack_id: 'some-id'))
+      frames = result.fetch('frames')
+
+      expect(frames.size).to eq(50)
+    end
+
     context 'class and function name parsing' do
       it 'parses labels with plain function names' do
         location = location_struct.new('path/to/file.rb', 15, 'some_method')

--- a/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
+++ b/spec/datadog/appsec/actions_handler/serializable_backtrace_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+
+RSpec.describe Datadog::AppSec::ActionsHandler::SerializableBacktrace do
+  let(:location_struct) do
+    Struct.new(:path, :lineno, :label) do
+      def to_s
+        "#{path}:#{lineno}:in `#{label}'"
+      end
+    end
+  end
+
+  describe '#to_msgpack' do
+    it 'correctly serializes stack attributes' do
+      result = pack_and_unpack(described_class.new(locations: [], stack_id: 1))
+
+      expect(result.fetch('stack_id')).to eq(1)
+      expect(result.fetch('language')).to eq('ruby')
+    end
+
+    it 'correctly serializes stack frames' do
+      location = location_struct.new('path/to/file.rb', 15, 'SomeModule::SomeClass#some_method')
+
+      result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+      frames = result.fetch('frames')
+
+      expect(frames.size).to eq(1)
+
+      aggregate_failures('frame attributes') do
+        expect(frames[0].fetch('id')).to eq(0)
+        expect(frames[0].fetch('text')).to eq('path/to/file.rb:15:in `SomeModule::SomeClass#some_method\'')
+        expect(frames[0].fetch('file')).to eq('path/to/file.rb')
+        expect(frames[0].fetch('line')).to eq(15)
+        expect(frames[0].fetch('class_name')).to eq('SomeModule::SomeClass')
+        expect(frames[0].fetch('function')).to eq('some_method')
+      end
+    end
+
+    it 'drops datadog library frames and does not increase frame id for them' do
+      location_1 = location_struct.new('path/to/file.rb', 20, 'SomeModule.some_method')
+      location_2 = location_struct.new('lib/datadog/file.rb', 25, 'Datadog::SomeClass.some_method')
+      location_3 = location_struct.new('path/to/another/file.rb', 30, 'AnotherModule.another_method')
+
+      result = pack_and_unpack(described_class.new(locations: [location_1, location_2, location_3], stack_id: 1))
+      frames = result.fetch('frames')
+
+      expect(frames.size).to eq(2)
+
+      expect(frames[0].fetch('id')).to eq(0)
+      expect(frames[0].fetch('file')).to eq('path/to/file.rb')
+
+      expect(frames[1].fetch('id')).to eq(1)
+      expect(frames[1].fetch('file')).to eq('path/to/another/file.rb')
+    end
+
+    it 'drops frames from the middle of a big stack but keeps original frame ids' do
+      locations = 0.upto(49).map do |i|
+        location_struct.new("path/to/file_#{i}.rb", 10, "SomeModule::SomeClass#some_method_#{i}")
+      end
+
+      result = pack_and_unpack(described_class.new(locations: locations, stack_id: 1))
+      frames = result.fetch('frames')
+
+      expect(frames.size).to eq(32)
+
+      aggregate_failures('top frames') do
+        0.upto(23) do |i|
+          expect(frames[i].fetch('id')).to eq(i)
+          expect(frames[i].fetch('file')).to eq(locations[i].path)
+        end
+      end
+
+      aggregate_failures('bottom frames') do
+        1.upto(8) do |i|
+          expect(frames[-i].fetch('id')).to eq(50 - i)
+          expect(frames[-i].fetch('file')).to eq(locations[50 - i].path)
+        end
+      end
+    end
+
+    context 'class and function name parsing' do
+      it 'parses labels with plain function names' do
+        location = location_struct.new('path/to/file.rb', 15, 'some_method')
+
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        frame = result.fetch('frames')[0]
+
+        aggregate_failures('frame attributes') do
+          expect(frame.fetch('class_name')).to be_nil
+          expect(frame.fetch('function')).to eq('some_method')
+        end
+      end
+
+      it 'parses instance function names' do
+        location = location_struct.new('path/to/file.rb', 15, 'SomeClass#some_method')
+
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        frame = result.fetch('frames')[0]
+
+        aggregate_failures('frame attributes') do
+          expect(frame.fetch('class_name')).to eq('SomeClass')
+          expect(frame.fetch('function')).to eq('some_method')
+        end
+      end
+
+      it 'parses class function names' do
+        location = location_struct.new('path/to/file.rb', 15, 'SomeClass.some_class_method')
+
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        frame = result.fetch('frames')[0]
+
+        aggregate_failures('frame attributes') do
+          expect(frame.fetch('class_name')).to eq('SomeClass')
+          expect(frame.fetch('function')).to eq('some_class_method')
+        end
+      end
+
+      it 'parses namespaced class names' do
+        location = location_struct.new('path/to/file.rb', 15, 'SomeModule::SomeClass#some_method')
+
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        frame = result.fetch('frames')[0]
+
+        aggregate_failures('frame attributes') do
+          expect(frame.fetch('class_name')).to eq('SomeModule::SomeClass')
+          expect(frame.fetch('function')).to eq('some_method')
+        end
+      end
+
+      it 'ignores block labels' do
+        location_one = location_struct.new('path/to/file.rb', 15, 'block in some_method')
+        location_two = location_struct.new('path/to/file.rb', 15, 'block (2 levels) in SomeClass.some_method')
+
+        result = pack_and_unpack(described_class.new(locations: [location_one, location_two], stack_id: 1))
+        frames = result.fetch('frames')
+
+        aggregate_failures('for first level blocks') do
+          expect(frames[0].fetch('class_name')).to be_nil
+          expect(frames[0].fetch('function')).to eq('some_method')
+        end
+
+        aggregate_failures('for n level blocks') do
+          expect(frames[1].fetch('class_name')).to eq('SomeClass')
+          expect(frames[1].fetch('function')).to eq('some_method')
+        end
+      end
+
+      it 'parses labels for top scope' do
+        location = location_struct.new('path/to/file.rb', 15, 'block (3 levels) in <top (required)>')
+
+        result = pack_and_unpack(described_class.new(locations: [location], stack_id: 1))
+        frame = result.fetch('frames')[0]
+
+        aggregate_failures('frame attributes') do
+          expect(frame.fetch('class_name')).to be_nil
+          expect(frame.fetch('function')).to be_nil
+        end
+      end
+    end
+  end
+
+  def pack_and_unpack(serializable_backtrace)
+    serialized_result = MessagePack.pack(serializable_backtrace)
+    MessagePack.unpack(serialized_result)
+  end
+end

--- a/spec/datadog/appsec/actions_handler_spec.rb
+++ b/spec/datadog/appsec/actions_handler_spec.rb
@@ -150,9 +150,8 @@ RSpec.describe Datadog::AppSec::ActionsHandler do
       end
 
       it 'does not add stack trace to metastruct' do
-        expect do
-          described_class.generate_stack(action_params)
-        end.not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
+        expect { described_class.generate_stack(action_params) }
+          .not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
       end
     end
 
@@ -177,25 +176,22 @@ RSpec.describe Datadog::AppSec::ActionsHandler do
     end
 
     it 'does nothing when stack_id is missing' do
-      expect do
-        described_class.generate_stack({})
-      end.not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
+      expect { described_class.generate_stack({}) }
+        .not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
     end
 
     it 'does nothing when stack trace is disabled' do
       allow(Datadog.configuration.appsec.stack_trace).to receive(:enabled).and_return(false)
 
-      expect do
-        described_class.generate_stack({})
-      end.not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
+      expect { described_class.generate_stack({}) }
+        .not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
     end
 
     it 'does nothing when there is no active span' do
       allow(active_context).to receive(:span).and_return(nil)
 
-      expect do
-        described_class.generate_stack({})
-      end.not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
+      expect { described_class.generate_stack({}) }
+        .not_to(change { active_span.get_metastruct_tag(Datadog::AppSec::Ext::TAG_METASTRUCT_STACK_TRACE) })
     end
   end
 end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -735,6 +735,54 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
     end
 
+    describe 'stack_trace.max_stack_traces' do
+      subject(:stack_trace_max_stack_traces) { settings.appsec.stack_trace.max_stack_traces }
+
+      context 'when DD_APPSEC_MAX_STACK_TRACES' do
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_MAX_STACK_TRACES' => env_var_value) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:env_var_value) { nil }
+
+          it { is_expected.to eq 2 }
+        end
+
+        context 'is defined' do
+          let(:env_var_value) { '4' }
+
+          it { is_expected.to eq(4) }
+        end
+      end
+    end
+
+    describe 'stack_trace.max_stack_traces=' do
+      subject(:set_stack_trace_max_stack_traces) { settings.appsec.stack_trace.max_stack_traces = config_value }
+
+      before { set_stack_trace_max_stack_traces }
+
+      context 'given a correct value' do
+        let(:config_value) { 5 }
+
+        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(5) }
+      end
+
+      context 'given a value less than 1' do
+        let(:config_value) { 0 }
+
+        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(1) }
+      end
+
+      context 'given a value less than 0' do
+        let(:config_value) { -100 }
+
+        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(1) }
+      end
+    end
+
     describe 'auto_user_instrumentation.mode' do
       before { allow(Datadog).to receive(:logger).and_return(logger) }
 

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -607,6 +607,134 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
       end
     end
 
+    describe 'stack_trace.enabled' do
+      subject(:stack_trace_enabled) { settings.appsec.stack_trace.enabled }
+
+      context 'when DD_APPSEC_ENABLED' do
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_STACK_TRACE_ENABLED' => env_var_value) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:env_var_value) { nil }
+
+          it { is_expected.to eq true }
+        end
+
+        context 'is defined' do
+          let(:env_var_value) { 'false' }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
+    describe 'stack_trace.enabled=' do
+      subject(:set_stack_trace_enabled) { settings.appsec.stack_trace.enabled = config_value }
+
+      [true, false].each do |value|
+        context "when given #{value}" do
+          let(:config_value) { value }
+
+          before { set_stack_trace_enabled }
+
+          it { expect(settings.appsec.stack_trace.enabled).to eq(value) }
+        end
+      end
+    end
+
+    describe 'stack_trace.max_depth' do
+      subject(:stack_trace_max_depth) { settings.appsec.stack_trace.max_depth }
+
+      context 'when DD_APPSEC_STACK_TRACE_MAX_DEPTH' do
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_MAX_STACK_TRACE_DEPTH' => env_var_value) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:env_var_value) { nil }
+
+          it { is_expected.to eq 32 }
+        end
+
+        context 'is defined' do
+          let(:env_var_value) { '50' }
+
+          it { is_expected.to eq(50) }
+        end
+      end
+    end
+
+    describe 'stack_trace.max_depth=' do
+      subject(:set_stack_trace_max_depth) { settings.appsec.stack_trace.max_depth = config_value }
+
+      before { set_stack_trace_max_depth }
+
+      context 'given a correct value' do
+        let(:config_value) { 50 }
+
+        it { expect(settings.appsec.stack_trace.max_depth).to eq(50) }
+      end
+
+      context 'given a value less than 10' do
+        let(:config_value) { 5 }
+
+        it { expect(settings.appsec.stack_trace.max_depth).to eq(10) }
+      end
+    end
+
+    describe 'stack_trace.top_percentage' do
+      subject(:stack_trace_top_percentage) { settings.appsec.stack_trace.top_percentage }
+
+      context 'when DD_APPSEC_STACK_TRACE_MAX_DEPTH_TOP_PERCENT' do
+        around do |example|
+          ClimateControl.modify('DD_APPSEC_MAX_STACK_TRACE_DEPTH_TOP_PERCENT' => env_var_value) do
+            example.run
+          end
+        end
+
+        context 'is not defined' do
+          let(:env_var_value) { nil }
+
+          it { is_expected.to eq 75 }
+        end
+
+        context 'is defined' do
+          let(:env_var_value) { '50' }
+
+          it { is_expected.to eq(50) }
+        end
+      end
+    end
+
+    describe 'stack_trace.top_percentage=' do
+      subject(:set_stack_trace_top_percentage) { settings.appsec.stack_trace.top_percentage = config_value }
+
+      before { set_stack_trace_top_percentage }
+
+      context 'given a correct value' do
+        let(:config_value) { 50 }
+
+        it { expect(settings.appsec.stack_trace.top_percentage).to eq(50) }
+      end
+
+      context 'given a value more than 100' do
+        let(:config_value) { 200 }
+
+        it { expect(settings.appsec.stack_trace.top_percentage).to eq(100) }
+      end
+
+      context 'given a value less than 0' do
+        let(:config_value) { -100 }
+
+        it { expect(settings.appsec.stack_trace.top_percentage).to eq(0) }
+      end
+    end
+
     describe 'auto_user_instrumentation.mode' do
       before { allow(Datadog).to receive(:logger).and_return(logger) }
 

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -680,10 +680,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         it { expect(settings.appsec.stack_trace.max_depth).to eq(50) }
       end
 
-      context 'given a value less than 10' do
-        let(:config_value) { 5 }
+      context 'given a value less than 0' do
+        let(:config_value) { -5 }
 
-        it { expect(settings.appsec.stack_trace.max_depth).to eq(10) }
+        it { expect(settings.appsec.stack_trace.max_depth).to eq(0) }
       end
     end
 
@@ -770,16 +770,10 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
         it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(5) }
       end
 
-      context 'given a value less than 1' do
-        let(:config_value) { 0 }
-
-        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(1) }
-      end
-
       context 'given a value less than 0' do
-        let(:config_value) { -100 }
+        let(:config_value) { -1 }
 
-        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(1) }
+        it { expect(settings.appsec.stack_trace.max_stack_traces).to eq(0) }
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds Stack Trace reporting to the Datadog Agent in case of an AppSec event with `generate_stack` action.

**Motivation:**
We are not handling `generate_stack` action yet.

**Change log entry**
Yes. AppSec: Add stack trace reporting for security events.

**Additional Notes:**
None.

**How to test the change?**
CI and local testing with app-generator (SSRF or SQLi variants).
