### PR TITLE
[PROF-11524] Upgrade libdatadog dependency to 17.1

### DIFF
--- a/benchmarks/profiler_http_transport.rb
+++ b/benchmarks/profiler_http_transport.rb
@@ -37,13 +37,17 @@ class ProfilerHttpTransportBenchmark
       api_key: nil,
       upload_timeout_seconds: 10,
     )
-    flush_finish = Time.now.utc
-    @flush = Datadog::Profiling::Flush.new(
-      start: flush_finish - 60,
-      finish: flush_finish,
-      encoded_profile: Datadog::Profiling::StackRecorder.for_testing.serialize!,
+    @flush_finish = Time.now.utc
+    @stack_recorder = Datadog::Profiling::StackRecorder.for_testing
+  end
+
+  def flush
+    Datadog::Profiling::Flush.new(
+      start: @flush_finish - 60,
+      finish: @flush_finish,
+      encoded_profile: @stack_recorder.serialize!,
       code_provenance_file_name: 'example_code_provenance_file_name.json',
-      code_provenance_data: '', # Random.new(1).bytes(4_000),
+      code_provenance_data: '',
       tags_as_array: [],
       internal_metadata: { no_signals_workaround_enabled: false },
       info_json: JSON.fast_generate({ profiler: { benchmarking: true } }),
@@ -89,7 +93,7 @@ class ProfilerHttpTransportBenchmark
   end
 
   def run_once
-    success = @transport.export(@flush)
+    success = @transport.export(flush)
 
     raise('Unexpected: Export failed') unless success
   end

--- a/ext/datadog_profiling_native_extension/encoded_profile.h
+++ b/ext/datadog_profiling_native_extension/encoded_profile.h
@@ -5,3 +5,4 @@
 
 VALUE from_ddog_prof_EncodedProfile(ddog_prof_EncodedProfile profile);
 VALUE enforce_encoded_profile_instance(VALUE object);
+ddog_prof_EncodedProfile *to_ddog_prof_EncodedProfile(VALUE object);

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -116,11 +116,12 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
 }
 
 static VALUE _native_stop(DDTRACE_UNUSED VALUE _self) {
-  ddog_VoidResult result = ddog_crasht_shutdown();
+  // FIXME: What should happen here now? Maybe just remove
+  // ddog_VoidResult result = ddog_crasht_shutdown();
 
-  if (result.tag == DDOG_VOID_RESULT_ERR) {
-    rb_raise(rb_eRuntimeError, "Failed to stop the crash tracker: %"PRIsVALUE, get_error_details_and_drop(&result.err));
-  }
+  // if (result.tag == DDOG_VOID_RESULT_ERR) {
+  //   rb_raise(rb_eRuntimeError, "Failed to stop the crash tracker: %"PRIsVALUE, get_error_details_and_drop(&result.err));
+  // }
 
   return Qtrue;
 }

--- a/ext/libdatadog_api/crashtracker.c
+++ b/ext/libdatadog_api/crashtracker.c
@@ -98,10 +98,17 @@ static VALUE _native_start_or_update_on_fork(int argc, VALUE *argv, DDTRACE_UNUS
     .optional_stdout_filename = {},
   };
 
+  fprintf(stderr, "Crashtracker started in %d\n", getpid());
+
+  // static bool initialized = false;
+  // if (initialized && action == start_action) return Qtrue;
+
   ddog_VoidResult result =
     action == start_action ?
       ddog_crasht_init(config, receiver_config, metadata) :
       ddog_crasht_update_on_fork(config, receiver_config, metadata);
+
+  // initialized = true;
 
   // Clean up before potentially raising any exceptions
   ddog_Vec_Tag_drop(tags);

--- a/lib/datadog/profiling/ext.rb
+++ b/lib/datadog/profiling/ext.rb
@@ -19,7 +19,6 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME = "runtime"
           FORM_FIELD_TAG_RUNTIME_ENGINE = "runtime_engine"
           FORM_FIELD_TAG_RUNTIME_ID = "runtime-id"
-          FORM_FIELD_TAG_RUNTIME_PLATFORM = "runtime_platform"
           FORM_FIELD_TAG_RUNTIME_VERSION = "runtime_version"
           FORM_FIELD_TAG_SERVICE = "service"
           FORM_FIELD_TAG_VERSION = "version"

--- a/lib/datadog/profiling/http_transport.rb
+++ b/lib/datadog/profiling/http_transport.rb
@@ -29,12 +29,7 @@ module Datadog
         status, result = self.class._native_do_export(
           exporter_configuration,
           @upload_timeout_milliseconds,
-          flush,
-          # TODO: This is going to be removed once we move to libdatadog 17
-          flush.start.tv_sec,
-          flush.start.tv_nsec,
-          flush.finish.tv_sec,
-          flush.finish.tv_nsec,
+          flush
         )
 
         if status == :ok

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -19,12 +19,9 @@ module Datadog
         host: Core::Environment::Socket.hostname,
         language: Core::Environment::Identity.lang,
         pid: Process.pid.to_s,
-        # TODO: If profiling is extracted and its version diverges from the datadog gem, this is inaccurate.
-        #       Update if this ever occurs.
         profiler_version: Core::Environment::Identity.gem_datadog_version,
         runtime_engine: Core::Environment::Identity.lang_engine,
         runtime_id: Core::Environment::Identity.id,
-        runtime_platform: Core::Environment::Identity.lang_platform,
         runtime_version: Core::Environment::Identity.lang_version,
         git_repository_url: Core::Environment::Git.git_repository_url,
         git_commit_sha: Core::Environment::Git.git_commit_sha,
@@ -41,7 +38,6 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME => language, # This is known to be repeated from language, above
           FORM_FIELD_TAG_RUNTIME_ENGINE => runtime_engine,
           FORM_FIELD_TAG_RUNTIME_ID => runtime_id,
-          FORM_FIELD_TAG_RUNTIME_PLATFORM => runtime_platform,
           FORM_FIELD_TAG_RUNTIME_VERSION => runtime_version,
         }
         tags[FORM_FIELD_TAG_ENV] = env if env
@@ -50,7 +46,7 @@ module Datadog
         tags[TAG_GIT_REPOSITORY_URL] = git_repository_url if git_repository_url
         tags[TAG_GIT_COMMIT_SHA] = git_commit_sha if git_commit_sha
 
-        # Make sure everything is an utf-8 string, to avoid encoding issues in native code/libddprof/further downstream
+        # Make sure everything is an utf-8 string, to avoid encoding issues in native code/further downstream
         user_tags.merge(tags).map do |key, value|
           [Datadog::Core::Utils.utf8_encode(key), Datadog::Core::Utils.utf8_encode(value)]
         end.to_h

--- a/sig/datadog/profiling/ext.rbs
+++ b/sig/datadog/profiling/ext.rbs
@@ -17,7 +17,6 @@ module Datadog
           FORM_FIELD_TAG_RUNTIME: "runtime"
           FORM_FIELD_TAG_RUNTIME_ENGINE: "runtime_engine"
           FORM_FIELD_TAG_RUNTIME_ID: "runtime-id"
-          FORM_FIELD_TAG_RUNTIME_PLATFORM: "runtime_platform"
           FORM_FIELD_TAG_RUNTIME_VERSION: "runtime_version"
           FORM_FIELD_TAG_SERVICE: "service"
           FORM_FIELD_TAG_VERSION: "version"

--- a/sig/datadog/profiling/http_transport.rbs
+++ b/sig/datadog/profiling/http_transport.rbs
@@ -27,10 +27,6 @@ module Datadog
         exporter_configuration_array exporter_configuration,
         ::Integer upload_timeout_milliseconds,
         Datadog::Profiling::Flush flush,
-        ::Integer start_timespec_seconds,
-        ::Integer start_timespec_nanoseconds,
-        ::Integer finish_timespec_seconds,
-        ::Integer finish_timespec_nanoseconds,
       ) -> [:ok | :error, ::Integer | ::String]
 
       def config_without_api_key: () -> ::String

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -56,12 +56,13 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       info_json: info_json,
     )
   end
-  let(:start_timestamp) { "2022-02-07T15:59:53.987654321Z" }
-  let(:end_timestamp) { "2023-11-11T16:00:00.123456789Z" }
-  let(:start) { Time.iso8601(start_timestamp) }
-  let(:finish) { Time.iso8601(end_timestamp) }
-  let(:encoded_profile) { Datadog::Profiling::StackRecorder.for_testing.serialize! }
-  let(:pprof_file_name) { "rubyprofile.pprof" }
+  let(:serialize_result) { Datadog::Profiling::StackRecorder.for_testing.serialize }
+  let(:start) { serialize_result[0] }
+  let(:finish) { serialize_result[1] }
+  let(:encoded_profile) { serialize_result[2] }
+  let(:start_timestamp) { start.iso8601(9) }
+  let(:end_timestamp) { finish.iso8601(9) }
+  let(:pprof_file_name) { "profile.pprof" }
   let(:code_provenance_file_name) { "the_code_provenance_file_name.json" }
   let(:code_provenance_data) { "the_code_provenance_data" }
   let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
@@ -185,21 +186,12 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     subject(:export) { http_transport.export(flush) }
 
     it "calls the native export method with the data from the flush" do
-      # Manually converted from the lets above :)
       upload_timeout_milliseconds = 10_000
-      start_timespec_seconds = 1644249593
-      start_timespec_nanoseconds = 987654321
-      finish_timespec_seconds = 1699718400
-      finish_timespec_nanoseconds = 123456789
 
       expect(described_class).to receive(:_native_do_export).with(
         kind_of(Array), # exporter_configuration
         upload_timeout_milliseconds,
         flush,
-        start_timespec_seconds,
-        start_timespec_nanoseconds,
-        finish_timespec_seconds,
-        finish_timespec_nanoseconds,
       ).and_return([:ok, 200])
 
       export
@@ -208,6 +200,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     context "when successful" do
       before do
         expect(described_class).to receive(:_native_do_export).and_return([:ok, 200])
+        serialize_result # Trigger the serialization
       end
 
       it "logs a debug message" do
@@ -331,6 +324,20 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     let!(:encoded_profile_bytes) { encoded_profile._native_bytes }
 
     shared_examples "correctly reports profiling data" do
+      let(:expected_data_in_payload) {
+        {
+          "attachments" => contain_exactly(pprof_file_name, code_provenance_file_name),
+          "tags_profiler" => start_with("tag_a:value_a,tag_b:value_b,runtime_platform:#{RUBY_PLATFORM.split("-").first}"),
+          "start" => start_timestamp,
+          "end" => end_timestamp,
+          "family" => "ruby",
+          "version" => "4",
+          "endpoint_counts" => nil,
+          "internal" => hash_including("no_signals_workaround_enabled" => true),
+          "info" => info_string_keys,
+        }
+      }
+
       it "correctly reports profiling data" do
         success = http_transport.export(flush)
 
@@ -347,17 +354,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
         event_data = JSON.parse(body.fetch("event"))
 
-        expect(event_data).to match(
-          "attachments" => contain_exactly(pprof_file_name, code_provenance_file_name),
-          "tags_profiler" => "tag_a:value_a,tag_b:value_b",
-          "start" => start_timestamp,
-          "end" => end_timestamp,
-          "family" => "ruby",
-          "version" => "4",
-          "endpoint_counts" => nil,
-          "internal" => {"no_signals_workaround_enabled" => true},
-          "info" => info_string_keys,
-        )
+        expect(event_data).to match(expected_data_in_payload)
       end
 
       it "reports the payload as lz4-compressed files, that get automatically compressed by libdatadog" do
@@ -396,17 +393,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
         event_data = JSON.parse(body.fetch("event"))
 
-        expect(event_data).to eq(
-          "attachments" => [pprof_file_name],
-          "tags_profiler" => "tag_a:value_a,tag_b:value_b",
-          "start" => start_timestamp,
-          "end" => end_timestamp,
-          "family" => "ruby",
-          "version" => "4",
-          "endpoint_counts" => nil,
-          "internal" => {"no_signals_workaround_enabled" => true},
-          "info" => info_string_keys,
-        )
+        expect(event_data).to match(expected_data_in_payload.merge("attachments" => [pprof_file_name]))
 
         expect(body[code_provenance_file_name]).to be nil
       end
@@ -445,7 +432,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       end
 
       it "logs an error" do
-        expect(Datadog.logger).to receive(:error).with(/error trying to connect/)
+        expect(Datadog.logger).to receive(:error).with(/ddog_prof_Exporter_send failed/)
         expect(Datadog::Core::Telemetry::Logger).to receive(:error).with("Failed to report profiling data")
 
         http_transport.export(flush)
@@ -504,7 +491,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
         event_data = JSON.parse(body.fetch("event"))
 
-        expect(event_data["tags_profiler"]).to eq "valid1:valid1,valid2:valid2"
+        expect(event_data["tags_profiler"]).to start_with("valid1:valid1,valid2:valid2,runtime_platform:")
       end
 
       it "logs a warning" do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -320,21 +320,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         expect(labels).to eq(label_a: "value_a", label_b: "value_b")
       end
 
-      it "encodes a single empty mapping" do
-        expect(decoded_profile.mapping.size).to be 1
-
-        expect(decoded_profile.mapping.first).to have_attributes(
-          id: 1,
-          memory_start: 0,
-          memory_limit: 0,
-          file_offset: 0,
-          filename: 0,
-          build_id: 0,
-          has_functions: false,
-          has_filenames: false,
-          has_line_numbers: false,
-          has_inline_frames: false,
-        )
+      it "does not emit any mappings" do
+        expect(decoded_profile.mapping).to be_empty
       end
 
       it "returns stats reporting one recorded sample" do
@@ -346,25 +333,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             heap_profile_build_time_ns: be >= 0,
           )
         )
-      end
-    end
-
-    context "when sample is invalid" do
-      context "because the local root span id is being defined using a string instead of as a number" do
-        let(:metric_values) { {"cpu-time" => 123, "cpu-samples" => 456, "wall-time" => 789} }
-
-        it do
-          # We're using `_native_sample` here to test the behavior of `record_sample` in `stack_recorder.c`
-          expect do
-            Datadog::Profiling::Collectors::Stack::Testing._native_sample(
-              Thread.current,
-              stack_recorder,
-              metric_values,
-              {"local root span id" => "incorrect", "state" => "unknown"}.to_a,
-              [],
-            )
-          end.to raise_error(ArgumentError)
-        end
       end
     end
 

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         "runtime" => "ruby",
         "runtime_engine" => RUBY_ENGINE,
         "runtime-id" => Datadog::Core::Environment::Identity.id,
-        "runtime_platform" => RUBY_PLATFORM,
         "runtime_version" => RUBY_VERSION,
       )
     end


### PR DESCRIPTION
**What does this PR do?**

Updates the native bits in the gem (profiling, crashtracking) to be able to work with the latest libdatadog 17.

I'm opening it as a draft so we can use it to test the upcoming libdatadog 17.1 release. Once that release is out and on rubygems.org, I plan to:

1. Push the actual gem dependency change on this PR
2. Do a pass on the TODO/FIXME things that are still missing

**Motivation:**

There's a number of fixes and additions in libdatadog that we want to make use of.

**Change log entry**

Yes. Upgrade libdatadog dependency to 17.1

**Additional Notes:**

With this PR, I'm able to build both crashtracking AND profiling with libdatadog master as of 11th of April. I'm also able to get a green test suite for profiling, but not for crashtracking: I've reported the issue to the folks working on that, so they're aware.

**How to test the change?**

Once everything is in place, our existing test coverage will be enough to validate these changes. Until then it's expected that CI is going to be red.
