### PR TITLE
Use Core::Utils::Time.now instead of Time.now

### DIFF
--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -79,7 +79,7 @@ module Datadog
 
           # @return [String] current time in ISO8601 format
           def date
-            Time.now.utc.iso8601
+            Core::Utils::Time.now.utc.iso8601
           end
 
           # Best portable guess of OS information.

--- a/lib/datadog/core/telemetry/metric.rb
+++ b/lib/datadog/core/telemetry/metric.rb
@@ -108,9 +108,9 @@ module Datadog
             value = value.to_i
 
             if values.empty?
-              values << [Time.now.to_i, value]
+              values << [Core::Utils::Time.now.to_i, value]
             else
-              values[0][0] = Time.now.to_i
+              values[0][0] = Core::Utils::Time.now.to_i
               values[0][1] += value
             end
             nil
@@ -129,9 +129,9 @@ module Datadog
 
           def track(value)
             if values.empty?
-              values << [Time.now.to_i, value]
+              values << [Core::Utils::Time.now.to_i, value]
             else
-              values[0][0] = Time.now.to_i
+              values[0][0] = Core::Utils::Time.now.to_i
               values[0][1] = value
             end
             nil
@@ -155,7 +155,7 @@ module Datadog
 
           def track(value = 1.0)
             @value += value
-            @values = [[Time.now.to_i, @value / interval]]
+            @values = [[Core::Utils::Time.now.to_i, @value / interval]]
             nil
           end
         end

--- a/lib/datadog/core/telemetry/request.rb
+++ b/lib/datadog/core/telemetry/request.rb
@@ -21,7 +21,7 @@ module Datadog
               request_type: event.type,
               runtime_id: Core::Environment::Identity.id,
               seq_id: seq_id,
-              tracer_time: Time.now.to_i,
+              tracer_time: Core::Utils::Time.now.to_i,
             }
             hash.compact!
             hash

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -191,7 +191,7 @@ module Datadog
       end
 
       def timestamp_now
-        (Time.now.to_f * 1000).to_i
+        (Core::Utils::Time.now.to_f * 1000).to_i
       end
 
       def get_local_variables(trace_point)

--- a/lib/datadog/profiling/collectors/info.rb
+++ b/lib/datadog/profiling/collectors/info.rb
@@ -31,6 +31,9 @@ module Datadog
         # Instead of trying to figure out real process start time by checking
         # /proc or some other complex/non-portable way, approximate start time
         # by time of requirement of this file.
+        #
+        # Note: this does not use Core::Utils::Time.now because this constant
+        # gets initialized before a user has a chance to configure the library.
         START_TIME = Time.now.utc.freeze
 
         def collect_platform_info

--- a/lib/datadog/tracing/contrib/rack/request_queue.rb
+++ b/lib/datadog/tracing/contrib/rack/request_queue.rb
@@ -17,7 +17,7 @@ module Datadog
 
           module_function
 
-          def get_request_start(env, now = Time.now.utc)
+          def get_request_start(env, now = Core::Utils::Time.now.utc)
             header = env[REQUEST_START] || env[QUEUE_START]
             return unless header
 

--- a/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/server_tracer.rb
@@ -61,7 +61,7 @@ module Datadog
               span.set_tag(Ext::TAG_JOB_RETRY_COUNT, job['retry_count'])
               span.set_tag(Ext::TAG_JOB_QUEUE, job['queue'])
               span.set_tag(Ext::TAG_JOB_WRAPPER, job['class']) if job['wrapped']
-              span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Time.now.utc.to_f - job['enqueued_at'].to_f))
+              span.set_tag(Ext::TAG_JOB_DELAY, 1000.0 * (Core::Utils::Time.now.utc.to_f - job['enqueued_at'].to_f))
 
               args = job['args']
               if args && !args.empty?

--- a/lib/datadog/tracing/span_event.rb
+++ b/lib/datadog/tracing/span_event.rb
@@ -33,7 +33,7 @@ module Datadog
 
         # OpenTelemetry SDK stores span event timestamps in nanoseconds (not seconds).
         # We will do the same here to avoid unnecessary conversions and inconsistencies.
-        @time_unix_nano = time_unix_nano || (Time.now.to_r * 1_000_000_000).to_i
+        @time_unix_nano = time_unix_nano || (Core::Utils::Time.now.to_r * 1_000_000_000).to_i
       end
 
       # Converts the span event into a hash to be used by with the span tag serialization


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes existing `Time.now` calls in `lib` to instead use `Core::Utils::Time.now`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
The time provider is overridable by users but not all code uses the time provider mechanism. I think everything under `lib` should use the time provider except for the one location where the time is retrieved at class definition.

**Change log entry**
Yes: Use time provider consistently
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
