### PR TITLE
Warn when ignoring on_error argument due to it not being a proc

### DIFF
--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -93,8 +93,14 @@ module Datadog
         @events = events || Events.new
         @span = nil
 
-        # Subscribe :on_error event
-        @events.on_error.wrap_default(&on_error) if on_error.is_a?(Proc)
+        if on_error.nil?
+          # Nothing, default error handler is already set up.
+        elsif on_error.is_a?(Proc)
+          # Subscribe :on_error event
+          @events.on_error.wrap_default(&on_error)
+        else
+          Datadog.logger.warn("on_error argument to SpanOperation ignored because is not a Proc: #{on_error}")
+        end
 
         # Start the span with start time, if given.
         start(start_time) if start_time

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Datadog::Tracing::SpanOperation do
       end
 
       context ':on_error' do
-        let(:options) { { on_error: block } }
+        let(:options) { { on_error: on_error } }
 
         let(:block) { proc { raise error } }
         let(:error) { error_class.new('error message') }
@@ -162,6 +162,7 @@ RSpec.describe Datadog::Tracing::SpanOperation do
             before { allow(span_op).to receive(:set_error) }
 
             it 'propagates the error' do
+              expect(Datadog.logger).not_to receive(:warn)
               expect { measure }.to raise_error(error)
               expect(span_op).to have_received(:set_error).with(error)
             end
@@ -172,6 +173,7 @@ RSpec.describe Datadog::Tracing::SpanOperation do
           let(:on_error) { block }
 
           it 'yields to the error block and raises the error' do
+            expect(Datadog.logger).not_to receive(:warn)
             expect do
               expect do |b|
                 options[:on_error] = b.to_proc
@@ -191,7 +193,7 @@ RSpec.describe Datadog::Tracing::SpanOperation do
           let(:on_error) { 'not a proc' }
 
           it 'fallbacks to default error handler and log a debug message' do
-            expect(Datadog.logger).to receive(:debug).at_least(:once)
+            expect(Datadog.logger).to receive(:warn).with(/on_error argument to SpanOperation ignored because is not a Proc: not a proc/)
             expect do
               span_op.measure(&block)
             end.to raise_error(error)

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -193,7 +193,9 @@ RSpec.describe Datadog::Tracing::SpanOperation do
           let(:on_error) { 'not a proc' }
 
           it 'fallbacks to default error handler and log a debug message' do
-            expect(Datadog.logger).to receive(:warn).with(/on_error argument to SpanOperation ignored because is not a Proc: not a proc/)
+            expect(Datadog.logger).to receive(:warn).with(
+              /on_error argument to SpanOperation ignored because is not a Proc: not a proc/
+            )
             expect do
               span_op.measure(&block)
             end.to raise_error(error)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds a warning when customer provides `on_error` argument which is not a `Proc`. Previously the argument was silently ignored.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Better diagnostics of unexpected/incorrect usage of the library

**Change log entry**
Yes: warn when `on_error` argument is not a `Proc` (and would therefore be ignored)
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The existing tests for on_error behavior had incorrect setup and did not actually test the path when on_error argument was not a proc.

**How to test the change?**
Repaired unit tests in this PR.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
