### PR TITLE
DEBUG-3700 agentless settings resolver

### DIFF
--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -41,6 +41,7 @@ module Datadog
           end
 
           super(settings, logger: logger)
+
           @host_prefix = host_prefix
           @url_override = url_override
           @url_override_source = url_override_source

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -82,6 +82,21 @@ module Datadog
           @configured_port = if parsed_url
             parsed_url.port
           end
+
+          @configured_port = pick_from(
+            try_parsing_as_integer(
+              friendly_name: '"c.agent.port"',
+              value: settings.agent.port,
+            ),
+            DetectedConfiguration.new(
+              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_URL} environment variable",
+              value: parsed_http_url&.port,
+            ),
+            try_parsing_as_integer(
+              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_PORT} environment variable",
+              value: ENV[Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_PORT],
+            )
+          )
         end
 
         # Note that this method should always return true or false
@@ -105,7 +120,7 @@ module Datadog
         end
 
         def port
-          if configured_hostname
+          if configured_port
             configured_port
           else
             # If no hostname is specified, we are communicating with the

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -137,8 +137,7 @@ module Datadog
                 parsed
               else
                 log_warning(
-                  "Invalid URI scheme '#{parsed.scheme}' for #{url_override_source} " \
-                  "environment variable ('#{unparsed_url_from_env}'). " \
+                  "Invalid URI scheme '#{parsed.scheme}' for #{url_override_source}. " \
                   "Ignoring the contents of #{url_override_source}."
                 )
                 nil

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -35,14 +35,19 @@ module Datadog
       # However, agentless resolver does respect the timeout specified via
       # c.agent.timeout_seconds or DD_TRACE_AGENT_TIMEOUT_SECONDS.
       class AgentlessSettingsResolver < AgentSettingsResolver
-
         # To avoid coupling this class to telemetry, the URL override is
         # taken here as a parameter instead of being read out of
         # c.telemetry.agentless_url_override. For the same reason, the
         # +url_override_source+ parameter should be set to the string
         # "c.telemetry.agentless_url_override".
         def self.call(settings, host_prefix:, url_override: nil, url_override_source: nil, logger: Datadog.logger)
-          new(settings, host_prefix: host_prefix, url_override: url_override, url_override_source: url_override_source, logger: logger).send(:call)
+          new(
+            settings,
+            host_prefix: host_prefix,
+            url_override: url_override,
+            url_override_source: url_override_source,
+            logger: logger
+          ).send(:call)
         end
 
         private
@@ -71,19 +76,13 @@ module Datadog
         def configured_hostname
           return @configured_hostname if defined?(@configured_hostname)
 
-          @configured_hostname = if parsed_url
-            parsed_url.hostname
-          else
-            nil
-          end
+          @configured_hostname = (parsed_url.hostname if parsed_url)
         end
 
         def configured_port
           return @configured_port if defined?(@configured_port)
 
-          @configured_port = if parsed_url
-            parsed_url.port
-          end
+          @configured_port = (parsed_url.port if parsed_url)
         end
 
         # Note that this method should always return true or false
@@ -101,9 +100,7 @@ module Datadog
         def configured_ssl
           return @configured_ssl if defined?(@configured_ssl)
 
-          @configured_ssl = if parsed_url
-            parsed_url_ssl?
-          end
+          @configured_ssl = (parsed_url_ssl? if parsed_url)
         end
 
         def port
@@ -139,14 +136,11 @@ module Datadog
               if http_scheme?(parsed) || unix_scheme?(parsed)
                 parsed
               else
-                # rubocop:disable Layout/LineLength
                 log_warning(
                   "Invalid URI scheme '#{parsed.scheme}' for #{url_override_source} " \
                   "environment variable ('#{unparsed_url_from_env}'). " \
                   "Ignoring the contents of #{url_override_source}."
                 )
-                # rubocop:enable Layout/LineLength
-
                 nil
               end
             end

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -95,6 +95,13 @@ module Datadog
           end
         end
 
+        def can_use_uds?
+          # While in theory agentless transport could communicate via UDS,
+          # in practice "agentless" means we are communicating with Datadog
+          # infrastructure which is always remote.
+          false
+        end
+
         def parsed_url
           return @parsed_url if defined?(@parsed_url)
 

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -84,9 +84,10 @@ module Datadog
           end
         end
 
+        # Note that this method should always return true or false
         def ssl?
           if configured_hostname
-            configured_ssl
+            configured_ssl || false
           else
             # If no hostname is specified, we are communicating with the
             # default Datadog intake, which uses TLS.
@@ -94,6 +95,7 @@ module Datadog
           end
         end
 
+        # Note that this method can return nil
         def configured_ssl
           return @configured_ssl if defined?(@configured_ssl)
 

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/*
+
 require 'uri'
 
 require_relative 'agent_settings_resolver'
@@ -116,7 +118,7 @@ module Datadog
         end
 
         def port
-          if configured_port # rubocop:disable Style/RedundantCondition
+          if configured_port
             configured_port
           else
             if should_use_uds?
@@ -170,3 +172,5 @@ module Datadog
     end
   end
 end
+
+# rubocop:enable Style/*

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+require_relative 'agent_settings_resolver'
+
+module Datadog
+  module Core
+    module Configuration
+      # Agent settings resolver for agentless operations (currently, telemetry
+      # in agentless mode).
+      #
+      # The terminology gets a little confusing here, but transports communicate
+      # with servers which are - for most components in the tracer - the
+      # (local) agent. Hence, "agent settings" to refer to where the server
+      # is located. Telemetry supports sending to the local agent but also
+      # implements agentless mode where it sends directly to Datadog intake
+      # endpoints. The agentless mode is configured using different settings,
+      # and this class produces AgentSettings instances when in agentless mode.
+      class AgentlessSettingsResolver < AgentSettingsResolver
+
+        # To avoid coupling this class to telemetry, the URL override is
+        # taken here as a parameter instead of being read out of
+        # c.telemetry.agentless_url_override. For the same reason, the
+        # +url_override_source+ parameter should be set to the string
+        # "c.telemetry.agentless_url_override".
+        def self.call(settings, url_override: nil, url_override_source: nil, logger: Datadog.logger)
+          new(settings, url_override: url_override, url_override_source: url_override_source, logger: logger).send(:call)
+        end
+
+        private
+
+        attr_reader \
+          :url_override,
+          :url_override_source
+
+        def initialize(settings, url_override: nil, url_override_source: nil, logger: Datadog.logger)
+          super(settings, logger: logger)
+          @url_override = url_override
+          @url_override_source = url_override_source
+        end
+
+        def configured_hostname
+          return @configured_hostname if defined?(@configured_hostname)
+
+          @configured_hostname = if parsed_url
+            parsed_url.hostname
+          else
+            nil
+          end
+
+          @configured_hostname = pick_from(
+            DetectedConfiguration.new(
+              friendly_name: "'c.agent.host'",
+              value: settings.agent.host
+            ),
+            DetectedConfiguration.new(
+              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_URL} environment variable",
+              value: parsed_http_url&.hostname
+            ),
+            DetectedConfiguration.new(
+              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_HOST} environment variable",
+              value: ENV[Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_HOST]
+            )
+          )
+        end
+
+        def configured_port
+          return @configured_port if defined?(@configured_port)
+
+          @configured_port = if parsed_url
+            parsed_url.port
+          else
+            80
+          end
+        end
+
+        def configured_ssl
+          return @configured_ssl if defined?(@configured_ssl)
+
+          @configured_ssl = if parsed_url
+            parsed_url_ssl?
+          else
+            true
+          end
+        end
+
+        def configured_uds_path
+          return @configured_uds_path if defined?(@configured_uds_path)
+
+          @configured_uds_path = if parsed_url
+            parsed_url_uds_path
+          else
+            false
+          end
+        end
+
+        def parsed_url
+          return @parsed_url if defined?(@parsed_url)
+
+          @parsed_url =
+            if @url_override
+              parsed = URI.parse(@url_override)
+
+              # Agentless URL should never refer to a UDS?
+              if http_scheme?(parsed) || unix_scheme?(parsed)
+                parsed
+              else
+                # rubocop:disable Layout/LineLength
+                log_warning(
+                  "Invalid URI scheme '#{parsed.scheme}' for #{url_override_source} " \
+                  "environment variable ('#{unparsed_url_from_env}'). " \
+                  "Ignoring the contents of #{url_override_source}."
+                )
+                # rubocop:enable Layout/LineLength
+
+                nil
+              end
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -104,7 +104,7 @@ module Datadog
         end
 
         def port
-          if configured_port
+          if configured_port # rubocop:disable Style/RedundantCondition
             configured_port
           else
             # If no hostname is specified, we are communicating with the

--- a/lib/datadog/core/configuration/agentless_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agentless_settings_resolver.rb
@@ -36,6 +36,10 @@ module Datadog
           :url_override_source
 
         def initialize(settings, host_prefix:, url_override: nil, url_override_source: nil, logger: Datadog.logger)
+          if url_override && url_override_source.nil?
+            raise ArgumentError, 'url_override_source must be provided when url_override is provided'
+          end
+
           super(settings, logger: logger)
           @host_prefix = host_prefix
           @url_override = url_override
@@ -76,8 +80,6 @@ module Datadog
 
           @configured_port = if parsed_url
             parsed_url.port
-          else
-            80
           end
         end
 
@@ -96,8 +98,6 @@ module Datadog
 
           @configured_ssl = if parsed_url
             parsed_url_ssl?
-          else
-            true
           end
         end
 
@@ -112,13 +112,8 @@ module Datadog
         end
 
         def configured_uds_path
-          return @configured_uds_path if defined?(@configured_uds_path)
-
-          @configured_uds_path = if parsed_url
-            parsed_url_uds_path
-          else
-            false
-          end
+          # We do not permit UDS, see the note under #can_use_uds?.
+          nil
         end
 
         def can_use_uds?

--- a/sig/datadog/core/configuration/agentless_settings_resolver.rbs
+++ b/sig/datadog/core/configuration/agentless_settings_resolver.rbs
@@ -1,0 +1,48 @@
+module Datadog
+  module Core
+    module Configuration
+      class AgentlessSettingsResolver < AgentSettingsResolver
+        @host_prefix: untyped
+
+        @url_override: untyped
+
+        @url_override_source: untyped
+
+        @configured_hostname: untyped
+
+        @configured_port: untyped
+
+        @configured_ssl: untyped
+
+        @parsed_url: untyped
+        def self.call: (untyped settings, host_prefix: untyped, ?url_override: untyped?, ?url_override_source: untyped?, ?logger: untyped) -> untyped
+
+        private
+
+        attr_reader host_prefix: untyped
+
+        attr_reader url_override: untyped
+
+        attr_reader url_override_source: untyped
+
+        def initialize: (untyped settings, host_prefix: untyped, ?url_override: untyped?, ?url_override_source: untyped?, ?logger: untyped) -> void
+
+        def hostname: () -> untyped
+
+        def configured_hostname: () -> untyped
+
+        def configured_port: () -> untyped
+        def ssl?: () -> (untyped | true)
+        def configured_ssl: () -> untyped
+
+        def port: () -> (untyped | 443)
+
+        def configured_uds_path: () -> nil
+
+        def can_use_uds?: () -> false
+
+        def parsed_url: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/datadog/core/configuration/agentless_settings_resolver.rbs
+++ b/sig/datadog/core/configuration/agentless_settings_resolver.rbs
@@ -27,19 +27,21 @@ module Datadog
 
         def initialize: (untyped settings, host_prefix: untyped, ?url_override: untyped?, ?url_override_source: untyped?, ?logger: untyped) -> void
 
-        def hostname: () -> untyped
+        def hostname: () -> (nil | untyped)
 
         def configured_hostname: () -> untyped
 
         def configured_port: () -> untyped
-        def ssl?: () -> (untyped | true)
+        def ssl?: () -> (untyped | false | true)
         def configured_ssl: () -> untyped
 
-        def port: () -> (untyped | 443)
+        def port: () -> (untyped | nil | 443)
 
-        def configured_uds_path: () -> nil
+        def mixed_http_and_uds: () -> false
 
-        def can_use_uds?: () -> false
+        def configured_uds_path: () -> untyped
+
+        def can_use_uds?: () -> untyped
 
         def parsed_url: () -> untyped
       end

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -1,0 +1,33 @@
+require 'datadog/core/configuration/agentless_settings_resolver'
+require 'datadog/core/configuration/settings'
+
+RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
+  let(:settings) { Datadog::Core::Configuration::Settings.new }
+  let(:logger) { instance_double(Datadog::Core::Logger) }
+  let(:logger) { Logger.new(STDERR) }
+
+  subject(:resolver) { described_class.new(settings,
+    #url_override: url_override, url_override_source: url_override_source,
+    logger: logger) }
+
+  let(:resolved) { resolver.send(:call) }
+
+  let(:url_override) { nil }
+  let(:url_override_source) { nil }
+
+  context 'by default' do
+    it 'returns' do
+      expect(resolver.send(:should_use_uds?)).to be false
+
+      expect(resolved).to eq(
+        Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+          adapter: :net_http,
+          hostname: '127.0.0.1',
+          port: 8126,
+          ssl: false,
+          timeout_seconds: 30,
+        )
+      )
+    end
+  end
+end

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
   let(:url_override_source) { nil }
 
   let(:logger) { instance_double(Datadog::Core::Logger) }
-  let(:logger) { Logger.new($stderr) }
 
   subject(:resolver) do
     described_class.new(

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -49,4 +49,37 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
       )
     end
   end
+
+  context 'when url_override is provided' do
+    let(:url_override_source) { 'setting' }
+
+    context 'url is https' do
+      let(:url_override) { "https://foo.bar" }
+
+      it 'returns expected values' do
+        expect(resolver.send(:can_use_uds?)).to be false
+        expect(resolver.send(:should_use_uds?)).to be false
+
+        expect(resolver.send(:parsed_url)).to eq URI.parse(url_override)
+
+        expect(resolver.send(:configured_hostname)).to eq 'foo.bar'
+        expect(resolver.send(:hostname)).to eq 'foo.bar'
+        expect(resolver.send(:configured_port)).to be 443
+        expect(resolver.send(:port)).to eq 443
+        expect(resolver.send(:configured_ssl)).to be true
+        expect(resolver.send(:ssl?)).to be true
+        expect(resolver.send(:configured_uds_path)).to be nil
+
+        expect(resolved).to eq(
+          Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+            adapter: :net_http,
+            hostname: 'foo.bar',
+            port: 443,
+            ssl: true,
+            timeout_seconds: 30,
+          )
+        )
+      end
+    end
+  end
 end

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -160,5 +160,34 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
         )
       )
     end
+
+    context 'when DD_AGENT_PORT is also used' do
+      with_env 'DD_AGENT_PORT' => '443'
+
+      it 'uses the specified port (but does not enable TLS)' do
+        expect(resolver.send(:can_use_uds?)).to be false
+        expect(resolver.send(:should_use_uds?)).to be false
+
+        expect(resolver.send(:parsed_url)).to be nil
+
+        expect(resolver.send(:configured_hostname)).to eq 'test-agent-host'
+        expect(resolver.send(:hostname)).to eq 'test-agent-host'
+        expect(resolver.send(:configured_port)).to be 443
+        expect(resolver.send(:port)).to be 443
+        expect(resolver.send(:configured_ssl)).to be nil
+        expect(resolver.send(:ssl?)).to be false
+        expect(resolver.send(:configured_uds_path)).to be nil
+
+        expect(resolved).to eq(
+          Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+            adapter: :net_http,
+            hostname: 'test-agent-host',
+            port: 443,
+            ssl: false,
+            timeout_seconds: 30,
+          )
+        )
+      end
+    end
   end
 end

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
         let(:url_override) { 'xyz://hello.world' }
 
         before do
-          expect(logger).to receive(:warn).with("Invalid URI scheme 'xyz' for c.telemetry.agentless_url_override. Ignoring the contents of c.telemetry.agentless_url_override.")
+          expect(logger).to receive(:warn).with("Invalid URI scheme 'xyz' for c.telemetry.agentless_url_override. Ignoring the contents of c.telemetry.agentless_url_override.") # rubocop:disable Layout/LineLength
         end
 
         include_examples 'returns values expected by default'

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -24,8 +24,19 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
   let(:url_override_source) { nil }
 
   context 'by default' do
-    it 'returns' do
+    it 'returns expected values' do
+      expect(resolver.send(:can_use_uds?)).to be false
       expect(resolver.send(:should_use_uds?)).to be false
+
+      expect(resolver.send(:parsed_url)).to be nil
+
+      expect(resolver.send(:configured_hostname)).to be nil
+      expect(resolver.send(:hostname)).to eq 'test-host-prefix.test.dog'
+      expect(resolver.send(:configured_port)).to be nil
+      expect(resolver.send(:port)).to eq 443
+      expect(resolver.send(:configured_ssl)).to be nil
+      expect(resolver.send(:ssl?)).to be true
+      expect(resolver.send(:configured_uds_path)).to be nil
 
       expect(resolved).to eq(
         Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -7,24 +7,28 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
       settings.site = site
     end
   end
-
-  let(:logger) { instance_double(Datadog::Core::Logger) }
-  let(:logger) { Logger.new(STDERR) }
-
-  subject(:resolver) { described_class.new(settings,
-    host_prefix: host_prefix,
-    url_override: url_override, url_override_source: url_override_source,
-    logger: logger) }
-
   let(:resolved) { resolver.send(:call) }
-
   let(:site) { 'test.dog' }
   let(:host_prefix) { 'test-host-prefix' }
   let(:url_override) { nil }
   let(:url_override_source) { nil }
 
+  let(:logger) { instance_double(Datadog::Core::Logger) }
+  let(:logger) { Logger.new($stderr) }
+
+  subject(:resolver) do
+    described_class.new(
+      settings,
+      host_prefix: host_prefix,
+      url_override: url_override,
+      url_override_source: url_override_source,
+      logger: logger
+    )
+  end
+
   # DD_AGENT_HOST is set in CI and alters the settings tested here
-  with_env 'DD_AGENT_HOST' => nil, 'DD_AGENT_PORT' => nil,
+  with_env 'DD_AGENT_HOST' => nil,
+    'DD_AGENT_PORT' => nil,
     'DD_TRACE_AGENT_TIMEOUT_SECONDS' => nil
 
   shared_examples 'returns values expected by default' do
@@ -62,7 +66,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
     let(:url_override_source) { 'setting' }
 
     context 'url is https' do
-      let(:url_override) { "https://foo.bar" }
+      let(:url_override) { 'https://foo.bar' }
 
       it 'returns expected values' do
         expect(resolver.send(:can_use_uds?)).to be false
@@ -91,7 +95,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
     end
 
     context 'url is http' do
-      let(:url_override) { "http://foo.bar" }
+      let(:url_override) { 'http://foo.bar' }
 
       it 'returns expected values' do
         expect(resolver.send(:can_use_uds?)).to be false

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
           hostname: 'test-host-prefix.test.dog',
           port: 443,
           ssl: true,
+          uds_path: nil,
           timeout_seconds: 30,
         )
       )
@@ -87,6 +88,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
             hostname: 'foo.bar',
             port: 443,
             ssl: true,
+            uds_path: nil,
             timeout_seconds: 30,
           )
         )
@@ -156,6 +158,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
             hostname: 'foo.bar',
             port: 80,
             ssl: false,
+            uds_path: nil,
             timeout_seconds: 30,
           )
         )
@@ -172,6 +175,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
             hostname: 'test-host-prefix.test.dog',
             port: 443,
             ssl: true,
+            uds_path: nil,
             timeout_seconds: 42,
           )
         )

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -2,16 +2,24 @@ require 'datadog/core/configuration/agentless_settings_resolver'
 require 'datadog/core/configuration/settings'
 
 RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
-  let(:settings) { Datadog::Core::Configuration::Settings.new }
+  let(:settings) do
+    Datadog::Core::Configuration::Settings.new.tap do |settings|
+      settings.site = site
+    end
+  end
+
   let(:logger) { instance_double(Datadog::Core::Logger) }
   let(:logger) { Logger.new(STDERR) }
 
   subject(:resolver) { described_class.new(settings,
-    #url_override: url_override, url_override_source: url_override_source,
+    host_prefix: host_prefix,
+    url_override: url_override, url_override_source: url_override_source,
     logger: logger) }
 
   let(:resolved) { resolver.send(:call) }
 
+  let(:site) { 'test.dog' }
+  let(:host_prefix) { 'test-host-prefix' }
   let(:url_override) { nil }
   let(:url_override_source) { nil }
 
@@ -22,9 +30,9 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
       expect(resolved).to eq(
         Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
           adapter: :net_http,
-          hostname: '127.0.0.1',
-          port: 8126,
-          ssl: false,
+          hostname: 'test-host-prefix.test.dog',
+          port: 443,
+          ssl: true,
           timeout_seconds: 30,
         )
       )

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
   end
 
   context 'when url_override is provided' do
-    let(:url_override_source) { 'setting' }
+    let(:url_override_source) { 'c.telemetry.agentless_url_override' }
 
     context 'url is https' do
       let(:url_override) { 'https://foo.bar' }
@@ -90,6 +90,16 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
             timeout_seconds: 30,
           )
         )
+      end
+
+      context 'when url uses an unknown protocol' do
+        let(:url_override) { 'xyz://hello.world' }
+
+        before do
+          expect(logger).to receive(:warn).with("Invalid URI scheme 'xyz' for c.telemetry.agentless_url_override. Ignoring the contents of c.telemetry.agentless_url_override.")
+        end
+
+        include_examples 'returns values expected by default'
       end
     end
 

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -92,6 +92,36 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
         )
       end
 
+      context 'when url uses UDS' do
+        let(:url_override) { 'unix:///var/run/test.sock' }
+
+        it 'returns expected values' do
+          expect(resolver.send(:can_use_uds?)).to be true
+          expect(resolver.send(:should_use_uds?)).to be true
+
+          expect(resolver.send(:parsed_url)).to eq URI.parse(url_override)
+
+          expect(resolver.send(:configured_hostname)).to be nil
+          expect(resolver.send(:hostname)).to be nil
+          expect(resolver.send(:configured_port)).to be nil
+          expect(resolver.send(:port)).to be nil
+          expect(resolver.send(:configured_ssl)).to be false
+          expect(resolver.send(:ssl?)).to be false
+          expect(resolver.send(:configured_uds_path)).to eq '/var/run/test.sock'
+
+          expect(resolved).to eq(
+            Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+              adapter: :unix,
+              hostname: nil,
+              port: nil,
+              ssl: false,
+              uds_path: '/var/run/test.sock',
+              timeout_seconds: 30,
+            )
+          )
+        end
+      end
+
       context 'when url uses an unknown protocol' do
         let(:url_override) { 'xyz://hello.world' }
 

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -81,5 +81,34 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
         )
       end
     end
+
+    context 'url is http' do
+      let(:url_override) { "http://foo.bar" }
+
+      it 'returns expected values' do
+        expect(resolver.send(:can_use_uds?)).to be false
+        expect(resolver.send(:should_use_uds?)).to be false
+
+        expect(resolver.send(:parsed_url)).to eq URI.parse(url_override)
+
+        expect(resolver.send(:configured_hostname)).to eq 'foo.bar'
+        expect(resolver.send(:hostname)).to eq 'foo.bar'
+        expect(resolver.send(:configured_port)).to be 80
+        expect(resolver.send(:port)).to eq 80
+        expect(resolver.send(:configured_ssl)).to be false
+        expect(resolver.send(:ssl?)).to be false
+        expect(resolver.send(:configured_uds_path)).to be nil
+
+        expect(resolved).to eq(
+          Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+            adapter: :net_http,
+            hostname: 'foo.bar',
+            port: 80,
+            ssl: false,
+            timeout_seconds: 30,
+          )
+        )
+      end
+    end
   end
 end

--- a/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
+++ b/spec/datadog/core/configuration/agentless_settings_resolver_spec.rb
@@ -111,4 +111,22 @@ RSpec.describe Datadog::Core::Configuration::AgentlessSettingsResolver do
       end
     end
   end
+
+  context 'when timeout is overridden' do
+    before do
+      settings.agent.timeout_seconds = 42
+    end
+
+    it 'uses the overridden timeout' do
+      expect(resolved).to eq(
+        Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings.new(
+          adapter: :net_http,
+          hostname: 'test-host-prefix.test.dog',
+          port: 443,
+          ssl: true,
+          timeout_seconds: 42,
+        )
+      )
+    end
+  end
 end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -75,7 +75,7 @@ module CoreHelpers
     # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
     # should be used in any given call.
     def with_env(*args, **opts)
-      if args.any? && opts.any?
+      if args.any? && opts.any? # rubocop:disable Style/IfUnlessModifier
         raise ArgumentError, 'Do not pass both args and opts'
       end
 

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -71,9 +71,12 @@ module CoreHelpers
       end
     end
 
-    def with_env(**opts)
+    # Positional and keyword arguments are both accepted to make the method
+    # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
+    # should be used in any given call.
+    def with_env(*args, **opts)
       around do |example|
-        ClimateControl.modify(**opts) do
+        ClimateControl.modify(*args, **opts) do
           example.run
         end
       end

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -70,6 +70,14 @@ module CoreHelpers
         end
       end
     end
+
+    def with_env(**opts)
+      around do |example|
+        ClimateControl.modify(**opts) do
+          example.run
+        end
+      end
+    end
   end
 
   def self.included(base)

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -75,9 +75,19 @@ module CoreHelpers
     # work on Ruby 2.5/2.6 and 2.7+. In practice only one type of arguments
     # should be used in any given call.
     def with_env(*args, **opts)
+      if args.any? && opts.any?
+        raise ArgumentError, 'Do not pass both args and opts'
+      end
+
       around do |example|
-        ClimateControl.modify(*args, **opts) do
-          example.run
+        if args.any?
+          ClimateControl.modify(*args) do
+            example.run
+          end
+        else
+          ClimateControl.modify(**opts) do
+            example.run
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds an agentless settings resolver, which performs the same function as the agent settings resolver to go from settings/Datadog configuration to agent settings, but for agentless operations (currently only telemetry).

**Motivation:**
Existing code (telemetry transport) did not have the agent settings resolution as an encapsulated concept. As a result, there was low test coverage for this code and for example the timeout was always fixed at 30 seconds.

With the upcoming PR that will change telemetry to use core transport code, telemetry will need to provide agent settings to the transport even in agentless mode. The agentless settings resolver that this PR adds provides the required bridge.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes: improve agentless mode telemetry configuration - it now respects timeout specified for the agent
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
This PR shares the `with_env` helper with https://github.com/DataDog/dd-trace-rb/pull/4588. I originally wrote it for this PR and cherry-picked it into 4588.

**How to test the change?**
A bunch of tests/assertions are added with this PR.

This PR was also tested as part of the in-progress PR for UDS support (https://github.com/DataDog/dd-trace-rb/pull/4630).
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
