### PR TITLE
APMS-15322 Reproducer for loading core only and configuring the library

### DIFF
--- a/lib/datadog/tracing/component.rb
+++ b/lib/datadog/tracing/component.rb
@@ -6,6 +6,7 @@ require_relative 'sync_writer'
 require_relative 'sampling/span/rule_parser'
 require_relative 'sampling/span/sampler'
 require_relative 'diagnostics/environment_logger'
+require_relative 'contrib/component'
 
 module Datadog
   module Tracing

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -38,3 +38,25 @@ RSpec.describe 'loading of products' do
     end
   end
 end
+
+RSpec.describe 'load core only and configure library' do
+  let(:code) do
+    <<-E
+      if defined?(Datadog)
+        unless Datadog.constants == [:VERSION]
+          exit 1
+        end
+      end
+
+      require 'datadog/core'
+
+      Datadog.configure do
+      end
+    E
+  end
+
+  it 'configures successfully' do
+    rv = system("ruby -e #{Shellwords.shellescape(code)}")
+    expect(rv).to be true
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds a test that the tracer can be configured when only core part of the code is loaded.

Also adds a require from tracing to its contrib to avoid leaking tracing internals to core/customers.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
A customer reported an exception when initializing dd-trace-rb 2.12.2 which I was able to reproduce with the following code:
```
require 'datadog/core'
require 'datadog/tracing/contrib'

Datadog.configure do
end
```

The above code worked on 2.4.0 and is failing from 2.5.0 through 2.12.2 with the following exception:
```
/home/w/apps/dd-trace-rb/lib/datadog/core/remote/transport/http.rb:105:in `block in default_headers': undefined method `appsec' for an instance of Datadog::Core::Configuration::Settings (NoMethodError)

              if Datadog.configuration.appsec.standalone.enabled
                                      ^^^^^^^
	from <internal:kernel>:90:in `tap'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/remote/transport/http.rb:99:in `default_headers'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/remote/transport/http.rb:47:in `block in root'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/transport/http/builder.rb:37:in `initialize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/transport/http.rb:33:in `new'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/transport/http.rb:33:in `build'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/remote/transport/http.rb:34:in `new'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/remote/transport/http.rb:45:in `root'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/environment/agent_info.rb:58:in `initialize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:104:in `new'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:104:in `initialize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:253:in `new'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:253:in `build_components'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:92:in `block in configure'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:235:in `block in safely_synchronize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:233:in `synchronize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:233:in `safely_synchronize'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:87:in `configure'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/contrib/extensions.rb:66:in `configure'
	from repro.rb:4:in `<main>'
```

The issue causing the exception is already repaired on master (via https://github.com/DataDog/dd-trace-rb/pull/4498) however there was no existing test coverage for this particular usage of the library, which the present PR is now adding.

**Change log entry**
None for this PR, however https://github.com/DataDog/dd-trace-rb/pull/4498 also repairs the failure to configure dd-trace-rb which I added to its change log entry.
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Test added in this PR
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
