### PR TITLE
Move `apm-idm-ruby` ownership to `tracing-ruby`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@ docs/GettingStarted.md @DataDog/documentation
 lib/datadog/appsec/ @DataDog/asm-ruby
 lib/datadog/appsec.rb @DataDog/asm-ruby
 lib/datadog/tracing/ @DataDog/tracing-ruby
-lib/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+lib/datadog/tracing/contrib/ @DataDog/tracing-ruby
 lib/datadog/tracing.rb @DataDog/tracing-ruby
 lib/datadog/opentelemetry/ @DataDog/tracing-ruby
 lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
@@ -21,7 +21,7 @@ ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 sig/datadog/appsec/ @DataDog/asm-ruby
 sig/datadog/appsec.rbs @DataDog/asm-ruby
 sig/datadog/tracing/ @DataDog/tracing-ruby
-sig/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+sig/datadog/tracing/contrib/ @DataDog/tracing-ruby
 sig/datadog/tracing.rbs @DataDog/tracing-ruby
 sig/datadog/opentelemetry/ @DataDog/tracing-ruby
 sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
@@ -31,7 +31,7 @@ sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 # Specs
 spec/datadog/appsec/ @DataDog/asm-ruby
 spec/datadog/tracing/ @DataDog/tracing-ruby
-spec/datadog/tracing/contrib/ @DataDog/apm-idm-ruby
+spec/datadog/tracing/contrib/ @DataDog/tracing-ruby
 spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
 spec/datadog/opentelemetry/ @DataDog/tracing-ruby
 spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby


### PR DESCRIPTION
The bus factor is too low for `apm-idm-ruby` today.
With only two members:
* A PR from one of the two members HAS to be approved by the other; no replacement reviewer qualifies. If one member is away, the other cannot merge their work.
* If both members are away, no PR touching `tracing/contrib` can be merged.

This PR changes the ownership of `tracing/contrib` files to `tracing-ruby`, which has four members and already owns `tracing` and `opentelemetry`. The members `tracing-ruby` are: both `apm-idm-ruby` members plus two other very smart and handsome Ruby engineers.

**Change log entry**
No