### PR TITLE
Publish gem improvement

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       checks: read
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -47,8 +48,62 @@ jobs:
             echo "Version $GEM_VERSION is not published yet"
           fi
 
-      # TODO: Verify draft release
-      # TODO: Verify milestone
+      # Check if there is a draft release for this version
+      # API: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+      - name: Verify draft release
+        if: ${{ !inputs.force }}
+        continue-on-error: true # TODO: Remove when figuring out why draft release are not returned from API
+        env:
+          GEM_VERSION: ${{ steps.version.outputs.version }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            console.log(releases);
+
+            const versionTag = `v${process.env.GEM_VERSION}`;
+            const draftRelease = releases.find(
+              release => release.tag_name === versionTag && release.draft === true
+            );
+
+            if (!draftRelease) {
+              core.setFailed(`No draft release found with tag ${versionTag}. Please create a draft release first.`);
+              return;
+            }
+
+            console.log(`Found draft release with tag ${versionTag} (ID: ${draftRelease.id})`);
+
+      # Check if there is an open milestone for this version
+      # API: https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#list-milestones
+      - name: Verify milestone
+        if: ${{ !inputs.force }}
+        env:
+          GEM_VERSION: ${{ steps.version.outputs.version }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: milestones } = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            console.log(milestones);
+
+            const versionMilestone = milestones.find(
+              milestone => milestone.title === process.env.GEM_VERSION
+            );
+
+            if (!versionMilestone) {
+              core.setFailed(`No open milestone found with title ${process.env.GEM_VERSION}. Please create a milestone first.`);
+              return;
+            }
+
+            console.log(`Found open milestone ${process.env.GEM_VERSION} (ID: ${versionMilestone.number})`);
 
       # Check if the commit has passed all Github checks
       # API: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
@@ -111,7 +166,7 @@ jobs:
             echo "::error::Status check state is '$STATUS'. See: $COMMIT_URL"
             exit 1
           fi
-      - name: Emergency release notification
+      - name: Warning for bypassing checks
         if: ${{ inputs.force }}
         run: |
           echo "::warning::Bypassing verification checks"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,14 @@
 name: Publish gem
 
 # TODO: Implement a dry-run mode to verify the checks without publishing
-on: workflow_dispatch # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force release bypassing verification checks'
+        type: boolean
+        default: false
+        required: false
 
 concurrency: "rubygems" # Only one publish job at a time
 
@@ -29,6 +36,7 @@ jobs:
 
       # Check if the gem version is already published
       - name: Verify gem version
+        if: ${{ !inputs.force }}
         env:
           GEM_VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -45,6 +53,7 @@ jobs:
       # Check if the commit has passed all Github checks
       # API: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
       - name: Verify check runs
+        if: ${{ !inputs.force }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -69,6 +78,7 @@ jobs:
       # Check if the commit has passed external CI checks
       # API: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference
       - name: Verify commit status
+        if: ${{ !inputs.force }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -84,6 +94,7 @@ jobs:
 
       # Check if the commit has all the checks passed
       - name: Verify deferred commit data
+        if: ${{ !inputs.force }}
         # NOTE:
         #
         # This step uses Github's internal API (for rendering the status of the checks in UI),
@@ -100,7 +111,10 @@ jobs:
             echo "::error::Status check state is '$STATUS'. See: $COMMIT_URL"
             exit 1
           fi
-
+      - name: Emergency release notification
+        if: ${{ inputs.force }}
+        run: |
+          echo "::warning::Bypassing verification checks"
 
   rubygems-release:
     name: Build and push gem to RubyGems.org

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -93,10 +93,3 @@ jobs:
             _This is an auto-generated PR from [here](https://github.com/DataDog/dd-trace-rb/blob/master/.github/workflows/update-latest-dependency.yml), which creates a pull request that will be continually updated with new changes until it is merged or closed)_
 
             The PR updates latest versions of defined dependencies. Please review the changes and merge when ready.
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
-        with:
-          token: ${{ secrets.GHA_PAT }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
**Motivation:**

Before releasing, in order to prevent accidentally merging, master branch is locked and auto-merge is disable. 

This configuration breaks to step that enable auto-merge for auto generated pull requests which leads to broken status blocking release.

**What does this PR do?**

1. Add option to bypass checks that are blocking release
2. Remove step that enable auto-merge 

**Change log entry**

None.
