### PR TITLE
[NO-TICKET] Minor: Make sure `datadog_ruby_common.h/.c` stay in sync

### DIFF
--- a/spec/datadog/core/datadog_ruby_common_spec.rb
+++ b/spec/datadog/core/datadog_ruby_common_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'datadog_ruby_common helpers' do
+  let(:profiling_folder) { File.join(__dir__, '../../../ext/datadog_profiling_native_extension') }
+  let(:libdatadog_api_folder) { File.join(__dir__, '../../../ext/libdatadog_api') }
+
+  ['datadog_ruby_common.c', 'datadog_ruby_common.h'].each do |filename|
+    describe filename do
+      it 'is identical between profiling and libdatadog_api' do
+        profiling_content = File.read(File.join(profiling_folder, filename))
+        libdatadog_api_content = File.read(File.join(libdatadog_api_folder, filename))
+
+        expect(profiling_content).to eq(libdatadog_api_content), "#{filename} files are not identical"
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

As per the comment we have on `datadog_ruby_common.h/.c`, to avoid having too much of a weird setup in our build, we have a copy of these files for profiling and libdatadog_api.

BUT rather than just having a comment saying "please remember to keep these up-to-date", let's add a test to make sure that happens.

**Motivation:**

As I was reviewing a PR and was about to add a comment saying "please keep these files in sync" I decided I would write some code instead of just leaving a comment.

**Change log entry**

None.

**Additional Notes:**

Suggestions are welcome on how to better solve this without having a too-weird `extconf.rb` setup.

**How to test the change?**

I've tried changing the files on only one of the folders and validated the test correctly failed.