### PR TITLE
[APPSEC-57303] Fingerprinting on non-attack non-business events

### DIFF
--- a/.github/forced-tests-list.json
+++ b/.github/forced-tests-list.json
@@ -1,3 +1,6 @@
 {
-  
+    "APPSEC_BLOCKING": [
+        "tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Endpoint_Preprocessor",
+        "tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_And_Network_Preprocessor"
+    ]
 }

--- a/lib/datadog/appsec.rb
+++ b/lib/datadog/appsec.rb
@@ -44,7 +44,7 @@ module Datadog
         appsec_component.reconfigure_lock(&block)
       end
 
-      def api_security_enabled?
+      def perform_api_security_check?
         Datadog.configuration.appsec.api_security.enabled &&
           Datadog.configuration.appsec.api_security.sample_rate.sample?
       end

--- a/lib/datadog/appsec/assets/waf_rules/recommended.json
+++ b/lib/datadog/appsec/assets/waf_rules/recommended.json
@@ -8629,5 +8629,1349 @@
       ],
       "transformers": []
     }
+  ],
+  "processors": [
+    {
+      "id": "http-endpoint-fingerprint",
+      "generator": "http_endpoint_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "method": [
+              {
+                "address": "server.request.method"
+              }
+            ],
+            "uri_raw": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "body": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "query": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.endpoint"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-content",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "_dd.appsec.s.req.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.cookies"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.s.req.query"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "output": "_dd.appsec.s.req.params"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "output": "_dd.appsec.s.res.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.all_resolvers"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.all_resolvers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.resolver"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "payment"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-headers",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.headers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.res.headers"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "credentials"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "http-header-fingerprint",
+      "generator": "http_header_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "headers": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.header"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "http-network-fingerprint",
+      "generator": "http_network_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "headers": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.network"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "session-fingerprint",
+      "generator": "session_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "cookies": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "session_id": [
+              {
+                "address": "usr.session_id"
+              }
+            ],
+            "user_id": [
+              {
+                "address": "usr.id"
+              }
+            ],
+            "output": "_dd.appsec.fp.session"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "406f8606-52c4-4663-8db9-df70f9e8766c",
+      "name": "ZIP Code",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:zip|postal)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^[0-9]{5}(?:-[0-9]{4})?$",
+          "options": {
+            "case_sensitive": true,
+            "min_length": 5
+          }
+        }
+      },
+      "tags": {
+        "type": "zipcode",
+        "category": "address"
+      }
+    },
+    {
+      "id": "JU1sRk3mSzqSUJn6GrVn7g",
+      "name": "American Express Card Scanner (4+4+4+3 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{3})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{3})|(?:-\\d{4}-\\d{4}-\\d{3})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{3}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "edmH513UTQWcRiQ9UnzHlw-mod",
+      "name": "American Express Card Scanner (4+6|5+5|6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{5,6}\\s\\d{5,6})|(?:\\.\\d{5,6}\\.\\d{5,6})|(?:-\\d{5,6}-\\d{5,6})|(?:,\\d{5,6},\\d{5,6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "e6K4h_7qTLaMiAbaNXoSZA",
+      "name": "American Express Card Scanner (8+7 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{6}(?:(?:\\s\\d{7})|(?:\\,\\d{7})|(?:-\\d{7})|(?:\\.\\d{7}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "K2rZflWzRhGM9HiTc6whyQ",
+      "name": "American Express Card Scanner (1x15 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{13}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9d7756e343cefa22a5c098e1092590f806eb5446",
+      "name": "Basic Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^basic\\s+[A-Za-z0-9+/=]+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "basic_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "mZy8XjZLReC9smpERXWnnw",
+      "name": "Bearer Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^bearer\\s+[-a-z0-9._~+/]{4,}",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "bearer_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "450239afc250a19799b6c03dc0e16fd6a4b2a1af",
+      "name": "Canadian Social Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:social[\\s_]?(?:insurance(?:\\s+number)?)?|SIN|Canadian[\\s_]?(?:social[\\s_]?(?:insurance)?|insurance[\\s_]?number)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}-\\d{3}-\\d{3}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "canadian_sin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "87a879ff33693b46c8a614d8211f5a2c289beca0",
+      "name": "Digest Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^digest\\s+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "digest_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "qWumeP1GQUa_E4ffAnT-Yg",
+      "name": "American Express Card Scanner (1x14 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "(?:30[0-59]\\d|3[689]\\d{2})(?:\\d{10})",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NlTWWM5LS6W0GSqBLuvtRw",
+      "name": "Diners Card Scanner (4+4+4+2 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{2})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{2})|(?:-\\d{4}-\\d{4}-\\d{2})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{2}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "Xr5VdbQSTXitYGGiTfxBpw",
+      "name": "Diners Card Scanner (4+6+4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{6}\\s\\d{4})|(?:\\.\\d{6}\\.\\d{4})|(?:-\\d{6}-\\d{4})|(?:,\\d{6},\\d{4}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gAbunN_WQNytxu54DjcbAA-mod",
+      "name": "Diners Card Scanner (8+6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d{5}|3[689]\\d{6})\\s?(?:(?:\\s\\d{6})|(?:\\,\\d{6})|(?:-\\d{6})|(?:\\.\\d{6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9cs4qCfEQBeX17U7AepOvQ",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{4}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "YBIDWJIvQWW_TFOyU0CGJg",
+      "name": "Discover Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{4}){2})|(?:6221\\s(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\s\\d{4}){2})|(?:6221\\.(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\.\\d{4}){2})|(?:6221-(?:2[6-9]|[3-9][0-9])\\d{2}(?:-\\d{4}){2}))|(?:(?:6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{4}){2})|(?:6229\\s(?:[01][0-9]|2[0-5])\\d{2}(?:\\s\\d{4}){2})|(?:6229\\.(?:[01][0-9]|2[0-5])\\d{2}(?:\\.\\d{4}){2})|(?:6229-(?:[01][0-9]|2[0-5])\\d{2}(?:-\\d{4}){2}))|(?:(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "12cpbjtVTMaMutFhh9sojQ",
+      "name": "Discover Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{10}|6229(?:[01][0-9]|2[0-5])\\d{10}|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "PuXiVTCkTHOtj0Yad1ppsw",
+      "name": "Standard E-mail Address",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:e[-\\s]?)?mail|address|sender|\\bto\\b|from|recipient)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 2
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 5
+          }
+        }
+      },
+      "tags": {
+        "type": "email",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "8VS2RKxzR8a_95L5fuwaXQ",
+      "name": "IBAN",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:iban|account|sender|receiver)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:NO\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{3}|BE\\d{2}(?:[ \\-]?\\d{4}){3}|(?:DK|FO|FI|GL|SD)\\d{2}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|NL\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}|MK\\d{2}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|SI\\d{17}|(?:AT|BA|EE|LT|XK)\\d{18}|(?:LU|KZ|EE|LT)\\d{5}[A-Z0-9]{13}|LV\\d{2}[A-Z]{4}[A-Z0-9]{13}|(?:LI|CH)\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]|HR\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d|GE\\d{2}[ \\-]?[A-Z0-9]{2}\\d{2}\\d{14}|VA\\d{20}|BG\\d{2}[A-Z]{4}\\d{6}[A-Z0-9]{8}|BH\\d{2}[A-Z]{4}[A-Z0-9]{14}|GB\\d{2}[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|IE\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|(?:CR|DE|ME|RS)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{2}|(?:AE|TL|IL)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{3}|GI\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{3}|IQ\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{3}|MD\\d{2}(?:[ \\-]?[A-Z0-9]{4}){5}|SA\\d{2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}|RO\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:PK|VG)\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){4}|AD\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){3}|(?:CZ|SK|ES|SE|TN)\\d{2}(?:[ \\-]?\\d{4}){5}|(?:LY|PT|ST)\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|TR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{2}|IS\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{2}|(?:IT|SM)\\d{2}[ \\-]?[A-Z]\\d{3}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]{3}|GR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){3}[A-Z0-9]{3}|(?:FR|MC)\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|MR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}|(?:SV|DO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}|BY\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{4}){4}|GT\\d{2}(?:[ \\-]?[A-Z0-9]{4}){6}|AZ\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{5}){4}|LB\\d{2}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{5}){4}|(?:AL|CY)\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:HU|PL)\\d{2}(?:[ \\-]?\\d{4}){6}|QA\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]|PS\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|UA\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}[ \\-]?[A-Z0-9]|BR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}[A-Z0-9][ \\-]?[A-Z0-9]|EG\\d{2}(?:[ \\-]?\\d{4}){6}\\d|MU\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){4}\\d{3}[A-Z][ \\-]?[A-Z]{2}|(?:KW|JO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]{2}|MT\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{3}){4}[ \\-]?[A-Z0-9]{3}|SC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?[A-Z]{3}|LC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){6})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "iban",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "h6WJcecQTwqvN9KeEtwDvg",
+      "name": "JCB Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gcEaMu_VSJ2-bGCEkgyC0w",
+      "name": "JCB Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "imTliuhXT5GAeRNhqChXQQ",
+      "name": "JCB Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9osY3xc9Q7ONAV0zw9Uz4A",
+      "name": "JSON Web Token",
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(\\.[\\w.+\\/=-]+)?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 20
+          }
+        }
+      },
+      "tags": {
+        "type": "json_web_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "d1Q9D3YMRxuVKf6CZInJPw",
+      "name": "Maestro Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "M3YIQKKjRVmoeQuM3pjzrw",
+      "name": "Maestro Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{6}|6\\d{7})(?:\\s\\d{8}|\\.\\d{8}|-\\d{8}|,\\d{8})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "hRxiQBlSSVKcjh5U7LZYLA",
+      "name": "Maestro Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NwhIYNS4STqZys37WlaIKA",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "axxJkyjhRTOuhjwlsA35Vw",
+      "name": "MasterCard Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "76EhmoK3TPqJcpM-fK0pLw",
+      "name": "MasterCard Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "18b608bd7a764bff5b2344c0",
+      "name": "Phone number",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bphone|number|mobile\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^(?:\\(\\+\\d{1,3}\\)|\\+\\d{1,3}|00\\d{1,3})?[-\\s\\.]?(?:\\(\\d{3}\\)[-\\s\\.]?)?(?:\\d[-\\s\\.]?){6,10}$",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 6
+          }
+        }
+      },
+      "tags": {
+        "type": "phone",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "de0899e0cbaaa812bb624cf04c912071012f616d-mod",
+      "name": "UK National Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^nin$|\\binsurance\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-Z]{2}[\\s-]?\\d{6}[\\s-]?[A-Z]?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "uk_nin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "d962f7ddb3f55041e39195a60ff79d4814a7c331",
+      "name": "US Passport Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bpassport\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[0-9A-Z]{9}\\b|\\b[0-9]{6}[A-Z][0-9]{2}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "passport_number",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "7771fc3b-b205-4b93-bcef-28608c5c1b54",
+      "name": "United States Social Security Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:SSN|(?:(?:social)?[\\s_]?(?:security)?[\\s_]?(?:number)?)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}[-\\s\\.]{1}\\d{2}[-\\s\\.]{1}\\d{4}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "us_ssn",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "ac6d683cbac77f6e399a14990793dd8fd0fca333",
+      "name": "US Vehicle Identification Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:vehicle[_\\s-]*identification[_\\s-]*number|vin)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-HJ-NPR-Z0-9]{17}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "vin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "wJIgOygRQhKkR69b_9XbRQ",
+      "name": "Visa Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "0o71SJxXQNK7Q6gMbBesFQ",
+      "name": "Visa Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:,\\d{4}){3}|(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "QrHD6AfgQm6z-j0wStxTvA",
+      "name": "Visa Card Scanner (1x15 & 1x16 & 1x19 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "4[0-9]{12}(?:[0-9]{3})?",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    }
   ]
 }

--- a/lib/datadog/appsec/assets/waf_rules/strict.json
+++ b/lib/datadog/appsec/assets/waf_rules/strict.json
@@ -1745,5 +1745,1349 @@
       ],
       "transformers": []
     }
+  ],
+  "processors": [
+    {
+      "id": "http-endpoint-fingerprint",
+      "generator": "http_endpoint_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "method": [
+              {
+                "address": "server.request.method"
+              }
+            ],
+            "uri_raw": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "body": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "query": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.endpoint"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-content",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "_dd.appsec.s.req.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.cookies"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.s.req.query"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "output": "_dd.appsec.s.req.params"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "output": "_dd.appsec.s.res.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.all_resolvers"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.all_resolvers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.resolver"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "payment"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-headers",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.headers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.res.headers"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "credentials"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "http-header-fingerprint",
+      "generator": "http_header_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "headers": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.header"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "http-network-fingerprint",
+      "generator": "http_network_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "headers": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.fp.http.network"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "session-fingerprint",
+      "generator": "session_fingerprint",
+      "conditions": [
+        {
+          "operator": "exists",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
+              }
+            ]
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "cookies": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "session_id": [
+              {
+                "address": "usr.session_id"
+              }
+            ],
+            "user_id": [
+              {
+                "address": "usr.id"
+              }
+            ],
+            "output": "_dd.appsec.fp.session"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "406f8606-52c4-4663-8db9-df70f9e8766c",
+      "name": "ZIP Code",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:zip|postal)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^[0-9]{5}(?:-[0-9]{4})?$",
+          "options": {
+            "case_sensitive": true,
+            "min_length": 5
+          }
+        }
+      },
+      "tags": {
+        "type": "zipcode",
+        "category": "address"
+      }
+    },
+    {
+      "id": "JU1sRk3mSzqSUJn6GrVn7g",
+      "name": "American Express Card Scanner (4+4+4+3 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{3})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{3})|(?:-\\d{4}-\\d{4}-\\d{3})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{3}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "edmH513UTQWcRiQ9UnzHlw-mod",
+      "name": "American Express Card Scanner (4+6|5+5|6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{5,6}\\s\\d{5,6})|(?:\\.\\d{5,6}\\.\\d{5,6})|(?:-\\d{5,6}-\\d{5,6})|(?:,\\d{5,6},\\d{5,6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "e6K4h_7qTLaMiAbaNXoSZA",
+      "name": "American Express Card Scanner (8+7 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{6}(?:(?:\\s\\d{7})|(?:\\,\\d{7})|(?:-\\d{7})|(?:\\.\\d{7}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "K2rZflWzRhGM9HiTc6whyQ",
+      "name": "American Express Card Scanner (1x15 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{13}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9d7756e343cefa22a5c098e1092590f806eb5446",
+      "name": "Basic Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^basic\\s+[A-Za-z0-9+/=]+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "basic_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "mZy8XjZLReC9smpERXWnnw",
+      "name": "Bearer Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^bearer\\s+[-a-z0-9._~+/]{4,}",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "bearer_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "450239afc250a19799b6c03dc0e16fd6a4b2a1af",
+      "name": "Canadian Social Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:social[\\s_]?(?:insurance(?:\\s+number)?)?|SIN|Canadian[\\s_]?(?:social[\\s_]?(?:insurance)?|insurance[\\s_]?number)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}-\\d{3}-\\d{3}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "canadian_sin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "87a879ff33693b46c8a614d8211f5a2c289beca0",
+      "name": "Digest Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^digest\\s+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "digest_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "qWumeP1GQUa_E4ffAnT-Yg",
+      "name": "American Express Card Scanner (1x14 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "(?:30[0-59]\\d|3[689]\\d{2})(?:\\d{10})",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NlTWWM5LS6W0GSqBLuvtRw",
+      "name": "Diners Card Scanner (4+4+4+2 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{2})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{2})|(?:-\\d{4}-\\d{4}-\\d{2})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{2}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "Xr5VdbQSTXitYGGiTfxBpw",
+      "name": "Diners Card Scanner (4+6+4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{6}\\s\\d{4})|(?:\\.\\d{6}\\.\\d{4})|(?:-\\d{6}-\\d{4})|(?:,\\d{6},\\d{4}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gAbunN_WQNytxu54DjcbAA-mod",
+      "name": "Diners Card Scanner (8+6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d{5}|3[689]\\d{6})\\s?(?:(?:\\s\\d{6})|(?:\\,\\d{6})|(?:-\\d{6})|(?:\\.\\d{6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9cs4qCfEQBeX17U7AepOvQ",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{4}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "YBIDWJIvQWW_TFOyU0CGJg",
+      "name": "Discover Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{4}){2})|(?:6221\\s(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\s\\d{4}){2})|(?:6221\\.(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\.\\d{4}){2})|(?:6221-(?:2[6-9]|[3-9][0-9])\\d{2}(?:-\\d{4}){2}))|(?:(?:6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{4}){2})|(?:6229\\s(?:[01][0-9]|2[0-5])\\d{2}(?:\\s\\d{4}){2})|(?:6229\\.(?:[01][0-9]|2[0-5])\\d{2}(?:\\.\\d{4}){2})|(?:6229-(?:[01][0-9]|2[0-5])\\d{2}(?:-\\d{4}){2}))|(?:(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "12cpbjtVTMaMutFhh9sojQ",
+      "name": "Discover Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{10}|6229(?:[01][0-9]|2[0-5])\\d{10}|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "PuXiVTCkTHOtj0Yad1ppsw",
+      "name": "Standard E-mail Address",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:e[-\\s]?)?mail|address|sender|\\bto\\b|from|recipient)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 2
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 5
+          }
+        }
+      },
+      "tags": {
+        "type": "email",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "8VS2RKxzR8a_95L5fuwaXQ",
+      "name": "IBAN",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:iban|account|sender|receiver)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:NO\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{3}|BE\\d{2}(?:[ \\-]?\\d{4}){3}|(?:DK|FO|FI|GL|SD)\\d{2}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|NL\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}|MK\\d{2}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|SI\\d{17}|(?:AT|BA|EE|LT|XK)\\d{18}|(?:LU|KZ|EE|LT)\\d{5}[A-Z0-9]{13}|LV\\d{2}[A-Z]{4}[A-Z0-9]{13}|(?:LI|CH)\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]|HR\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d|GE\\d{2}[ \\-]?[A-Z0-9]{2}\\d{2}\\d{14}|VA\\d{20}|BG\\d{2}[A-Z]{4}\\d{6}[A-Z0-9]{8}|BH\\d{2}[A-Z]{4}[A-Z0-9]{14}|GB\\d{2}[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|IE\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|(?:CR|DE|ME|RS)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{2}|(?:AE|TL|IL)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{3}|GI\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{3}|IQ\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{3}|MD\\d{2}(?:[ \\-]?[A-Z0-9]{4}){5}|SA\\d{2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}|RO\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:PK|VG)\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){4}|AD\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){3}|(?:CZ|SK|ES|SE|TN)\\d{2}(?:[ \\-]?\\d{4}){5}|(?:LY|PT|ST)\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|TR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{2}|IS\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{2}|(?:IT|SM)\\d{2}[ \\-]?[A-Z]\\d{3}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]{3}|GR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){3}[A-Z0-9]{3}|(?:FR|MC)\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|MR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}|(?:SV|DO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}|BY\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{4}){4}|GT\\d{2}(?:[ \\-]?[A-Z0-9]{4}){6}|AZ\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{5}){4}|LB\\d{2}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{5}){4}|(?:AL|CY)\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:HU|PL)\\d{2}(?:[ \\-]?\\d{4}){6}|QA\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]|PS\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|UA\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}[ \\-]?[A-Z0-9]|BR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}[A-Z0-9][ \\-]?[A-Z0-9]|EG\\d{2}(?:[ \\-]?\\d{4}){6}\\d|MU\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){4}\\d{3}[A-Z][ \\-]?[A-Z]{2}|(?:KW|JO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]{2}|MT\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{3}){4}[ \\-]?[A-Z0-9]{3}|SC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?[A-Z]{3}|LC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){6})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "iban",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "h6WJcecQTwqvN9KeEtwDvg",
+      "name": "JCB Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gcEaMu_VSJ2-bGCEkgyC0w",
+      "name": "JCB Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "imTliuhXT5GAeRNhqChXQQ",
+      "name": "JCB Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9osY3xc9Q7ONAV0zw9Uz4A",
+      "name": "JSON Web Token",
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(\\.[\\w.+\\/=-]+)?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 20
+          }
+        }
+      },
+      "tags": {
+        "type": "json_web_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "d1Q9D3YMRxuVKf6CZInJPw",
+      "name": "Maestro Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "M3YIQKKjRVmoeQuM3pjzrw",
+      "name": "Maestro Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{6}|6\\d{7})(?:\\s\\d{8}|\\.\\d{8}|-\\d{8}|,\\d{8})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "hRxiQBlSSVKcjh5U7LZYLA",
+      "name": "Maestro Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NwhIYNS4STqZys37WlaIKA",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "axxJkyjhRTOuhjwlsA35Vw",
+      "name": "MasterCard Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "76EhmoK3TPqJcpM-fK0pLw",
+      "name": "MasterCard Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "18b608bd7a764bff5b2344c0",
+      "name": "Phone number",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bphone|number|mobile\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^(?:\\(\\+\\d{1,3}\\)|\\+\\d{1,3}|00\\d{1,3})?[-\\s\\.]?(?:\\(\\d{3}\\)[-\\s\\.]?)?(?:\\d[-\\s\\.]?){6,10}$",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 6
+          }
+        }
+      },
+      "tags": {
+        "type": "phone",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "de0899e0cbaaa812bb624cf04c912071012f616d-mod",
+      "name": "UK National Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^nin$|\\binsurance\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-Z]{2}[\\s-]?\\d{6}[\\s-]?[A-Z]?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "uk_nin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "d962f7ddb3f55041e39195a60ff79d4814a7c331",
+      "name": "US Passport Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bpassport\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[0-9A-Z]{9}\\b|\\b[0-9]{6}[A-Z][0-9]{2}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "passport_number",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "7771fc3b-b205-4b93-bcef-28608c5c1b54",
+      "name": "United States Social Security Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:SSN|(?:(?:social)?[\\s_]?(?:security)?[\\s_]?(?:number)?)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}[-\\s\\.]{1}\\d{2}[-\\s\\.]{1}\\d{4}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "us_ssn",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "ac6d683cbac77f6e399a14990793dd8fd0fca333",
+      "name": "US Vehicle Identification Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:vehicle[_\\s-]*identification[_\\s-]*number|vin)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-HJ-NPR-Z0-9]{17}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "vin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "wJIgOygRQhKkR69b_9XbRQ",
+      "name": "Visa Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "0o71SJxXQNK7Q6gMbBesFQ",
+      "name": "Visa Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:,\\d{4}){3}|(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "QrHD6AfgQm6z-j0wStxTvA",
+      "name": "Visa Card Scanner (1x15 & 1x16 & 1x19 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "4[0-9]{12}(?:[0-9]{3})?",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    }
   ]
 }

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -61,9 +61,16 @@ module Datadog
 
           exclusions = AppSec::Processor::RuleLoader.load_exclusions(ip_passlist: settings.appsec.ip_passlist)
 
+          # NOTE: This is a temporary solution before the RuleMerger refactoring
+          #       with new RemoteConfig setup
+          processors = rules.delete('processors')
+          scanners = rules.delete('scanners')
+
           ruleset = AppSec::Processor::RuleMerger.merge(
             rules: [rules],
             data: data,
+            scanners: scanners,
+            processors: processors,
             exclusions: exclusions,
             telemetry: telemetry
           )

--- a/lib/datadog/appsec/contrib/active_record/instrumentation.rb
+++ b/lib/datadog/appsec/contrib/active_record/instrumentation.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../../event'
+require_relative '../../security_event'
+
 module Datadog
   module AppSec
     module Contrib
@@ -28,16 +31,13 @@ module Datadog
             result = context.run_rasp(Ext::RASP_SQLI, {}, ephemeral_data, waf_timeout)
 
             if result.match?
-              Datadog::AppSec::Event.tag_and_keep!(context, result)
+              AppSec::Event.tag_and_keep!(context, result)
 
-              event = {
-                waf_result: result,
-                trace: context.trace,
-                span: context.span
-              }
-              context.events << event
+              context.events.push(
+                AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+              )
 
-              ActionsHandler.handle(result.actions)
+              AppSec::ActionsHandler.handle(result.actions)
             end
           end
 

--- a/lib/datadog/appsec/contrib/active_record/instrumentation.rb
+++ b/lib/datadog/appsec/contrib/active_record/instrumentation.rb
@@ -33,9 +33,7 @@ module Datadog
               event = {
                 waf_result: result,
                 trace: context.trace,
-                span: context.span,
-                sql: sql,
-                actions: result.actions
+                span: context.span
               }
               context.events << event
 

--- a/lib/datadog/appsec/contrib/excon/ssrf_detection_middleware.rb
+++ b/lib/datadog/appsec/contrib/excon/ssrf_detection_middleware.rb
@@ -25,9 +25,7 @@ module Datadog
               context.events << {
                 waf_result: result,
                 trace: context.trace,
-                span: context.span,
-                request_url: request_url,
-                actions: result.actions
+                span: context.span
               }
 
               ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/faraday/ssrf_detection_middleware.rb
+++ b/lib/datadog/appsec/contrib/faraday/ssrf_detection_middleware.rb
@@ -24,9 +24,7 @@ module Datadog
               context.events << {
                 waf_result: result,
                 trace: context.trace,
-                span: context.span,
-                request_url: request_env.url,
-                actions: result.actions
+                span: context.span
               }
 
               ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
@@ -35,8 +35,7 @@ module Datadog
                         waf_result: result,
                         trace: context.trace,
                         span: context.span,
-                        multiplex: gateway_multiplex,
-                        actions: result.actions
+                        multiplex: gateway_multiplex
                       }
 
                       Datadog::AppSec::ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/watcher.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'json'
+
+require_relative '../../../event'
+require_relative '../../../security_event'
 require_relative '../../../instrumentation/gateway'
 
 module Datadog
@@ -29,16 +32,13 @@ module Datadog
                     result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
                     if result.match?
-                      Datadog::AppSec::Event.tag_and_keep!(context, result)
+                      AppSec::Event.tag_and_keep!(context, result)
 
-                      context.events << {
-                        waf_result: result,
-                        trace: context.trace,
-                        span: context.span,
-                        multiplex: gateway_multiplex
-                      }
+                      context.events.push(
+                        AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                      )
 
-                      Datadog::AppSec::ActionsHandler.handle(result.actions)
+                      AppSec::ActionsHandler.handle(result.actions)
                     end
                   end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -38,13 +38,14 @@ module Datadog
 
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
-                  if result.match?
-                    AppSec::Event.tag_and_keep!(context, result)
-
+                  if result.match? || !result.derivatives.empty?
                     context.events.push(
                       AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
                     )
+                  end
 
+                  if result.match?
+                    AppSec::Event.tag_and_keep!(context, result)
                     AppSec::ActionsHandler.handle(result.actions)
                   end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -43,9 +43,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      request: gateway_request,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)
@@ -73,9 +71,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      response: gateway_response,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)
@@ -101,9 +97,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      request: gateway_request,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require_relative '../ext'
-require_relative '../../../instrumentation/gateway'
 require_relative '../../../event'
+require_relative '../../../security_event'
+require_relative '../../../instrumentation/gateway'
 
 module Datadog
   module AppSec
@@ -23,7 +24,7 @@ module Datadog
 
               def watch_request(gateway = Instrumentation.gateway)
                 gateway.watch('rack.request', :appsec) do |stack, gateway_request|
-                  context = gateway_request.env[Datadog::AppSec::Ext::CONTEXT_KEY]
+                  context = gateway_request.env[AppSec::Ext::CONTEXT_KEY]
 
                   persistent_data = {
                     'server.request.cookies' => gateway_request.cookies,
@@ -38,15 +39,13 @@ module Datadog
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
                   if result.match?
-                    Datadog::AppSec::Event.tag_and_keep!(context, result)
+                    AppSec::Event.tag_and_keep!(context, result)
 
-                    context.events << {
-                      waf_result: result,
-                      trace: context.trace,
-                      span: context.span
-                    }
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
 
-                    Datadog::AppSec::ActionsHandler.handle(result.actions)
+                    AppSec::ActionsHandler.handle(result.actions)
                   end
 
                   stack.call(gateway_request.request)
@@ -66,15 +65,13 @@ module Datadog
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
                   if result.match?
-                    Datadog::AppSec::Event.tag_and_keep!(context, result)
+                    AppSec::Event.tag_and_keep!(context, result)
 
-                    context.events << {
-                      waf_result: result,
-                      trace: context.trace,
-                      span: context.span
-                    }
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
 
-                    Datadog::AppSec::ActionsHandler.handle(result.actions)
+                    AppSec::ActionsHandler.handle(result.actions)
                   end
 
                   stack.call(gateway_response.response)
@@ -83,7 +80,7 @@ module Datadog
 
               def watch_request_body(gateway = Instrumentation.gateway)
                 gateway.watch('rack.request.body', :appsec) do |stack, gateway_request|
-                  context = gateway_request.env[Datadog::AppSec::Ext::CONTEXT_KEY]
+                  context = gateway_request.env[AppSec::Ext::CONTEXT_KEY]
 
                   persistent_data = {
                     'server.request.body' => gateway_request.form_hash
@@ -92,15 +89,13 @@ module Datadog
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
                   if result.match?
-                    Datadog::AppSec::Event.tag_and_keep!(context, result)
+                    AppSec::Event.tag_and_keep!(context, result)
 
-                    context.events << {
-                      waf_result: result,
-                      trace: context.trace,
-                      span: context.span
-                    }
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
 
-                    Datadog::AppSec::ActionsHandler.handle(result.actions)
+                    AppSec::ActionsHandler.handle(result.actions)
                   end
 
                   stack.call(gateway_request.request)

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -4,9 +4,12 @@ require 'json'
 
 require_relative 'gateway/request'
 require_relative 'gateway/response'
-require_relative '../../instrumentation/gateway'
-require_relative '../../processor'
+
+require_relative '../../event'
 require_relative '../../response'
+require_relative '../../processor'
+require_relative '../../security_event'
+require_relative '../../instrumentation/gateway'
 
 require_relative '../../../tracing/client_ip'
 require_relative '../../../tracing/contrib/rack/header_collection'
@@ -98,11 +101,9 @@ module Datadog
             end
 
             if AppSec.perform_api_security_check?
-              ctx.events << {
-                trace: ctx.trace,
-                span: ctx.span,
-                waf_result: ctx.extract_schema,
-              }
+              ctx.events.push(
+                AppSec::SecurityEvent.new(ctx.extract_schema, trace: ctx.trace, span: ctx.span)
+              )
             end
 
             AppSec::Event.record(ctx, request: gateway_request, response: gateway_response)

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -97,7 +97,7 @@ module Datadog
               http_response = AppSec::Response.from_interrupt_params(interrupt_params, env['HTTP_ACCEPT']).to_rack
             end
 
-            if AppSec.api_security_enabled?
+            if AppSec.perform_api_security_check?
               ctx.events << {
                 trace: ctx.trace,
                 span: ctx.span,

--- a/lib/datadog/appsec/contrib/rack/request_middleware.rb
+++ b/lib/datadog/appsec/contrib/rack/request_middleware.rb
@@ -36,7 +36,7 @@ module Datadog
             @rack_headers = {}
           end
 
-          # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+          # rubocop:disable Metrics/MethodLength
           def call(env)
             return @app.call(env) unless Datadog::AppSec.enabled?
 
@@ -105,12 +105,7 @@ module Datadog
               }
             end
 
-            ctx.events.each do |e|
-              e[:response] ||= gateway_response
-              e[:request]  ||= gateway_request
-            end
-
-            AppSec::Event.record(ctx.span, *ctx.events)
+            AppSec::Event.record(ctx, request: gateway_request, response: gateway_response)
 
             http_response
           ensure
@@ -119,7 +114,7 @@ module Datadog
               Datadog::AppSec::Context.deactivate
             end
           end
-          # rubocop:enable Metrics/AbcSize,Metrics/MethodLength
+          # rubocop:enable Metrics/MethodLength
 
           private
 

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -34,9 +34,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      request: gateway_request,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -29,13 +29,14 @@ module Datadog
 
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
-                  if result.match?
-                    AppSec::Event.tag_and_keep!(context, result)
-
+                  if result.match? || !result.derivatives.empty?
                     context.events.push(
                       AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
                     )
+                  end
 
+                  if result.match?
+                    AppSec::Event.tag_and_keep!(context, result)
                     AppSec::ActionsHandler.handle(result.actions)
                   end
 

--- a/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../../../instrumentation/gateway'
 require_relative '../../../event'
+require_relative '../../../security_event'
+require_relative '../../../instrumentation/gateway'
 
 module Datadog
   module AppSec
@@ -19,7 +20,7 @@ module Datadog
 
               def watch_request_action(gateway = Instrumentation.gateway)
                 gateway.watch('rails.request.action', :appsec) do |stack, gateway_request|
-                  context = gateway_request.env[Datadog::AppSec::Ext::CONTEXT_KEY]
+                  context = gateway_request.env[AppSec::Ext::CONTEXT_KEY]
 
                   persistent_data = {
                     'server.request.body' => gateway_request.parsed_body,
@@ -29,15 +30,13 @@ module Datadog
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
                   if result.match?
-                    Datadog::AppSec::Event.tag_and_keep!(context, result)
+                    AppSec::Event.tag_and_keep!(context, result)
 
-                    context.events << {
-                      waf_result: result,
-                      trace: context.trace,
-                      span: context.span
-                    }
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
 
-                    Datadog::AppSec::ActionsHandler.handle(result.actions)
+                    AppSec::ActionsHandler.handle(result.actions)
                   end
 
                   stack.call(gateway_request.request)

--- a/lib/datadog/appsec/contrib/rest_client/request_ssrf_detection_patch.rb
+++ b/lib/datadog/appsec/contrib/rest_client/request_ssrf_detection_patch.rb
@@ -21,9 +21,7 @@ module Datadog
               context.events << {
                 waf_result: result,
                 trace: context.trace,
-                span: context.span,
-                request_url: url,
-                actions: result.actions
+                span: context.span
               }
 
               ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/contrib/rest_client/request_ssrf_detection_patch.rb
+++ b/lib/datadog/appsec/contrib/rest_client/request_ssrf_detection_patch.rb
@@ -1,6 +1,9 @@
 # rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
+require_relative '../../event'
+require_relative '../../security_event'
+
 module Datadog
   module AppSec
     module Contrib
@@ -16,15 +19,13 @@ module Datadog
             result = context.run_rasp(Ext::RASP_SSRF, {}, ephemeral_data, Datadog.configuration.appsec.waf_timeout)
 
             if result.match?
-              Datadog::AppSec::Event.tag_and_keep!(context, result)
+              AppSec::Event.tag_and_keep!(context, result)
 
-              context.events << {
-                waf_result: result,
-                trace: context.trace,
-                span: context.span
-              }
+              context.events.push(
+                AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+              )
 
-              ActionsHandler.handle(result.actions)
+              AppSec::ActionsHandler.handle(result.actions)
             end
 
             super(&block)

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -29,13 +29,14 @@ module Datadog
 
                   result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
-                  if result.match?
-                    AppSec::Event.tag_and_keep!(context, result)
-
+                  if result.match? || !result.derivatives.empty?
                     context.events.push(
                       AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
                     )
+                  end
 
+                  if result.match?
+                    AppSec::Event.tag_and_keep!(context, result)
                     AppSec::ActionsHandler.handle(result.actions)
                   end
 

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -34,9 +34,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      request: gateway_request,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)
@@ -62,9 +60,7 @@ module Datadog
                     context.events << {
                       waf_result: result,
                       trace: context.trace,
-                      span: context.span,
-                      request: gateway_request,
-                      actions: result.actions
+                      span: context.span
                     }
 
                     Datadog::AppSec::ActionsHandler.handle(result.actions)

--- a/lib/datadog/appsec/security_event.rb
+++ b/lib/datadog/appsec/security_event.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    # A class that represents a security event of any kind. It could be an event
+    # representing an attack or fingerprinting results as derivatives or an API
+    # security check with extracted schema.
+    class SecurityEvent
+      SCHEMA_KEY_PREFIX = '_dd.appsec.s.'
+      FINGERPRINT_KEY_PREFIX = '_dd.appsec.fp.'
+
+      attr_reader :waf_result, :trace, :span
+
+      def initialize(waf_result, trace:, span:)
+        @waf_result = waf_result
+        @trace = trace
+        @span = span
+      end
+
+      def attack?
+        return @is_attack if defined?(@is_attack)
+
+        @is_attack = @waf_result.is_a?(SecurityEngine::Result::Match)
+      end
+
+      def schema?
+        return @has_schema if defined?(@has_schema)
+
+        @has_schema = @waf_result.derivatives.any? { |name, _| name.start_with?(SCHEMA_KEY_PREFIX) }
+      end
+
+      def fingerprint?
+        return @has_fingerprint if defined?(@has_fingerprint)
+
+        @has_fingerprint = @waf_result.derivatives.any? { |name, _| name.start_with?(FINGERPRINT_KEY_PREFIX) }
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec.rbs
+++ b/sig/datadog/appsec.rbs
@@ -12,7 +12,7 @@ module Datadog
 
     def self.reconfigure_lock: () { (?) -> untyped } -> void
 
-    def self.api_security_enabled?: () -> bool
+    def self.perform_api_security_check?: () -> bool
 
     private
 

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -1,6 +1,19 @@
 module Datadog
   module AppSec
     module Event
+      interface _RequestInterface
+        def host: () -> ::String?
+        def user_agent: () -> ::String?
+        def remote_addr: () -> ::String?
+        def headers: () -> Enumerable[[::String, ::String]]
+      end
+
+      interface _ResponseInterface
+        def headers: () -> Enumerable[[::String, ::String]]
+      end
+
+      type tags = ::Hash[::String, ::String]
+
       DERIVATIVE_SCHEMA_KEY_PREFIX: ::String
 
       DERIVATIVE_SCHEMA_MAX_COMPRESSED_SIZE: ::Integer
@@ -9,19 +22,21 @@ module Datadog
 
       ALLOWED_RESPONSE_HEADERS: ::Array[::String]
 
-      def self.record: (Tracing::SpanOperation span, *untyped events) -> void
+      def self.record: (Context context, ?request: _RequestInterface?, ?response: _ResponseInterface?) -> void
 
-      def self.record_via_span: (Tracing::SpanOperation span, *untyped events) -> void
-
-      def self.build_service_entry_tags: (untyped event_group) -> ::Hash[::String, untyped]
-
-      def self.tag_and_keep!: (untyped context, untyped waf_result) -> void
+      def self.tag_and_keep!: (Context context, WAF::Result waf_result) -> void
 
       private
 
+      def self.events_tags: (::Array[untyped]) -> tags
+
+      def self.request_tags: (_RequestInterface request) -> tags
+
+      def self.response_tags: (_ResponseInterface response) -> tags
+
       def self.json_parse: (untyped value) -> ::String?
 
-      def self.add_distributed_tags: (untyped trace) -> void
+      def self.add_distributed_tags: (::Datadog::Tracing::TraceOperation? trace) -> void
     end
   end
 end

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -28,7 +28,7 @@ module Datadog
 
       private
 
-      def self.events_tags: (::Array[untyped]) -> tags
+      def self.waf_tags: (::Array[untyped]) -> tags
 
       def self.request_tags: (_RequestInterface request) -> tags
 

--- a/sig/datadog/appsec/security_event.rbs
+++ b/sig/datadog/appsec/security_event.rbs
@@ -1,0 +1,35 @@
+module Datadog
+  module AppSec
+    class SecurityEvent
+      @waf_result: SecurityEngine::result
+
+      @trace: Tracing::TraceOperation?
+
+      @span: Tracing::SpanOperation?
+
+      @is_attack: bool
+
+      @has_schema: bool
+
+      @has_fingerprint: bool
+
+      attr_reader waf_result: SecurityEngine::result
+
+      attr_reader trace: Tracing::TraceOperation?
+
+      attr_reader span: Tracing::SpanOperation?
+
+      SCHEMA_KEY_PREFIX: ::String
+
+      FINGERPRINT_KEY_PREFIX: ::String
+
+      def initialize: (SecurityEngine::result waf_result, trace: Tracing::TraceOperation?, span: Tracing::SpanOperation?) -> void
+
+      def attack?: () -> bool
+
+      def schema?: () -> bool
+
+      def fingerprint?: () -> bool
+    end
+  end
+end

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -330,6 +330,7 @@ RSpec.describe 'Rails integration tests' do
 
         context 'with an event-triggering request in application/x-www-form-url-encoded body' do
           let(:params) { { q: '1 OR 1;' } }
+          let(:headers) { { 'HTTP_X_Forwarded' => '2001:db8:85a3:8d3:1319:8a2e:370:7348' } }
 
           it { is_expected.to be_ok }
 
@@ -343,6 +344,10 @@ RSpec.describe 'Rails integration tests' do
             let(:appsec_ruleset) { crs_942_100 }
 
             it { is_expected.to be_forbidden }
+
+            it 'sets HTTP request headers as span tags' do
+              expect(span.meta).to include('http.request.headers.x-forwarded' => '2001:db8:85a3:8d3:1319:8a2e:370:7348')
+            end
 
             it_behaves_like 'normal with tracing disable'
             it_behaves_like 'a POST 403 span'

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Datadog::AppSec::Event do
           2.times { |i| trace_op.measure("other span #{i}") { 'noop' } }
 
           context = Datadog::AppSec::Context.new(trace_op, span, security_engine)
-          context.events.push(trace: trace_op, span: span, waf_result: waf_result)
+          context.events.push(
+            Datadog::AppSec::SecurityEvent.new(waf_result, trace: trace_op, span: span)
+          )
 
           described_class.record(context, request: rack_request, response: rack_response)
         end
@@ -222,7 +224,9 @@ RSpec.describe Datadog::AppSec::Event do
           trace_op = Datadog::Tracing::TraceOperation.new
           trace_op.measure('request') do |span|
             context = Datadog::AppSec::Context.new(trace_op, span, security_engine)
-            context.events.push(trace: trace_op, span: span, waf_result: waf_result)
+            context.events.push(
+              Datadog::AppSec::SecurityEvent.new(waf_result, trace: trace_op, span: span)
+            )
 
             described_class.record(context, request: rack_request, response: rack_response)
           end
@@ -250,7 +254,9 @@ RSpec.describe Datadog::AppSec::Event do
           2.times { |i| trace_op.measure("other span #{i}") { 'noop' } }
 
           context = Datadog::AppSec::Context.new(trace_op, span, security_engine)
-          context.events.push(trace: trace_op, span: span, waf_result: waf_result)
+          context.events.push(
+            Datadog::AppSec::SecurityEvent.new(waf_result, trace: trace_op, span: span)
+          )
 
           described_class.record(context, request: rack_request, response: rack_response)
         end

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -4,357 +4,162 @@ require 'datadog/appsec/spec_helper'
 require 'datadog/appsec/event'
 
 RSpec.describe Datadog::AppSec::Event do
-  context 'ALLOWED_REQUEST_HEADERS' do
-    it 'store the correct values' do
-      expect(described_class::ALLOWED_REQUEST_HEADERS).to eq(
-        [
-          'x-forwarded-for',
-          'x-client-ip',
-          'x-real-ip',
-          'x-forwarded',
-          'x-cluster-client-ip',
-          'forwarded-for',
-          'forwarded',
-          'via',
-          'true-client-ip',
-          'content-length',
-          'content-type',
-          'content-encoding',
-          'content-language',
-          'host',
-          'user-agent',
-          'accept',
-          'accept-encoding',
-          'accept-language'
-        ]
-      )
-    end
-  end
-
-  context 'ALLOWED_RESPONSE_HEADERS' do
-    it 'store the correct values' do
-      expect(described_class::ALLOWED_RESPONSE_HEADERS).to eq(
-        [
-          'content-length',
-          'content-type',
-          'content-encoding',
-          'content-language'
-        ]
-      )
-    end
-  end
-
   describe '.record' do
-    before do
-      # prevent rate limiter to bias tests
-      Datadog::AppSec::RateLimiter.reset!
-    end
+    before { Datadog::AppSec::RateLimiter.reset! }
 
-    let(:options) { {} }
-    let(:trace_op) { Datadog::Tracing::TraceOperation.new(**options) }
-    let(:trace) { trace_op.flush! }
+    context 'when multiple spans present and a single security event is recorded' do
+      before { stub_const('Datadog::AppSec::Event::ALLOWED_REQUEST_HEADERS', ['user-agent']) }
 
-    let(:rack_request_headers) do
-      {
-        'user-agent' => 'Ruby/0.0',
-        'SERVER_NAME' => 'example.com',
-        'REMOTE_ADDR' => '127.0.0.1',
-      }
-    end
-
-    let(:rack_response_headers) do
-      {
-        'content-type' => 'text/html'
-      }
-    end
-
-    let(:rack_request) do
-      dbl = double
-
-      allow(dbl).to receive(:host).and_return('example.com')
-      allow(dbl).to receive(:user_agent).and_return('Ruby/0.0')
-      allow(dbl).to receive(:remote_addr).and_return('127.0.0.1')
-
-      allow(dbl).to receive(:headers).and_return(rack_request_headers)
-
-      dbl
-    end
-
-    let(:rack_response) do
-      dbl = double
-
-      allow(dbl).to receive(:headers).and_return(rack_response_headers)
-
-      dbl
-    end
-
-    let(:waf_events) do
-      [1, { a: :b }]
-    end
-
-    let(:waf_result) do
-      dbl = double
-
-      allow(dbl).to receive(:events).and_return(waf_events)
-      allow(dbl).to receive(:derivatives).and_return(derivatives)
-
-      dbl
-    end
-
-    let(:event_count) { 1 }
-    let(:derivatives) { {} }
-
-    let(:events) do
-      Array.new(event_count) do
-        {
-          trace: trace_op,
-          span: nil, # backfilled later
-          request: rack_request,
-          response: rack_response,
-          waf_result: waf_result,
-        }
-      end
-    end
-
-    context 'with one event' do
+      let(:top_level_span) { trace.spans.find { |span| span.metrics['_dd.top_level'].to_f > 0.0 } }
       let(:trace) do
+        trace_op = Datadog::Tracing::TraceOperation.new
         trace_op.measure('request') do |span|
-          events.each { |e| e[:span] = span }
+          2.times { |i| trace_op.measure("other span #{i}") { 'noop' } }
 
-          10.times do |i|
-            trace_op.measure("span #{i}") {}
-          end
+          events = [
+            {
+              trace: trace_op,
+              span: span,
+              request: rack_request,
+              response: rack_response,
+              waf_result: waf_result,
+            }
+          ]
 
           described_class.record(span, *events)
         end
-
         trace_op.flush!
       end
 
-      let(:top_level_span) do
-        trace.spans.find { |s| s.metrics['_dd.top_level'] && s.metrics['_dd.top_level'] > 0.0 }
+      let(:rack_request) do
+        instance_double(
+          Datadog::AppSec::Contrib::Rack::Gateway::Request,
+          headers: { 'unknown-header' => 'hello', 'user-agent' => 'Ruby/0.0' },
+          host: 'example.com',
+          user_agent: 'Ruby/0.0',
+          remote_addr: '127.0.0.1'
+        )
       end
 
-      let(:other_spans) do
-        trace.spans - [top_level_span]
+      let(:rack_response) do
+        instance_double(
+          Datadog::AppSec::Contrib::Rack::Gateway::Response,
+          headers: { 'mystery-header' => '42', 'content-type' => 'text/html' }
+        )
       end
 
-      context 'request headers' do
-        context 'allowed headers' do
-          it 'records allowed headers' do
-            expect(top_level_span.meta).to include('http.request.headers.user-agent' => 'Ruby/0.0')
-          end
-        end
-
-        context 'discard not allowed headers' do
-          let(:rack_request_headers) do
-            {
-              'not-supported-header' => 'foo',
-            }
-          end
-
-          it 'does not records allowed headers' do
-            expect(top_level_span.meta).to_not include('http.request.headers.not-supported-header')
-          end
-        end
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [1],
+          actions: {},
+          derivatives: {
+            '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }]
+          },
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
       end
 
-      context 'response headers' do
-        context 'allowed headers' do
-          it 'records allowed headers' do
-            expect(top_level_span.meta).to include('http.response.headers.content-type' => 'text/html')
-          end
-        end
-
-        context 'discard not allowed headers' do
-          let(:rack_response_headers) do
-            {
-              'not-supported-header' => 'foo',
-            }
-          end
-
-          it 'does not records allowed headers' do
-            expect(top_level_span.meta).to_not include('http.response.headers.not-supported-header')
-          end
-        end
+      it 'keeps allowed headers and discards the rest' do
+        expect(top_level_span.meta).to include(
+          'http.request.headers.user-agent' => 'Ruby/0.0',
+          'http.response.headers.content-type' => 'text/html'
+        )
+        expect(top_level_span.meta).not_to include(
+          'http.request.headers.unknown-header',
+          'http.response.headers.mystery-header'
+        )
       end
 
-      context 'http information' do
-        it 'records http information' do
-          expect(top_level_span.meta).to include('http.host' => 'example.com')
-          expect(top_level_span.meta).to include('http.useragent' => 'Ruby/0.0')
-          expect(top_level_span.meta).to include('network.client.ip' => '127.0.0.1')
-        end
+      it 'sets HTTP information' do
+        expect(top_level_span.meta).to include(
+          'http.host' => 'example.com',
+          'http.useragent' => 'Ruby/0.0',
+          'network.client.ip' => '127.0.0.1'
+        )
       end
 
-      it 'records an event on the top level span' do
-        expect(top_level_span.meta).to include('_dd.appsec.json' => '{"triggers":[1,{"a":"b"}]}')
+      it 'sets origin and AppSec trigger information' do
+        expect(top_level_span.meta).to include('_dd.appsec.json' => '{"triggers":[1]}')
         expect(top_level_span.meta).to include('_dd.origin' => 'appsec')
       end
 
-      it 'records nothing on other spans' do
-        other_spans.each do |other_span|
-          expect(other_span.meta).to be_empty
-        end
+      it 'marks the trace to be kept and sets the sampling priority to ASM' do
+        expect(trace.sampling_priority).to eq(Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP)
+        expect(trace.sampling_decision_maker).to eq(Datadog::Tracing::Sampling::Ext::Decision::ASM)
       end
 
-      it 'marks the trace to be kept' do
-        expect(trace.sampling_priority).to eq Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP
+      it 'does not set AppSec information on non-top-level spans' do
+        other_spans = trace.spans.reject { |span| span == top_level_span }
+
+        expect(other_spans).not_to be_empty
+        expect(other_spans).to all(have_attributes(meta: be_empty))
       end
 
-      context 'waf_result derivatives' do
-        let(:derivatives) do
-          {
-            '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }]
-          }
-        end
+      it 'sets WAF derivatives as uncompressed JSON string when they are small' do
+        stub_const('Datadog::AppSec::CompressedJson::MIN_SIZE_FOR_COMPRESSION', 3000)
 
-        context 'JSON payload' do
-          it 'uses JSON string when do not exceeds MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
-            stub_const('Datadog::AppSec::CompressedJson::MIN_SIZE_FOR_COMPRESSION', 3000)
-            meta = top_level_span.meta
+        expect(top_level_span.meta['_dd.appsec.s.req.headers']).to eq('[{"host":[8],"version":[8]}]')
+      end
 
-            expect(meta['_dd.appsec.s.req.headers']).to eq('[{"host":[8],"version":[8]}]')
-          end
-        end
+      it 'sets WAF derivatives as compressed JSON string when they are large' do
+        stub_const('Datadog::AppSec::CompressedJson::MIN_SIZE_FOR_COMPRESSION', 1)
+        allow(Datadog::AppSec::CompressedJson).to receive(:dump).and_return('H4sIAOYoHGUAA4aphwAAAA=')
 
-        context 'Compressed payload' do
-          it 'uses compressed value when JSON string is bigger than MIN_SCHEMA_SIZE_FOR_COMPRESSION' do
-            stub_const('Datadog::AppSec::CompressedJson::MIN_SIZE_FOR_COMPRESSION', 1)
-            allow(Datadog::AppSec::CompressedJson).to receive(:dump).and_return('H4sIAOYoHGUAA4aphwAAAA=')
+        expect(top_level_span.meta['_dd.appsec.s.req.headers']).to eq('H4sIAOYoHGUAA4aphwAAAA=')
+      end
 
-            expect(top_level_span.meta['_dd.appsec.s.req.headers']).to eq('H4sIAOYoHGUAA4aphwAAAA=')
-          end
+      it 'does not set WAF derivatives when they exceed the max compressed size' do
+        stub_const('Datadog::AppSec::Event::DERIVATIVE_SCHEMA_MAX_COMPRESSED_SIZE', 1)
 
-          context 'with big derivatives' do
-            let(:derivatives) do
-              {
-                '_dd.appsec.s.req.headers' => [
-                  {
-                    'host' => [8],
-                    'version' => [8],
-                    'foo' => [8],
-                    'bar' => [8],
-                    'baz' => [8],
-                    'qux' => [8],
-                    'quux' => [8],
-                    'quuux' => [8],
-                    'quuuux' => [8],
-                    'quuuuux' => [8],
-                    'quuuuuux' => [8],
-                    'quuuuuuux' => [8],
-                    'quuuuuuuux' => [8],
-                    'quuuuuuuuux' => [8],
-                    'quuuuuuuuuux' => [8],
-                    'quuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuuuuuux' => [8],
-                    'quuuuuuuuuuuuuuuuuuuuuuuux' => [8],
-                  }
-                ]
-              }
-            end
-
-            it 'has no newlines when encoded' do
-              expect(top_level_span.meta['_dd.appsec.s.req.headers']).to_not match(/\n/)
-            end
-          end
-        end
-
-        context 'derivative values exceed Event::DERIVATIVE_SCHEMA_MAX_COMPRESSED_SIZE value' do
-          it 'do not add derivative key to meta' do
-            stub_const('Datadog::AppSec::Event::DERIVATIVE_SCHEMA_MAX_COMPRESSED_SIZE', 1)
-            meta = top_level_span.meta
-
-            expect(meta['_dd.appsec.s.req.headers']).to be_nil
-          end
-        end
+        expect(top_level_span.meta['_dd.appsec.s.req.headers']).to be_nil
       end
     end
 
-    context 'with no event' do
-      let(:event_count) { 0 }
-
+    context 'when no security events are recorded' do
       let(:trace) do
-        trace_op.measure('request') do |span|
-          events.each { |e| e[:span] = span }
-
-          described_class.record(span, *events)
-        end
-
+        trace_op = Datadog::Tracing::TraceOperation.new
+        trace_op.measure('request') { |span| described_class.record(span,) }
         trace_op.flush!
       end
 
-      it 'does not mark the trace to be kept' do
-        expect(trace.sampling_priority).to eq nil
-      end
-
-      it 'does not attempt to record in the trace' do
+      it 'does not record the event and does not mark the trace to be kept' do
+        expect(trace.sampling_priority).to be_nil
         expect(described_class).to_not receive(:record_via_span)
-
-        expect(trace).to_not be nil
-      end
-
-      it 'does not call the rate limiter' do
-        expect_any_instance_of(Datadog::AppSec::RateLimiter).to_not receive(:limit)
-
-        expect(trace).to_not be nil
       end
     end
 
-    context 'with no span' do
-      let(:event_count) { 1 }
-
-      it 'does not attempt to record in the trace' do
-        expect(described_class).to_not receive(:record_via_span)
-
-        described_class.record(nil, events)
+    context 'when no span is provided' do
+      let(:trace) do
+        trace_op = Datadog::Tracing::TraceOperation.new
+        trace_op.measure('request') { |_span| described_class.record(nil, 'does not matter') }
+        trace_op.flush!
       end
 
-      it 'does not call the rate limiter' do
-        expect_any_instance_of(Datadog::AppSec::RateLimiter).to_not receive(:limit)
-
-        described_class.record(nil, events)
+      it 'does not record the event and does not mark the trace to be kept' do
+        expect(trace.sampling_priority).to be_nil
+        expect(described_class).to_not receive(:record_via_span)
       end
     end
 
-    context 'with many traces' do
+    context 'when traces count exceeds the rate limit' do
       before do
         allow(Datadog::Core::Utils::Time).to receive(:get_time).and_return(0)
-        allow(Datadog::AppSec::RateLimiter).to receive(:trace_rate_limit).and_return(rate_limit)
+        allow(Datadog::AppSec::RateLimiter).to receive(:trace_rate_limit).and_return(50)
       end
 
-      let(:rate_limit) { 50 }
-      let(:trace_count) { rate_limit * 2 }
-
       let(:traces) do
-        Array.new(trace_count) do
-          trace_op = Datadog::Tracing::TraceOperation.new(**options)
-
-          trace_op.measure('request') do |span|
-            events.each { |e| e[:span] = span }
-
-            described_class.record(span, *events)
-          end
-
+        Array.new(100) do
+          trace_op = Datadog::Tracing::TraceOperation.new
+          trace_op.measure('request') { |span| described_class.record(span, 'does not matter') }
           trace_op.keep!
         end
       end
 
-      it 'rate limits event recording' do
-        expect(described_class).to receive(:record_via_span).exactly(rate_limit).times.and_call_original
-
-        expect(traces).to have_attributes(count: trace_count)
+      it 'performs exactly 50 recordings' do
+        expect(described_class).to receive(:record_via_span).exactly(50).times
+        expect(traces.count).to eq(100)
       end
     end
   end

--- a/spec/datadog/appsec/event_spec.rb
+++ b/spec/datadog/appsec/event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Datadog::AppSec::Event do
   describe '.record' do
     before { Datadog::AppSec::RateLimiter.reset! }
 
-    context 'when multiple spans present and a single security event is recorded' do
+    context 'when multiple spans present and a single security event with attack is recorded' do
       before { stub_const('Datadog::AppSec::Event::ALLOWED_REQUEST_HEADERS', ['user-agent']) }
 
       let(:top_level_span) { trace.spans.find { |span| span.metrics['_dd.top_level'].to_f > 0.0 } }
@@ -61,7 +61,7 @@ RSpec.describe Datadog::AppSec::Event do
         )
       end
 
-      it 'keeps allowed headers and discards the rest' do
+      it 'keeps allowed HTTP headers and discards the rest' do
         expect(top_level_span.meta).to include(
           'http.request.headers.user-agent' => 'Ruby/0.0',
           'http.response.headers.content-type' => 'text/html'

--- a/spec/datadog/appsec/security_event_spec.rb
+++ b/spec/datadog/appsec/security_event_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/security_event'
+
+RSpec.describe Datadog::AppSec::SecurityEvent do
+  let(:trace) { instance_double(Datadog::Tracing::TraceOperation) }
+  let(:span) { instance_double(Datadog::Tracing::SpanOperation) }
+
+  describe '#attack?' do
+    context 'when WAF result is a match' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).to be_attack }
+    end
+
+    context 'when WAF result is an ok' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 0, duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).not_to be_attack }
+    end
+
+    context 'when WAF result is an error' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+      let(:waf_result) { Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 0) }
+
+      it { expect(event).not_to be_attack }
+    end
+  end
+
+  describe '#schema?' do
+    context 'when WAF result contains schema derivatives' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [],
+          actions: {},
+          derivatives: { '_dd.appsec.s.req.headers' => [{ 'host' => [8], 'version' => [8] }] },
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).to be_schema }
+    end
+
+    context 'when WAF result does not contain schema derivatives' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [],
+          actions: {},
+          derivatives: { 'not_schema' => 'value' },
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).not_to be_schema }
+    end
+  end
+
+  describe '#fingerprint?' do
+    context 'when WAF result contains fingerprint derivatives' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [],
+          actions: {},
+          derivatives: { '_dd.appsec.fp.http.endpoint' => 'http-post-c1525143-2d711642-' },
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).to be_fingerprint }
+    end
+
+    context 'when WAF result does not contain fingerprint derivatives' do
+      subject(:event) { described_class.new(waf_result, trace: trace, span: span) }
+
+      let(:waf_result) do
+        Datadog::AppSec::SecurityEngine::Result::Ok.new(
+          events: [],
+          actions: {},
+          derivatives: { 'not_fingerprint' => 'value' },
+          timeout: false,
+          duration_ns: 0,
+          duration_ext_ns: 0
+        )
+      end
+
+      it { expect(event).not_to be_fingerprint }
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

1. Quick-Fix for AppSec rules files to make use of supplied keys before the refactoring comes
2. New abstraction - `SecurityEvent` which suppose to be used at the end of request lifecycle to tag spans
3. Fix for derivatives for non-attack non-business security events.

**Motivation:**

This work is done to complete feature [RFC-0979 Attacker Fingerprinting](https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit?pli=1&tab=t.0).

**Change log entry**

No. Will be part of the bundle

**Additional Notes:**

There is still missing abstraction and not well distributed responsibilities for security events of all kind, because we explicitly check security event before adding it to the list. And that complexity of the decision could be hidden.

**How to test the change?**

CI + ST