### PR TITLE
Enable AppSec auto-patching of ActiveRecord

### DIFF
--- a/lib/datadog/appsec/contrib/active_record/integration.rb
+++ b/lib/datadog/appsec/contrib/active_record/integration.rb
@@ -13,7 +13,7 @@ module Datadog
 
           MINIMUM_VERSION = Gem::Version.new('4')
 
-          register_as :active_record, auto_patch: false
+          register_as :active_record, auto_patch: true
 
           def self.version
             Gem.loaded_specs['activerecord'] && Gem.loaded_specs['activerecord'].version


### PR DESCRIPTION
**What does this PR do?**
This PR enables auto-patching of ActiveRecord.

**Motivation:**
We want to have SQL Injection detection turned on by default for AppSec users.

**Change log entry**
Yes. AppSec: Add auto-patching of ActiveRecord for SQL Injection detection.

**Additional Notes:**
None.

**How to test the change?**
CI