### PR TITLE
fix(global_tags): update ddtags to align with other sdks

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -619,38 +619,38 @@ module Datadog
           o.type :hash, nilable: true
           o.env [Core::Environment::Ext::ENV_TAGS, Core::Environment::Ext::ENV_OTEL_RESOURCE_ATTRIBUTES]
           o.env_parser do |env_value|
-            values = if env_value.include?(',')
-                       env_value.split(',')
-                     else
-                       env_value.split(' ') # rubocop:disable Style/RedundantArgument
-                     end
-            values.map! do |v|
-              v.gsub!(/\A[\s,]*|[\s,]*\Z/, '')
-
-              v.empty? ? nil : v
-            end
-
-            values.compact!
-            values.each_with_object({}) do |tag, tags|
-              key, value = tag.split(':', 2)
-              if value.nil?
-                # support tags/attributes delimited by the OpenTelemetry separator (`=`)
-                key, value = tag.split('=', 2)
+            # Parses a string containing key-value pairs and returns a hash.
+            # Key-value pairs are delimited by ':' OR `=`, and pairs are separated by whitespace, comma, OR BOTH.
+            values = {}
+            unless env_value.nil? || env_value.empty?
+              # falling back to comma as separator
+              sep = env_value.include?(',') ? ',' : ' '
+              # split by separator
+              env_value.split(sep).each do |tag|
+                tag.strip!
+                next if tag.empty?
+                # tag by : or = (for OpenTelemetry)
+                key, val = if tag.include?(':')
+                  tag.split(':', 2).map(&:strip)
+                elsif tag.include?('=')
+                  tag.split('=', 2).map(&:strip)
+                else
+                  [tag.strip, '']
+                end
+                next if key.empty?
+                # maps OpenTelemetry semantic attributes to Datadog tags
+                case key.downcase
+                when 'deployment.environment'
+                  key = 'env'
+                when 'service.version'
+                  key = 'version'
+                when 'service.name'
+                  key = 'service'
+                end
+                values[key] = val
               end
-              next if value.nil? || value.empty?
-
-              # maps OpenTelemetry semantic attributes to Datadog tags
-              case key.downcase
-              when 'deployment.environment'
-                tags['env'] = value
-              when 'service.version'
-                tags['version'] = value
-              when 'service.name'
-                tags['service'] = value
-              else
-                tags[key] = value
-              end
             end
+            values
           end
           o.setter do |new_value, old_value|
             raw_tags = new_value || {}

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -629,15 +629,17 @@ module Datadog
               env_value.split(sep).each do |tag|
                 tag.strip!
                 next if tag.empty?
+
                 # tag by : or = (for OpenTelemetry)
                 key, val = if tag.include?(':')
-                  tag.split(':', 2).map(&:strip)
-                elsif tag.include?('=')
-                  tag.split('=', 2).map(&:strip)
-                else
-                  [tag.strip, '']
-                end
+                             tag.split(':', 2).map(&:strip)
+                           elsif tag.include?('=')
+                             tag.split('=', 2).map(&:strip)
+                           else
+                             [tag.strip, '']
+                           end
                 next if key.empty?
+
                 # maps OpenTelemetry semantic attributes to Datadog tags
                 case key.downcase
                 when 'deployment.environment'

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1095,7 +1095,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
         it { is_expected.to include('a' => '1', 'b' => '2') }
 
         context 'with an invalid tag' do
-          ['', 'a', ':', ',', 'a:'].each do |invalid_tag|
+          ['', ':', ','].each do |invalid_tag|
             context "when tag is #{invalid_tag.inspect}" do
               let(:env_tags) { invalid_tag }
 
@@ -1104,6 +1104,14 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           end
         end
 
+        context 'with no seperator' do
+          ['key', 'key:', 'key: '].each do |tag|
+            context "when tag is #{tag.inspect}" do
+              let(:env_tags) { tag }
+              it { is_expected.to eq({"key" => ""}) }
+            end
+          end
+        end
         context 'with multiple colons' do
           let(:env_tags) { 'key:va:lue' }
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1108,10 +1108,11 @@ RSpec.describe Datadog::Core::Configuration::Settings do
           ['key', 'key:', 'key: '].each do |tag|
             context "when tag is #{tag.inspect}" do
               let(:env_tags) { tag }
-              it { is_expected.to eq({"key" => ""}) }
+              it { is_expected.to eq({ 'key' => '' }) }
             end
           end
         end
+
         context 'with multiple colons' do
           let(:env_tags) { 'key:va:lue' }
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Ensures the ruby tracer parses ddtags in a manner that is consistent with the trace agent and other datadog sdks.

**Motivation:**

Configuration consistency

**Change log entry**

Improves DD_TAGS configuration loading for consistent handling of whitespace and key-value pairs across all Datadog libraries and the Datadog Agent. Key-value pairs in the format `key:` or `key` are now stored as {"key": ""} instead of being ignored.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
