### PR TITLE
Repair warning message when worker does not end promptly

### DIFF
--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -53,7 +53,7 @@ module Datadog
                 worker.join
               end
             rescue Timeout::Error
-              Datadog.logger.debug { "Worker thread did not end after 0.5 seconds: #{self}" }
+              Datadog.logger.debug { "Worker thread did not end after #{SHUTDOWN_TIMEOUT} seconds: #{self}" }
             end
             true
           end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Repairs warning message to reflect the actual timeout
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
In https://github.com/DataDog/dd-trace-rb/pull/4588 I changed 0.5 second timeout to SHUTDOWN_TIMEOUT per review comments but forgot to update the warning message
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
