### PR TITLE
fix(datadog-headers): ignore invalid tid values in x-datadog-tags

### DIFF
--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -117,7 +117,7 @@ module Datadog
           return trace_id unless tags
           return trace_id unless (high_order = tags.delete(Tracing::Metadata::Ext::Distributed::TAG_TID))
           return trace_id unless high_order.size == 16
-          return trace_id unless high_order =~ /\A[0-9a-f]+\z/i
+          return trace_id unless /\A[0-9a-f]+\z/i.match?(high_order)
 
           Tracing::Utils::TraceId.concatenate(high_order.to_i(16), trace_id)
         end

--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -116,6 +116,8 @@ module Datadog
         def extract_trace_id!(trace_id, tags)
           return trace_id unless tags
           return trace_id unless (high_order = tags.delete(Tracing::Metadata::Ext::Distributed::TAG_TID))
+          return trace_id unless high_order.size == 16
+          return trace_id unless high_order =~ /\A[0-9a-f]+\z/i
 
           Tracing::Utils::TraceId.concatenate(high_order.to_i(16), trace_id)
         end


### PR DESCRIPTION
**What does this PR do?**

- Ensures only 16 character hexadecimals are extracted from the `_dd.p.tid` distributed tracing tag. This ensures the ruby tracer does not propagate invalid/unexpected trace ids. 

**Motivation:**

- Ensure the ruby tracer propagates 128bit trace ids in a manner that is consistent with other datadog libraries.

**Change log entry**

Ensures the Ruby tracer extracts only 16-character hex values from the _dd.p.tid tag in x-datadog-tags, preventing invalid trace ID propagation.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
