### PR TITLE
DEBUG-3700 DRY webrick usage in test suite

### DIFF
--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -168,16 +168,7 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         http_server do |http_server|
           http_server.mount_proc('/', &server_proc)
         end
-        let(:http_server_options) do
-          {
-            Logger: log,
-            AccessLog: access_log,
-          }
-        end
         let(:hostname) { '127.0.0.1' }
-        let(:log) { WEBrick::Log.new(StringIO.new, WEBrick::Log::WARN) }
-        let(:access_log_buffer) { StringIO.new }
-        let(:access_log) { [[access_log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
         let(:server_proc) do
           proc do |req, res|
             messages << req.tap { req.body } # Read body, store message before socket closes.
@@ -241,8 +232,6 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         end
         let(:http_server_options) do
           {
-            Logger: log,
-            AccessLog: access_log,
             DoNotListen: true,
           }
         end

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -165,13 +165,14 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
 
     context 'integration testing' do
       shared_context 'HTTP server' do
-        let(:server) do
-          WEBrick::HTTPServer.new(
-            Port: 0,
+        http_server do |http_server|
+          http_server.mount_proc('/', &server_proc)
+        end
+        let(:http_server_options) do
+          {
             Logger: log,
             AccessLog: access_log,
-            StartCallback: -> { init_signal.push(1) }
-          )
+          }
         end
         let(:hostname) { '127.0.0.1' }
         let(:log) { WEBrick::Log.new(StringIO.new, WEBrick::Log::WARN) }
@@ -186,30 +187,13 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         let(:init_signal) { Queue.new }
 
         let(:messages) { [] }
-
-        before do
-          server.mount_proc('/', &server_proc)
-          @server_thread = Thread.new { server.start }
-          init_signal.pop
-        end
-
-        after do
-          unless RSpec.current_example.skipped?
-            # When the test is skipped, server has not been initialized and @server_thread would be nil; thus we only
-            # want to touch them when the test actually run, otherwise we would cause the server to start (incorrectly)
-            # and join to be called on a nil @server_thread
-            server.shutdown
-            @server_thread.join
-          end
-        end
       end
 
       include_context 'HTTP server'
 
       let(:request) { messages.first }
-      let(:port) { server[:Port] }
 
-      let(:agent_base_url) { "http://#{hostname}:#{port}" }
+      let(:agent_base_url) { "http://#{hostname}:#{http_server_port}" }
 
       [:fiddle, :signal].each do |trigger|
         it "reports crashes via http when app crashes with #{trigger}" do
@@ -251,15 +235,16 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
         let(:temporary_directory) { Dir.mktmpdir }
         let(:socket_path) { "#{temporary_directory}/rspec_unix_domain_socket" }
         let(:unix_domain_socket) { UNIXServer.new(socket_path) } # Closing the socket is handled by webrick
-        let(:server) do
-          server = WEBrick::HTTPServer.new(
-            DoNotListen: true,
+        define_http_server do |http_server|
+          http_server.listeners << unix_domain_socket
+          http_server.mount_proc('/', &server_proc)
+        end
+        let(:http_server_options) do
+          {
             Logger: log,
             AccessLog: access_log,
-            StartCallback: -> { init_signal.push(1) }
-          )
-          server.listeners << unix_domain_socket
-          server
+            DoNotListen: true,
+          }
         end
         let(:agent_base_url) { "unix://#{socket_path}" }
 

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -4,6 +4,9 @@ require 'datadog/core/crashtracking/component'
 require 'webrick'
 require 'fiddle'
 
+# https://github.com/rubocop/rubocop-rspec/issues/2078
+# rubocop:disable RSpec/ScatteredLet
+
 RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelpers.supported? do
   let(:logger) { Logger.new($stdout) }
 
@@ -314,3 +317,5 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !CrashtrackingHelp
     described_class._native_stop
   end
 end
+
+# rubocop:enable RSpec/ScatteredLet

--- a/spec/datadog/di/integration/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/integration/probe_notifier_worker_spec.rb
@@ -1,6 +1,5 @@
 require "datadog/di/spec_helper"
 require 'datadog/di'
-require 'webrick'
 
 # standard tries to wreck regular expressions in this fiel
 # rubocop:disable Style/PercentLiteralDelimiters
@@ -23,7 +22,7 @@ RSpec.describe Datadog::DI::ProbeNotifierWorker do
   let(:settings) do
     Datadog::Core::Configuration::Settings.new.tap do |settings|
       settings.agent.host = 'localhost'
-      settings.agent.port = test_port
+      settings.agent.port = http_server_port
       settings.agent.use_ssl = false
       settings.agent.timeout_seconds = 1
     end
@@ -31,47 +30,24 @@ RSpec.describe Datadog::DI::ProbeNotifierWorker do
 
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
 
-  let(:test_port) { 48485 }
-
   di_logger_double
 
   let(:diagnostics_payloads) { [] }
   let(:input_payloads) { [] }
 
-  let(:server) do
-    WEBrick::HTTPServer.new(
-      Port: test_port,
-    ).tap do |server|
-      @received_snapshot_count = 0
-      @received_snapshot_bytes = 0
+  http_server do |http_server|
+    @received_snapshot_count = 0
+    @received_snapshot_bytes = 0
 
-      server.mount_proc('/debugger/v1/diagnostics') do |req, res|
-        # This request is a multipart form post
-        expect(req.content_type).to match(%r,^multipart/form-data;,)
-        diagnostics_payloads << req.body
-      end
+    http_server.mount_proc('/debugger/v1/diagnostics') do |req, res|
+      # This request is a multipart form post
+      expect(req.content_type).to match(%r,^multipart/form-data;,)
+      diagnostics_payloads << req.body
+    end
 
-      server.mount_proc('/debugger/v1/input') do |req, res|
-        payload = JSON.parse(req.body)
-        input_payloads << payload
-      end
-    end
-  end
-
-  around do |example|
-    @server_thread = Thread.new do
-      server.start
-    end
-    loop do
-      break if server.status == :Running || !@server_thread.alive?
-      sleep 0.5
-    end
-    expect(@server_thread).to be_alive
-    example.run
-    @server_thread.kill
-    loop do
-      break unless @server_thread.alive?
-      sleep 0.5
+    http_server.mount_proc('/debugger/v1/input') do |req, res|
+      payload = JSON.parse(req.body)
+      input_payloads << payload
     end
   end
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -282,13 +282,14 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
   context "integration testing" do
     shared_context "HTTP server" do
-      let(:server) do
-        WEBrick::HTTPServer.new(
-          Port: 0,
+      http_server do |http_server|
+        http_server.mount_proc('/', &server_proc)
+      end
+      let(:http_server_options) do
+        {
           Logger: log,
           AccessLog: access_log,
-          StartCallback: -> { init_signal.push(1) }
-        )
+        }
       end
       let(:hostname) { "127.0.0.1" }
       let(:log) { WEBrick::Log.new($stderr, WEBrick::Log::WARN) }
@@ -300,25 +301,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
           res.body = "{}"
         end
       end
-      let(:init_signal) { Queue.new }
 
       let(:messages) { [] }
-
-      before do
-        server.mount_proc("/", &server_proc)
-        @server_thread = Thread.new { server.start }
-        init_signal.pop
-      end
-
-      after do
-        unless RSpec.current_example.skipped?
-          # When the test is skipped, server has not been initialized and @server_thread would be nil; thus we only
-          # want to touch them when the test actually run, otherwise we would cause the server to start (incorrectly)
-          # and join to be called on a nil @server_thread
-          server.shutdown
-          @server_thread.join
-        end
-      end
     end
 
     include_context "HTTP server"
@@ -326,7 +310,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     let(:request) { messages.first }
 
     let(:hostname) { "127.0.0.1" }
-    let(:port) { server[:Port] }
+    let(:port) { http_server_port }
 
     let!(:encoded_profile_bytes) { encoded_profile._native_bytes }
 
@@ -416,15 +400,16 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       let(:temporary_directory) { Dir.mktmpdir }
       let(:socket_path) { "#{temporary_directory}/rspec_unix_domain_socket" }
       let(:unix_domain_socket) { UNIXServer.new(socket_path) } # Closing the socket is handled by webrick
-      let(:server) do
-        server = WEBrick::HTTPServer.new(
-          DoNotListen: true,
+      define_http_server do |http_server|
+        http_server.listeners << unix_domain_socket
+        http_server.mount_proc('/', &server_proc)
+      end
+      let(:http_server_options) do
+        {
           Logger: log,
           AccessLog: access_log,
-          StartCallback: -> { init_signal.push(1) }
-        )
-        server.listeners << unix_domain_socket
-        server
+          DoNotListen: true,
+        }
       end
       let(:adapter) { Datadog::Core::Transport::Ext::UnixSocket::ADAPTER }
       let(:uds_path) { socket_path }
@@ -440,7 +425,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
 
     context "when agent is down" do
       before do
-        server.shutdown
+        http_server.shutdown
         @server_thread.join
       end
 

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -285,16 +285,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       http_server do |http_server|
         http_server.mount_proc('/', &server_proc)
       end
-      let(:http_server_options) do
-        {
-          Logger: log,
-          AccessLog: access_log,
-        }
-      end
       let(:hostname) { "127.0.0.1" }
-      let(:log) { WEBrick::Log.new($stderr, WEBrick::Log::WARN) }
-      let(:access_log_buffer) { StringIO.new }
-      let(:access_log) { [[access_log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
       let(:server_proc) do
         proc do |req, res|
           messages << req.tap { req.body } # Read body, store message before socket closes.
@@ -406,8 +397,6 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       end
       let(:http_server_options) do
         {
-          Logger: log,
-          AccessLog: access_log,
           DoNotListen: true,
         }
       end

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -7,6 +7,9 @@ require "json"
 require "socket"
 require "webrick"
 
+# https://github.com/rubocop/rubocop-rspec/issues/2078
+# rubocop:disable RSpec/ScatteredLet
+
 # Design note for this class's specs: from the Ruby code side, we're treating the `_native_` methods as an API
 # between the Ruby code and the native methods, and thus in this class we have a bunch of tests to make sure the
 # native methods are invoked correctly.
@@ -523,3 +526,5 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     end
   end
 end
+
+# rubocop:enable RSpec/ScatteredLet

--- a/spec/datadog/tracing/contrib/ethon/integration_context.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_context.rb
@@ -17,21 +17,6 @@ RSpec.shared_context 'integration context' do
       end
     end
   end
-  let(:http_server_options) do
-    {
-      Logger: log,
-      AccessLog: access_log,
-    }
-  end
-  let(:log_buffer) do
-    StringIO.new # set to $stderr to debug
-  end
-  let(:log) do
-    WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
-  end
-  let(:access_log) do
-    [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-  end
 
   let(:host) { 'localhost' }
   let(:status) { '200' }

--- a/spec/datadog/tracing/contrib/ethon/integration_context.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_context.rb
@@ -2,21 +2,8 @@ require 'webrick'
 require 'spec/support/thread_helpers'
 
 RSpec.shared_context 'integration context' do
-  before(:all) do
-    # TODO: Consolidate mock webserver code
-    @log_buffer = StringIO.new # set to $stderr to debug
-    log = WEBrick::Log.new(@log_buffer, WEBrick::Log::DEBUG)
-    access_log = [[@log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-
-    init_signal = Queue.new
-    server = WEBrick::HTTPServer.new(
-      Port: 0,
-      Logger: log,
-      AccessLog: access_log,
-      StartCallback: -> { init_signal.push(1) }
-    )
-
-    server.mount_proc '/' do |req, res|
+  http_server do |http_server|
+    http_server.mount_proc '/' do |req, res|
       sleep(0.001) if req.query['simulate_timeout']
       res.status = (req.query['status'] || req.body['status']).to_i
       if req.query['return_headers']
@@ -29,26 +16,27 @@ RSpec.shared_context 'integration context' do
         res.body = 'response'
       end
     end
-
-    ThreadHelpers.with_leaky_thread_creation(:ethon_test_server) do
-      @thread = Thread.new { server.start }
-    end
-
-    init_signal.pop
-
-    @server = server
-    @port = server[:Port]
   end
-
-  after(:all) do
-    @server.shutdown
-    @thread.join
+  let(:http_server_options) do
+    {
+      Logger: log,
+      AccessLog: access_log,
+    }
+  end
+  let(:log_buffer) do
+    StringIO.new # set to $stderr to debug
+  end
+  let(:log) do
+    WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
+  end
+  let(:access_log) do
+    [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
   end
 
   let(:host) { 'localhost' }
   let(:status) { '200' }
   let(:path) { '/sample/path' }
-  let(:port) { @port }
+  let(:port) { http_server_port }
   let(:method) { 'GET' }
   let(:simulate_timeout) { false }
   let(:timeout) { 5 }
@@ -59,7 +47,7 @@ RSpec.shared_context 'integration context' do
     query[:simulate_timeout] = 'true' if simulate_timeout
   end
   let(:url) do
-    url = "http://#{host}:#{@port}#{path}?"
+    url = "http://#{host}:#{http_server_port}#{path}?"
     url += "status=#{status}&" if status
     url += 'return_headers=true&' if return_headers
     url += 'simulate_timeout=true' if simulate_timeout

--- a/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/integration_test_spec.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'stringio'
 require 'typhoeus'
-require 'webrick'
 
 require 'datadog/tracing/trace_digest'
 require 'datadog/tracing/contrib/ethon/easy_patch'

--- a/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
+++ b/spec/datadog/tracing/contrib/ethon/typhoeus_integration_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Datadog::Tracing::Contrib::Ethon do
   context 'with concurrent Hydra requests' do
     include_context 'integration context'
 
-    let(:url_1) { "http://#{host}:#{@port}#{path}?status=200&simulate_timeout=true" }
-    let(:url_2) { "http://#{host}:#{@port}#{path}" }
+    let(:url_1) { "http://#{host}:#{http_server_port}#{path}?status=200&simulate_timeout=true" }
+    let(:url_2) { "http://#{host}:#{http_server_port}#{path}" }
     let(:request_1) { Typhoeus::Request.new(url_1, timeout: 0.001) }
     let(:request_2) { Typhoeus::Request.new(url_2, method: :post, timeout: timeout, body: { status: 404 }) }
 

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -34,21 +34,6 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
       res.body = req.body
     end
   end
-  let(:http_server_options) do
-    {
-      Logger: log,
-      AccessLog: access_log,
-    }
-  end
-  let(:log_buffer) do
-    StringIO.new # set to $stderr to debug
-  end
-  let(:log) do
-    WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
-  end
-  let(:access_log) do
-    [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-  end
 
   let(:configuration_options) { {} }
 

--- a/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httpclient/instrumentation_spec.rb
@@ -20,14 +20,8 @@ require 'datadog/tracing/contrib/support/http'
 require 'spec/support/thread_helpers'
 
 RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
-  before(:all) do
-    # TODO: Consolidate mock webserver code
-    @log_buffer = StringIO.new # set to $stderr to debug
-    log = WEBrick::Log.new(@log_buffer, WEBrick::Log::DEBUG)
-    access_log = [[@log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-
-    server = WEBrick::HTTPServer.new(Port: 0, Logger: log, AccessLog: access_log)
-    server.mount_proc '/' do |req, res|
+  http_server do |http_server|
+    http_server.mount_proc '/' do |req, res|
       body = JSON.parse(req.body)
       res.status = body['code'].to_i
 
@@ -39,18 +33,21 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
 
       res.body = req.body
     end
-
-    ThreadHelpers.with_leaky_thread_creation(:httpclient_test_server) do
-      @thread = Thread.new { server.start }
-    end
-
-    @server = server
-    @port = server[:Port]
   end
-
-  after(:all) do
-    @server.shutdown
-    @thread.join
+  let(:http_server_options) do
+    {
+      Logger: log,
+      AccessLog: access_log,
+    }
+  end
+  let(:log_buffer) do
+    StringIO.new # set to $stderr to debug
+  end
+  let(:log) do
+    WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
+  end
+  let(:access_log) do
+    [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
   end
 
   let(:configuration_options) { {} }
@@ -73,8 +70,8 @@ RSpec.describe Datadog::Tracing::Contrib::Httpclient::Instrumentation do
     let(:host) { 'localhost' }
     let(:message) { 'OK' }
     let(:path) { '/sample/path' }
-    let(:port) { @port }
-    let(:url) { "http://#{host}:#{@port}#{path}" }
+    let(:port) { http_server_port }
+    let(:url) { "http://#{host}:#{http_server_port}#{path}" }
     let(:body) { { 'message' => message, 'code' => code } }
     let(:headers) { { accept: 'application/json' } }
     let(:client) { HTTPClient.new }

--- a/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
+++ b/spec/datadog/tracing/contrib/httprb/instrumentation_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe Datadog::Tracing::Contrib::Httprb::Instrumentation do
       res.body = req.body
     end
   end
-  let(:http_server_options) do
-    {
-      Logger: log,
-      AccessLog: access_log,
-    }
-  end
-  let(:log_buffer) do
-    StringIO.new # set to $stderr to debug
-  end
-  let(:log) do
-    WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
-  end
-  let(:access_log) do
-    [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-  end
 
   let(:configuration_options) { {} }
 

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -11,6 +11,9 @@ require 'rack'
 require 'rackup/handler/webrick' if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new('3')
 require 'webrick'
 
+# https://github.com/rubocop/rubocop-rspec/issues/2078
+# rubocop:disable RSpec/ScatteredLet
+
 RSpec.describe 'contrib integration testing', :integration do
   around do |example|
     ClimateControl.modify('DD_REMOTE_CONFIGURATION_ENABLED' => nil) { example.run }
@@ -259,3 +262,5 @@ RSpec.describe 'contrib integration testing', :integration do
     end
   end
 end
+
+# rubocop:enable RSpec/ScatteredLet

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -157,21 +157,6 @@ RSpec.describe 'contrib integration testing', :integration do
             http_server.mount '/', Rack::Handler::WEBrick, app
           end
         end
-        let(:http_server_options) do
-          {
-            Logger: log,
-            AccessLog: access_log,
-          }
-        end
-        let(:log_buffer) do
-          StringIO.new # set to $stderr to debug
-        end
-        let(:log) do
-          WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
-        end
-        let(:access_log) do
-          [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-        end
 
         let(:uri) { URI("http://localhost:#{http_server_port}/") }
         let(:request) { Net::HTTP::Get.new(uri, { 'test-header' => 'test-request' }) }

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -21,23 +21,30 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
     let(:messages) { [] }
 
     # HTTP
-    let(:http) do
-      WEBrick::HTTPServer.new(
+    http_server do |http_server|
+      http_server.mount_proc('/', &server_proc)
+    end
+    let(:http_server_options) do
+      {
         Logger: log,
         AccessLog: access_log,
-        StartCallback: -> { http_init_signal.push(1) }
-      )
+      }
     end
-    let(:log) { WEBrick::Log.new(log_buffer) }
-    let(:log_buffer) { StringIO.new }
-    let(:access_log) { [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]] }
+    let(:log_buffer) do
+      StringIO.new # set to $stderr to debug
+    end
+    let(:log) do
+      WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
+    end
+    let(:access_log) do
+      [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
+    end
     let(:server_proc) do
       proc do |req, res|
         messages << req
         res.body = '{}'
       end
     end
-    let(:http_init_signal) { Queue.new }
 
     def cleanup_socket
       File.delete(uds_path) if File.exist?(uds_path)
@@ -46,30 +53,22 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
     before do
       cleanup_socket
       server
-      http.mount_proc('/', &server_proc)
-
-      @http_server_thread = Thread.start do
-        http.start
-      end
 
       @unix_server_thread = Thread.start do
         begin
           sock = server.accept
-          http.run(sock)
+          # TODO webrick supports UDS listener to replace this manual code
+          http_server.run(sock)
         rescue => e
           puts "UNIX server error!: #{e}"
         end
       end
-
-      http_init_signal.pop
     end
 
     after do
       unless RSpec.current_example.skipped?
-        http.shutdown
         cleanup_socket
 
-        @http_server_thread.join
         @unix_server_thread.join
       end
     end

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
       @unix_server_thread = Thread.start do
         begin
           sock = server.accept
-          # TODO webrick supports UDS listener to replace this manual code
+          # TODO: webrick supports UDS listener to replace this manual code
           http_server.run(sock)
         rescue => e
           puts "UNIX server error!: #{e}"

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -24,21 +24,6 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
     http_server do |http_server|
       http_server.mount_proc('/', &server_proc)
     end
-    let(:http_server_options) do
-      {
-        Logger: log,
-        AccessLog: access_log,
-      }
-    end
-    let(:log_buffer) do
-      StringIO.new # set to $stderr to debug
-    end
-    let(:log) do
-      WEBrick::Log.new(log_buffer, WEBrick::Log::DEBUG)
-    end
-    let(:access_log) do
-      [[log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
-    end
     let(:server_proc) do
       proc do |req, res|
         messages << req

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ require 'support/synchronization_helpers'
 require 'support/test_helpers'
 require 'support/tracer_helpers'
 require 'support/crashtracking_helpers'
+require 'support/http_server_helpers'
 
 begin
   # Ignore interpreter warnings from external libraries
@@ -69,6 +70,7 @@ RSpec.configure do |config|
   config.include SynchronizationHelpers
   config.include TracerHelpers
   config.include TestHelpers::RSpec::Integration, :integration
+  config.include HttpServerHelpers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/http_server_helpers.rb
+++ b/spec/support/http_server_helpers.rb
@@ -8,10 +8,28 @@ module HttpServerHelpers
 
       let(:http_server_port) { http_server[:Port] }
       let(:http_server_init_signal) { Queue.new }
-      let(:http_server_options) { {} }
+
+      # Additional options to pass to the Webrick server.
+      # To change log destination, override +http_server_log+ or
+      # +http_server_log_buffer+ or +http_server_access_log+.
+      let(:http_server_options) do
+        {}
+      end
+
+      let(:http_server_log_buffer) do
+        StringIO.new # set to $stderr to debug
+      end
+      let(:http_server_log) do
+        WEBrick::Log.new(http_server_log_buffer, WEBrick::Log::DEBUG)
+      end
+      let(:http_server_access_log) do
+        [[http_server_log_buffer, WEBrick::AccessLog::COMBINED_LOG_FORMAT]]
+      end
 
       let(:http_server) do
         options = {
+          Logger: http_server_log,
+          AccessLog: http_server_access_log,
           Port: 0,
           StartCallback: -> { http_server_init_signal.push(1) }
         }.merge(http_server_options)

--- a/spec/support/http_server_helpers.rb
+++ b/spec/support/http_server_helpers.rb
@@ -45,7 +45,7 @@ module HttpServerHelpers
       around do |example|
         @server_thread = Thread.new do
           http_server.start
-        rescue Exception
+        rescue Exception # rubocop:disable Lint/RescueException
           http_server_init_signal.push(1)
           raise
         end

--- a/spec/support/http_server_helpers.rb
+++ b/spec/support/http_server_helpers.rb
@@ -1,0 +1,38 @@
+require 'webrick'
+
+module HttpServerHelpers
+  module ClassMethods
+    def http_server(&block)
+      let(:http_server_port) { http_server[:Port] }
+
+      let(:http_server) do
+        WEBrick::HTTPServer.new(
+          Port: 0,
+        ).tap do |http_server|
+          instance_exec(http_server,&block)
+        end
+      end
+
+      around do |example|
+        @server_thread = Thread.new do
+          http_server.start
+        end
+        loop do
+          break if http_server.status == :Running || !@server_thread.alive?
+          sleep 0.5
+        end
+        expect(@server_thread).to be_alive
+        example.run
+        @server_thread.kill
+        loop do
+          break unless @server_thread.alive?
+          sleep 0.5
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+end

--- a/spec/support/http_server_helpers.rb
+++ b/spec/support/http_server_helpers.rb
@@ -4,10 +4,12 @@ module HttpServerHelpers
   module ClassMethods
     def http_server(&block)
       let(:http_server_port) { http_server[:Port] }
+      let(:http_server_init_signal) { Queue.new }
 
       let(:http_server) do
         WEBrick::HTTPServer.new(
           Port: 0,
+          StartCallback: -> { http_server_init_signal.push(1) }
         ).tap do |http_server|
           instance_exec(http_server,&block)
         end
@@ -16,11 +18,11 @@ module HttpServerHelpers
       around do |example|
         @server_thread = Thread.new do
           http_server.start
+        rescue Exception
+          http_server_init_signal.push(1)
+          raise
         end
-        loop do
-          break if http_server.status == :Running || !@server_thread.alive?
-          sleep 0.5
-        end
+        http_server_init_signal.pop
         expect(@server_thread).to be_alive
         example.run
         @server_thread.kill

--- a/spec/support/http_server_helpers.rb
+++ b/spec/support/http_server_helpers.rb
@@ -2,18 +2,27 @@ require 'webrick'
 
 module HttpServerHelpers
   module ClassMethods
-    def http_server(&block)
+    def define_http_server(&block)
+      # If you wish to override any of the following let blocks, be sure
+      # you do so AFTER calling +http_server+.
+
       let(:http_server_port) { http_server[:Port] }
       let(:http_server_init_signal) { Queue.new }
+      let(:http_server_options) { {} }
 
       let(:http_server) do
-        WEBrick::HTTPServer.new(
+        options = {
           Port: 0,
           StartCallback: -> { http_server_init_signal.push(1) }
-        ).tap do |http_server|
-          instance_exec(http_server,&block)
+        }.merge(http_server_options)
+        WEBrick::HTTPServer.new(options).tap do |http_server|
+          instance_exec(http_server, &block)
         end
       end
+    end
+
+    def http_server(&block)
+      define_http_server(&block)
 
       around do |example|
         @server_thread = Thread.new do
@@ -24,12 +33,11 @@ module HttpServerHelpers
         end
         http_server_init_signal.pop
         expect(@server_thread).to be_alive
+
         example.run
-        @server_thread.kill
-        loop do
-          break unless @server_thread.alive?
-          sleep 0.5
-        end
+
+        http_server.shutdown
+        @server_thread.join
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Creates a `http_server` helper that holds all of the webrick setup.

The helper combines functionality from the setup I used for DI (namely, if there is an exception in the webrick server thread during initialization, it won't hang the test suite) and the rest of the tracer (which was hiding log output by default).

Previously, some tests created the webrick server for each test individually, and some for "all" tests. The current implementation in this PR creates the server per-test. This is easier to follow and I think the actual performance difference is minimal because there are very few tests that actually use webrick.

**Motivation:**
For replacing telemetry transport with the core transport we need some integration tests to ensure everything is working correctly for both agent and agentless modes. These integration tests will use webrick on the receiving side. Instead of copy-pasting existing webrick setup code I decided to go through it and make a common helper.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
Two tests use unix domain socket with webrick. These are spelled slightly differently and I haven't touched the UDS part in this PR; I might combine them in a later PR since the ultimate goal of this sequence of changes is UDS support for telemetry.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
