### PR TITLE
Try DD_API_KEY instead of DD_APPSEC_SYSTEM_TESTS_API_KEY

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -399,7 +399,7 @@ jobs:
           ./run.sh ++docker ${{ matrix.scenario }} \
             ${{ env.FORCED_TESTS_LIST && fromJSON(env.FORCED_TESTS_LIST)[matrix.scenario] && format('-F {0}', join(fromJSON(env.FORCED_TESTS_LIST)[matrix.scenario], ' -F ')) || ''}}
         env:
-          DD_API_KEY: ${{ secrets.DD_APPSEC_SYSTEM_TESTS_API_KEY }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
           SYSTEM_TESTS_AWS_ACCESS_KEY_ID: ${{ secrets.SYSTEM_TESTS_IDM_AWS_ACCESS_KEY_ID }}
           SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY: ${{ secrets.SYSTEM_TESTS_IDM_AWS_SECRET_ACCESS_KEY }}
           FORCED_TESTS_LIST: ${{ needs.build-apps.outputs.FORCED_TESTS_LIST }}


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes usage of DD_APPSEC_SYSTEM_TESTS_API_KEY GH secret to DD_API_KEY.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Profiling system test is failing due to missing DD_API_KEY. This key is taken from the  DD_APPSEC_SYSTEM_TESTS_API_KEY secret even though we also have the DD_API_KEY secret. The DD_API_KEY secret appears to work therefore let's use it to avoid having to create a second API key.

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing CI
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
