### PR TITLE
[NO-TICKET] Add logging during configuration initialization

### DIFF
--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe Datadog::Core::Configuration do
 
       context 'when debug mode' do
         it 'is toggled with default settings' do
+          # If configuration is not initialized, and components neither, we create a temporary logger with debug level
+          # In order to test that the default log level is INFO, we need to ensure that configuration is initialized.
+          test_class.configuration
+
           # Assert initial state
           expect(test_class.logger.level).to be default_log_level
 
@@ -403,13 +407,58 @@ RSpec.describe Datadog::Core::Configuration do
       subject(:logger) { test_class.logger }
 
       it { is_expected.to be_a_kind_of(Datadog::Core::Logger) }
-      it { expect(logger.level).to be default_log_level }
 
-      context 'when components are not initialized' do
+      it 'has the default log level' do
+        # If configuration is not initialized, and components neither, we create a temporary logger with debug level
+        # In order to test that the default log level is INFO, we need to ensure that configuration is initialized.
+        test_class.configuration
+
+        expect(logger.level).to be default_log_level
+      end
+
+      context 'when components are not initialized but configuration is' do
+        before do
+          test_class.configuration
+        end
+
+        it 'calls logger_without_components' do
+          expect(test_class).to receive(:logger_without_components)
+
+          logger
+        end
+
+        it 'does not call logger_without_configuration' do
+          expect(test_class).to_not receive(:logger_without_configuration)
+
+          logger
+        end
+
         it 'does not cause them to be initialized' do
           logger
 
           expect(test_class.send(:components?)).to be false
+        end
+      end
+
+      context 'when configuration is not initialized' do
+        it { expect(logger.level).to be ::Logger::DEBUG }
+
+        it 'calls logger_without_configuration' do
+          expect(test_class).to receive(:logger_without_configuration)
+
+          logger
+        end
+
+        it 'does not call configuration' do
+          expect(test_class).to_not receive(:configuration)
+
+          logger
+        end
+
+        it 'returns a logger without configuration' do
+          logger
+
+          expect(logger).to be_a_kind_of(Datadog::Core::Logger)
         end
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR adds a default logger during configuration initialization.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
During config initialization, stable config will be able to log errors related to reading or parsing config files. But when doing this, configuration isn't loaded. `logger_without_components` still rely on configuration, and will create an infinite loop.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
CI.

<!-- Unsure? Have a question? Request a review! -->
