### PR TITLE
Add marking of spans as blocked on redirect_request action

### DIFF
--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -142,7 +142,10 @@ module Datadog
           context.trace.keep! if context.trace
 
           if context.span
-            context.span.set_tag('appsec.blocked', 'true') if waf_result.actions.key?('block_request')
+            if waf_result.actions.key?('block_request') || waf_result.actions.key?('redirect_request')
+              context.span.set_tag('appsec.blocked', 'true')
+            end
+
             context.span.set_tag('appsec.event', 'true')
           end
 

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -409,9 +409,9 @@ RSpec.describe Datadog::AppSec::Event do
       end
     end
 
-    context 'with block action' do
+    context 'with block_request action' do
       let(:waf_actions) do
-        { 'block_request' => { 'grpc_status_code' => '10', 'status_core' => '403', 'type' => 'auto' } }
+        { 'block_request' => { 'grpc_status_code' => '10', 'status_code' => '403', 'type' => 'auto' } }
       end
 
       it 'adds appsec.blocked tag to span' do
@@ -419,6 +419,17 @@ RSpec.describe Datadog::AppSec::Event do
         expect(context.span.send(:meta)['appsec.event']).to eq('true')
         expect(context.trace.send(:meta)['_dd.p.dm']).to eq('-5')
         expect(context.trace.send(:meta)['_dd.p.ts']).to eq('02')
+      end
+    end
+
+    context 'with redirect_request action' do
+      let(:waf_actions) do
+        { 'redirect_request' => { 'status_code' => '302', 'location' => 'https://datadoghq.com' } }
+      end
+
+      it 'adds appsec.blocked tag to span' do
+        expect(context.span.send(:meta)['appsec.blocked']).to eq('true')
+        expect(context.span.send(:meta)['appsec.event']).to eq('true')
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
It adds `blocked: true` meta tag to spans when redirecting the request because of an AppSec event.

**Motivation:**
We want to mark blocked requests in Datadog dashboard for customers who configured AppSec to redirect blocked requests.

**Change log entry**
Yes. AppSec: Fix for blocked requests not marked correctly when using custom redirect blocking action.

**Additional Notes:**
None.

**How to test the change?**
Manual testing with app-generator. You have to add a custom blocking action via remote config for your test application.