### PR TITLE
repair type check on master: add format_trace_id_128 to types

### DIFF
--- a/sig/datadog/tracing/correlation.rbs
+++ b/sig/datadog/tracing/correlation.rbs
@@ -45,6 +45,8 @@ module Datadog
       def self?.identifier_from_digest: (untyped digest) -> untyped
 
       def self?.format_trace_id: (untyped trace_id) -> untyped
+
+      def self?.format_trace_id_128: (untyped trace_id) -> untyped
     end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Makes type checking pass on master by adding  format_trace_id_128 to types

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Red CI on master

**Change log entry**
None: I added the change log entry to https://github.com/DataDog/dd-trace-rb/pull/4499 which would also cover the changes in this PR
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The issue was the combination of https://github.com/DataDog/dd-trace-rb/pull/4499 and https://github.com/DataDog/dd-trace-rb/pull/4528 - the first PR enabled type checking of correlation.rb and the second one added a method but not a type signature when type checking ignored the file.

**How to test the change?**
Existing CI
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
