### PR TITLE
Properly reset telemetry state in tests

### DIFF
--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -66,9 +66,10 @@ module Datadog
         end
 
         def enqueue(event)
-          return if !enabled? || forked?
+          return false if !enabled? || forked?
 
           buffer.push(event)
+          true
         end
 
         def sent_started_event?

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -52,10 +52,15 @@ module Datadog
 
         attr_reader :logger
 
+        # Returns true if worker thread is successfully started,
+        # false if worker thread was not started but telemetry is enabled,
+        # nil if telemetry is disabled.
         def start
           return if !enabled? || forked?
 
           # starts async worker
+          # perform should return true if thread was actually started,
+          # false otherwise
           perform
         end
 

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -137,6 +137,8 @@ module Datadog
 
         def flush_events(events)
           return if events.empty?
+          # TODO can this method silently drop events which are
+          # generated prior to the started event being submitted?
           return if !enabled? || !sent_started_event?
 
           events = deduplicate_logs(events)

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -137,7 +137,7 @@ module Datadog
 
         def flush_events(events)
           return if events.empty?
-          # TODO can this method silently drop events which are
+          # TODO: can this method silently drop events which are
           # generated prior to the started event being submitted?
           return if !enabled? || !sent_started_event?
 

--- a/lib/datadog/core/telemetry/worker.rb
+++ b/lib/datadog/core/telemetry/worker.rb
@@ -65,8 +65,12 @@ module Datadog
           super
         end
 
+        # Returns true if event was enqueued, nil if not.
+        # While returning false may seem more reasonable, the only reason
+        # for not enqueueing event (presently) is that telemetry is disabled
+        # altogether, and in this case other methods return nil.
         def enqueue(event)
-          return false if !enabled? || forked?
+          return if !enabled? || forked?
 
           buffer.push(event)
           true

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -120,23 +120,33 @@ module Datadog
             @worker ||= nil
           end
 
+          # Returns true if worker thread is successfully started,
+          # false if it is not started. Reasons for not starting the worker
+          # thread: it is already running, or the process forked and fork
+          # policy is to stop the workers on fork (which means they are
+          # not started in children, really).
           def start_async(&block)
             mutex.synchronize do
-              return if running?
+              return false if running?
 
               if forked?
                 case fork_policy
                 when FORK_POLICY_STOP
                   stop_fork
+                  false
                 when FORK_POLICY_RESTART
+                  # restart_after_fork should return true
                   restart_after_fork(&block)
                 end
               elsif !run_async?
+                # start_worker should return true
                 start_worker(&block)
               end
             end
           end
 
+          # Returns true if worker thread is successfully started,
+          # which should generally be always.
           def start_worker
             @run_async = true
             @pid = Process.pid
@@ -159,7 +169,7 @@ module Datadog
             @worker.name = self.class.name
             @worker.thread_variable_set(:fork_safe, true)
 
-            nil
+            true
           end
 
           def stop_fork

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -153,7 +153,8 @@ RSpec.describe 'Telemetry integration tests' do
       mark_telemetry_started
 
       it 'sends expected payload' do
-        component.error('test error')
+        ok = component.error('test error')
+        expect(ok).to be true
 
         component.flush
         expect(sent_payloads.length).to eq 1

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -377,6 +377,9 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
   end
 
   describe '#enqueue' do
+    # Telemetry may drop events silently if it is not started?
+    mark_telemetry_started
+
     it 'adds events to the buffer and flushes them later' do
       events_received = 0
       mutex = Mutex.new

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -395,7 +395,8 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
         response
       end
 
-      worker.start
+      ok = worker.start
+      expect(ok).to be true
 
       events_sent = 3
       events_sent.times do

--- a/spec/datadog/core/telemetry/worker_spec.rb
+++ b/spec/datadog/core/telemetry/worker_spec.rb
@@ -368,7 +368,8 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
         response
       end
 
-      worker.enqueue(Datadog::Core::Telemetry::Event::AppIntegrationsChange.new)
+      ok = worker.enqueue(Datadog::Core::Telemetry::Event::AppIntegrationsChange.new)
+      expect(ok).to be true
       worker.stop(true)
 
       try_wait_until { events_received == 1 }
@@ -395,7 +396,8 @@ RSpec.describe Datadog::Core::Telemetry::Worker do
 
       events_sent = 3
       events_sent.times do
-        worker.enqueue(Datadog::Core::Telemetry::Event::AppIntegrationsChange.new)
+        ok = worker.enqueue(Datadog::Core::Telemetry::Event::AppIntegrationsChange.new)
+        expect(ok).to be true
       end
 
       try_wait_until { events_received == events_sent }

--- a/spec/datadog/core/workers/async_spec.rb
+++ b/spec/datadog/core/workers/async_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe Datadog::Core::Workers::Async::Thread do
           )
         end
 
-        it 'returns nil' do
-          expect(perform).to be nil
+        it 'returns true' do
+          expect(perform).to be true
         end
       end
     end

--- a/spec/support/telemetry_helpers.rb
+++ b/spec/support/telemetry_helpers.rb
@@ -2,9 +2,11 @@ module TelemetryHelpers
   module ClassMethods
     def mark_telemetry_started
       before do
+        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.send(:reset_ran_once_state_for_tests)
         Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
           true
         end
+        expect(Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE).to be_success
       end
     end
   end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
For tests that expect telemetry to be started, the run once state still needs to be reset before setting it to true - because a previous test may have failed initialization (intentionally), and without resetting that failure stays around for subsequent tests.

This PR also adds additional assertions on return values I used for debugging to ensure workers are started and events are accepted.

**Motivation:**
Flaky telemetry tests in CI
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing CI
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
