### PR TITLE
Fix method override warning in profiler

### DIFF
--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -80,7 +80,7 @@ module Datadog
     private_class_method def self.replace_noop_allocation_count
       class << self
         remove_method :allocation_count
-        def allocation_count # rubocop:disable Lint/NestedMethodDefinition (On purpose!)
+        def allocation_count
           Datadog::Profiling::Collectors::CpuAndWallTimeWorker._native_allocation_count
         end
       end

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -78,8 +78,11 @@ module Datadog
     end
 
     private_class_method def self.replace_noop_allocation_count
-      def self.allocation_count # rubocop:disable Lint/NestedMethodDefinition (On purpose!)
-        Datadog::Profiling::Collectors::CpuAndWallTimeWorker._native_allocation_count
+      class << self
+        remove_method :allocation_count
+        def allocation_count # rubocop:disable Lint/NestedMethodDefinition (On purpose!)
+          Datadog::Profiling::Collectors::CpuAndWallTimeWorker._native_allocation_count
+        end
       end
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Repairs the warning generated with `ruby -w`:
```
/home/w/apps/dd-trace-rb/lib/datadog/profiling.rb:81: warning: method redefined; discarding old allocation_count
/home/w/apps/dd-trace-rb/lib/datadog/profiling.rb:57: warning: previous definition of allocation_count was here
```

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Warning-clean library

**Change log entry**
Yes: repair `ruby -w` warning in profiler
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
PRs fixing warnings in other components: #4547, #4548 
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tested manually with:
```
irb -Ilib -rdatadog/profiliing
```
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
