### PR TITLE
[NO-TICKET] Fix profiling flaky tests due to time conversions, second try

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -70,21 +70,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     end
   end
 
-  # What's the deal with the `reset_monotonic_to_system_state`? TL;DR there's a cache in the monotonic-to-system-clock
-  # conversion code (see `monotonic_to_system_epoch_ns` in time_helpers.c). Because this conversion includes a cache,
-  # any tests that compare timestamps in profiles to `Time.now` could become flaky because of drift between clocks.
-  #
-  # That is, because the profiler is **estimating** the system clock based on this cache, it may say that something
-  # happened a few nanos before `Time.now` when in fact it happened a few nanos after.
-  # Thus, all tests comparing timestamps to `Time.now` are executed with `reset_monotonic_to_system_state: true` to
-  # avoid running into this issue.
-  #
-  # Why not execute **all tests** with this flag? I considered it, but on the other hand it seems dangerous to not
-  # have any code coverage of this cache during tests, since in production we always use it. Yay complexity! :)
-
-  def sample(profiler_overhead_stack_thread: Thread.current, reset_monotonic_to_system_state: false, allow_exception: false)
-    maybe_reset_monotonic_to_system_state(reset_monotonic_to_system_state)
-
+  def sample(profiler_overhead_stack_thread: Thread.current, allow_exception: false)
     described_class::Testing._native_sample(cpu_and_wall_time_collector, profiler_overhead_stack_thread, allow_exception)
   end
 
@@ -96,9 +82,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_on_gc_finish(cpu_and_wall_time_collector)
   end
 
-  def sample_after_gc(reset_monotonic_to_system_state: false, allow_exception: false)
-    maybe_reset_monotonic_to_system_state(reset_monotonic_to_system_state)
-
+  def sample_after_gc(allow_exception: false)
     described_class::Testing._native_sample_after_gc(cpu_and_wall_time_collector, allow_exception)
   end
 
@@ -110,9 +94,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_sample_skipped_allocation_samples(cpu_and_wall_time_collector, skipped_samples)
   end
 
-  def on_gvl_waiting(thread, reset_monotonic_to_system_state: false)
-    maybe_reset_monotonic_to_system_state(reset_monotonic_to_system_state)
-
+  def on_gvl_waiting(thread)
     described_class::Testing._native_on_gvl_waiting(thread)
   end
 
@@ -149,8 +131,29 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       ._native_apply_delta_to_cpu_time_at_previous_sample_ns(cpu_and_wall_time_collector, thread, delta_ns)
   end
 
-  def maybe_reset_monotonic_to_system_state(do_reset)
-    described_class::Testing._native_reset_monotonic_to_system_state(cpu_and_wall_time_collector) if do_reset
+  # What's the deal with the `profiler_system_epoch_time_now_ns`? Internally the profiler uses a monotonic clock
+  # when measuring wall-time, and then needs to turn it into system time.
+  #
+  # Since there's no way (that I know of) to get both a monotonic and a system clock timestamp at once, our
+  # conversion code gets both in sequence and then uses that for the conversions.
+  #
+  # For a while in our tests, we were using `Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)` directly, but
+  # this caused a bunch of flakiness since sometimes the conversion was slightly off from the measurements we got
+  # when reading the system clock directly.
+  #
+  # To solve this flakiness once and for all, the tests were changed to **use the same clock source** as the profiler,
+  # thus guaranteeing that if we get a timestamp here (call it t1), and then call the profiler and it gets a timestamp
+  # (call it t2), that t2 >= t1 (and vice-versa).
+  #
+  # Just in case, we still expect any timestamp output by the profiler to very close to the system clock,
+  # which is why there's that extra expectation there. (To avoid us missing any bugs if the system clock code
+  # in the profiler is ever changed.)
+
+  def profiler_system_epoch_time_now_ns
+    result = described_class::Testing._native_system_epoch_time_now_ns(cpu_and_wall_time_collector)
+    ten_seconds_ns = 10 * 1e9
+    expect(result).to be_within(ten_seconds_ns).of(Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now))
+    result
   end
 
   # This method exists only so we can look for its name in the stack trace in a few tests
@@ -1156,9 +1159,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         let(:timeline_enabled) { true }
 
         it "includes a end_timestamp_ns containing epoch time in every sample" do
-          time_before = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
-          sample(reset_monotonic_to_system_state: true)
-          time_after = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+          time_before = profiler_system_epoch_time_now_ns
+          sample
+          time_after = profiler_system_epoch_time_now_ns
 
           expect(samples.first.labels).to include(end_timestamp_ns: be_between(time_before, time_after))
         end
@@ -1172,9 +1175,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
             @previous_sample_timestamp_ns = per_thread_context.dig(t1, :wall_time_at_previous_sample_ns)
 
-            @time_before_gvl_waiting = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
-            on_gvl_waiting(t1, reset_monotonic_to_system_state: true)
-            @time_after_gvl_waiting = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+            @time_before_gvl_waiting = profiler_system_epoch_time_now_ns
+            on_gvl_waiting(t1)
+            @time_after_gvl_waiting = profiler_system_epoch_time_now_ns
 
             @gvl_waiting_at = gvl_waiting_at_for(t1)
 
@@ -1194,9 +1197,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           end
 
           it "records a second sample to represent the time spent Waiting for GVL" do
-            time_before_sample = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
-            sample(reset_monotonic_to_system_state: true)
-            time_after_sample = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+            time_before_sample = profiler_system_epoch_time_now_ns
+            sample
+            time_after_sample = profiler_system_epoch_time_now_ns
 
             second_sample = samples_for_thread(samples, t1, expected_size: 2).last
 
@@ -1238,12 +1241,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
           def sample_and_check(expected_state:)
             monotonic_time_before_sample = per_thread_context.dig(t1, :wall_time_at_previous_sample_ns)
-            time_before_sample = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+            time_before_sample = profiler_system_epoch_time_now_ns
             monotonic_time_sanity_check = Datadog::Core::Utils::Time.get_time(:nanosecond)
 
-            sample(reset_monotonic_to_system_state: true)
+            sample
 
-            time_after_sample = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+            time_after_sample = profiler_system_epoch_time_now_ns
             monotonic_time_after_sample = per_thread_context.dig(t1, :wall_time_at_previous_sample_ns)
 
             expect(monotonic_time_after_sample).to be >= monotonic_time_sanity_check
@@ -1550,12 +1553,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
       before do
         on_gc_start
-        @time_before = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
-        # Note: This doesn't need reset_monotonic_to_system_state when comparing to Time.now because the
-        # time conversion only happens in `sample_after_gc` (and that's why the test below that looks
-        # at the timestamps does need the reset)
+        @time_before = profiler_system_epoch_time_now_ns
         on_gc_finish
-        @time_after = Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)
+        @time_after = profiler_system_epoch_time_now_ns
       end
 
       context "when called more than once in a row" do
@@ -1630,7 +1630,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         it "creates a Garbage Collection sample using the timestamp set by on_gc_finish, converted to epoch ns" do
-          sample_after_gc(reset_monotonic_to_system_state: true)
+          sample_after_gc
 
           expect(gc_sample.labels.fetch(:end_timestamp_ns)).to be_between(@time_before, @time_after)
         end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes flaky tests such as
[this one](https://github.com/DataDog/dd-trace-rb/actions/runs/14359324310/job/40256546138?pr=4570):

```
Failures:

  1) Datadog::Profiling::Collectors::ThreadContext#sample timeline support when timeline is enabled when thread starts Waiting for GVL records a second sample to represent the time spent Waiting for GVL
     Failure/Error:
       expect(second_sample.labels).to include(
         state: "waiting for gvl",
         end_timestamp_ns: be_between(time_before_sample, time_after_sample),
       )

       expected {:end_timestamp_ns => 1744208274700408014, :state => "waiting for gvl", :"thread id" => "10030 (29328)", :"thread name" => "/__w/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:276"} to include {end_timestamp_ns: (be between 1744208274700440756 and 1744208274700556813 (inclusive))}
       Diff:
       @@ -1,3 +1,5 @@
       -:end_timestamp_ns => (be between 1744208274700440756 and 1744208274700556813 (inclusive)),
       +:"thread id" => "10030 (29328)",
       +:"thread name" => "/__w/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:276",
       +:end_timestamp_ns => 1744208274700408014,
        :state => "waiting for gvl",
     # ./spec/datadog/profiling/collectors/thread_context_spec.rb:1205:in 'block (6 levels) in <top (required)>'
     # ./spec/spec_helper.rb:261:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:146:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in 'block (2 levels) in <top (required)>'

Finished in 20.91 seconds (files took 1.01 seconds to load)
764 examples, 1 failure, 19 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/thread_context_spec.rb:1196 # Datadog::Profiling::Collectors::ThreadContext#sample timeline support when timeline is enabled when thread starts Waiting for GVL records a second sample to represent the time spent Waiting for GVL

Randomized with seed 49054
```

We previously tried to solve this problem in #4495 but the previous attempt was clearly not entirely successful.

The core of the issue is that internally the profiler uses a monotonic clock when measuring wall-time, and then needs to turn it into system time.

Since there's no way (that I know of) to get both a monotonic and a system clock timestamp at once, our conversion code gets both in sequence and then uses that for the conversions.

Prior to this PR, our tests used
`Datadog::Core::Utils::Time.as_utc_epoch_ns(Time.now)` and then tried to compare it with what the profiler saw.

This was the source of the flakiness: sometimes the conversion was slightly off from the measurements we got when reading the system clock directly.

For instance, here's an example of a situation where this can happen:
1. Test code reads system_clock = 100
2. Profiler code reads monotonic_clock = 2000
3. Profiler code wants to convert to system clock, and needs to initialize the conversion code.
3.1 Profiler reads system_clock = 105
3.2 Profiler reads monotonic_clock = 2010
3.3 Profiler delta to epoch ns is 105-2010 => −1905
4. Profiler converts monotonic_clock = 2000 to system using delta: 2000-1905 => 95
5. Test code expected 95 > 100 => failure

I suspect a variant of this is what happened in the test above.

To solve this flakiness once and for all, the tests were changed to **use the same clock source** as the profiler, thus guaranteeing that if the tests get a timestamp (call it t1), and then call the profiler and it gets a timestamp (call it t2), that t2 >= t1 (and vice-versa).

**Motivation:**

Get profiler to zero flaky tests!

**Change log entry**

None.

**Additional Notes:**

This isn't the only way to solve this issue... We could for instance inject the timestamps from the tests to inside the profiler, which would kind-of be the reverse of this solution: get the profiler to use the Ruby-level test timestamps.

But, that would need a lot more plumbing and changing of production code which doesn't seem like the right trade-off for this problem.

Finally we could always move the profiler to use system clock directly, but that's a whole can of worms too, and arguably it wouldn't be any better than it is now.

**How to test the change?**

The tests should be green and remain green and not be flaky!