### PR TITLE
DEBUG-3700 Telemetry integration test

### DIFF
--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -130,7 +130,7 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued, up to 30 seconds. Returns whether all events have
+        # been queued, up to 10 seconds. Returns whether all events have
         # been flushed.
         #
         # @api private

--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -130,7 +130,7 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued, up to 10 seconds. Returns whether all events have
+        # been queued, up to 15 seconds. Returns whether all events have
         # been flushed.
         #
         # @api private

--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -130,10 +130,8 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued.
-        #
-        # Note that if events are being constantly enqueued, this method
-        # may wait indefinitely.
+        # been queued, up to 30 seconds. Returns whether all events have
+        # been flushed.
         #
         # @api private
         def flush

--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -129,6 +129,17 @@ module Datadog
           @worker.enqueue(event)
         end
 
+        # Wait for the worker to send out all events that have already
+        # been queued.
+        #
+        # Note that if events are being constantly enqueued, this method
+        # may wait indefinitely.
+        #
+        # @api private
+        def flush
+          @worker.flush
+        end
+
         # Report configuration changes caused by Remote Configuration.
         def client_configuration_change!(changes)
           return if !@enabled || forked?

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -89,7 +89,19 @@ module Datadog
 
           started = Utils::Time.get_time
           loop do
-            return true if buffer.empty?
+            # The AppStarted event is triggered by the worker itself,
+            # from the worker thread. As such the main thread has no way
+            # to delay itself until that event is queued and we need some
+            # way to wait until that event is sent out to assert on it in
+            # the test suite. Check the run once flag which *should*
+            # indicate the event has been queued (at which point our queue
+            # depth check should waint until it's sent).
+            # This is still a hack because the flag can be overridden
+            # either way with or without the event being sent out.
+            # Note that if the AppStarted sending fails, this check
+            # will return false and flushing will be blocked until the
+            # 30 second timeout.
+            return true if buffer.empty? && TELEMETRY_STARTED_ONCE.success?
             sleep 0.5
 
             return false if Utils::Time.get_time - started > 30

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -80,18 +80,19 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued.
-        #
-        # Note that if events are being constantly enqueued, this method
-        # may wait indefinitely.
+        # been queued, up to 30 seconds. Returns whether all events have
+        # been flushed.
         #
         # @api private
         def flush
-          return unless enabled? || !run_loop?
+          return true unless enabled? || !run_loop?
 
+          started = Utils::Time.get_time
           loop do
-            break if buffer.empty? && sent_started_event?
-            sleep 0.1
+            return true if buffer.empty? && sent_started_event?
+            sleep 0.5
+
+            return false if Utils::Time.get_time - started > 30
           end
         end
 

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -89,7 +89,7 @@ module Datadog
 
           started = Utils::Time.get_time
           loop do
-            return true if buffer.empty? && sent_started_event?
+            return true if buffer.empty?
             sleep 0.5
 
             return false if Utils::Time.get_time - started > 30

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -80,7 +80,7 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued, up to 10 seconds. Returns whether all events have
+        # been queued, up to 15 seconds. Returns whether all events have
         # been flushed.
         #
         # @api private
@@ -100,11 +100,14 @@ module Datadog
             # either way with or without the event being sent out.
             # Note that if the AppStarted sending fails, this check
             # will return false and flushing will be blocked until the
-            # 10 second timeout.
+            # 15 second timeout.
+            # Note that the first wait interval between telemetry event
+            # sending is 10 seconds, the timeout needs to be strictly
+            # greater than that.
             return true if buffer.empty? && !in_iteration? && TELEMETRY_STARTED_ONCE.success?
             sleep 0.5
 
-            return false if Utils::Time.get_time - started > 10
+            return false if Utils::Time.get_time - started > 15
           end
         end
 

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -90,7 +90,7 @@ module Datadog
           return unless enabled? || !run_loop?
 
           loop do
-            break if buffer.empty?
+            break if buffer.empty? && sent_started_event?
             sleep 0.1
           end
         end

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -79,6 +79,22 @@ module Datadog
           TELEMETRY_STARTED_ONCE.failed?
         end
 
+        # Wait for the worker to send out all events that have already
+        # been queued.
+        #
+        # Note that if events are being constantly enqueued, this method
+        # may wait indefinitely.
+        #
+        # @api private
+        def flush
+          return unless enabled? || !run_loop?
+
+          loop do
+            break if buffer.empty?
+            sleep 0.1
+          end
+        end
+
         private
 
         def perform(*events)

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -105,6 +105,7 @@ module Datadog
             # sending is 10 seconds, the timeout needs to be strictly
             # greater than that.
             return true if buffer.empty? && !in_iteration? && TELEMETRY_STARTED_ONCE.success?
+
             sleep 0.5
 
             return false if Utils::Time.get_time - started > 15

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -101,7 +101,7 @@ module Datadog
             # Note that if the AppStarted sending fails, this check
             # will return false and flushing will be blocked until the
             # 10 second timeout.
-            return true if buffer.empty? && TELEMETRY_STARTED_ONCE.success?
+            return true if buffer.empty? && !in_iteration? && TELEMETRY_STARTED_ONCE.success?
             sleep 0.5
 
             return false if Utils::Time.get_time - started > 10

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -80,7 +80,7 @@ module Datadog
         end
 
         # Wait for the worker to send out all events that have already
-        # been queued, up to 30 seconds. Returns whether all events have
+        # been queued, up to 10 seconds. Returns whether all events have
         # been flushed.
         #
         # @api private
@@ -100,11 +100,11 @@ module Datadog
             # either way with or without the event being sent out.
             # Note that if the AppStarted sending fails, this check
             # will return false and flushing will be blocked until the
-            # 30 second timeout.
+            # 10 second timeout.
             return true if buffer.empty? && TELEMETRY_STARTED_ONCE.success?
             sleep 0.5
 
-            return false if Utils::Time.get_time - started > 30
+            return false if Utils::Time.get_time - started > 10
           end
         end
 

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -49,7 +49,7 @@ module Datadog
             worker.terminate
             # Wait for the worker thread to end
             begin
-              Timeout.timeout(0.5) do
+              Timeout.timeout(SHUTDOWN_TIMEOUT) do
                 worker.join
               end
             rescue Timeout::Error

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -47,6 +47,14 @@ module Datadog
             @run_async = false
             Datadog.logger.debug { "Forcibly terminating worker thread for: #{self}" }
             worker.terminate
+            # Wait for the worker thread to end
+            begin
+              Timeout.timeout(0.5) do
+                worker.join
+              end
+            rescue Timeout::Error
+              Datadog.logger.debug { "Worker thread did not end after 0.5 seconds: #{self}" }
+            end
             true
           end
 

--- a/lib/datadog/core/workers/interval_loop.rb
+++ b/lib/datadog/core/workers/interval_loop.rb
@@ -21,7 +21,18 @@ module Datadog
         # Methods that must be prepended
         module PrependedMethods
           def perform(*args)
-            perform_loop { super(*args) }
+            perform_loop do
+              @in_iteration = true
+              begin
+                super(*args)
+              ensure
+                @in_iteration = false
+              end
+            end
+          end
+
+          def in_iteration?
+            defined?(@in_iteration) && @in_iteration
           end
         end
 

--- a/sig/datadog/core/telemetry/worker.rbs
+++ b/sig/datadog/core/telemetry/worker.rbs
@@ -35,6 +35,8 @@ module Datadog
         def enqueue: (Event::Base event) -> void
 
         def dequeue: () -> Array[Event::Base]
+	
+	def flush: () -> (true | false)
 
         private
 

--- a/sig/datadog/core/workers/interval_loop.rbs
+++ b/sig/datadog/core/workers/interval_loop.rbs
@@ -44,6 +44,8 @@ module Datadog
         private
 
         def perform_loop: () { () -> untyped } -> (nil | untyped)
+	
+	def in_iteration?: () -> (true | false)
 
         def shutdown: () -> untyped
       end

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+require 'datadog/core/telemetry/component'
+
+RSpec.describe 'Telemetry integration tests' do
+  let(:component) do
+    Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)
+  end
+
+  let(:agent_settings) do
+    Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
+  end
+
+  let(:logger) { logger_allowing_debug }
+
+  after do
+    # TODO why is there no shutdown! method on telemetry component?
+    component.stop!
+  end
+
+  let(:sent_payloads) { [] }
+
+  shared_examples 'telemetry' do
+    it 'initializes correctly' do
+      expect(component.enabled).to be true
+    end
+
+    let(:expected_base_headers) do
+      {
+        # Webrick provides each header value as an array
+        'dd-client-library-language' => %w(ruby),
+        'dd-client-library-version' => %w(2.14.0),
+        'dd-internal-untraced-request' => %w(1),
+        'dd-telemetry-api-version' => %w(v2),
+      }
+    end
+
+    let(:expected_agentless_headers) do
+      expected_base_headers.merge(
+        'dd-api-key' => %w(1234),
+      )
+    end
+
+    context 'first run' do
+      before do
+        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
+      end
+
+      it 'sends startup payloads' do
+        expect(settings.telemetry.dependency_collection).to be true
+
+        component
+
+        sleep 1
+        expect(sent_payloads.length).to eq 2
+
+        payload = sent_payloads[0]
+        expect(payload.fetch(:payload)).to match(
+          'api_version' => 'v2',
+          'application' => Hash,
+          'debug' => false,
+          'host' => Hash,
+          'payload' => {
+            'configuration' => Array,
+            'products' => Hash,
+            'install_signature' => Hash,
+          },
+          'request_type' => 'app-started',
+          'runtime_id' => String,
+          'seq_id' => Integer,
+          'tracer_time' => Integer,
+        )
+        expect(payload.fetch(:headers)).to include(
+          expected_headers.merge('dd-telemetry-request-type' => %w(app-started)))
+
+        payload = sent_payloads[1]
+        expect(payload.fetch(:payload)).to match(
+          'api_version' => 'v2',
+          'application' => Hash,
+          'debug' => false,
+          'host' => Hash,
+          'payload' => {
+            'dependencies' => Array,
+          },
+          'request_type' => 'app-dependencies-loaded',
+          'runtime_id' => String,
+          'seq_id' => Integer,
+          'tracer_time' => Integer,
+        )
+        expect(payload.fetch(:headers)).to include(
+          expected_headers.merge('dd-telemetry-request-type' => %w(app-dependencies-loaded)))
+      end
+    end
+
+    context 'not first run' do
+      before do
+        # To avoid noise from the startup events, turn those off.
+        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run
+      end
+
+      it 'sends expected payload' do
+        component.error('test error')
+
+        sleep 1
+        expect(sent_payloads.length).to eq 1
+
+        payload = sent_payloads[0]
+        expect(payload.fetch(:payload)).to match(
+          'api_version' => 'v2',
+          'application' => Hash,
+          'debug' => false,
+          'host' => Hash,
+          'payload' => [
+            'payload' => {
+              'logs' => [
+                'count' => 1,
+                'level' => 'ERROR',
+                'message' => 'test error',
+              ],
+            },
+            'request_type' => 'logs',
+          ],
+          'request_type' => 'message-batch',
+          'runtime_id' => String,
+          'seq_id' => Integer,
+          'tracer_time' => Integer,
+        )
+        expect(payload.fetch(:headers)).to include(
+          expected_headers.merge('dd-telemetry-request-type' => %w(message-batch)))
+      end
+    end
+  end
+
+  let(:handler_proc) do
+    lambda do |req, res|
+      expect(req.content_type).to eq('application/json')
+      payload = JSON.parse(req.body)
+      sent_payloads << {
+        headers: req.header,
+        payload: payload,
+      }
+    end
+  end
+
+  context 'agentful' do
+    http_server do |http_server|
+      http_server.mount_proc('/telemetry/proxy/api/v2/apmtelemetry', &handler_proc)
+    end
+
+    let(:settings) do
+      Datadog::Core::Configuration::Settings.new.tap do |settings|
+        settings.agent.port = http_server_port
+        settings.telemetry.enabled = true
+      end
+    end
+
+    let(:expected_headers) { expected_base_headers }
+
+    include_examples 'telemetry'
+  end
+
+  context 'agentless' do
+    http_server do |http_server|
+      http_server.mount_proc('/api/v2/apmtelemetry', &handler_proc)
+    end
+
+    let(:settings) do
+      Datadog::Core::Configuration::Settings.new.tap do |settings|
+        settings.agent.port = http_server_port
+        settings.telemetry.enabled = true
+        settings.telemetry.agentless_enabled = true
+        settings.telemetry.agentless_url_override = "http://127.0.0.1:#{http_server_port}"
+        settings.api_key = '1234'
+      end
+    end
+
+    let(:expected_headers) { expected_agentless_headers }
+
+    include_examples 'telemetry'
+  end
+end

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe 'Telemetry integration tests' do
     context 'not first run' do
       before do
         # To avoid noise from the startup events, turn those off.
-        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run
+        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
+          # nothing
+        end
       end
 
       it 'sends expected payload' do

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -52,9 +52,10 @@ RSpec.describe 'Telemetry integration tests' do
       it 'sends startup payloads' do
         expect(settings.telemetry.dependency_collection).to be true
 
+        # Instantiate the component
         component
 
-        sleep 1
+        component.flush
         expect(sent_payloads.length).to eq 2
 
         payload = sent_payloads[0]
@@ -108,7 +109,7 @@ RSpec.describe 'Telemetry integration tests' do
       it 'sends expected payload' do
         component.error('test error')
 
-        sleep 1
+        component.flush
         expect(sent_payloads.length).to eq 1
 
         payload = sent_payloads[0]

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -8,7 +8,10 @@ require 'datadog/core/telemetry/component'
 # rubocop:disable RSpec/ScatteredLet
 
 RSpec.describe 'Telemetry integration tests' do
-  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
+  # Although the tests override the environment variables, if any,
+  # with programmatic configuration, that may produce warnings from the
+  # configuration code. Remove environment variables to suppress the warnings.
+  #with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
 
   let(:component) do
     Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Telemetry integration tests' do
 
   let(:sent_payloads) { [] }
 
-  shared_examples 'telemetry' do
+  shared_examples 'telemetry integration tests' do
     it 'initializes correctly' do
       expect(component.enabled).to be true
     end
@@ -51,12 +51,12 @@ RSpec.describe 'Telemetry integration tests' do
       )
     end
 
-    context 'first run' do
+    describe 'startup events' do
       before do
         Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
       end
 
-      it 'sends startup payloads' do
+      it 'sends expected startup events' do
         expect(settings.telemetry.dependency_collection).to be true
 
         # Instantiate the component
@@ -105,7 +105,7 @@ RSpec.describe 'Telemetry integration tests' do
       end
     end
 
-    context 'not first run' do
+    describe 'error event' do
       before do
         # To avoid noise from the startup events, turn those off.
         Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
@@ -172,7 +172,7 @@ RSpec.describe 'Telemetry integration tests' do
 
     let(:expected_headers) { expected_base_headers }
 
-    include_examples 'telemetry'
+    include_examples 'telemetry integration tests'
   end
 
   context 'agentless' do
@@ -192,7 +192,7 @@ RSpec.describe 'Telemetry integration tests' do
 
     let(:expected_headers) { expected_agentless_headers }
 
-    include_examples 'telemetry'
+    include_examples 'telemetry integration tests'
   end
 end
 

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'Telemetry integration tests' do
   # Although the tests override the environment variables, if any,
   # with programmatic configuration, that may produce warnings from the
   # configuration code. Remove environment variables to suppress the warnings.
-  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
+  # DD_AGENT_HOST is set in CI and *must* be overridden.
+  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil,
+    DD_AGENT_HOST: nil
 
   let(:component) do
     Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Telemetry integration tests' do
       {
         # Webrick provides each header value as an array
         'dd-client-library-language' => %w[ruby],
-        'dd-client-library-version' => %w[2.14.0],
+        'dd-client-library-version' => [String],
         'dd-internal-untraced-request' => %w[1],
         'dd-telemetry-api-version' => %w[v2],
       }

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Telemetry integration tests' do
     end
   end
 
-  context 'agentful' do
+  context 'in agent mode' do
     http_server do |http_server|
       http_server.mount_proc('/telemetry/proxy/api/v2/apmtelemetry', &handler_proc)
     end
@@ -175,7 +175,7 @@ RSpec.describe 'Telemetry integration tests' do
     include_examples 'telemetry integration tests'
   end
 
-  context 'agentless' do
+  context 'in agentless mode' do
     http_server do |http_server|
       http_server.mount_proc('/api/v2/apmtelemetry', &handler_proc)
     end

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'datadog/core/telemetry/component'

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'Telemetry integration tests' do
   # with programmatic configuration, that may produce warnings from the
   # configuration code. Remove environment variables to suppress the warnings.
   # DD_AGENT_HOST is set in CI and *must* be overridden.
-  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil,
+  with_env DD_TRACE_AGENT_PORT: nil,
+    DD_TRACE_AGENT_URL: nil,
     DD_AGENT_HOST: nil
 
   let(:component) do

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 require 'datadog/core/telemetry/component'
 
+# https://github.com/rubocop/rubocop-rspec/issues/2078
+# rubocop:disable RSpec/ScatteredLet
+
 RSpec.describe 'Telemetry integration tests' do
   let(:component) do
     Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)
@@ -179,3 +182,5 @@ RSpec.describe 'Telemetry integration tests' do
     include_examples 'telemetry'
   end
 end
+
+# rubocop:enable RSpec/ScatteredLet

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Telemetry integration tests' do
   # Although the tests override the environment variables, if any,
   # with programmatic configuration, that may produce warnings from the
   # configuration code. Remove environment variables to suppress the warnings.
-  #with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
+  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
 
   let(:component) do
     Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Telemetry integration tests' do
   let(:logger) { logger_allowing_debug }
 
   after do
-    # TODO why is there no shutdown! method on telemetry component?
+    # TODO: why is there no shutdown! method on telemetry component?
     component.stop!
   end
 
@@ -31,16 +31,16 @@ RSpec.describe 'Telemetry integration tests' do
     let(:expected_base_headers) do
       {
         # Webrick provides each header value as an array
-        'dd-client-library-language' => %w(ruby),
-        'dd-client-library-version' => %w(2.14.0),
-        'dd-internal-untraced-request' => %w(1),
-        'dd-telemetry-api-version' => %w(v2),
+        'dd-client-library-language' => %w[ruby],
+        'dd-client-library-version' => %w[2.14.0],
+        'dd-internal-untraced-request' => %w[1],
+        'dd-telemetry-api-version' => %w[v2],
       }
     end
 
     let(:expected_agentless_headers) do
       expected_base_headers.merge(
-        'dd-api-key' => %w(1234),
+        'dd-api-key' => %w[1234],
       )
     end
 
@@ -74,7 +74,8 @@ RSpec.describe 'Telemetry integration tests' do
           'tracer_time' => Integer,
         )
         expect(payload.fetch(:headers)).to include(
-          expected_headers.merge('dd-telemetry-request-type' => %w(app-started)))
+          expected_headers.merge('dd-telemetry-request-type' => %w[app-started])
+        )
 
         payload = sent_payloads[1]
         expect(payload.fetch(:payload)).to match(
@@ -91,7 +92,8 @@ RSpec.describe 'Telemetry integration tests' do
           'tracer_time' => Integer,
         )
         expect(payload.fetch(:headers)).to include(
-          expected_headers.merge('dd-telemetry-request-type' => %w(app-dependencies-loaded)))
+          expected_headers.merge('dd-telemetry-request-type' => %w[app-dependencies-loaded])
+        )
       end
     end
 
@@ -129,13 +131,14 @@ RSpec.describe 'Telemetry integration tests' do
           'tracer_time' => Integer,
         )
         expect(payload.fetch(:headers)).to include(
-          expected_headers.merge('dd-telemetry-request-type' => %w(message-batch)))
+          expected_headers.merge('dd-telemetry-request-type' => %w[message-batch])
+        )
       end
     end
   end
 
   let(:handler_proc) do
-    lambda do |req, res|
+    lambda do |req, _res|
       expect(req.content_type).to eq('application/json')
       payload = JSON.parse(req.body)
       sent_payloads << {

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -8,6 +8,8 @@ require 'datadog/core/telemetry/component'
 # rubocop:disable RSpec/ScatteredLet
 
 RSpec.describe 'Telemetry integration tests' do
+  with_env DD_TRACE_AGENT_PORT: nil, DD_TRACE_AGENT_URL: nil
+
   let(:component) do
     Datadog::Core::Telemetry::Component.build(settings, agent_settings, logger)
   end

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Telemetry integration tests' do
       before do
         # To avoid noise from the startup events, turn those off.
         Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
-          # nothing
+          true
         end
       end
 

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -281,11 +281,6 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
 
       context 'several workers running' do
 
-        before do
-          # This test expects the AppStarted event
-          Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
-        end
-
         let(:started_workers) { [] }
 
         after do

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -56,8 +56,6 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
   after do
     worker.stop(true)
     worker.join
-
-    Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
   end
 
   describe '.new' do
@@ -73,6 +71,10 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
   end
 
   describe '#start' do
+    before do
+      Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
+    end
+
     context 'when enabled' do
       context "when backend doesn't support telemetry" do
         let(:backend_supports_telemetry?) { false }

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -280,7 +280,6 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
       end
 
       context 'several workers running' do
-
         let(:started_workers) { [] }
 
         after do

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -336,6 +336,11 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
     let(:heartbeat_interval_seconds) { 60 }
     let(:metrics_aggregation_interval_seconds) { 30 }
 
+    before do
+      # This test expects the AppStarted event apparently
+      Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
+    end
+
     it 'flushes events and stops the worker' do
       worker.start
 

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
           expect(started_events).to be(1)
 
           workers.each do |w|
-            w.stop(true, 0)
+            w.stop(true, 1)
             w.join
           end
         end

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -278,6 +278,12 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
       end
 
       context 'several workers running' do
+
+        before do
+          # This test expects the AppStarted event
+          Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
+        end
+
         it 'sends single started event' do
           started_events = 0
           mutex = Mutex.new

--- a/spec/datadog/di/integration/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/integration/probe_notifier_worker_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Datadog::DI::ProbeNotifierWorker do
     end
 
     http_server.mount_proc('/debugger/v1/input') do |req, res|
+      expect(req.content_type).to eq('application/json')
       payload = JSON.parse(req.body)
       input_payloads << payload
     end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -75,7 +75,7 @@ module CoreHelpers
     # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
     # should be used in any given call.
     def with_env(*args, **opts)
-      if args.any? && opts.any?
+      if args.any? && opts.any? # rubocop:disable Style/IfUnlessModifier
         raise ArgumentError, 'Do not pass both args and opts'
       end
 

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -71,9 +71,12 @@ module CoreHelpers
       end
     end
 
-    def with_env(**opts)
+    # Positional and keyword arguments are both accepted to make the method
+    # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
+    # should be used in any given call.
+    def with_env(*args, **opts)
       around do |example|
-        ClimateControl.modify(**opts) do
+        ClimateControl.modify(*args, **opts) do
           example.run
         end
       end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -70,6 +70,14 @@ module CoreHelpers
         end
       end
     end
+
+    def with_env(**opts)
+      around do |example|
+        ClimateControl.modify(**opts) do
+          example.run
+        end
+      end
+    end
   end
 
   def self.included(base)

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -75,9 +75,19 @@ module CoreHelpers
     # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
     # should be used in any given call.
     def with_env(*args, **opts)
+      if args.any? && opts.any?
+        raise ArgumentError, 'Do not pass both args and opts'
+      end
+
       around do |example|
-        ClimateControl.modify(*args, **opts) do
-          example.run
+        if args.any?
+          ClimateControl.modify(*args) do
+            example.run
+          end
+        else
+          ClimateControl.modify(**opts) do
+            example.run
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds integration tests for agent and agentless telemetry

**Motivation:**
Test coverage for upcoming code changes to the core transport within telemetry
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
I added a wait to the termination code for async worker, without it the workers were not terminated within the test's scope and the thread leak checker was complaining.

I added a flushing feature to telemetry worker, since there was no way to wait for the events to be sent before asserting on them being received.

To implement flushing  I added a flag that is set when one iteration of the interval loop is being processed, without it the sending would be happening concurrently with the assertions.

Some of the existing telemetry tests were not properly preparing global state, namely whether the AppStarted event has been sent out. I added resets as needed.

Also added a `with_env` helper to set environment variables declaratively for examples.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
PR is tests only, however I verified them also in the stacked PR that implements UDS transport.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
