### PR TITLE
[Bug] declaring the missing EMPTY_HASH

### DIFF
--- a/lib/datadog/tracing/contrib/karafka/monitor.rb
+++ b/lib/datadog/tracing/contrib/karafka/monitor.rb
@@ -15,9 +15,7 @@ module Datadog
             worker.processed
           ].freeze
 
-          EMPTY_HASH = {}.freeze
-
-          def instrument(event_id, payload = EMPTY_HASH, &block)
+          def instrument(event_id, payload = {}, &block)
             return super unless TRACEABLE_EVENTS.include?(event_id)
 
             Datadog::Tracing.trace(Ext::SPAN_WORKER_PROCESS) do |span|

--- a/lib/datadog/tracing/contrib/karafka/monitor.rb
+++ b/lib/datadog/tracing/contrib/karafka/monitor.rb
@@ -15,6 +15,8 @@ module Datadog
             worker.processed
           ].freeze
 
+          EMPTY_HASH = {}.freeze
+
           def instrument(event_id, payload = EMPTY_HASH, &block)
             return super unless TRACEABLE_EVENTS.include?(event_id)
 

--- a/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
@@ -1,0 +1,66 @@
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/tracing/contrib/analytics_examples'
+
+require 'karafka'
+require 'datadog'
+
+RSpec.describe 'Karafka monitor' do
+  subject(:monitor) { described_class.new }
+  let(:configuration_options) { { distributed_tracing: true } }
+
+  before do
+    Datadog.configure do |c|
+      c.tracing.instrument :karafka, configuration_options
+    end
+  end
+
+  around do |example|
+    # Reset before and after each example; don't allow global state to linger.
+    Datadog.registry[:karafka].reset_configuration!
+    example.run
+    Datadog.registry[:karafka].reset_configuration!
+  end
+
+  describe '.instrument' do
+    context 'when the event is not traceable' do
+      it 'does not create a trace' do
+        allow(Datadog::Tracing).to receive(:trace)
+
+        Karafka.monitor.instrument('worker.completed')
+
+        expect(Datadog::Tracing).not_to have_received(:trace)
+      end
+    end
+
+    context 'when the event is traceable' do
+      let(:span) { instance_double('Span', set_tag: nil) }
+      let(:event_id) { 'some_event' }
+      let(:payload) { { job: job } }
+      let(:job) { instance_double('Job', class: job_class, executor: executor, messages: messages) }
+      let(:job_class) { Class.new }
+      let(:executor) { instance_double('Executor', topic: topic, partition: 1) }
+      let(:topic) { instance_double('Topic', consumer: 'Consumer', name: 'topic_name') }
+      let(:messages) { [instance_double('Message', metadata: metadata)] }
+      let(:metadata) { instance_double('Metadata', offset: 42) }
+
+      it 'creates a trace' do
+        allow(span).to receive(:resource=)
+        allow(Datadog::Tracing).to receive(:trace).and_yield(span)
+
+        Karafka.monitor.instrument(
+          'worker.processed',
+          payload
+        )
+
+        expect(Datadog::Tracing).to have_received(:trace)
+        expect(span).to have_received(:resource=).with('Consumer#consume')
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Karafka::Ext::TAG_MESSAGE_COUNT, 1)
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Karafka::Ext::TAG_PARTITION, 1)
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Karafka::Ext::TAG_OFFSET, 42)
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Karafka::Ext::TAG_CONSUMER, 'Consumer')
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Ext::Messaging::TAG_DESTINATION, 'topic_name')
+        expect(span).to have_received(:set_tag).with(Datadog::Tracing::Contrib::Ext::Messaging::TAG_SYSTEM, Datadog::Tracing::Contrib::Karafka::Ext::TAG_SYSTEM)
+      end
+    end
+  end
+end

--- a/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
@@ -8,11 +8,10 @@ require 'datadog'
 
 RSpec.describe 'Karafka monitor' do
   subject(:monitor) { described_class.new }
-  let(:configuration_options) { { distributed_tracing: true } }
 
   before do
     Datadog.configure do |c|
-      c.tracing.instrument :karafka, configuration_options
+      c.tracing.instrument :karafka, { distributed_tracing: true }
     end
   end
 

--- a/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/tracing/contrib/analytics_examples'
 

--- a/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Karafka monitor' do
   describe '.instrument' do
     context 'when the event is not traceable' do
       it 'does not create a trace' do
-        allow(Datadog::Tracing).to receive(:trace)
-
         Karafka.monitor.instrument('worker.completed')
 
-        expect(Datadog::Tracing).not_to have_received(:trace)
+        # NOTE: This helper doesn't workt with `change` matcher well.
+        expect(traces).to have(0).items
+        expect(spans).to have(0).items
       end
     end
 
@@ -42,7 +42,8 @@ RSpec.describe 'Karafka monitor' do
       it 'traces a consumer job' do
         Karafka.monitor.instrument('worker.processed', { job: job })
 
-        expect(spans).to have(1).items
+        expect(traces).to have(1).item
+        expect(spans).to have(1).item
 
         expect(spans[0].resource).to eq('Consumer#consume')
         expect(spans[0].tags).to include(


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This pull request introduces a fix to the `Karafka` integration for Datadog tracing. The `EMPTY_HASH` error is happening intermittently in some of my projects due to inconsistent loaders. In some Ruby projects, we used declarative require, hence they have `EMPTY_HASH`, but some don’t, e.g Rails Railtie, which would load `karafka.rb` file before the EMPTY_HASH is available.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Despite there are some workaround solutions, e.g monkey patch our datadog gem and define the `EMPTY_HASH`, or just define it somewhere globally, but eventually, this error should be fixed asap.

**Change log entry**

Yes. Tracing: Fix Karafka contrib monitor to avoid referencing Karafka-specific constants that may raise errors due to load order. (updated by @Strech)

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

### Before

![Screenshot 2025-04-23 at 4 27 02 PM](https://github.com/user-attachments/assets/78278d13-9f38-40c6-8d72-66e260184373)


### After

![Screenshot 2025-04-23 at 4 53 33 PM](https://github.com/user-attachments/assets/6984c7ac-8df7-4238-8886-8a4233266c1a)


<!-- Unsure? Have a question? Request a review! -->
