### PR TITLE
Fix a warning related to regular expression in AppSec

### DIFF
--- a/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
+++ b/lib/datadog/appsec/actions_handler/serializable_backtrace.rb
@@ -11,7 +11,7 @@ module Datadog
       #
       # It represents the stack trace that is added to span metastruct field.
       class SerializableBacktrace
-        CLASS_AND_FUNCTION_NAME_REGEX = /\b([\w+:{2}]*\w+)?[#|.]?\b(\w+)\z/.freeze
+        CLASS_AND_FUNCTION_NAME_REGEX = /\b((?:\w+::)*\w+)?[#.]?\b(\w+)\z/.freeze
 
         def initialize(locations:, stack_id:)
           @stack_id = stack_id


### PR DESCRIPTION
**What does this PR do?**
It fixes a following warning:
```bash
dd-trace-rb/lib/datadog/appsec/actions_handler/serializable_backtrace.rb:14: warning: character class has duplicated range: /\b([\w+:{2}]*\w+)?[#|.]?\b(\w+)\z/
```

**Motivation:**
We don't want any warnings to be triggered by our library code.

**Change log entry**
None. This change is internal.

**Additional Notes:**
None.

**How to test the change?**
```bash
ruby -W lib/datadog/appsec/actions_handler/serializable_backtrace.rb
```