### PR TITLE
default logger arguments for compatibility with previous dd-trace-rb …

### DIFF
--- a/lib/datadog/core/environment/agent_info.rb
+++ b/lib/datadog/core/environment/agent_info.rb
@@ -53,7 +53,7 @@ module Datadog
       class AgentInfo
         attr_reader :agent_settings, :logger
 
-        def initialize(agent_settings, logger:)
+        def initialize(agent_settings, logger: Datadog.logger)
           @agent_settings = agent_settings
           @logger = logger
           @client = Remote::Transport::HTTP.root(agent_settings: agent_settings, logger: logger)

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -23,7 +23,7 @@ module Datadog
 
         attr_reader :statsd, :logger
 
-        def initialize(logger:, statsd: nil, enabled: true, **_)
+        def initialize(logger: Datadog.logger, statsd: nil, enabled: true, **_)
           @logger = logger
           @statsd =
             if supported?

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -15,7 +15,7 @@ module Datadog
 
         attr_reader :transport, :repository, :id, :dispatcher, :logger
 
-        def initialize(transport, capabilities, logger:, repository: Configuration::Repository.new)
+        def initialize(transport, capabilities, logger: Datadog.logger, repository: Configuration::Repository.new)
           @transport = transport
           @logger = logger
 

--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -9,7 +9,7 @@ module Datadog
       class Negotiation
         attr_reader :logger
 
-        def initialize(_settings, agent_settings, logger:, suppress_logging: {})
+        def initialize(_settings, agent_settings, logger: Datadog.logger, suppress_logging: {})
           @logger = logger
           @transport_root = Datadog::Core::Remote::Transport::HTTP.root(agent_settings: agent_settings, logger: logger)
           @logged = suppress_logging

--- a/lib/datadog/core/remote/transport/config.rb
+++ b/lib/datadog/core/remote/transport/config.rb
@@ -34,7 +34,7 @@ module Datadog
           class Transport
             attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-            def initialize(apis, default_api, logger)
+            def initialize(apis, default_api, logger = Datadog.logger)
               @apis = apis
               @logger = logger
 

--- a/lib/datadog/core/remote/transport/http.rb
+++ b/lib/datadog/core/remote/transport/http.rb
@@ -33,7 +33,7 @@ module Datadog
           # Pass a block to override any settings.
           def root(
             agent_settings:,
-            logger:,
+            logger: Datadog.logger,
             api_version: nil,
             headers: nil
           )
@@ -57,7 +57,7 @@ module Datadog
           # Pass a block to override any settings.
           def v7(
             agent_settings:,
-            logger:,
+            logger: Datadog.logger,
             api_version: nil,
             headers: nil
           )

--- a/lib/datadog/core/remote/transport/http/client.rb
+++ b/lib/datadog/core/remote/transport/http/client.rb
@@ -17,7 +17,7 @@ module Datadog
           class Client
             attr_reader :api, :logger
 
-            def initialize(api, logger)
+            def initialize(api, logger = Datadog.logger)
               @api = api
               @logger = logger
             end

--- a/lib/datadog/core/remote/transport/negotiation.rb
+++ b/lib/datadog/core/remote/transport/negotiation.rb
@@ -51,7 +51,7 @@ module Datadog
           class Transport
             attr_reader :client, :apis, :default_api, :current_api_id, :logger
 
-            def initialize(apis, default_api, logger)
+            def initialize(apis, default_api, logger = Datadog.logger)
               @apis = apis
               @logger = logger
 

--- a/lib/datadog/core/transport/http.rb
+++ b/lib/datadog/core/transport/http.rb
@@ -29,7 +29,7 @@ module Datadog
         # Helper function that delegates to Builder.new
         # but is under HTTP namespace so that client code requires this file
         # to get the adapters configured, and not the builder directly.
-        def build(api_instance_class:, agent_settings:, logger:, api_version: nil, headers: nil, &block)
+        def build(api_instance_class:, agent_settings:, logger: Datadog.logger, api_version: nil, headers: nil, &block)
           Builder.new(api_instance_class: api_instance_class, logger: logger) do |transport|
             transport.adapter(agent_settings)
             transport.headers(default_headers)

--- a/lib/datadog/core/transport/http/builder.rb
+++ b/lib/datadog/core/transport/http/builder.rb
@@ -21,7 +21,7 @@ module Datadog
             :default_headers,
             :logger
 
-          def initialize(api_instance_class:, logger:)
+          def initialize(api_instance_class:, logger: Datadog.logger)
             # Global settings
             @default_adapter = nil
             @default_headers = {}


### PR DESCRIPTION
…versions

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Defaults logger arguments added in 2.13.0 release to `Datadog.logger`
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
datadog-ci-rb used the Core classes and its existing versions are not working with dd-trace-rb 2.13.0
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes: default logger arguments added in dd-trace-rb 2.13.0
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Not tested in dd-trace-rb - should be tested manually in datadog-ci-rb
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
