### PR TITLE
[APMAPI-1068] Process discovery

### DIFF
--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -5,18 +5,9 @@
 
 static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static VALUE _native_stop(DDTRACE_UNUSED VALUE _self);
-static void crashtracker_init(VALUE crashtracking_module);
 
 // Used to report Ruby VM crashes.
 // Once initialized, segfaults will be reported automatically using libdatadog.
-
-void DDTRACE_EXPORT Init_libdatadog_api(void) {
-  VALUE datadog_module = rb_define_module("Datadog");
-  VALUE core_module = rb_define_module_under(datadog_module, "Core");
-  VALUE crashtracking_module = rb_define_module_under(core_module, "Crashtracking");
-
-  crashtracker_init(crashtracking_module);
-}
 
 void crashtracker_init(VALUE crashtracking_module) {
   VALUE crashtracker_class = rb_define_class_under(crashtracking_module, "Component", rb_cObject);

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -9,7 +9,8 @@ static VALUE _native_stop(DDTRACE_UNUSED VALUE _self);
 // Used to report Ruby VM crashes.
 // Once initialized, segfaults will be reported automatically using libdatadog.
 
-void crashtracker_init(VALUE crashtracking_module) {
+void crashtracker_init(VALUE core_module) {
+  VALUE crashtracking_module = rb_define_module_under(core_module, "Crashtracking");
   VALUE crashtracker_class = rb_define_class_under(crashtracking_module, "Component", rb_cObject);
 
   rb_define_singleton_method(crashtracker_class, "_native_start_or_update_on_fork", _native_start_or_update_on_fork, -1);

--- a/ext/libdatadog_api/crashtracker.h
+++ b/ext/libdatadog_api/crashtracker.h
@@ -2,4 +2,4 @@
 
 #include "datadog_ruby_common.h"
 
-void crashtracker_init(VALUE crashtracking_module);
+void crashtracker_init(VALUE core_module);

--- a/ext/libdatadog_api/crashtracker.h
+++ b/ext/libdatadog_api/crashtracker.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "datadog_ruby_common.h"
+
+void crashtracker_init(VALUE crashtracking_module);

--- a/ext/libdatadog_api/init.c
+++ b/ext/libdatadog_api/init.c
@@ -4,15 +4,10 @@
 #include "crashtracker.h"
 #include "process_discovery.h"
 
-// Used to report Ruby VM crashes.
-// Once initialized, segfaults will be reported automatically using libdatadog.
-
 void DDTRACE_EXPORT Init_libdatadog_api(void) {
   VALUE datadog_module = rb_define_module("Datadog");
   VALUE core_module = rb_define_module_under(datadog_module, "Core");
-  VALUE crashtracking_module = rb_define_module_under(core_module, "Crashtracking");
-  VALUE process_discovery_module = rb_define_module_under(core_module, "ProcessDiscovery");
 
-  crashtracker_init(crashtracking_module);
-  process_discovery_init(process_discovery_module);
+  crashtracker_init(core_module);
+  process_discovery_init(core_module);
 }

--- a/ext/libdatadog_api/init.c
+++ b/ext/libdatadog_api/init.c
@@ -1,0 +1,18 @@
+#include <ruby.h>
+
+#include "datadog_ruby_common.h"
+#include "crashtracker.h"
+#include "process_discovery.h"
+
+// Used to report Ruby VM crashes.
+// Once initialized, segfaults will be reported automatically using libdatadog.
+
+void DDTRACE_EXPORT Init_libdatadog_api(void) {
+  VALUE datadog_module = rb_define_module("Datadog");
+  VALUE core_module = rb_define_module_under(datadog_module, "Core");
+  VALUE crashtracking_module = rb_define_module_under(core_module, "Crashtracking");
+  VALUE process_discovery_module = rb_define_module_under(core_module, "ProcessDiscovery");
+
+  crashtracker_init(crashtracking_module);
+  process_discovery_init(process_discovery_module);
+}

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <ruby.h>
 #include <datadog/common.h>
 

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -93,11 +93,6 @@ static VALUE _native_to_rb_int(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {
 static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {
   int *fd;
   TypedData_Get_Struct(tracer_memfd, int, &tracer_memfd_type, fd);
-  if (fd == NULL) {
-    log_error(rb_sprintf("Failed to get the tracer configuration memory file descriptor: %s", strerror(errno)));
-    return Qnil;
-  }
-
   if (*fd == -1) {
     log_error(rb_sprintf("The tracer configuration memory file descriptor has already been closed"));
     return Qnil;

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -5,8 +5,8 @@
 
 static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 
-void process_discovery_init(VALUE process_discovery_module) {
-  VALUE process_discovery_class = rb_define_class_under(process_discovery_module, "Component", rb_cObject);
+void process_discovery_init(VALUE core_module) {
+  VALUE process_discovery_class = rb_define_class_under(core_module, "ProcessDiscovery", rb_cObject);
 
   rb_define_singleton_method(process_discovery_class, "_native_store_tracer_metadata", _native_store_tracer_metadata, -1);
 }
@@ -35,7 +35,7 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED
   ENFORCE_TYPE(service_version, T_STRING);
 
   ddog_Result_TracerMemfdHandle result = ddog_store_tracer_metadata(
-    (uint8_t)schema_version,
+    (uint8_t) NUM2UINT(schema_version),
     char_slice_from_ruby_string(runtime_id),
     char_slice_from_ruby_string(tracer_language),
     char_slice_from_ruby_string(tracer_version),

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -36,7 +36,8 @@ void process_discovery_init(VALUE core_module) {
   rb_define_singleton_method(process_discovery_class, "_native_close_tracer_memfd", _native_close_tracer_memfd, 2);
 }
 
-static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, VALUE self) {
+// TODO: Remove DDTRACE_UNUSED and rename _self to self once we have updated libdatadog to 17.1
+static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
   VALUE logger;
   VALUE options;
   rb_scan_args(argc, argv, "1:", &logger, &options);
@@ -60,6 +61,7 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, VALUE self) {
   ENFORCE_TYPE(service_env, T_STRING);
   ENFORCE_TYPE(service_version, T_STRING);
 
+  /*
   ddog_Result_TracerMemfdHandle result = ddog_store_tracer_metadata(
     (uint8_t) NUM2UINT(schema_version),
     char_slice_from_ruby_string(runtime_id),
@@ -84,6 +86,9 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, VALUE self) {
   VALUE tracer_memfd_class = rb_const_get(self, rb_intern("TracerMemfd"));
   VALUE tracer_memfd = TypedData_Wrap_Struct(tracer_memfd_class, &tracer_memfd_type, fd);
   return tracer_memfd;
+  */
+
+  rb_raise(rb_eNotImpError, "TODO: Not in use yet, waiting for libdatadog 17.1");
 }
 
 static VALUE _native_to_rb_int(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -9,10 +9,18 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED
 static VALUE _native_to_rb_int(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd);
 static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd, VALUE logger);
 
+static void tracer_memfd_free(void *ptr) {
+  int *fd = (int *)ptr;
+  if (*fd != -1) {
+    close(*fd);
+  }
+  ruby_xfree(ptr);
+}
+
 static const rb_data_type_t tracer_memfd_type = {
   .wrap_struct_name = "Datadog::Core::ProcessDiscovery::TracerMemfd",
   .function = {
-    .dfree = RUBY_DEFAULT_FREE,
+    .dfree = tracer_memfd_free,
     .dsize = NULL,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -1,0 +1,55 @@
+#include <ruby.h>
+#include <datadog/common.h>
+
+#include "datadog_ruby_common.h"
+
+static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
+
+void process_discovery_init(VALUE process_discovery_module) {
+  VALUE process_discovery_class = rb_define_class_under(process_discovery_module, "Component", rb_cObject);
+
+  rb_define_singleton_method(process_discovery_class, "_native_store_tracer_metadata", _native_store_tracer_metadata, -1);
+}
+
+static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
+  VALUE options;
+  rb_scan_args(argc, argv, "0:", &options);
+  if (options == Qnil) options = rb_hash_new();
+
+  VALUE schema_version = rb_hash_fetch(options, ID2SYM(rb_intern("schema_version")));
+  VALUE runtime_id = rb_hash_fetch(options, ID2SYM(rb_intern("runtime_id")));
+  VALUE tracer_language = rb_hash_fetch(options, ID2SYM(rb_intern("tracer_language")));
+  VALUE tracer_version = rb_hash_fetch(options, ID2SYM(rb_intern("tracer_version")));
+  VALUE hostname = rb_hash_fetch(options, ID2SYM(rb_intern("hostname")));
+  VALUE service_name = rb_hash_fetch(options, ID2SYM(rb_intern("service_name")));
+  VALUE service_env = rb_hash_fetch(options, ID2SYM(rb_intern("service_env")));
+  VALUE service_version = rb_hash_fetch(options, ID2SYM(rb_intern("service_version")));
+
+  ENFORCE_TYPE(schema_version, T_FIXNUM);
+  ENFORCE_TYPE(runtime_id, T_STRING);
+  ENFORCE_TYPE(tracer_language, T_STRING);
+  ENFORCE_TYPE(tracer_version, T_STRING);
+  ENFORCE_TYPE(hostname, T_STRING);
+  ENFORCE_TYPE(service_name, T_STRING);
+  ENFORCE_TYPE(service_env, T_STRING);
+  ENFORCE_TYPE(service_version, T_STRING);
+
+  ddog_Result_TracerMemfdHandle result = ddog_store_tracer_metadata(
+    (uint8_t)schema_version,
+    char_slice_from_ruby_string(runtime_id),
+    char_slice_from_ruby_string(tracer_language),
+    char_slice_from_ruby_string(tracer_version),
+    char_slice_from_ruby_string(hostname),
+    char_slice_from_ruby_string(service_name),
+    char_slice_from_ruby_string(service_env),
+    char_slice_from_ruby_string(service_version)
+  );
+
+  if (result.tag == DDOG_RESULT_TRACER_MEMFD_HANDLE_ERR_TRACER_MEMFD_HANDLE) {
+    rb_raise(rb_eRuntimeError, "Failed to store the tracer configuration: %"PRIsVALUE, get_error_details_and_drop(&result.err));
+  }
+
+  // &result.ok is a ddog_TracerMemfdHandle, which is a struct only containing int fd, which is a file descriptor
+  // We should just return the fd to test everything is working
+  return INT2FIX(result.ok.fd);
+}

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdlib.h>
 #include <ruby.h>
 #include <datadog/common.h>
 
@@ -7,14 +8,24 @@
 static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE fd);
 
+static const rb_data_type_t tracer_memfd_type = {
+  .wrap_struct_name = "Datadog::Core::ProcessDiscovery::TracerMemfd",
+  .function = {
+    .dfree = RUBY_DEFAULT_FREE,
+    .dsize = NULL,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 void process_discovery_init(VALUE core_module) {
   VALUE process_discovery_class = rb_define_class_under(core_module, "ProcessDiscovery", rb_cObject);
+  rb_define_class_under(process_discovery_class, "TracerMemfd", rb_cObject);
 
   rb_define_singleton_method(process_discovery_class, "_native_store_tracer_metadata", _native_store_tracer_metadata, -1);
   rb_define_singleton_method(process_discovery_class, "_native_close_tracer_memfd", _native_close_tracer_memfd, 1);
 }
 
-static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
+static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, VALUE self) {
   VALUE options;
   rb_scan_args(argc, argv, "0:", &options);
   if (options == Qnil) options = rb_hash_new();
@@ -49,20 +60,34 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED
   );
 
   if (result.tag == DDOG_RESULT_TRACER_MEMFD_HANDLE_ERR_TRACER_MEMFD_HANDLE) {
-    rb_raise(rb_eRuntimeError, "Failed to store the tracer configuration: %"PRIsVALUE, get_error_details_and_drop(&result.err));
+    rb_raise(rb_eRuntimeError, "Failed to store the tracer configuration in a memory file descriptor: %"PRIsVALUE, get_error_details_and_drop(&result.err));
   }
 
   // &result.ok is a ddog_TracerMemfdHandle, which is a struct only containing int fd, which is a file descriptor
-  // We should just return the fd to test everything is working
-  return INT2FIX(result.ok.fd);
+  // We should just return the fd
+  int *fd = malloc(sizeof(int));
+  if (!fd) {
+    rb_raise(rb_eRuntimeError, "Failed to allocate memory for file descriptor");
+  }
+
+  *fd = result.ok.fd;
+  VALUE tracer_memfd_class = rb_const_get(self, rb_intern("TracerMemfd"));
+  VALUE tracer_memfd = TypedData_Wrap_Struct(tracer_memfd_class, &tracer_memfd_type, fd);
+  return tracer_memfd;
 }
 
-static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE fd) {
-  ENFORCE_TYPE(fd, T_FIXNUM);
+static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {
+  int *fd;
+  TypedData_Get_Struct(tracer_memfd, int, &tracer_memfd_type, fd);
+  if (fd == NULL) {
+    rb_raise(rb_eRuntimeError, "Failed to get the tracer configuration memory file descriptor: %s", strerror(errno));
+  }
 
-  int close_result = close(NUM2INT(fd));
+  int close_result = close(*fd);
+  free(fd);
+
   if (close_result == -1) {
-    rb_raise(rb_eRuntimeError, "Failed to close the tracer configuration: %s", strerror(errno));
+    rb_raise(rb_eRuntimeError, "Failed to close the tracer configuration memory file descriptor: %s", strerror(errno));
   }
 
   return Qnil;

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -6,6 +6,7 @@
 #include "datadog_ruby_common.h"
 
 static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
+static VALUE _native_to_rb_int(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd);
 static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE fd);
 
 static VALUE log_error(VALUE error) {
@@ -30,6 +31,7 @@ void process_discovery_init(VALUE core_module) {
   rb_undef_alloc_func(tracer_memfd_class); // Class cannot be instantiated from Ruby
 
   rb_define_singleton_method(process_discovery_class, "_native_store_tracer_metadata", _native_store_tracer_metadata, -1);
+  rb_define_singleton_method(process_discovery_class, "_native_to_rb_int", _native_to_rb_int, 1);
   rb_define_singleton_method(process_discovery_class, "_native_close_tracer_memfd", _native_close_tracer_memfd, 1);
 }
 
@@ -80,6 +82,12 @@ static VALUE _native_store_tracer_metadata(int argc, VALUE *argv, VALUE self) {
   VALUE tracer_memfd_class = rb_const_get(self, rb_intern("TracerMemfd"));
   VALUE tracer_memfd = TypedData_Wrap_Struct(tracer_memfd_class, &tracer_memfd_type, fd);
   return tracer_memfd;
+}
+
+static VALUE _native_to_rb_int(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {
+  int *fd;
+  TypedData_Get_Struct(tracer_memfd, int, &tracer_memfd_type, fd);
+  return INT2NUM(*fd);
 }
 
 static VALUE _native_close_tracer_memfd(DDTRACE_UNUSED VALUE _self, VALUE tracer_memfd) {

--- a/ext/libdatadog_api/process_discovery.h
+++ b/ext/libdatadog_api/process_discovery.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "datadog_ruby_common.h"
+
+void process_discovery_init(VALUE process_discovery_module);

--- a/ext/libdatadog_api/process_discovery.h
+++ b/ext/libdatadog_api/process_discovery.h
@@ -2,4 +2,4 @@
 
 #include "datadog_ruby_common.h"
 
-void process_discovery_init(VALUE process_discovery_module);
+void process_discovery_init(VALUE core_module);

--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -11,6 +11,14 @@ module Datadog
   # for higher-level features.
   module Core
     extend Core::Deprecations
+
+    LIBDATADOG_API_FAILURE =
+      begin
+        require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"
+        nil
+      rescue LoadError => e
+        e.message
+      end
   end
 
   extend Core::Extensions

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -206,7 +206,7 @@ module Datadog
           telemetry.emit_closing! unless replacement
           telemetry.stop!
 
-          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd)
+          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd) if @process_discovery_fd
         end
       end
     end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -69,7 +69,7 @@ module Datadog
           def build_crashtracker(settings, agent_settings, logger:)
             return unless settings.crashtracking.enabled
 
-            if (libdatadog_api_failure = Datadog::Core::Crashtracking::Component::LIBDATADOG_API_FAILURE)
+            if (libdatadog_api_failure = Datadog::Core::LIBDATADOG_API_FAILURE)
               logger.debug("Cannot enable crashtracking: #{libdatadog_api_failure}")
               return
             end
@@ -124,7 +124,7 @@ module Datadog
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
           @environment_logger_extra[:dynamic_instrumentation_enabled] = !!@dynamic_instrumentation
-          @process_discovery_fd = Core::ProcessDiscovery.get_and_store_metadata(settings)
+          @process_discovery_fd = Core::ProcessDiscovery.get_and_store_metadata(settings, @logger)
 
           self.class.configure_tracing(settings)
         end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -124,7 +124,8 @@ module Datadog
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
           @environment_logger_extra[:dynamic_instrumentation_enabled] = !!@dynamic_instrumentation
-          @process_discovery_fd = Core::ProcessDiscovery.get_and_store_metadata(settings, @logger)
+          # TODO: Re-enable this once we have updated libdatadog to 17.1
+          # @process_discovery_fd = Core::ProcessDiscovery.get_and_store_metadata(settings, @logger)
 
           self.class.configure_tracing(settings)
         end
@@ -206,7 +207,8 @@ module Datadog
           telemetry.emit_closing! unless replacement
           telemetry.stop!
 
-          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd, @logger) if @process_discovery_fd
+          # TODO: Re-enable this once we have updated libdatadog to 17.1
+          # Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd, @logger) if @process_discovery_fd
         end
       end
     end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -206,7 +206,7 @@ module Datadog
           telemetry.emit_closing! unless replacement
           telemetry.stop!
 
-          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd) if @process_discovery_fd
+          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd, @logger) if @process_discovery_fd
         end
       end
     end

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -124,9 +124,7 @@ module Datadog
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
           @environment_logger_extra[:dynamic_instrumentation_enabled] = !!@dynamic_instrumentation
-          @process_discovery_fd = Core::ProcessDiscovery._native_store_tracer_metadata(
-            **Core::ProcessDiscovery.get_metadata(settings)
-          )
+          @process_discovery_fd = Core::ProcessDiscovery.get_and_store_metadata(settings)
 
           self.class.configure_tracing(settings)
         end

--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -18,14 +18,6 @@ module Datadog
       #
       # Methods prefixed with _native_ are implemented in `crashtracker.c`
       class Component
-        LIBDATADOG_API_FAILURE =
-          begin
-            require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"
-            nil
-          rescue LoadError => e
-            e.message
-          end
-
         ONLY_ONCE = Core::Utils::OnlyOnce.new
 
         def self.build(settings, agent_settings, logger:)

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -9,8 +9,8 @@ module Datadog
         _native_store_tracer_metadata(**metadata)
       end
 
-      # According to RFC, runtime_id, service_name, service_env, service_version are optional.
-      # ddcommon memfd_create exposer replace empty strings in these fields by None.
+      # According to the RFC, runtime_id, service_name, service_env, service_version are optional.
+      # In the C method exposed by ddcommon, memfd_create replaces empty strings by None for these fields.
       def self.get_metadata(settings)
         {
           schema_version: 1,

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -15,7 +15,7 @@ module Datadog
 
       # According to the RFC, runtime_id, service_name, service_env, service_version are optional.
       # In the C method exposed by ddcommon, memfd_create replaces empty strings by None for these fields.
-      def self.get_metadata(settings)
+      private_class_method def self.get_metadata(settings)
         {
           schema_version: 1,
           runtime_id: Core::Environment::Identity.id,

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -4,7 +4,11 @@ module Datadog
   module Core
     # Class used to store tracer metadata in a native file descriptor.
     class ProcessDiscovery
-      def self.get_and_store_metadata(settings)
+      def self.get_and_store_metadata(settings, logger)
+        if (libdatadog_api_failure = Datadog::Core::LIBDATADOG_API_FAILURE)
+          logger.debug("Cannot enable crashtracking: #{libdatadog_api_failure}")
+          return
+        end
         metadata = get_metadata(settings)
         _native_store_tracer_metadata(**metadata)
       end

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -10,7 +10,7 @@ module Datadog
           return
         end
         metadata = get_metadata(settings)
-        _native_store_tracer_metadata(**metadata)
+        _native_store_tracer_metadata(logger, **metadata)
       end
 
       # According to the RFC, runtime_id, service_name, service_env, service_version are optional.

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -6,7 +6,7 @@ module Datadog
     class ProcessDiscovery
       def self.get_and_store_metadata(settings, logger)
         if (libdatadog_api_failure = Datadog::Core::LIBDATADOG_API_FAILURE)
-          logger.debug("Cannot enable crashtracking: #{libdatadog_api_failure}")
+          logger.debug("Cannot enable process discovery: #{libdatadog_api_failure}")
           return
         end
         metadata = get_metadata(settings)

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    # Class  used to store tracer metadata in a native file descriptor.
+    class ProcessDiscovery
+      # According to RFC, runtime_id, service_name, service_env, service_version are optional.
+      # ddcommon memfd_create exposer replace empty strings in these fields by None.
+      def self.get_metadata(settings)
+        {
+          schema_version: 1,
+          runtime_id: Core::Environment::Identity.id || '',
+          tracer_language: Core::Environment::Identity.lang,
+          tracer_version: Core::Environment::Identity.gem_datadog_version_semver2,
+          hostname: Core::Environment::Socket.hostname,
+          service_name: settings.service || '',
+          service_env: settings.env || '',
+          service_version: settings.version || ''
+        }
+      end
+    end
+  end
+end

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -2,14 +2,19 @@
 
 module Datadog
   module Core
-    # Class  used to store tracer metadata in a native file descriptor.
+    # Class used to store tracer metadata in a native file descriptor.
     class ProcessDiscovery
+      def self.get_and_store_metadata(settings)
+        metadata = get_metadata(settings)
+        _native_store_tracer_metadata(**metadata)
+      end
+
       # According to RFC, runtime_id, service_name, service_env, service_version are optional.
       # ddcommon memfd_create exposer replace empty strings in these fields by None.
       def self.get_metadata(settings)
         {
           schema_version: 1,
-          runtime_id: Core::Environment::Identity.id || '',
+          runtime_id: Core::Environment::Identity.id,
           tracer_language: Core::Environment::Identity.lang,
           tracer_version: Core::Environment::Identity.gem_datadog_version_semver2,
           hostname: Core::Environment::Socket.hostname,

--- a/sig/datadog/core.rbs
+++ b/sig/datadog/core.rbs
@@ -1,5 +1,6 @@
 module Datadog
   module Core
+    LIBDATADOG_API_FAILURE: ::String?
   end
 
   extend Core::Deprecations

--- a/sig/datadog/core/crashtracking/component.rbs
+++ b/sig/datadog/core/crashtracking/component.rbs
@@ -2,7 +2,6 @@ module Datadog
   module Core
     module Crashtracking
       class Component
-        LIBDATADOG_API_FAILURE: ::String?
         ONLY_ONCE: Core::Utils::OnlyOnce
 
         def self.build: (

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -14,11 +14,11 @@ module Datadog
         service_name: String,
         service_env: String,
         service_version: String
-      ) -> TracerMemfd
+      ) -> TracerMemfd?
 
       def self._native_close_tracer_memfd: (TracerMemfd tracer_memfd) -> void
 
-      def self.get_and_store_metadata: (Datadog::Core::Configuration::Settings settings) -> TracerMemfd
+      def self.get_and_store_metadata: (Datadog::Core::Configuration::Settings settings) -> TracerMemfd?
 
       def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> {
         schema_version: Integer,

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -1,6 +1,6 @@
 module Datadog
   module Core
-    module ProcessDiscovery
+    class ProcessDiscovery
       def self._native_store_tracer_metadata: (
         schema_version: Integer,
         runtime_id: String,
@@ -12,5 +12,9 @@ module Datadog
         service_version: String
       ) -> Integer # C file descriptor
     end
+
+    def self._native_close_tracer_memfd: (Integer fd) -> nil
+
+    def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> Hash[Symbol, String | Integer]
   end
 end

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -18,7 +18,10 @@ module Datadog
 
       def self._native_close_tracer_memfd: (TracerMemfd tracer_memfd) -> void
 
-      def self.get_and_store_metadata: (Datadog::Core::Configuration::Settings settings) -> TracerMemfd?
+      def self.get_and_store_metadata: (
+        Datadog::Core::Configuration::Settings settings,
+        Datadog::Core::Logger logger
+      ) -> TracerMemfd?
 
       def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> {
         schema_version: Integer,

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module Core
+    module ProcessDiscovery
+      def self._native_store_tracer_metadata: (
+        schema_version: Integer,
+        runtime_id: String,
+        tracer_language: String,
+        tracer_version: String,
+        hostname: String,
+        service_name: String,
+        service_env: String,
+        service_version: String
+      ) -> Integer # C file descriptor
+    end
+  end
+end

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -6,6 +6,7 @@ module Datadog
       end
 
       def self._native_store_tracer_metadata: (
+        Datadog::Core::Logger logger,
         schema_version: Integer,
         runtime_id: String,
         tracer_language: String,
@@ -16,7 +17,7 @@ module Datadog
         service_version: String
       ) -> TracerMemfd?
 
-      def self._native_close_tracer_memfd: (TracerMemfd tracer_memfd) -> void
+      def self._native_close_tracer_memfd: (TracerMemfd tracer_memfd, Datadog::Core::Logger logger) -> void
 
       def self.get_and_store_metadata: (
         Datadog::Core::Configuration::Settings settings,

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -1,6 +1,10 @@
 module Datadog
   module Core
     class ProcessDiscovery
+      # defined in C. struct containing int fd.
+      class TracerMemfd
+      end
+
       def self._native_store_tracer_metadata: (
         schema_version: Integer,
         runtime_id: String,
@@ -10,11 +14,22 @@ module Datadog
         service_name: String,
         service_env: String,
         service_version: String
-      ) -> Integer # C file descriptor
+      ) -> TracerMemfd
+
+      def self._native_close_tracer_memfd: (TracerMemfd tracer_memfd) -> void
+
+      def self.get_and_store_metadata: (Datadog::Core::Configuration::Settings settings) -> TracerMemfd
+
+      def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> {
+        schema_version: Integer,
+        runtime_id: String,
+        tracer_language: String,
+        tracer_version: String,
+        hostname: String,
+        service_name: String,
+        service_env: String,
+        service_version: String
+      }
     end
-
-    def self._native_close_tracer_memfd: (Integer fd) -> nil
-
-    def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> Hash[Symbol, String | Integer]
   end
 end

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -7,7 +7,7 @@ require 'fiddle'
 # https://github.com/rubocop/rubocop-rspec/issues/2078
 # rubocop:disable RSpec/ScatteredLet
 
-RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelpers.supported? do
+RSpec.describe Datadog::Core::Crashtracking::Component, skip: !LibdatadogHelpers.supported? do
   let(:logger) { Logger.new($stdout) }
 
   describe '.build' do

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -5,7 +5,8 @@ require 'msgpack'
 require 'spec_helper'
 require 'datadog/core/process_discovery'
 
-RSpec.describe Datadog::Core::ProcessDiscovery do
+# TODO: Re-enable this once we have updated libdatadog to 17.1
+RSpec.xdescribe Datadog::Core::ProcessDiscovery do
   describe '.get_and_store_metadata' do
     context 'when libdatadog API is not available' do
       it 'returns nil' do

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -6,13 +6,20 @@ require 'spec_helper'
 require 'datadog/core/process_discovery'
 
 RSpec.describe Datadog::Core::ProcessDiscovery do
-  describe '.get_and_store_metadata', skip: !LibdatadogHelpers.supported? do
+  describe '.get_and_store_metadata' do
+    context 'when libdatadog API is not available' do
+      it 'returns nil' do
+        stub_const('Datadog::Core::LIBDATADOG_API_FAILURE', LoadError.new('test'))
+        expect(described_class.get_and_store_metadata(nil, Datadog::Core::Logger.new($stdout))).to be_nil
+      end
+    end
+
     context 'when libdatadog API is available' do
       let(:settings) do
         instance_double(
           'Datadog::Core::Configuration::Setting',
           service: 'test-service',
-          env: 'TEST_ENV=true',
+          env: 'test-env',
           version: '1.0.0'
         )
       end
@@ -35,7 +42,7 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
             'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
             'hostname' => Datadog::Core::Environment::Socket.hostname,
             'service_name' => 'test-service',
-            'service_env' => 'TEST_ENV=true',
+            'service_env' => 'test-env',
             'service_version' => '1.0.0'
           }
         )
@@ -49,7 +56,7 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
         instance_double(
           'Datadog::Core::Configuration::Setting',
           service: 'test-service',
-          env: 'TEST_ENV=true',
+          env: 'test-env',
           version: '1.0.0'
         )
       end
@@ -63,7 +70,7 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
             tracer_version: Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
             hostname: Datadog::Core::Environment::Socket.hostname,
             service_name: 'test-service',
-            service_env: 'TEST_ENV=true',
+            service_env: 'test-env',
             service_version: '1.0.0'
           }
         )

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -15,91 +15,73 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
     end
 
     context 'when libdatadog API is available' do
-      let(:settings) do
-        instance_double(
-          'Datadog::Core::Configuration::Setting',
-          service: 'test-service',
-          env: 'test-env',
-          version: '1.0.0'
-        )
+      context 'with all settings provided' do
+        let(:settings) do
+          instance_double(
+            'Datadog::Core::Configuration::Setting',
+            service: 'test-service',
+            env: 'test-env',
+            version: '1.0.0'
+          )
+        end
+
+        it 'stores metadata successfully' do
+          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
+
+          # Extract content from created memfd
+          fd = described_class._native_to_rb_int(native_fd)
+          buffer = IO.new(fd)
+          buffer.rewind
+          raw_content = buffer.read
+          content = MessagePack.unpack(raw_content)
+
+          expect(content).to eq(
+            {
+              'schema_version' => 1,
+              'runtime_id' => Datadog::Core::Environment::Identity.id,
+              'tracer_language' => Datadog::Core::Environment::Identity.lang,
+              'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+              'hostname' => Datadog::Core::Environment::Socket.hostname,
+              'service_name' => 'test-service',
+              'service_env' => 'test-env',
+              'service_version' => '1.0.0'
+            }
+          )
+        end
       end
 
-      it 'stores metadata successfully' do
-        native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
+      context 'with missing optional settings' do
+        let(:settings) do
+          instance_double(
+            'Datadog::Core::Configuration::Setting',
+            service: nil,
+            env: nil,
+            version: nil
+          )
+        end
 
-        # Extract content from created memfd
-        fd = described_class._native_to_rb_int(native_fd)
-        buffer = IO.new(fd)
-        buffer.rewind
-        raw_content = buffer.read
-        content = MessagePack.unpack(raw_content)
+        it 'stores metadata successfully' do
+          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
 
-        expect(content).to eq(
-          {
-            'schema_version' => 1,
-            'runtime_id' => Datadog::Core::Environment::Identity.id,
-            'tracer_language' => Datadog::Core::Environment::Identity.lang,
-            'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
-            'hostname' => Datadog::Core::Environment::Socket.hostname,
-            'service_name' => 'test-service',
-            'service_env' => 'test-env',
-            'service_version' => '1.0.0'
-          }
-        )
-      end
-    end
-  end
+          # Extract content from created memfd
+          fd = described_class._native_to_rb_int(native_fd)
+          buffer = IO.new(fd)
+          buffer.rewind
+          raw_content = buffer.read
+          content = MessagePack.unpack(raw_content)
 
-  describe '.get_metadata' do
-    context 'with all settings provided' do
-      let(:settings) do
-        instance_double(
-          'Datadog::Core::Configuration::Setting',
-          service: 'test-service',
-          env: 'test-env',
-          version: '1.0.0'
-        )
-      end
-
-      it 'returns complete metadata' do
-        expect(described_class.get_metadata(settings)).to eq(
-          {
-            schema_version: 1,
-            runtime_id: Datadog::Core::Environment::Identity.id,
-            tracer_language: Datadog::Core::Environment::Identity.lang,
-            tracer_version: Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
-            hostname: Datadog::Core::Environment::Socket.hostname,
-            service_name: 'test-service',
-            service_env: 'test-env',
-            service_version: '1.0.0'
-          }
-        )
-      end
-    end
-
-    context 'with missing optional settings' do
-      let(:settings) do
-        instance_double(
-          'Datadog::Core::Configuration::Setting',
-          service: nil,
-          env: nil,
-          version: nil
-        )
-      end
-
-      it 'returns metadata with empty strings for missing values' do
-        expect(described_class.get_metadata(settings)).to eq(
-          {
-            schema_version: 1,
-            runtime_id: Datadog::Core::Environment::Identity.id,
-            tracer_language: Datadog::Core::Environment::Identity.lang,
-            tracer_version: Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
-            hostname: Datadog::Core::Environment::Socket.hostname,
-            service_name: '',
-            service_env: '',
-            service_version: ''
-          }
-        )
+          # If the string is empty, it should be replaced by None when converting C strings to Rust types.
+          # Thus not appearing in the content.
+          expect(content).to eq(
+            {
+              'schema_version' => 1,
+              'runtime_id' => Datadog::Core::Environment::Identity.id,
+              'tracer_language' => Datadog::Core::Environment::Identity.lang,
+              'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+              'hostname' => Datadog::Core::Environment::Socket.hostname
+            }
+          )
+        end
       end
     end
   end

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'msgpack'
+
+require 'spec_helper'
+require 'datadog/core/process_discovery'
+
+RSpec.describe Datadog::Core::ProcessDiscovery do
+  describe '.get_and_store_metadata', skip: !LibdatadogHelpers.supported? do
+    context 'when libdatadog API is available' do
+      let(:settings) do
+        instance_double(
+          'Datadog::Core::Configuration::Setting',
+          service: 'test-service',
+          env: 'TEST_ENV=true',
+          version: '1.0.0'
+        )
+      end
+
+      it 'stores metadata successfully' do
+        native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
+
+        # Extract content from created memfd
+        fd = described_class._native_to_rb_int(native_fd)
+        buffer = IO.new(fd)
+        buffer.rewind
+        raw_content = buffer.read
+        content = MessagePack.unpack(raw_content)
+
+        expect(content).to eq(
+          {
+            'schema_version' => 1,
+            'runtime_id' => Datadog::Core::Environment::Identity.id,
+            'tracer_language' => Datadog::Core::Environment::Identity.lang,
+            'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+            'hostname' => Datadog::Core::Environment::Socket.hostname,
+            'service_name' => 'test-service',
+            'service_env' => 'TEST_ENV=true',
+            'service_version' => '1.0.0'
+          }
+        )
+      end
+    end
+  end
+
+  describe '.get_metadata' do
+    context 'with all settings provided' do
+      let(:settings) do
+        instance_double(
+          'Datadog::Core::Configuration::Setting',
+          service: 'test-service',
+          env: 'TEST_ENV=true',
+          version: '1.0.0'
+        )
+      end
+
+      it 'returns complete metadata' do
+        expect(described_class.get_metadata(settings)).to eq(
+          {
+            schema_version: 1,
+            runtime_id: Datadog::Core::Environment::Identity.id,
+            tracer_language: Datadog::Core::Environment::Identity.lang,
+            tracer_version: Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+            hostname: Datadog::Core::Environment::Socket.hostname,
+            service_name: 'test-service',
+            service_env: 'TEST_ENV=true',
+            service_version: '1.0.0'
+          }
+        )
+      end
+    end
+
+    context 'with missing optional settings' do
+      let(:settings) do
+        instance_double(
+          'Datadog::Core::Configuration::Setting',
+          service: nil,
+          env: nil,
+          version: nil
+        )
+      end
+
+      it 'returns metadata with empty strings for missing values' do
+        expect(described_class.get_metadata(settings)).to eq(
+          {
+            schema_version: 1,
+            runtime_id: Datadog::Core::Environment::Identity.id,
+            tracer_language: Datadog::Core::Environment::Identity.lang,
+            tracer_version: Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+            hostname: Datadog::Core::Environment::Socket.hostname,
+            service_name: '',
+            service_env: '',
+            service_version: ''
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
   describe '.get_and_store_metadata' do
     context 'when libdatadog API is not available' do
       it 'returns nil' do
-        stub_const('Datadog::Core::LIBDATADOG_API_FAILURE', LoadError.new('test'))
-        expect(described_class.get_and_store_metadata(nil, Datadog::Core::Logger.new($stdout))).to be_nil
+        stub_const('Datadog::Core::LIBDATADOG_API_FAILURE', 'test')
+        expect(described_class.get_and_store_metadata(nil, Datadog::Core::Logger.new(StringIO.new))).to be_nil
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
         end
 
         it 'stores metadata successfully' do
-          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
+          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new(StringIO.new))
 
           # Extract content from created memfd
           fd = described_class._native_to_rb_int(native_fd)
@@ -61,7 +61,7 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
         end
 
         it 'stores metadata successfully' do
-          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new($stdout))
+          native_fd = described_class.get_and_store_metadata(settings, Datadog::Core::Logger.new(StringIO.new))
 
           # Extract content from created memfd
           fd = described_class._native_to_rb_int(native_fd)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ require 'support/spy_transport'
 require 'support/synchronization_helpers'
 require 'support/test_helpers'
 require 'support/tracer_helpers'
-require 'support/crashtracking_helpers'
+require 'support/libdatadog_helpers'
 require 'support/http_server_helpers'
 
 begin

--- a/spec/support/crashtracking_helpers.rb
+++ b/spec/support/crashtracking_helpers.rb
@@ -5,8 +5,8 @@ module CrashtrackingHelpers
   def self.supported?
     # Only works with MRI on Linux
     if PlatformHelpers.mri? && PlatformHelpers.linux?
-      if Datadog::Core::Crashtracking::Component::LIBDATADOG_API_FAILURE
-        raise " does not seem to be available: #{Datadog::Core::Crashtracking::Component::LIBDATADOG_API_FAILURE}. " \
+      if Datadog::Core::LIBDATADOG_API_FAILURE
+        raise " does not seem to be available: #{Datadog::Core::LIBDATADOG_API_FAILURE}. " \
           'Try running `bundle exec rake compile` before running this test.'
       end
       true

--- a/spec/support/libdatadog_helpers.rb
+++ b/spec/support/libdatadog_helpers.rb
@@ -1,7 +1,7 @@
-require 'datadog/core/crashtracking/component'
+require 'datadog/core'
 require 'support/platform_helpers'
 
-module CrashtrackingHelpers
+module LibdatadogHelpers
   def self.supported?
     # Only works with MRI on Linux
     if PlatformHelpers.mri? && PlatformHelpers.linux?

--- a/spec/support/libdatadog_helpers.rb
+++ b/spec/support/libdatadog_helpers.rb
@@ -6,7 +6,7 @@ module LibdatadogHelpers
     # Only works with MRI on Linux
     if PlatformHelpers.mri? && PlatformHelpers.linux?
       if Datadog::Core::LIBDATADOG_API_FAILURE
-        raise " does not seem to be available: #{Datadog::Core::LIBDATADOG_API_FAILURE}. " \
+        raise "Libdatadog does not seem to be available: #{Datadog::Core::LIBDATADOG_API_FAILURE}. " \
           'Try running `bundle exec rake compile` before running this test.'
       end
       true


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Store tracer configuration in an in-memory file using libdatadog.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Service Discovery will become the primary entry point of all products built on top of tracing libraries.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Yes. Add Service Discovery capability, enabling the tracer to reliably determine which process are instrumented using Datadog's tracer.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
This PR cannot be merged until libdatadog 17.1 and its corresponding gem is released, and libdatadog gem is updated on dd-trace-rb.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Parametric system-tests (cannot be force-enabled yet)

<!-- Unsure? Have a question? Request a review! -->
