### PR TITLE
feat: add record_exception in the datadog api

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -288,6 +288,15 @@ current_span = Datadog::Tracing.active_span
 current_span.set_tag('my_tag', 'my_value') unless current_span.nil?
 ```
 
+You can record an exception in the current span. It will add the recorded exception as a span event. If you also want to set the span error tags, you should set `escaped` to true.
+```ruby
+# e.g. recording an exception in the active span
+rescue StandardError => e
+  current_span = Datadog::Tracing.active_span
+  current_span.record_exception(e, attributes={"foo":"bar"}, escaped=False)
+end
+```
+
 You can also get the current active trace using the `active_trace` method. This method will return `nil` if there is no active trace.
 
 ```ruby

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -278,12 +278,19 @@ module Datadog
         set_error_tags(e)
       end
 
-      # Record an exception during the execution of this span by creating a span event.
+      # Record an exception during the execution of this span. Multiple exceptions
+      # can be recorded on a span.
+      # If escaped is true, it will set the span error tags
       #
-      # If escaped is True, it will also set the span error tags
+      # @param [Exception] exception The exception to recorded
+      # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}]
+      #   attributes One or more key:value pairs, where the keys must be
+      #   strings and the values may be (array of) string, boolean or numeric
+      #   type.
+      # @param [optional Integer] timestamp Time when the exception was raised, in nanoseconds since epoch
+      # @param [optional Boolean] escaped Whether the exception escaped the scope of the span
       #
       # @return [void]
-      # @public_api
       def record_exception(exception, attributes: nil, timestamp: nil, escaped: false)
         exc = Core::Error.build_from(exception)
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds a record_exception call in the tracer API. It mimics the behavior of the OTEL one for which you can find the documentation here: https://opentelemetry.io/docs/specs/otel/trace/exceptions/

**Motivation:**
Some customers using Sentry complained they were not capable of recording an exception. It appears that if they are using the OTEL api from our tracer, they can. However, as we want to be a competitor to Sentry, I found that it is not a good solution as it is simpler to use this capability directly from our tracer. In addition the feature is easy to emplement 

**Change log entry**
Yes. Record an exception through span events with the `record_exception`call.

**How to test the change?**
- Tests we added in the span_operation spec
