### PR TITLE
DEBUG-3700 Inject telemetry into metrics client

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -42,13 +42,13 @@ module Datadog
             logger
           end
 
-          def build_runtime_metrics(settings, logger)
+          def build_runtime_metrics(settings, logger, telemetry)
             options = { enabled: settings.runtime_metrics.enabled }
             options[:statsd] = settings.runtime_metrics.statsd unless settings.runtime_metrics.statsd.nil?
             options[:services] = [settings.service] unless settings.service.nil?
             options[:experimental_runtime_id_enabled] = settings.runtime_metrics.experimental_runtime_id_enabled
 
-            Core::Runtime::Metrics.new(logger: logger, **options)
+            Core::Runtime::Metrics.new(logger: logger, telemetry: telemetry, **options)
           end
 
           def build_runtime_metrics_worker(settings, logger)
@@ -119,7 +119,7 @@ module Datadog
           )
           @environment_logger_extra.merge!(profiler_logger_extra) if profiler_logger_extra
 
-          @runtime_metrics = self.class.build_runtime_metrics_worker(settings, @logger)
+          @runtime_metrics = self.class.build_runtime_metrics_worker(settings, @logger, telemetry)
           @health_metrics = self.class.build_health_metrics(settings, @logger, telemetry)
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -59,7 +59,7 @@ module Datadog
               logger: logger,
             )
 
-            Core::Workers::RuntimeMetrics.new(options)
+            Core::Workers::RuntimeMetrics.new(telemetry: telemetry, **options)
           end
 
           def build_telemetry(settings, agent_settings, logger)

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -51,11 +51,11 @@ module Datadog
             Core::Runtime::Metrics.new(logger: logger, telemetry: telemetry, **options)
           end
 
-          def build_runtime_metrics_worker(settings, logger)
+          def build_runtime_metrics_worker(settings, logger, telemetry)
             # NOTE: Should we just ignore building the worker if its not enabled?
             options = settings.runtime_metrics.opts.merge(
               enabled: settings.runtime_metrics.enabled,
-              metrics: build_runtime_metrics(settings, logger),
+              metrics: build_runtime_metrics(settings, logger, telemetry),
               logger: logger,
             )
 

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -27,12 +27,12 @@ module Datadog
         class << self
           include Datadog::Tracing::Component
 
-          def build_health_metrics(settings, logger)
+          def build_health_metrics(settings, logger, telemetry)
             settings = settings.health_metrics
             options = { enabled: settings.enabled }
             options[:statsd] = settings.statsd unless settings.statsd.nil?
 
-            Core::Diagnostics::Health::Metrics.new(logger: logger, **options)
+            Core::Diagnostics::Health::Metrics.new(telemetry: telemetry, logger: logger, **options)
           end
 
           def build_logger(settings)
@@ -120,7 +120,7 @@ module Datadog
           @environment_logger_extra.merge!(profiler_logger_extra) if profiler_logger_extra
 
           @runtime_metrics = self.class.build_runtime_metrics_worker(settings, @logger)
-          @health_metrics = self.class.build_health_metrics(settings, @logger)
+          @health_metrics = self.class.build_health_metrics(settings, @logger, telemetry)
           @appsec = Datadog::AppSec::Component.build_appsec_component(settings, telemetry: telemetry)
           @dynamic_instrumentation = Datadog::DI::Component.build(settings, agent_settings, @logger, telemetry: telemetry)
           @environment_logger_extra[:dynamic_instrumentation_enabled] = !!@dynamic_instrumentation

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -21,9 +21,10 @@ module Datadog
         extend Options
         extend Helpers
 
-        attr_reader :statsd, :logger
+        attr_reader :statsd, :logger, :telemetry
 
-        def initialize(logger: Datadog.logger, statsd: nil, enabled: true, **_)
+        def initialize(telemetry: nil, logger: Datadog.logger, statsd: nil, enabled: true, **_)
+          @telemetry = telemetry
           @logger = logger
           @statsd =
             if supported?
@@ -102,7 +103,7 @@ module Datadog
           logger.error(
             "Failed to send count stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          Telemetry::Logger.report(e, description: 'Failed to send count stat')
+          telemetry&.report(e, description: 'Failed to send count stat')
         end
 
         def distribution(stat, value = nil, options = nil, &block)
@@ -116,7 +117,7 @@ module Datadog
           logger.error(
             "Failed to send distribution stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          Telemetry::Logger.report(e, description: 'Failed to send distribution stat')
+          telemetry&.report(e, description: 'Failed to send distribution stat')
         end
 
         def increment(stat, options = nil)
@@ -129,7 +130,7 @@ module Datadog
           logger.error(
             "Failed to send increment stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          Telemetry::Logger.report(e, description: 'Failed to send increment stat')
+          telemetry&.report(e, description: 'Failed to send increment stat')
         end
 
         def gauge(stat, value = nil, options = nil, &block)
@@ -143,7 +144,7 @@ module Datadog
           logger.error(
             "Failed to send gauge stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          Telemetry::Logger.report(e, description: 'Failed to send gauge stat')
+          telemetry&.report(e, description: 'Failed to send gauge stat')
         end
 
         def time(stat, options = nil)
@@ -163,7 +164,7 @@ module Datadog
             logger.error(
               "Failed to send time stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
             )
-            Telemetry::Logger.report(e, description: 'Failed to send time stat')
+            telemetry&.report(e, description: 'Failed to send time stat')
           end
         end
 

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -23,7 +23,7 @@ module Datadog
 
         attr_reader :statsd, :logger, :telemetry
 
-        def initialize(telemetry: nil, logger: Datadog.logger, statsd: nil, enabled: true, **_)
+        def initialize(telemetry:, logger: Datadog.logger, statsd: nil, enabled: true, **_)
           @telemetry = telemetry
           @logger = logger
           @statsd =

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -103,7 +103,7 @@ module Datadog
           logger.error(
             "Failed to send count stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          telemetry&.report(e, description: 'Failed to send count stat')
+          telemetry.report(e, description: 'Failed to send count stat')
         end
 
         def distribution(stat, value = nil, options = nil, &block)
@@ -117,7 +117,7 @@ module Datadog
           logger.error(
             "Failed to send distribution stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          telemetry&.report(e, description: 'Failed to send distribution stat')
+          telemetry.report(e, description: 'Failed to send distribution stat')
         end
 
         def increment(stat, options = nil)
@@ -130,7 +130,7 @@ module Datadog
           logger.error(
             "Failed to send increment stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          telemetry&.report(e, description: 'Failed to send increment stat')
+          telemetry.report(e, description: 'Failed to send increment stat')
         end
 
         def gauge(stat, value = nil, options = nil, &block)
@@ -144,7 +144,7 @@ module Datadog
           logger.error(
             "Failed to send gauge stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
-          telemetry&.report(e, description: 'Failed to send gauge stat')
+          telemetry.report(e, description: 'Failed to send gauge stat')
         end
 
         def time(stat, options = nil)
@@ -164,7 +164,7 @@ module Datadog
             logger.error(
               "Failed to send time stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
             )
-            telemetry&.report(e, description: 'Failed to send time stat')
+            telemetry.report(e, description: 'Failed to send time stat')
           end
         end
 

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -14,7 +14,7 @@ module Datadog
     module Runtime
       # For generating runtime metrics
       class Metrics < Core::Metrics::Client
-        def initialize(**options)
+        def initialize(telemetry:, **options)
           super
 
           # Initialize service list

--- a/lib/datadog/core/workers/runtime_metrics.rb
+++ b/lib/datadog/core/workers/runtime_metrics.rb
@@ -20,8 +20,8 @@ module Datadog
         attr_reader \
           :metrics
 
-        def initialize(options = {})
-          @metrics = options.fetch(:metrics) { Core::Runtime::Metrics.new(logger: options[:logger]) }
+        def initialize(telemetry:, **options)
+          @metrics = options.fetch(:metrics) { Core::Runtime::Metrics.new(logger: options[:logger], telemetry: telemetry) }
 
           # Workers::Async::Thread settings
           self.fork_policy = options.fetch(:fork_policy, Workers::Async::Thread::FORK_POLICY_STOP)

--- a/sig/datadog/core/metrics/client.rbs
+++ b/sig/datadog/core/metrics/client.rbs
@@ -13,7 +13,7 @@ module Datadog
         attr_reader statsd: untyped
 	attr_reader logger: Core::Logger
 
-        def initialize: (?statsd: untyped?, ?enabled: bool, logger: Core::Logger, **untyped _) -> void
+        def initialize: (telemetry: Core::Telemetry::Component, ?statsd: untyped?, ?enabled: bool, logger: Core::Logger, **untyped _) -> void
 
         def supported?: () -> untyped
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         .and_return(runtime_metrics)
 
       expect(described_class).to receive(:build_health_metrics)
-        .with(settings, logger)
+        .with(settings, logger, telemetry)
         .and_return(health_metrics)
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   end
 
   describe '::build_health_metrics' do
-    subject(:build_health_metrics) { described_class.build_health_metrics(settings, logger) }
+    subject(:build_health_metrics) { described_class.build_health_metrics(settings, logger, telemetry) }
 
     context 'given settings' do
       shared_examples_for 'new health metrics' do
@@ -165,7 +165,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         before do
           expect(Datadog::Core::Diagnostics::Health::Metrics).to receive(:new)
-            .with(default_options.merge(options).merge(logger: logger))
+            .with(default_options.merge(options).merge(logger: logger, telemetry: telemetry))
             .and_return(health_metrics)
         end
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
       ).and_return([profiler, environment_logger_extra])
 
       expect(described_class).to receive(:build_runtime_metrics_worker)
-        .with(settings, logger)
+        .with(settings, logger, telemetry)
         .and_return(runtime_metrics)
 
       expect(described_class).to receive(:build_health_metrics)
@@ -291,7 +291,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   end
 
   describe '::build_runtime_metrics' do
-    subject(:build_runtime_metrics) { described_class.build_runtime_metrics(settings, logger) }
+    subject(:build_runtime_metrics) { described_class.build_runtime_metrics(settings, logger, telemetry) }
 
     context 'given settings' do
       shared_examples_for 'new runtime metrics' do
@@ -305,7 +305,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         before do
           expect(Datadog::Core::Runtime::Metrics).to receive(:new)
-            .with(default_options.merge(options).merge(logger: logger))
+            .with(**default_options.merge(options).merge(logger: logger, telemetry: telemetry))
             .and_return(runtime_metrics)
         end
 
@@ -375,7 +375,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
   end
 
   describe '::build_runtime_metrics_worker' do
-    subject(:build_runtime_metrics_worker) { described_class.build_runtime_metrics_worker(settings, logger) }
+    subject(:build_runtime_metrics_worker) { described_class.build_runtime_metrics_worker(settings, logger, telemetry) }
 
     context 'given settings' do
       shared_examples_for 'new runtime metrics worker' do
@@ -391,11 +391,11 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         before do
           allow(described_class).to receive(:build_runtime_metrics)
-            .with(settings, logger)
+            .with(settings, logger, telemetry)
             .and_return(runtime_metrics)
 
           expect(Datadog::Core::Workers::RuntimeMetrics).to receive(:new)
-            .with(default_options.merge(options).merge(logger: logger))
+            .with(**default_options.merge(options).merge(logger: logger, telemetry: telemetry))
             .and_return(runtime_metrics_worker)
         end
 

--- a/spec/datadog/core/metrics/client_spec.rb
+++ b/spec/datadog/core/metrics/client_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Datadog::Core::Metrics::Client do
   include_context 'metrics'
 
   let(:logger) { Logger.new($stderr) }
+  let(:telemetry) { double(Datadog::Core::Telemetry::Component) }
   let(:options) { { statsd: statsd } }
 
-  subject(:metrics) { described_class.new(logger: logger, **options) }
+  subject(:metrics) { described_class.new(telemetry: telemetry, logger: logger, **options) }
   after { metrics.close }
 
   it { is_expected.to have_attributes(statsd: statsd) }
@@ -19,7 +20,7 @@ RSpec.describe Datadog::Core::Metrics::Client do
       expect(logger).to receive(:error).with(
         /Failed to send #{action} stat/
       )
-      expect(Datadog::Core::Telemetry::Logger).to receive(:report).with(
+      expect(telemetry).to receive(:report).with(
         a_kind_of(StandardError),
         description: "Failed to send #{action} stat"
       )
@@ -758,6 +759,7 @@ RSpec.describe Datadog::Core::Metrics::Client do
       context 'which raises an error' do
         before do
           expect(statsd).to receive(:distribution).and_raise(StandardError)
+          expect(telemetry).to receive(:report)
           expect(logger).to receive(:error)
         end
 

--- a/spec/datadog/core/metrics/logging_spec.rb
+++ b/spec/datadog/core/metrics/logging_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Datadog::Core::Metrics::Logging::Adapter do
   subject(:adapter) { described_class.new(logger) }
 
   let(:logger) { instance_double(Logger) }
+  let(:telemetry) { double(Datadog::Core::Telemetry::Component) }
 
   def have_received_json_metric(expected_hash)
     have_received(:info) do |msg|
@@ -121,7 +122,7 @@ RSpec.describe Datadog::Core::Metrics::Logging::Adapter do
   end
 
   context 'when used in Datadog::Metrics' do
-    subject(:metrics) { Datadog::Core::Metrics::Client.new(statsd: adapter, logger: logger) }
+    subject(:metrics) { Datadog::Core::Metrics::Client.new(statsd: adapter, logger: logger, telemetry: telemetry) }
 
     describe 'and #count is sent' do
       subject(:count) { metrics.count(stat, value, options) }

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -5,8 +5,9 @@ require 'datadog/core/runtime/metrics'
 
 RSpec.describe Datadog::Core::Runtime::Metrics do
   let(:logger) { logger_allowing_debug }
+  let(:telemetry) { double(Datadog::Core::Telemetry::Component) }
   let(:options) { {} }
-  subject(:runtime_metrics) { described_class.new(logger: logger, **options) }
+  subject(:runtime_metrics) { described_class.new(logger: logger, telemetry: telemetry, **options) }
 
   describe '::new' do
     context 'given :services' do

--- a/spec/datadog/core/workers/runtime_metrics_spec.rb
+++ b/spec/datadog/core/workers/runtime_metrics_spec.rb
@@ -4,12 +4,13 @@ require 'datadog'
 require 'datadog/core/workers/runtime_metrics'
 
 RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
-  subject(:worker) { described_class.new(options) }
+  subject(:worker) { described_class.new(telemetry: telemetry, **options) }
 
   let(:metrics) { instance_double(Datadog::Core::Runtime::Metrics, close: nil) }
   let(:options) { { metrics: metrics, enabled: true } }
 
   let(:logger) { logger_allowing_debug }
+  let(:telemetry) { double(Datadog::Core::Telemetry::Component) }
 
   before { allow(metrics).to receive(:flush) }
 
@@ -19,7 +20,7 @@ RSpec.describe Datadog::Core::Workers::RuntimeMetrics do
     it { expect(worker).to be_a_kind_of(Datadog::Core::Workers::Polling) }
 
     context 'by default' do
-      subject(:worker) { described_class.new(logger: logger) }
+      subject(:worker) { described_class.new(logger: logger, telemetry: telemetry) }
 
       it { expect(worker.enabled?).to be false }
       it { expect(worker.loop_base_interval).to eq 10 }

--- a/spec/datadog/tracing/diagnostics/health_spec.rb
+++ b/spec/datadog/tracing/diagnostics/health_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Datadog::Tracing::Diagnostics::Health::Metrics do
   # TODO: Core::Health::Metrics directly extends Tracing::Health::Metrics
   #       In the future, have tracing add this behavior itself. For now,
   #       just use the core metrics class to drive the tests.
-  subject(:health_metrics) { Datadog::Core::Diagnostics::Health::Metrics.new(logger: logger) }
+  subject(:health_metrics) { Datadog::Core::Diagnostics::Health::Metrics.new(logger: logger, telemetry: telemetry) }
 
   let(:logger) { logger_allowing_debug }
+  let(:telemetry) { double(Datadog::Core::Telemetry::Component) }
 
   shared_examples_for 'a health metric' do |type, name, stat|
     subject(:health_metric) { health_metrics.send(name, *args, &block) }


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Injects telemetry into metrics client instead of retrieving it from the components tree.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
References to the components tree currently create the tree if it does not exist by default (`allow_initialization` option to `components`). This creation is problematic in the test suite (see https://github.com/DataDog/dd-trace-rb/pull/4619). Some components appear to rely on this automatic instantiation (profiling, possibly tracing), therefore removing it is non-trivial. In the meantime, metrics client can have telemetry injected into it to avoid the issue altogether (and remove what is effectively a global variable reference).

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Existing CI

<!-- Unsure? Have a question? Request a review! -->
