### PR TITLE
DEBUG-3573 Add integration test for telemetry app-heartbeat event payloads

### DIFF
--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Telemetry integration tests' do
         'hostname' => String,
         'kernel_name' => String,
         'kernel_release' => String,
-        'kernel_version' => String,
+        'kernel_version' => (RUBY_ENGINE == 'jruby' ? nil : String),
       }
     end
 

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe 'Telemetry integration tests' do
     end
 
     describe 'heartbeat event' do
-      include_context 'mark telemetry started'
+      mark_telemetry_started
 
       it 'sends expected payload' do
         component.worker.send(:heartbeat!)

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -157,7 +157,8 @@ RSpec.describe 'Telemetry integration tests' do
     end
 
     describe 'error event' do
-      include_context 'mark telemetry started'
+      # To avoid noise from the startup events, turn those off.
+      mark_telemetry_started
 
       it 'sends expected payload' do
         component.error('test error')

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe 'Telemetry integration tests' do
 
     let(:expected_products_hash) do
       {
-        'appsec' => {'enabled' => false},
-        'profiler' => {'enabled' => false},
+        'appsec' => { 'enabled' => false },
+        'profiler' => { 'enabled' => false },
       }
     end
 

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe 'Telemetry integration tests' do
       it 'sends expected startup events' do
         expect(settings.telemetry.dependency_collection).to be true
 
+        # Profiling will return the unsupported reason, and telemetry will
+        # report it as an error, even if profiling was not requested to
+        # be enabled.
+        # The most common unsupported reason is failure to load profiling
+        # C extension due to it not having been compiled - we get that in
+        # some CI configurations.
+        expect(Datadog::Profiling).to receive(:enabled?).and_return(false)
+        expect(Datadog::Profiling).to receive(:unsupported_reason).and_return(nil)
+
         # Instantiate the component
         component
 

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -33,15 +33,6 @@ RSpec.describe 'Telemetry integration tests' do
 
   let(:sent_payloads) { [] }
 
-  shared_context 'mark telemetry started' do
-    before do
-      # To avoid noise from the startup events, turn those off.
-      Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
-        true
-      end
-    end
-  end
-
   shared_examples 'telemetry integration tests' do
     it 'initializes correctly' do
       expect(component.enabled).to be true

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Telemetry integration tests' do
         'env' => nil,
         'language_name' => 'ruby',
         'language_version' => String,
-        'runtime_name' => 'ruby',
+        'runtime_name' => /\Aj?ruby\z/i,
         'runtime_version' => String,
         'service_name' => String,
         'service_version' => nil,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ require 'support/span_helpers'
 require 'support/spy_transport'
 require 'support/synchronization_helpers'
 require 'support/test_helpers'
+require 'support/telemetry_helpers'
 require 'support/tracer_helpers'
 require 'support/libdatadog_helpers'
 require 'support/http_server_helpers'
@@ -68,6 +69,7 @@ RSpec.configure do |config|
   config.include LoadedGem::Helpers
   config.include SpanHelpers
   config.include SynchronizationHelpers
+  config.include TelemetryHelpers
   config.include TracerHelpers
   config.include TestHelpers::RSpec::Integration, :integration
   config.include HttpServerHelpers

--- a/spec/support/telemetry_helpers.rb
+++ b/spec/support/telemetry_helpers.rb
@@ -1,0 +1,15 @@
+module TelemetryHelpers
+  module ClassMethods
+    def mark_telemetry_started
+      before do
+        Datadog::Core::Telemetry::Worker::TELEMETRY_STARTED_ONCE.run do
+          true
+        end
+      end
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds an integration test for AppHeartbeat telemetry event with payload assertions

**Motivation:**
Debugging why telemetry is not working properly for dynamic instrumentation - the UI requires telemetry heartbeats to show correct information but these are not seen by the backend 
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
This PR duplicates the `mark_telemetry_started` helper from https://github.com/DataDog/dd-trace-rb/pull/4640

**How to test the change?**
PR is tests only
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
