### PR TITLE
[NO-TICKET] Add `forced-tests-list.json` to `changes` step in `system-tests` workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/forced-tests-list.json'
               - '.github/workflows/**'
               - 'lib/**'
               - 'ext/**'


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This adds `forced-tests-list.json` to the `changes` step of `system-tests` workflow. As this file is a list of force-executed system-tests, I believe that any changes on them should execute system-tests. This file is not added in the `parametric-tests` workflow as it does not take into account that file for now.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
The post-release PR does not execute system-tests but we should check that removing force-executed tests still executes them as they should be activated in system-tests manifest.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Once merged, the post-release PR should execute system-tests (after a rebase on master)

<!-- Unsure? Have a question? Request a review! -->
