### PR TITLE
Add reporting of incompatible FFI gem version to Telemetry

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -12,7 +12,18 @@ module Datadog
       class << self
         def build_appsec_component(settings, telemetry:)
           return if !settings.respond_to?(:appsec) || !settings.appsec.enabled
-          return if incompatible_ffi_version?
+
+          if incompatible_ffi_version?
+            Datadog.logger.warn(
+              'AppSec is not supported in Ruby versions above 3.3.0 when using `ffi` versions older than 1.16.0, ' \
+              'and will be forcibly disabled due to a memory leak in `ffi`. ' \
+              'Please upgrade your `ffi` version to 1.16.0 or higher.'
+            )
+
+            telemetry.report(StandardError.new, description: 'incompatible ffi version')
+
+            return
+          end
 
           processor = create_processor(settings, telemetry)
 
@@ -31,18 +42,9 @@ module Datadog
 
         def incompatible_ffi_version?
           ffi_version = Gem.loaded_specs['ffi'] && Gem.loaded_specs['ffi'].version
-          return true unless ffi_version
+          return false unless ffi_version
 
-          return false unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3') &&
-            ffi_version < Gem::Version.new('1.16.0')
-
-          Datadog.logger.warn(
-            'AppSec is not supported in Ruby versions above 3.3.0 when using `ffi` versions older than 1.16.0, ' \
-            'and will be forcibly disabled due to a memory leak in `ffi`. ' \
-            'Please upgrade your `ffi` version to 1.16.0 or higher.'
-          )
-
-          true
+          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3') && ffi_version < Gem::Version.new('1.16.0')
         end
 
         def create_processor(settings, telemetry)

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Datadog::AppSec::Component do
 
         it 'returns a Datadog::AppSec::Component instance with a nil processor' do
           expect(Datadog.logger).to receive(:warn)
+          expect(telemetry).to receive(:report)
 
           component = described_class.build_appsec_component(settings, telemetry: telemetry)
           expect(component).to be_nil
@@ -38,9 +39,10 @@ RSpec.describe Datadog::AppSec::Component do
 
         it 'returns a Datadog::AppSec::Component instance with a nil processor and does not warn' do
           expect(Datadog.logger).not_to receive(:warn)
+          expect(telemetry).not_to receive(:report)
 
           component = described_class.build_appsec_component(settings, telemetry: telemetry)
-          expect(component).to be_nil
+          expect(component.processor).to be_a(Datadog::AppSec::Processor)
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**
This PR reports when an older version of `ffi` gem is used with Ruby version > 3.3 via Telemetry.

**Motivation:**
This combination of older `ffi` gem and Ruby >= 3.3 causes a known memory leak. We want to be notified about this via Telemetry.

**Change log entry**
None. This is an internal change.

**Additional Notes:**
None.

**How to test the change?**
CI is enough.