### PR TITLE
[NO-TICKET] Adjust build coverage matrix method

### DIFF
--- a/appraisal/generate.rb
+++ b/appraisal/generate.rb
@@ -13,13 +13,13 @@
 # Usage: `bundle exec ruby appraisal/generate.rb`
 
 require 'bundler'
-require "appraisal/appraisal"
+require 'appraisal/appraisal'
 
-require_relative "../tasks/appraisal_conversion"
+require_relative '../tasks/appraisal_conversion'
 
 gemfile = Appraisal::Gemfile.new.tap do |g|
   # Support `eval_gemfile` for `Bundler::DSL`
-  g.define_singleton_method(:eval_gemfile) {|file| load(file) }
+  g.define_singleton_method(:eval_gemfile) { |file| load(file) }
   g.load(Bundler.default_gemfile)
 end
 
@@ -53,20 +53,56 @@ end
 # `gem`  : optional, gem name to test (gem name can be different from the integration name)
 # `min`  : optional, minimum version to test
 # `meta` : optional, additional metadata (development dependencies, etc.) for the group
+#
+# Examples:
+#
+# 1. Generating coverage starting minimal version
+#
+#    build_coverage_matrix('devise', min: '3.1.4')
+#     ├─ appraise 'devise-min'
+#     │   └─ gem 'devise', '= 3.1.4'
+#     └─ appraise 'devise-latest'
+#         └─ gem 'devise'
+#
+# 2. Generating coverage starting minimal version with some additional gems with
+#    specific version tied to only minimal version
+#
+#    build_coverage_matrix('devise', min: '3.1.4', meta: { min: { 'bigdecimal' => '1.3.4' } })
+#     ├─ appraise 'devise-min'
+#     │   ├─ gem 'devise', '= 3.1.4'
+#     │   └─ gem 'bigdecimal', '1.3.4'
+#     └─ appraise 'devise-latest'
+#         └─ gem 'devise'
+#
+# 3. Generating coverage starting minimal version with some additional gems with
+#    specific version for all possible combinations
+#
+#    build_coverage_matrix('devise', min: '3.1.4', meta: { 'bigdecimal' => '3.0.0' })
+#     ├─ appraise 'devise-min'
+#     │   ├─ gem 'devise', '= 3.1.4'
+#     │   └─ gem 'bigdecimal', '3.0.0'
+#     └─ appraise 'devise-latest'
+#         ├─ gem 'devise'
+#         └─ gem 'bigdecimal', '3.0.0'
 def build_coverage_matrix(integration, range = [], gem: nil, min: nil, meta: {})
   gem ||= integration
+
+  meta_versions = meta.each_with_object({}) do |(key, value), memo|
+    memo[key] = meta.delete(key) if value.is_a?(Hash)
+  end
 
   if min
     appraise "#{integration}-min" do
       gem gem, "= #{min}"
-      meta.each { |k, v| v ? gem(k, v) : gem(k) }
+
+      meta_versions[:min].to_h.merge(meta).each { |k, v| v ? gem(k, v) : gem(k) }
     end
   end
 
   range.each do |n|
     appraise "#{integration}-#{n}" do
       gem gem, "~> #{n}"
-      meta.each { |k, v| v ? gem(k, v) : gem(k) }
+      meta_versions[n].to_h.merge(meta).each { |k, v| v ? gem(k, v) : gem(k) }
     end
   end
 
@@ -75,7 +111,7 @@ def build_coverage_matrix(integration, range = [], gem: nil, min: nil, meta: {})
     # still requires being updated to pick up the next major version and
     # committing the changes to lockfiles.
     gem gem
-    meta.each { |k, v| v ? gem(k, v) : gem(k) }
+    meta_versions[:latest].to_h.merge(meta).each { |k, v| v ? gem(k, v) : gem(k) }
   end
 end
 

--- a/appraisal/ruby-2.5.rb
+++ b/appraisal/ruby-2.5.rb
@@ -223,7 +223,7 @@ build_coverage_matrix('excon')
 build_coverage_matrix('rest-client')
 build_coverage_matrix('mongo', min: '2.1.0')
 build_coverage_matrix('dalli')
-build_coverage_matrix('devise', min: '3.2.1')
+build_coverage_matrix('devise', min: '3.2.1', meta: { min: { 'bigdecimal' => '1.3.4' } })
 
 appraise 'relational_db' do
   gem 'activerecord', '~> 5'

--- a/appraisal/ruby-2.6.rb
+++ b/appraisal/ruby-2.6.rb
@@ -176,7 +176,7 @@ build_coverage_matrix('excon')
 build_coverage_matrix('rest-client')
 build_coverage_matrix('mongo', min: '2.1.0')
 build_coverage_matrix('dalli', [2])
-build_coverage_matrix('devise', min: '3.2.1')
+build_coverage_matrix('devise', min: '3.2.1', meta: { min: { 'bigdecimal' => '1.4.1' } })
 
 appraise 'relational_db' do
   gem 'activerecord', '~> 6.0.0'

--- a/gemfiles/ruby_2.5_devise_min.gemfile
+++ b/gemfiles/ruby_2.5_devise_min.gemfile
@@ -25,6 +25,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "devise", "= 3.2.1"
+gem "bigdecimal", "1.3.4"
 
 group :dev do
 

--- a/gemfiles/ruby_2.5_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_devise_min.gemfile.lock
@@ -37,7 +37,7 @@ GEM
     benchmark-ips (2.14.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
-    bigdecimal (3.1.9)
+    bigdecimal (1.3.4)
     builder (3.3.0)
     byebug (11.1.3)
     climate_control (1.2.0)
@@ -162,6 +162,7 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)
+  bigdecimal (= 1.3.4)
   byebug
   climate_control (~> 1.2.0)
   concurrent-ruby

--- a/gemfiles/ruby_2.6_devise_min.gemfile
+++ b/gemfiles/ruby_2.6_devise_min.gemfile
@@ -25,6 +25,7 @@ gem "simplecov-cobertura", "~> 2.1.0"
 gem "warning", "~> 1"
 gem "webmock", ">= 3.10.0"
 gem "devise", "= 3.2.1"
+gem "bigdecimal", "1.4.1"
 
 group :dev do
 

--- a/gemfiles/ruby_2.6_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_min.gemfile.lock
@@ -37,7 +37,7 @@ GEM
     benchmark-ips (2.14.0)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
-    bigdecimal (3.1.9)
+    bigdecimal (1.4.1)
     builder (3.3.0)
     byebug (11.1.3)
     climate_control (1.2.0)
@@ -160,6 +160,7 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips (~> 2.8)
   benchmark-memory (< 0.2)
+  bigdecimal (= 1.4.1)
   byebug
   climate_control (~> 1.2.0)
   concurrent-ruby


### PR DESCRIPTION
**What does this PR do?**

Extend `build_coverage_matrix` method to allow us less boilerplate for auto-generated appraisal groups.

in addition devise group was adjusted to follow the actual state with older Ruby versions (reduce coverage to 2.5 and 2.6 and define specific bigdecimal gem versions)

**Motivation:**

I don't want to define manually appraisal groups and I find that `meta` argument allows you to add gems to all auto-generated groups, but I guess it will be cool to give it a bit more flexibility.

Of course any tool could be abused, but it will be obvious to spot in PR.

**Change log entry**

No.

**Additional Notes:**

I hope you like it folks, I've added some examples, but want to have a bit more

**How to test the change?**

CI is good enough