### PR TITLE
Add a gatekeeper job for PR

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -16,17 +16,18 @@ permissions:
 jobs:
   all-jobs-are-green:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Run Ensure CI Success
-        uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754
+        uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754 # v2.1.1
         with:
           # How long to wait before we start checking the job status
           # GitHub's API has a limit, so this helps avoid making too many calls
           # Note: If the job is retried, we'll check it once right away before waiting
-          initial-delay-seconds: "900"
+          initial-delay-seconds: 900
 
           # How long to wait between each check
-          max-retries: "60"
+          max-retries: 60
 
           # Sleep time between each check (default: 60 seconds)
           # polling-interval-seconds: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Ensure CI Success
-        uses: DataDog/ensure-ci-success@1517bce5564037de6a02562a6b4f119503c9781d
+        uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754
         with:
           initial-delay-seconds: "900"
           max-retries: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Ensure CI Success
-        uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
+        uses: DataDog/ensure-ci-success@1517bce5564037de6a02562a6b4f119503c9781d
         with:
           initial-delay-seconds: "900"
           max-retries: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -2,10 +2,8 @@ name: Check Pull Request CI Status
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,0 +1,26 @@
+name: Check Pull Request CI Status
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  statuses: read
+
+jobs:
+  all-jobs-are-green:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Ensure CI Success
+        uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
+        with:
+          initial-delay-seconds: "600"
+          max-retries: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run Ensure CI Success
         uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
         with:
-          initial-delay-seconds: "600"
+          initial-delay-seconds: "900"
           max-retries: "60"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -20,5 +20,19 @@ jobs:
       - name: Run Ensure CI Success
         uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754
         with:
+          # How long to wait before we start checking the job status
+          # GitHub's API has a limit, so this helps avoid making too many calls
+          # Note: If the job is retried, we'll check it once right away before waiting
           initial-delay-seconds: "900"
+
+          # How long to wait between each check
           max-retries: "60"
+
+          # Sleep time between each check (default: 60 seconds)
+          # polling-interval-seconds: "60"
+
+          # Excluded jobs names, each line is a regular expression that must fullm atch the job name
+          # it's currently empty, but here is an example:
+          # ignored-name-patterns: |
+          #   .*-test-flaky
+          #   useless-job

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,6 +1,6 @@
 name: Check Pull Request CI Status
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - opened


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Add a job in the CI that runs in PR. The job will be a success if all other jobs are skipped/success, and fails otherwise

**Motivation:**

While it's possible to enforce a green CI policy using GitHub's native "required status checks" feature, doing so requires explicitly listing all job names under branch protection rules. This approach has two key drawbacks:

- It does not support optional jobs
- It introduces ongoing maintenance overhead as the job list evolves

We can also add "job that runs at the end of each workflows", and make them a requirement, but we need to do so for each workflow. This jobs achieve the same, but all-in-one by checking all jobs that are executed for a PR. 

The action used offers a `ignored-name-patterns` parameters`, but right now, dd-trace-rb CI seems to be in a very good health, so it's empty.

The two other parameters are only for the retry logic. Please not that an itinitial check is performed before the initial delay, to handle the use case where somebody re-run all-green when all other are green.

The plan is to merge this PR, wait few days to be sure that everything is fine. Then add it as a requirement.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
