### PR TITLE
Fix warnings in DI and tracing generated with -w

### DIFF
--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../core'
-
 module Datadog
   module DI
     # Component for dynamic instrumentation.

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -227,20 +227,6 @@ module Datadog
           start
         end
 
-        # Determine how much longer the worker thread should sleep
-        # so as not to send in less than min send interval since the last send.
-        # Important: this method must be called when @lock is held.
-        #
-        # Returns the time remaining to sleep.
-        def set_sleep_remaining
-          now = Core::Utils::Time.get_time
-          @sleep_remaining = if last_sent
-            [last_sent + min_send_interval - now, 0].max
-          else
-            0
-          end
-        end
-
         public "add_#{event_type}"
 
         # Sends pending probe statuses or snapshots.
@@ -285,6 +271,20 @@ module Datadog
           @lock.synchronize do
             @io_in_progress = false
           end
+        end
+      end
+
+      # Determine how much longer the worker thread should sleep
+      # so as not to send in less than min send interval since the last send.
+      # Important: this method must be called when @lock is held.
+      #
+      # Returns the time remaining to sleep.
+      def set_sleep_remaining
+        now = Core::Utils::Time.get_time
+        @sleep_remaining = if last_sent
+          [last_sent + min_send_interval - now, 0].max
+        else
+          0
         end
       end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -2,7 +2,6 @@
 
 require_relative '../core/environment/identity'
 require_relative '../core/utils'
-require_relative 'tracer'
 require_relative 'event'
 require_relative 'metadata/tagging'
 require_relative 'sampling/ext'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Fixes the following warnings:

```
big% irb -w -Ilib -rdatadog   
/home/w/apps/dd-trace-rb/lib/datadog/tracing/trace_operation.rb:5: warning: /home/w/apps/dd-trace-rb/lib/datadog/tracing/trace_operation.rb:5: warning: loading in progress, circular require considered harmful - /home/w/apps/dd-trace-rb/lib/datadog/tracing/tracer.rb
	from /home/w/.rbenv/versions/3.3/bin/irb:25:in  `<main>'
	from /home/w/.rbenv/versions/3.3/bin/irb:25:in  `load'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/exe/irb:9:in  `<top (required)>'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb.rb:898:in  `start'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:56:in  `setup'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:467:in  `load_modules'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:467:in  `each'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:469:in  `block in load_modules'
	from <internal:/home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /home/w/apps/dd-trace-rb/lib/datadog.rb:4:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog.rb:4:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core.rb:4:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core.rb:4:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/extensions.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/extensions.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:13:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:13:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/component.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/component.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/tracer.rb:16:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/tracer.rb:16:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/trace_operation.rb:5:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing/trace_operation.rb:5:in  `require_relative'

/home/w/apps/dd-trace-rb/lib/datadog/di/component.rb:3: warning: /home/w/apps/dd-trace-rb/lib/datadog/di/component.rb:3: warning: loading in progress, circular require considered harmful - /home/w/apps/dd-trace-rb/lib/datadog/core.rb
	from /home/w/.rbenv/versions/3.3/bin/irb:25:in  `<main>'
	from /home/w/.rbenv/versions/3.3/bin/irb:25:in  `load'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/exe/irb:9:in  `<top (required)>'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb.rb:898:in  `start'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:56:in  `setup'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:467:in  `load_modules'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:467:in  `each'
	from /home/w/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/irb-1.14.1/lib/irb/init.rb:469:in  `block in load_modules'
	from <internal:/home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from <internal:/home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in  `require'
	from /home/w/apps/dd-trace-rb/lib/datadog.rb:4:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog.rb:4:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/tracing.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core.rb:4:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core.rb:4:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/extensions.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/extensions.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration.rb:3:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:16:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/core/configuration/components.rb:16:in  `require_relative'
	from /home/w/apps/dd-trace-rb/lib/datadog/di/component.rb:3:in  `<top (required)>'
	from /home/w/apps/dd-trace-rb/lib/datadog/di/component.rb:3:in  `require_relative'

/home/w/apps/dd-trace-rb/lib/datadog/di/probe_notifier_worker.rb:235: warning: method redefined; discarding old set_sleep_remaining
/home/w/apps/dd-trace-rb/lib/datadog/di/probe_notifier_worker.rb:235: warning: previous definition of set_sleep_remaining was here
```


**Motivation:**
<!-- What inspired you to submit this pull request? -->
Warning-cleanliness of dd-trace-rb

**Change log entry**
Yes: repair warnings printed by `ruby -w` when loading dd-trace-rb
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
Does not fix the appsec warnings:
```
/home/w/apps/dd-trace-rb/lib/datadog/appsec/contrib/devise/patcher.rb:39: warning: possibly useless use of :: in void context
/home/w/apps/dd-trace-rb/lib/datadog/appsec/actions_handler/serializable_backtrace.rb:14: warning: character class has duplicated range: /\b([\w+:{2}]*\w+)?[#|.]?\b(\w+)\z/
```
And also the profiling warnings:
```
/home/w/apps/dd-trace-rb/lib/datadog/profiling.rb:81: warning: method redefined; discarding old allocation_count
/home/w/apps/dd-trace-rb/lib/datadog/profiling.rb:57: warning: previous definition of allocation_count was here
```
**How to test the change?**
Manually tested with:
```
irb -Ilib -rdatadog
```
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
