### PR TITLE
Add tests verifying library is -w warning-clean

### DIFF
--- a/lib/datadog.rb
+++ b/lib/datadog.rb
@@ -9,5 +9,5 @@ require_relative 'datadog/profiling'
 require_relative 'datadog/appsec'
 # Line probes will not work on Ruby < 2.6 because of lack of :script_compiled
 # trace point. Only load DI on supported Ruby versions.
-require_relative 'datadog/di' if RUBY_VERSION >= '2.6'
+require_relative 'datadog/di' if RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby'
 require_relative 'datadog/kit'

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -1,6 +1,8 @@
 require 'shellwords'
+require 'open3'
 
 REQUIRES = {
+  'datadog' => 'Datadog::Core',
   'datadog/appsec' => 'Datadog::AppSec',
   'datadog/core' => 'Datadog::Core',
   'datadog/di' => 'Datadog::DI',
@@ -34,6 +36,16 @@ RSpec.describe 'loading of products' do
       it 'loads successfully by itself' do
         rv = system("ruby -e #{Shellwords.shellescape(code)}")
         expect(rv).to be true
+      end
+
+      it 'produces no output' do
+        out, status = Open3.capture2e('ruby', '-w', stdin_data: code)
+        unless status.exitstatus == 0
+          fail("Test script failed with exit status #{status.exitstatus}:\n#{out}")
+        end
+        unless out.empty?
+          fail("Test script produced unexpected output: #{out}")
+        end
       end
     end
   end

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -6,9 +6,9 @@ REQUIRES = [
   ['datadog/appsec', 'Datadog::AppSec'],
   ['datadog/core', 'Datadog::Core'],
   ['datadog/di', 'Datadog::DI',
-    lambda { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
+   -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
   ['datadog/di/preload', 'Datadog::DI::CodeTracker',
-    lambda { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
+   -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
   ['datadog/kit', 'Datadog::Kit'],
   ['datadog/profiling', 'Datadog::Profiling'],
   ['datadog/tracing', 'Datadog::Tracing'],
@@ -19,9 +19,7 @@ RSpec.describe 'loading of products' do
     context req do
       if condition
         before do
-          unless condition.call
-            skip 'condition is false'
-          end
+          skip 'condition is false' unless condition.call
         end
       end
 
@@ -50,12 +48,8 @@ RSpec.describe 'loading of products' do
 
       it 'produces no output' do
         out, status = Open3.capture2e('ruby', '-w', stdin_data: code)
-        unless status.exitstatus == 0
-          fail("Test script failed with exit status #{status.exitstatus}:\n#{out}")
-        end
-        unless out.empty?
-          fail("Test script produced unexpected output: #{out}")
-        end
+        raise("Test script failed with exit status #{status.exitstatus}:\n#{out}") unless status.exitstatus == 0
+        raise("Test script produced unexpected output: #{out}") unless out.empty?
       end
     end
   end

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'loading of products' do
 
       it 'produces no output' do
         out, status = Open3.capture2e('ruby', '-w', stdin_data: code)
-        raise("Test script failed with exit status #{status.exitstatus}:\n#{out}") unless status.exitstatus == 0
+        raise("Test script failed with exit status #{status.exitstatus}:\n#{out}") unless status.success?
         raise("Test script produced unexpected output: #{out}") unless out.empty?
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds a test that no warnings (`ruby -v`) are emitted when the tracer is loaded (#4548, #4547, #4548)

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Customer feedback that they don't want tracer to emit warnings

**Change log entry**
None (warnings removed by the other PRs, this PR only adds test coverage)
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tests are added in this PR
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
