### PR TITLE
[NO-TICKET] Decouple environment variable from programmatic config precedence

### DIFF
--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -32,17 +32,19 @@ module Datadog
           end
 
           # Remote configuration provided through the Datadog app.
-          REMOTE_CONFIGURATION = Value.new(2, :remote_configuration).freeze
+          REMOTE_CONFIGURATION = Value.new(3, :remote_configuration).freeze
 
           # Configuration provided in Ruby code, in this same process
-          # or via Environment variable
-          PROGRAMMATIC = Value.new(1, :programmatic).freeze
+          PROGRAMMATIC = Value.new(2, :programmatic).freeze
+
+          # Configuration provided via environment variable
+          ENVIRONMENT = Value.new(1, :environment).freeze
 
           # Configuration that comes from default values
           DEFAULT = Value.new(0, :default).freeze
 
           # All precedences, sorted from highest to lowest
-          LIST = [REMOTE_CONFIGURATION, PROGRAMMATIC, DEFAULT].sort.reverse.freeze
+          LIST = [REMOTE_CONFIGURATION, PROGRAMMATIC, ENVIRONMENT, DEFAULT].sort.reverse.freeze
         end
 
         def initialize(definition, context)
@@ -294,7 +296,7 @@ module Datadog
 
               resolved_env = env
               value = coerce_env_variable(ENV[env])
-              precedence = Precedence::PROGRAMMATIC
+              precedence = Precedence::ENVIRONMENT
               break
             end
           end
@@ -302,7 +304,7 @@ module Datadog
           if value.nil? && definition.deprecated_env && ENV[definition.deprecated_env]
             resolved_env = definition.deprecated_env
             value = coerce_env_variable(ENV[definition.deprecated_env])
-            precedence = Precedence::PROGRAMMATIC
+            precedence = Precedence::ENVIRONMENT
 
             Datadog::Core.log_deprecation do
               "#{definition.deprecated_env} environment variable is deprecated, use #{definition.env} instead."

--- a/sig/datadog/core/configuration/option.rbs
+++ b/sig/datadog/core/configuration/option.rbs
@@ -15,6 +15,7 @@ module Datadog
         module Precedence
           REMOTE_CONFIGURATION: Value
           PROGRAMMATIC: Value
+          ENVIRONMENT: Value
           DEFAULT: Value
           LIST: [Value]
 

--- a/sig/datadog/core/configuration/options.rbs
+++ b/sig/datadog/core/configuration/options.rbs
@@ -37,7 +37,7 @@ module Datadog
 
           private
 
-          def resolve_option: (Symbol name) -> Datadog::Core::Configuration::Option
+          def resolve_option: (Symbol name) -> Option
 
           def add_option: (untyped name) -> untyped
 

--- a/sig/datadog/core/configuration/options.rbs
+++ b/sig/datadog/core/configuration/options.rbs
@@ -37,6 +37,8 @@ module Datadog
 
           private
 
+          def resolve_option: (Symbol name) -> Datadog::Core::Configuration::Option
+
           def add_option: (untyped name) -> untyped
 
           def assert_valid_option!: (untyped name) -> untyped

--- a/spec/datadog/core/configuration/option_spec.rb
+++ b/spec/datadog/core/configuration/option_spec.rb
@@ -561,7 +561,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       end
 
       context 'when no precedence value is set and try to unset a precedence that is not set' do
-        subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC) }
+        before { option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC) }
 
         it 'does not modify the option' do
           expect(option.get).to eq(default)
@@ -570,7 +570,7 @@ RSpec.describe Datadog::Core::Configuration::Option do
       end
 
       context 'when no precedence value is set and try to unset DEFAULT' do
-        subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::DEFAULT) }
+        before { option.unset(Datadog::Core::Configuration::Option::Precedence::DEFAULT) }
 
         it 'does not modify the option' do
           expect(option.get).to eq(default)
@@ -585,9 +585,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
               Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC,
               precedence: Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC
             )
-          end
 
-          subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::DEFAULT) }
+            option.unset(Datadog::Core::Configuration::Option::Precedence::DEFAULT)
+          end
 
           it 'does not modify the option' do
             expect(option.get).to eq(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC)
@@ -601,9 +601,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
               Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC,
               precedence: Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC
             )
-          end
 
-          subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC) }
+            option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC)
+          end
 
           it 'removes the only precedence value' do
             expect(option.get).to eq(default)
@@ -617,9 +617,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
               Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC,
               precedence: Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC
             )
-          end
 
-          subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::REMOTE_CONFIGURATION) }
+            option.unset(Datadog::Core::Configuration::Option::Precedence::REMOTE_CONFIGURATION)
+          end
 
           it 'does not modify the option' do
             expect(option.get).to eq(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC)
@@ -639,9 +639,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
               Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC,
               precedence: Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC
             )
-          end
 
-          subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC) }
+            option.unset(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC)
+          end
 
           it 'falls back to lower precedence value' do
             expect(option.get).to eq(Datadog::Core::Configuration::Option::Precedence::ENVIRONMENT)
@@ -659,9 +659,9 @@ RSpec.describe Datadog::Core::Configuration::Option do
               Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC,
               precedence: Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC
             )
-          end
 
-          subject!(:unset) { option.unset(Datadog::Core::Configuration::Option::Precedence::ENVIRONMENT) }
+            option.unset(Datadog::Core::Configuration::Option::Precedence::ENVIRONMENT)
+          end
 
           it 'does not modify the option' do
             expect(option.get).to eq(Datadog::Core::Configuration::Option::Precedence::PROGRAMMATIC)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR decouples environment variables and programmatic configuration precedence value by adding an environment precedence value.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
in https://github.com/DataDog/dd-trace-rb/pull/4592, I need to add a new precedence value higher than environment but lower than programmatic.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
Yes. Change behaviour of programmatic configurations previously overwriting environment variables. Unsetting a programmatic configuration will now restore the environment variable value.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
I'm not sure if this is considered a breaking change, it seems like this was a bug in the first place (booting an app with an env var, a programmatic config and unsetting that programmatic config previously dismissed the env var too)

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI.

<!-- Unsure? Have a question? Request a review! -->
