### PR TITLE
Inject logger into tracing operations

### DIFF
--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -222,7 +222,7 @@ module Datadog
         # trace is already completed. Prevents multiple
         # root spans with parent_span_id = 0.
         return yield( # rubocop:disable Style/MultilineIfModifier
-          SpanOperation.new(op_name logger: logger), # rubocop:disable Style/NestedParenthesizedCalls
+          SpanOperation.new(op_name, logger: logger), # rubocop:disable Style/NestedParenthesizedCalls
           TraceOperation.new(logger: logger)) if finished? || full?
 
         # Create new span

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -222,7 +222,7 @@ module Datadog
         # trace is already completed. Prevents multiple
         # root spans with parent_span_id = 0.
         return yield( # rubocop:disable Style/MultilineIfModifier
-          SpanOperation.new(op_name, logger: logger), # rubocop:disable Style/NestedParenthesizedCalls
+          SpanOperation.new(op_name, logger: logger),
           TraceOperation.new(logger: logger)) if finished? || full?
 
         # Create new span

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -266,7 +266,7 @@ module Datadog
           parent_id = parent ? parent.id : @parent_span_id || 0
 
           # Build events
-          events ||= SpanOperation::Events.new
+          events ||= SpanOperation::Events.new(logger: logger)
 
           # Before start: activate the span, publish events.
           events.before_start.subscribe do |span_op|

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -221,8 +221,8 @@ module Datadog
         # Don't allow more span measurements if the
         # trace is already completed. Prevents multiple
         # root spans with parent_span_id = 0.
-        return yield(
-          SpanOperation.new(op_name logger: logger),
+        return yield( # rubocop:disable Style/MultilineIfModifier
+          SpanOperation.new(op_name logger: logger), # rubocop:disable Style/NestedParenthesizedCalls
           TraceOperation.new(logger: logger)) if finished? || full?
 
         # Create new span

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -40,6 +40,7 @@ module Datadog
         :baggage
 
       attr_reader \
+        :logger,
         :active_span_count,
         :active_span,
         :id,
@@ -55,6 +56,7 @@ module Datadog
         :service
 
       def initialize(
+        logger: Datadog.logger,
         agent_sample_rate: nil,
         events: nil,
         hostname: nil,
@@ -79,8 +81,9 @@ module Datadog
         remote_parent: false,
         tracer: nil,
         baggage: nil
-
       )
+        @logger = logger
+
         # Attributes
         @id = id || Tracing::Utils::TraceId.next_id
         @max_length = max_length || DEFAULT_MAX_LENGTH
@@ -204,6 +207,7 @@ module Datadog
 
       def measure(
         op_name,
+        logger: Datadog.logger,
         events: nil,
         on_error: nil,
         resource: nil,
@@ -217,7 +221,9 @@ module Datadog
         # Don't allow more span measurements if the
         # trace is already completed. Prevents multiple
         # root spans with parent_span_id = 0.
-        return yield(SpanOperation.new(op_name), TraceOperation.new) if finished? || full?
+        return yield(
+          SpanOperation.new(op_name logger: logger),
+          TraceOperation.new(logger: logger)) if finished? || full?
 
         # Create new span
         span_op = build_span(
@@ -238,6 +244,7 @@ module Datadog
 
       def build_span(
         op_name,
+        logger: Datadog.logger,
         events: nil,
         on_error: nil,
         resource: nil,
@@ -274,6 +281,7 @@ module Datadog
           # Build a new span operation
           SpanOperation.new(
             op_name,
+            logger: logger,
             events: events,
             on_error: on_error,
             parent_id: parent_id,
@@ -286,10 +294,10 @@ module Datadog
             id: id
           )
         rescue StandardError => e
-          Datadog.logger.debug { "Failed to build new span: #{e}" }
+          logger.debug { "Failed to build new span: #{e}" }
 
           # Return dummy span
-          SpanOperation.new(op_name)
+          SpanOperation.new(op_name, logger: logger)
         end
       end
 
@@ -465,7 +473,7 @@ module Datadog
           # Publish :span_before_start event
           events.span_before_start.publish(span_op, self)
         rescue StandardError => e
-          Datadog.logger.debug { "Error starting span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
+          logger.debug { "Error starting span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
         end
       end
 
@@ -489,7 +497,7 @@ module Datadog
           # Publish :trace_finished event
           events.trace_finished.publish(self) if finished?
         rescue StandardError => e
-          Datadog.logger.debug { "Error finishing span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
+          logger.debug { "Error finishing span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
         end
       end
 

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -342,6 +342,7 @@ module Datadog
                                 digest.trace_sampling_priority
                               end
           TraceOperation.new(
+            logger: logger,
             hostname: hostname,
             profiling_enabled: profiling_enabled,
             apm_tracing_enabled: apm_tracing_enabled,
@@ -359,6 +360,7 @@ module Datadog
           )
         else
           TraceOperation.new(
+            logger: logger,
             hostname: hostname,
             profiling_enabled: profiling_enabled,
             apm_tracing_enabled: apm_tracing_enabled,
@@ -416,6 +418,7 @@ module Datadog
           # Ignore start time if a block has been given
           trace.measure(
             name,
+            logger: logger,
             events: events,
             on_error: on_error,
             resource: resource,
@@ -429,6 +432,7 @@ module Datadog
           # Return the new span
           span = trace.build_span(
             name,
+            logger: logger,
             events: events,
             on_error: on_error,
             resource: resource,
@@ -541,10 +545,10 @@ module Datadog
 
       # TODO: Make these dummy objects singletons to preserve memory.
       def skip_trace(name)
-        span = SpanOperation.new(name)
+        span = SpanOperation.new(name, logger: logger)
 
         if block_given?
-          trace = TraceOperation.new
+          trace = TraceOperation.new(logger: logger)
           yield(span, trace)
         else
           span

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -412,7 +412,7 @@ module Datadog
       )
         trace = _trace || start_trace(continue_from: continue_from)
 
-        events = SpanOperation::Events.new
+        events = SpanOperation::Events.new(logger: logger)
 
         if block
           # Ignore start time if a block has been given

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -99,7 +99,7 @@ module Datadog
 
         attr_reader before_start: untyped
 
-        def initialize: (?on_error: on_error) -> void
+        def initialize: (?logger: Core::Logger, ?on_error: on_error) -> void
 
         def on_error: () -> OnError
 
@@ -116,7 +116,7 @@ module Datadog
         end
 
         class OnError
-          def initialize: (untyped default) -> void
+          def initialize: (untyped default, ?logger: Core::Logger) -> void
 	
           attr_reader logger: Core::Logger
 

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -5,6 +5,10 @@ module Datadog
       include Metadata::Tagging
       include Metadata::Errors
       prepend Metadata::Analytics
+      
+      @logger: Core::Logger
+      
+      attr_reader logger: Core::Logger
 
       attr_reader links: untyped
 
@@ -86,6 +90,8 @@ module Datadog
         include Tracing::Events
 
         DEFAULT_ON_ERROR: on_error
+	
+	attr_reader logger: Core::Logger
 
         attr_reader after_finish: untyped
 
@@ -111,6 +117,8 @@ module Datadog
 
         class OnError
           def initialize: (untyped default) -> void
+	
+          attr_reader logger: Core::Logger
 
           def wrap_default: () { (untyped, untyped) -> untyped } -> untyped
 

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -4,6 +4,10 @@ module Datadog
       include Metadata::Tagging
 
       DEFAULT_MAX_LENGTH: ::Integer
+      
+      @logger: Core::Logger
+      
+      attr_reader logger: Core::Logger
 
       attr_accessor agent_sample_rate: untyped
       attr_accessor hostname: untyped

--- a/sig/datadog/tracing/tracer.rbs
+++ b/sig/datadog/tracing/tracer.rbs
@@ -1,6 +1,11 @@
 module Datadog
   module Tracing
     class Tracer
+      
+      @logger: Core::Logger
+
+      attr_reader logger: Core::Logger
+
       def active_root_span: (?untyped? key) -> Datadog::Tracing::Span
 
       def active_span: (?untyped? key) -> Datadog::Tracing::Span


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Replaces global references `Datadog.logger` with injected `logger` instances in tracing operations

**Motivation:**
Continuing to inject logger into tracer classes
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->


**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
