### PR TITLE
[PROF-11524] Refactor: Avoid reading profile start_time + Remove indirections during reporting

### DIFF
--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -11,6 +11,7 @@ for file in \
   `dirname "$0"`/profiler_allocation.rb \
   `dirname "$0"`/profiler_gc.rb \
   `dirname "$0"`/profiler_hold_resume_interruptions.rb \
+  `dirname "$0"`/profiler_http_transport.rb \
   `dirname "$0"`/profiler_memory_sample_serialize.rb \
   `dirname "$0"`/profiler_sample_loop_v2.rb \
   `dirname "$0"`/profiler_sample_serialize.rb \

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -129,7 +129,6 @@ static VALUE perform_export(
   ddog_Timespec finish,
   ddog_prof_Exporter_Slice_File files_to_compress_and_export,
   ddog_prof_Exporter_Slice_File files_to_export_unmodified,
-  ddog_Vec_Tag *additional_tags,
   ddog_CharSlice internal_metadata,
   ddog_CharSlice info
 ) {
@@ -140,7 +139,7 @@ static VALUE perform_export(
     finish,
     files_to_compress_and_export,
     files_to_export_unmodified,
-    additional_tags,
+    /* optional_additional_tags: */ NULL,
     endpoints_stats,
     &internal_metadata,
     &info
@@ -224,6 +223,7 @@ static VALUE _native_do_export(
   ENFORCE_TYPE(finish_timespec_nanoseconds, T_FIXNUM);
   enforce_encoded_profile_instance(encoded_profile);
   ENFORCE_TYPE(code_provenance_file_name, T_STRING);
+  ENFORCE_TYPE(tags_as_array, T_ARRAY);
   ENFORCE_TYPE(internal_metadata_json, T_STRING);
   ENFORCE_TYPE(info_json, T_STRING);
 
@@ -263,7 +263,6 @@ static VALUE _native_do_export(
     };
   }
 
-  ddog_Vec_Tag *null_additional_tags = NULL;
   ddog_CharSlice internal_metadata = char_slice_from_ruby_string(internal_metadata_json);
   ddog_CharSlice info = char_slice_from_ruby_string(info_json);
 
@@ -288,7 +287,6 @@ static VALUE _native_do_export(
     finish,
     files_to_compress_and_export,
     files_to_export_unmodified,
-    null_additional_tags,
     internal_metadata,
     info
   );

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -79,22 +79,17 @@ static ddog_prof_Endpoint endpoint_from(VALUE exporter_configuration) {
   ENFORCE_TYPE(exporter_working_mode, T_SYMBOL);
   ID working_mode = SYM2ID(exporter_working_mode);
 
-  ID agentless_id = rb_intern("agentless");
-  ID agent_id = rb_intern("agent");
-
-  if (working_mode != agentless_id && working_mode != agent_id) {
-    rb_raise(rb_eArgError, "Failed to initialize transport: Unexpected working mode, expected :agentless or :agent");
-  }
-
-  if (working_mode == agentless_id) {
+  if (working_mode == rb_intern("agentless")) {
     VALUE site = rb_ary_entry(exporter_configuration, 1);
     VALUE api_key = rb_ary_entry(exporter_configuration, 2);
 
     return ddog_prof_Endpoint_agentless(char_slice_from_ruby_string(site), char_slice_from_ruby_string(api_key));
-  } else { // agent_id
+  } else if (working_mode == rb_intern("agent")) {
     VALUE base_url = rb_ary_entry(exporter_configuration, 1);
 
     return ddog_prof_Endpoint_agent(char_slice_from_ruby_string(base_url));
+  } else {
+    rb_raise(rb_eArgError, "Failed to initialize transport: Unexpected working mode, expected :agentless or :agent");
   }
 }
 

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -30,16 +30,11 @@ static VALUE _native_do_export(
   VALUE self,
   VALUE exporter_configuration,
   VALUE upload_timeout_milliseconds,
+  VALUE flush,
   VALUE start_timespec_seconds,
   VALUE start_timespec_nanoseconds,
   VALUE finish_timespec_seconds,
-  VALUE finish_timespec_nanoseconds,
-  VALUE encoded_profile,
-  VALUE code_provenance_file_name,
-  VALUE code_provenance_data,
-  VALUE tags_as_array,
-  VALUE internal_metadata_json,
-  VALUE info_json
+  VALUE finish_timespec_nanoseconds
 );
 static void *call_exporter_without_gvl(void *call_args);
 static void interrupt_exporter_call(void *cancel_token);
@@ -48,7 +43,7 @@ void http_transport_init(VALUE profiling_module) {
   VALUE http_transport_class = rb_define_class_under(profiling_module, "HttpTransport", rb_cObject);
 
   rb_define_singleton_method(http_transport_class, "_native_validate_exporter",  _native_validate_exporter, 1);
-  rb_define_singleton_method(http_transport_class, "_native_do_export",  _native_do_export, 12);
+  rb_define_singleton_method(http_transport_class, "_native_do_export",  _native_do_export, 7);
 
   ok_symbol = ID2SYM(rb_intern_const("ok"));
   error_symbol = ID2SYM(rb_intern_const("error"));
@@ -214,17 +209,19 @@ static VALUE _native_do_export(
   DDTRACE_UNUSED VALUE _self,
   VALUE exporter_configuration,
   VALUE upload_timeout_milliseconds,
+  VALUE flush,
   VALUE start_timespec_seconds,
   VALUE start_timespec_nanoseconds,
   VALUE finish_timespec_seconds,
-  VALUE finish_timespec_nanoseconds,
-  VALUE encoded_profile,
-  VALUE code_provenance_file_name,
-  VALUE code_provenance_data,
-  VALUE tags_as_array,
-  VALUE internal_metadata_json,
-  VALUE info_json
+  VALUE finish_timespec_nanoseconds
 ) {
+  VALUE encoded_profile = rb_funcall(flush, rb_intern("encoded_profile"), 0);
+  VALUE code_provenance_file_name = rb_funcall(flush, rb_intern("code_provenance_file_name"), 0);
+  VALUE code_provenance_data = rb_funcall(flush, rb_intern("code_provenance_data"), 0);
+  VALUE tags_as_array = rb_funcall(flush, rb_intern("tags_as_array"), 0);
+  VALUE internal_metadata_json = rb_funcall(flush, rb_intern("internal_metadata_json"), 0);
+  VALUE info_json = rb_funcall(flush, rb_intern("info_json"), 0);
+
   ENFORCE_TYPE(upload_timeout_milliseconds, T_FIXNUM);
   ENFORCE_TYPE(start_timespec_seconds, T_FIXNUM);
   ENFORCE_TYPE(start_timespec_nanoseconds, T_FIXNUM);

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -182,6 +182,7 @@ typedef struct {
 typedef struct {
   ddog_prof_Profile profile;
   stats_slot stats;
+  ddog_Timespec start_timestamp;
 } profile_slot;
 
 // Contains native state for each instance
@@ -253,7 +254,7 @@ static ddog_Timespec system_epoch_now_timespec(void);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_instance);
 static void serializer_set_start_timestamp_for_next_profile(stack_recorder_state *state, ddog_Timespec start_time);
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint);
-static void reset_profile_slot(profile_slot *slot, ddog_Timespec *start_time /* Can be null */);
+static void reset_profile_slot(profile_slot *slot, ddog_Timespec start_timestamp);
 static VALUE _native_track_object(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE new_obj, VALUE weight, VALUE alloc_class);
 static VALUE _native_check_heap_hashes(DDTRACE_UNUSED VALUE _self, VALUE locations);
 static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
@@ -359,24 +360,26 @@ static void initialize_slot_concurrency_control(stack_recorder_state *state) {
 }
 
 static void initialize_profiles(stack_recorder_state *state, ddog_prof_Slice_ValueType sample_types) {
+  ddog_Timespec start_timestamp = system_epoch_now_timespec();
+
   ddog_prof_Profile_NewResult slot_one_profile_result =
-    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, &start_timestamp);
 
   if (slot_one_profile_result.tag == DDOG_PROF_PROFILE_NEW_RESULT_ERR) {
     rb_raise(rb_eRuntimeError, "Failed to initialize slot one profile: %"PRIsVALUE, get_error_details_and_drop(&slot_one_profile_result.err));
   }
 
-  state->profile_slot_one = (profile_slot) { .profile = slot_one_profile_result.ok };
+  state->profile_slot_one = (profile_slot) { .profile = slot_one_profile_result.ok, .start_timestamp = start_timestamp };
 
   ddog_prof_Profile_NewResult slot_two_profile_result =
-    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, NULL /* start_time is optional */);
+    ddog_prof_Profile_new(sample_types, NULL /* period is optional */, &start_timestamp);
 
   if (slot_two_profile_result.tag == DDOG_PROF_PROFILE_NEW_RESULT_ERR) {
     // Note: No need to take any special care of slot one, it'll get cleaned up by stack_recorder_typed_data_free
     rb_raise(rb_eRuntimeError, "Failed to initialize slot two profile: %"PRIsVALUE, get_error_details_and_drop(&slot_two_profile_result.err));
   }
 
-  state->profile_slot_two = (profile_slot) { .profile = slot_two_profile_result.ok };
+  state->profile_slot_two = (profile_slot) { .profile = slot_two_profile_result.ok, .start_timestamp = start_timestamp };
 }
 
 static void stack_recorder_typed_data_free(void *state_ptr) {
@@ -568,11 +571,8 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   // Once we wrap this into a Ruby object, our `EncodedProfile` class will automatically manage memory for it
   VALUE encoded_profile = from_ddog_prof_EncodedProfile(serialized_profile.ok);
 
-  ddog_Timespec ddprof_start = serialized_profile.ok.start;
-  ddog_Timespec ddprof_finish = serialized_profile.ok.end;
-
-  VALUE start = ruby_time_from(ddprof_start);
-  VALUE finish = ruby_time_from(ddprof_finish);
+  VALUE start = ruby_time_from(args.slot->start_timestamp);
+  VALUE finish = ruby_time_from(finish_timestamp);
   VALUE profile_stats = build_profile_stats(args.slot, serialization_time_ns, heap_iteration_prep_time_ns, args.heap_profile_build_time_ns);
 
   return rb_ary_new_from_args(2, ok_symbol, rb_ary_new_from_args(4, start, finish, encoded_profile, profile_stats));
@@ -889,9 +889,9 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_
   // In case the fork happened halfway through `serializer_flip_active_and_inactive_slots` execution and the
   // resulting state is inconsistent, we make sure to reset it back to the initial state.
   initialize_slot_concurrency_control(state);
-
-  reset_profile_slot(&state->profile_slot_one, /* start_time: */ NULL);
-  reset_profile_slot(&state->profile_slot_two, /* start_time: */ NULL);
+  ddog_Timespec start_timestamp = system_epoch_now_timespec();
+  reset_profile_slot(&state->profile_slot_one, start_timestamp);
+  reset_profile_slot(&state->profile_slot_two, start_timestamp);
 
   heap_recorder_after_fork(state->heap_recorder);
 
@@ -903,7 +903,7 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_
 static void serializer_set_start_timestamp_for_next_profile(stack_recorder_state *state, ddog_Timespec start_time) {
   // Before making this profile active, we reset it so that it uses the correct start_time for its start
   profile_slot *next_profile_slot = (state->active_slot == 1) ? &state->profile_slot_two : &state->profile_slot_one;
-  reset_profile_slot(next_profile_slot, &start_time);
+  reset_profile_slot(next_profile_slot, start_time);
 }
 
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint) {
@@ -948,11 +948,12 @@ static VALUE _native_check_heap_hashes(DDTRACE_UNUSED VALUE _self, VALUE locatio
   return Qnil;
 }
 
-static void reset_profile_slot(profile_slot *slot, ddog_Timespec *start_time /* Can be null */) {
-  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(&slot->profile, start_time);
+static void reset_profile_slot(profile_slot *slot, ddog_Timespec start_timestamp) {
+  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(&slot->profile, &start_timestamp);
   if (reset_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
     rb_raise(rb_eRuntimeError, "Failed to reset profile: %"PRIsVALUE, get_error_details_and_drop(&reset_result.err));
   }
+  slot->start_timestamp = start_timestamp;
   slot->stats = (stats_slot) {};
 }
 

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -20,33 +20,21 @@ module Datadog
             [:agent, agent_settings.url].freeze
           end
 
-        status, result = validate_exporter(exporter_configuration)
+        status, result = self.class._native_validate_exporter(exporter_configuration)
 
         raise(ArgumentError, "Failed to initialize transport: #{result}") if status == :error
       end
 
       def export(flush)
-        status, result = do_export(
-          exporter_configuration: exporter_configuration,
-          upload_timeout_milliseconds: @upload_timeout_milliseconds,
-
-          # why "timespec"?
-          # libdatadog represents time using POSIX's struct timespec, see
-          # https://www.gnu.org/software/libc/manual/html_node/Time-Types.html
-          # aka it represents the seconds part separate from the nanoseconds part
-          start_timespec_seconds: flush.start.tv_sec,
-          start_timespec_nanoseconds: flush.start.tv_nsec,
-          finish_timespec_seconds: flush.finish.tv_sec,
-          finish_timespec_nanoseconds: flush.finish.tv_nsec,
-
-          encoded_profile: flush.encoded_profile,
-          code_provenance_file_name: flush.code_provenance_file_name,
-          code_provenance_data: flush.code_provenance_data,
-
-          tags_as_array: flush.tags_as_array,
-          internal_metadata_json: flush.internal_metadata_json,
-
-          info_json: flush.info_json
+        status, result = self.class._native_do_export(
+          exporter_configuration,
+          @upload_timeout_milliseconds,
+          flush,
+          # TODO: This is going to be removed once we move to libdatadog 17
+          flush.start.tv_sec,
+          flush.start.tv_nsec,
+          flush.finish.tv_sec,
+          flush.finish.tv_nsec,
         )
 
         if status == :ok
@@ -74,40 +62,6 @@ module Datadog
 
       def agentless?(site, api_key)
         site && api_key && Core::Environment::VariableHelpers.env_to_bool(Profiling::Ext::ENV_AGENTLESS, false)
-      end
-
-      def validate_exporter(exporter_configuration)
-        self.class._native_validate_exporter(exporter_configuration)
-      end
-
-      def do_export(
-        exporter_configuration:,
-        upload_timeout_milliseconds:,
-        start_timespec_seconds:,
-        start_timespec_nanoseconds:,
-        finish_timespec_seconds:,
-        finish_timespec_nanoseconds:,
-        encoded_profile:,
-        code_provenance_file_name:,
-        code_provenance_data:,
-        tags_as_array:,
-        internal_metadata_json:,
-        info_json:
-      )
-        self.class._native_do_export(
-          exporter_configuration,
-          upload_timeout_milliseconds,
-          start_timespec_seconds,
-          start_timespec_nanoseconds,
-          finish_timespec_seconds,
-          finish_timespec_nanoseconds,
-          encoded_profile,
-          code_provenance_file_name,
-          code_provenance_data,
-          tags_as_array,
-          internal_metadata_json,
-          info_json,
-        )
       end
 
       def config_without_api_key

--- a/sig/datadog/profiling/http_transport.rbs
+++ b/sig/datadog/profiling/http_transport.rbs
@@ -21,38 +21,16 @@ module Datadog
 
       def agentless?: (::String? site, ::String? api_key) -> bool
 
-      def validate_exporter: (exporter_configuration_array exporter_configuration) -> [:ok | :error, ::String?]
-
       def self._native_validate_exporter: (exporter_configuration_array exporter_configuration) -> [:ok | :error, ::String?]
-
-      def do_export: (
-        exporter_configuration: exporter_configuration_array,
-        upload_timeout_milliseconds: ::Integer,
-        start_timespec_seconds: ::Integer,
-        start_timespec_nanoseconds: ::Integer,
-        finish_timespec_seconds: ::Integer,
-        finish_timespec_nanoseconds: ::Integer,
-        encoded_profile: Datadog::Profiling::EncodedProfile,
-        code_provenance_file_name: ::String,
-        code_provenance_data: ::String?,
-        tags_as_array: Array[[::String, ::String]],
-        internal_metadata_json: ::String,
-        info_json: ::String,
-      ) -> [:ok | :error, ::Integer | ::String]
 
       def self._native_do_export: (
         exporter_configuration_array exporter_configuration,
         ::Integer upload_timeout_milliseconds,
+        Datadog::Profiling::Flush flush,
         ::Integer start_timespec_seconds,
         ::Integer start_timespec_nanoseconds,
         ::Integer finish_timespec_seconds,
         ::Integer finish_timespec_nanoseconds,
-        Datadog::Profiling::EncodedProfile encoded_profile,
-        ::String code_provenance_file_name,
-        ::String? code_provenance_data,
-        Array[[::String, ::String]] tags_as_array,
-        ::String internal_metadata_json,
-        ::String info_json,
       ) -> [:ok | :error, ::Integer | ::String]
 
       def config_without_api_key: () -> ::String

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -192,23 +192,14 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       finish_timespec_seconds = 1699718400
       finish_timespec_nanoseconds = 123456789
 
-      internal_metadata_json = '{"no_signals_workaround_enabled":true}'
-
-      info_json = '{"application":{"start_time":"2024-01-24T11:17:22Z"},"runtime":{"engine":"ruby"}}'
-
       expect(described_class).to receive(:_native_do_export).with(
         kind_of(Array), # exporter_configuration
         upload_timeout_milliseconds,
+        flush,
         start_timespec_seconds,
         start_timespec_nanoseconds,
         finish_timespec_seconds,
         finish_timespec_nanoseconds,
-        encoded_profile,
-        code_provenance_file_name,
-        code_provenance_data,
-        tags_as_array,
-        internal_metadata_json,
-        info_json,
       ).and_return([:ok, 200])
 
       export

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -238,6 +238,21 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         )
       end
 
+      context "when requesting multiple serializations of empty profiles" do
+        it "correctly sets the profile start timestamp in libdatadog" do
+          # The `start` timestamp returned is tracked locally by us. This test validates that the actual profile
+          # matches it, e.g. that we're passing it along correctly to libdatadog.
+          start_timestamps = []
+          4.times do
+            start, _, profile = stack_recorder.serialize
+            expect(decode_profile(profile).time_nanos).to eq(Datadog::Core::Utils::Time.as_utc_epoch_ns(start))
+
+            start_timestamps << start
+          end
+          expect(start_timestamps.sort).to eq(start_timestamps) # No later timestamp should come before an earlier one
+        end
+      end
+
       it "returns stats reporting no recorded samples" do
         expect(profile_stats).to match(
           hash_including(


### PR DESCRIPTION
**What does this PR do?**

This PR changes the `StackRecorder` so that instead of relying on libdatadog to track a profile's `start_time` (by passing `NULL` -- aka "use current timestamp") it now explicitly gets the current timestamp and passes it along to libdatadog.

This then means that we no longer need to read the `start_time` from libdatadog, because we're tracking it on our side.

**Motivation:**

Starting with libdatadog 17, we'll no longer be able to read the `start_time` from libdatadog, and this PR leaves us ready for that change.

**Change log entry**

None.

**Additional Notes:**

As I "was in the neighbourhood" I also did a few cleanups on the `HttpTransport` class which will also make it easier to upgrade to libdatadog 17.

**How to test the change?**

We had some existing test coverage, and I've added a bit more; I've also injected some bugs locally on purpose to validate that the test coverage is good. You can try doing the same ;)
