### PR TITLE
[NO-TICKET] Fix logger_without_configuration always being on DEBUG level

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -278,7 +278,6 @@ module Datadog
       def logger_without_components
         # Use default logger without initializing components.
         # This enables logging during initialization, otherwise we'd run into deadlocks.
-        return logger_without_configuration unless configuration?
 
         @temp_logger ||= begin
           logger = configuration.logger.instance || Core::Logger.new($stdout)

--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -290,9 +290,15 @@ module Datadog
       def logger_without_configuration
         # There's rare cases where we need to use logger during configuration initialization,
         # such as reading stable config. In this case we cannot access configuration.
+
         @temp_config_logger ||= begin
+          debug_env_var = ENV[Ext::Diagnostics::ENV_DEBUG_ENABLED]
+          debug_env_value = debug_env_var&.strip&.downcase
+          debug_value = debug_env_value == 'true' || debug_env_value == '1' # rubocop:disable Style/MultipleComparison
+
           logger = Core::Logger.new($stdout)
-          logger.level = ::Logger::DEBUG
+          # We cannot access config and the default level is INFO, so we need to set the level manually
+          logger.level = debug_value ? ::Logger::DEBUG : ::Logger::INFO
           logger
         end
       end

--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -291,8 +291,7 @@ module Datadog
         # such as reading stable config. In this case we cannot access configuration.
 
         @temp_config_logger ||= begin
-          debug_env_var = ENV[Ext::Diagnostics::ENV_DEBUG_ENABLED]
-          debug_env_value = debug_env_var&.strip&.downcase
+          debug_env_value = ENV[Ext::Diagnostics::ENV_DEBUG_ENABLED]&.strip&.downcase
           debug_value = debug_env_value == 'true' || debug_env_value == '1' # rubocop:disable Style/MultipleComparison
 
           logger = Core::Logger.new($stdout)

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -442,17 +442,8 @@ RSpec.describe Datadog::Core::Configuration do
 
     describe '#logger_without_configuration' do
       subject(:logger_without_configuration) { test_class.send(:logger_without_configuration) }
-
-      it { is_expected.to be_a_kind_of(Datadog::Core::Logger) }
-
       context 'when configuration is not initialized and DD_TRACE_DEBUG is not set' do
         it { expect(logger_without_configuration.level).to be ::Logger::INFO }
-
-        it 'returns a logger' do
-          logger_without_configuration
-
-          expect(logger_without_configuration).to be_a_kind_of(Datadog::Core::Logger)
-        end
       end
 
       context 'when configuration is not initialized and DD_TRACE_DEBUG is set' do

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -407,69 +407,14 @@ RSpec.describe Datadog::Core::Configuration do
       subject(:logger) { test_class.logger }
 
       it { is_expected.to be_a_kind_of(Datadog::Core::Logger) }
+      it { expect(logger.level).to be ::Logger::INFO }
 
-      it 'has the default log level' do
-        # If configuration is not initialized, and components neither, we create a temporary logger with debug level
-        # In order to test that the default log level is INFO, we need to ensure that configuration is initialized.
-        test_class.configuration
-
-        expect(logger.level).to be default_log_level
-      end
-
-      context 'when components are not initialized but configuration is' do
-        before do
-          test_class.configuration
-        end
-
-        it 'calls logger_without_components' do
-          expect(test_class).to receive(:logger_without_components)
-
-          logger
-        end
-
-        it 'does not call logger_without_configuration' do
-          expect(test_class).to_not receive(:logger_without_configuration)
-
-          logger
-        end
-
+      context 'when components are not initialized' do
         it 'does not cause them to be initialized' do
           logger
 
           expect(test_class.send(:components?)).to be false
         end
-      end
-
-      context 'when configuration is not initialized and DD_TRACE_DEBUG is not set' do
-        it { expect(logger.level).to be ::Logger::INFO }
-
-        it 'calls logger_without_configuration' do
-          expect(test_class).to receive(:logger_without_configuration)
-
-          logger
-        end
-
-        it 'does not call configuration' do
-          expect(test_class).to_not receive(:configuration)
-
-          logger
-        end
-
-        it 'returns a logger without configuration' do
-          logger
-
-          expect(logger).to be_a_kind_of(Datadog::Core::Logger)
-        end
-      end
-
-      context 'when configuration is not initialized and DD_TRACE_DEBUG is set' do
-        around do |example|
-          ClimateControl.modify('DD_TRACE_DEBUG' => 'true') do
-            example.run
-          end
-        end
-
-        it { expect(logger.level).to be ::Logger::DEBUG }
       end
 
       context 'when components are being replaced' do
@@ -492,6 +437,32 @@ RSpec.describe Datadog::Core::Configuration do
 
           expect(logger_during_component_replacement).to be old_logger
         end
+      end
+    end
+
+    describe '#logger_without_configuration' do
+      subject(:logger_without_configuration) { test_class.send(:logger_without_configuration) }
+
+      it { is_expected.to be_a_kind_of(Datadog::Core::Logger) }
+
+      context 'when configuration is not initialized and DD_TRACE_DEBUG is not set' do
+        it { expect(logger_without_configuration.level).to be ::Logger::INFO }
+
+        it 'returns a logger' do
+          logger_without_configuration
+
+          expect(logger_without_configuration).to be_a_kind_of(Datadog::Core::Logger)
+        end
+      end
+
+      context 'when configuration is not initialized and DD_TRACE_DEBUG is set' do
+        around do |example|
+          ClimateControl.modify('DD_TRACE_DEBUG' => 'true') do
+            example.run
+          end
+        end
+
+        it { expect(logger_without_configuration.level).to be ::Logger::DEBUG }
       end
     end
 

--- a/spec/datadog/core/configuration_spec.rb
+++ b/spec/datadog/core/configuration_spec.rb
@@ -440,8 +440,8 @@ RSpec.describe Datadog::Core::Configuration do
         end
       end
 
-      context 'when configuration is not initialized' do
-        it { expect(logger.level).to be ::Logger::DEBUG }
+      context 'when configuration is not initialized and DD_TRACE_DEBUG is not set' do
+        it { expect(logger.level).to be ::Logger::INFO }
 
         it 'calls logger_without_configuration' do
           expect(test_class).to receive(:logger_without_configuration)
@@ -460,6 +460,16 @@ RSpec.describe Datadog::Core::Configuration do
 
           expect(logger).to be_a_kind_of(Datadog::Core::Logger)
         end
+      end
+
+      context 'when configuration is not initialized and DD_TRACE_DEBUG is set' do
+        around do |example|
+          ClimateControl.modify('DD_TRACE_DEBUG' => 'true') do
+            example.run
+          end
+        end
+
+        it { expect(logger.level).to be ::Logger::DEBUG }
       end
 
       context 'when components are being replaced' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Fix `logger_without_configuration` always being set to DEBUG.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
It makes datadog-ci-rb's CI fail.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
CI.

<!-- Unsure? Have a question? Request a review! -->
