### PR TITLE
Replace JSON.fast_generate with JSON.generate

### DIFF
--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -49,7 +49,7 @@ module Datadog
         @internal_metadata = internal_metadata
         # NOTE: At the time of this comment collected info does not change over time so we'll hardcode
         #       it on startup to prevent serializing the same info on every flush.
-        @info_json = JSON.fast_generate(info_collector.info).freeze
+        @info_json = JSON.generate(info_collector.info).freeze
       end
 
       def flush


### PR DESCRIPTION
**Motivation:**

After JSON release 2.11.0, we found this failure: 

https://github.com/DataDog/dd-trace-rb/actions/runs/14641122329/job/41083646804

**What**

Replace JSON.fast_generate with JSON.generate

**Change log entry**
Yes.  Fix ArgumentError from JSON.fast_generate for old Ruby version