### PR TITLE
[PROF-11680] Add support for profiling 3.5.0-preview1

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'msgpack'
 
   # Used by the profiler native extension to support Ruby 2.5 and > 3.2, see NativeExtensionDesign.md for details
-  spec.add_dependency 'datadog-ruby_core_source', '~> 3.4'
+  spec.add_dependency 'datadog-ruby_core_source', '~> 3.4', '>= 3.4.1'
 
   # Used by appsec
   spec.add_dependency 'libddwaf', '~> 1.22.0.0.2'


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for profiling Ruby 3.5.0-preview1. The only work needed was importing the latest headers in
https://github.com/DataDog/datadog-ruby_core_source/pull/15 so this PR adds the new 3.4.1 release of the headers as the minimum version allowed.

**Motivation:**

By setting the minimum version of `datadog-ruby_core_source` to the latest release, we make sure bundler picks it up, and doesn't try to use an incorrect release with Ruby 3.5.

**Change log entry**

Yes. Add support for profiling 3.5.0-preview1

**Additional Notes:**

N/A

**How to test the change?**

We don't yet test with 3.5 on CI; I tested locally that the profiler test suite is working fine with 3.4 and 3.5.
