### PR TITLE
Avoid example redefinition warning in test suite

### DIFF
--- a/spec/datadog/core/configuration/settings_shared_examples.rb
+++ b/spec/datadog/core/configuration/settings_shared_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples_for 'a binary setting with' do |env_variable:, default:|
+  context "when #{env_variable}" do
+    around { |example| ClimateControl.modify(env_variable => environment) { example.run } }
+
+    context 'is not defined' do
+      let(:environment) { nil }
+
+      it { is_expected.to be default }
+    end
+
+    [true, false].each do |value|
+      context "is defined as #{value}" do
+        let(:environment) { value.to_s }
+
+        it { is_expected.to be value }
+      end
+    end
+  end
+end

--- a/spec/datadog/core/configuration/settings_shared_examples.rb
+++ b/spec/datadog/core/configuration/settings_shared_examples.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for 'a binary setting with' do |env_variable:, default:|
-  context "when #{env_variable}" do
+  context "when environment variable `#{env_variable}`" do
     around { |example| ClimateControl.modify(env_variable => environment) { example.run } }
 
     context 'is not defined' do

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -8,26 +8,7 @@ require 'datadog/core/environment/ext'
 require 'datadog/core/runtime/ext'
 require 'datadog/core/utils/time'
 require 'datadog/profiling/ext'
-
-RSpec.shared_examples_for 'a binary setting with' do |env_variable:, default:|
-  context "when #{env_variable}" do
-    around { |example| ClimateControl.modify(env_variable => environment) { example.run } }
-
-    context 'is not defined' do
-      let(:environment) { nil }
-
-      it { is_expected.to be default }
-    end
-
-    [true, false].each do |value|
-      context "is defined as #{value}" do
-        let(:environment) { value.to_s }
-
-        it { is_expected.to be value }
-      end
-    end
-  end
-end
+require_relative 'settings_shared_examples'
 
 RSpec.describe Datadog::Core::Configuration::Settings do
   subject(:settings) { described_class.new(options) }

--- a/spec/datadog/tracing/configuration/settings_spec.rb
+++ b/spec/datadog/tracing/configuration/settings_spec.rb
@@ -8,7 +8,7 @@ require 'datadog/tracing/flush'
 require 'datadog/tracing/sampling/priority_sampler'
 require 'datadog/tracing/tracer'
 require 'datadog/tracing/writer'
-require 'datadog/core/configuration/settings_spec'
+require_relative '../../core/configuration/settings_shared_examples'
 
 RSpec.describe Datadog::Tracing::Configuration::Settings do
   # TODO: Core::Configuration::Settings directly extends Tracing::Configuration::Settings


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Refactors the examples to avoid this warning:

```
WARNING: Shared example group 'a binary setting with' has been previously defined at:
  /home/w/apps/dd-trace-rb/spec/datadog/core/configuration/settings_spec.rb:12
...and you are now defining it at:
  /home/w/apps/dd-trace-rb/spec/datadog/core/configuration/settings_spec.rb:12
```

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Warning-clean test suite

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tested manually by running the relevant examples:
```
rspec spec/datadog/core/configuration/settings_spec.rb spec/datadog/tracing/configuration/settings_spec.rb
```
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
