### PR TITLE
check if @resolver is defined before accessing it to eliminate a Ruby…

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/integration.rb
+++ b/lib/datadog/tracing/contrib/active_record/integration.rb
@@ -57,7 +57,9 @@ module Datadog
           end
 
           def reset_resolver_cache
-            @resolver&.reset_cache
+            if defined?(@resolver)
+              @resolver&.reset_cache
+            end
           end
 
           Contrib::Component.register('activerecord') do |_config|

--- a/spec/datadog/tracing/contrib/active_record/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/integration_spec.rb
@@ -78,4 +78,32 @@ RSpec.describe Datadog::Tracing::Contrib::ActiveRecord::Integration do
 
     it { is_expected.to be_a_kind_of(Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver) }
   end
+
+  describe '#reset_resolver_cache' do
+    context 'when there is no resolver' do
+      before do
+        expect(integration.instance_variable_get('@resolver')).to be nil
+      end
+
+      it 'does not raise exceptions' do
+        expect do
+          integration.reset_resolver_cache
+        end.not_to raise_error
+      end
+    end
+
+    context 'when there is a resolver' do
+      before do
+        integration.resolver
+        expect(integration.instance_variable_get('@resolver')).to be_a(Datadog::Tracing::Contrib::ActiveRecord::Configuration::Resolver)
+      end
+
+      it 'does not raise exceptions and calls reset_cache on the resolver' do
+        expect(integration.resolver).to receive(:reset_cache)
+        expect do
+          integration.reset_resolver_cache
+        end.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
… warning

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Checks if `@resolver` is defined before accessing it to eliminate a Ruby warning. Also adds test coverage for the `reset_resolver_cache` method which previously was not covered (and per https://github.com/DataDog/dd-trace-rb/pull/4348, removing it completely made no tests fail).

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Running the tests produces many lines like this:
```
2025-04-11T14:23:40.3842709Z /__w/dd-trace-rb/dd-trace-rb/lib/datadog/tracing/contrib/active_record/integration.rb:60: warning: instance variable @resolver not initialized
```

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tests are added
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
