### PR TITLE
[APPSEC-57237] Handle business logic events

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: appsec-57504-enable-session-tracking-and-fingerprinting # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: appsec-57237-ruby-enable-session-fingerprinting # This must always be set to `main` on dd-trace-rb's master branch
 
 jobs:
   changes:

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -10,11 +10,17 @@ module Datadog
       module Gateway
         # Watcher for Apssec internal events
         module Watcher
+          ARBITRARY_VALUE = 'invalid'
+          EVENT_LOGIN_SUCCESS = 'users.login.success'
+          EVENT_LOGIN_FAILURE = 'users.login.failure'
+          WATCHED_LOGIN_EVENTS = [EVENT_LOGIN_SUCCESS, EVENT_LOGIN_FAILURE].freeze
+
           class << self
             def watch
               gateway = Instrumentation.gateway
 
               watch_user_id(gateway)
+              watch_user_login(gateway)
             end
 
             def watch_user_id(gateway = Instrumentation.gateway)
@@ -33,7 +39,7 @@ module Datadog
 
                 result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
-                if result.match? || !result.derivatives.empty?
+                if result.match? || result.derivatives.any?
                   context.events.push(
                     AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
                   )
@@ -45,6 +51,30 @@ module Datadog
                 end
 
                 stack.call(user)
+              end
+            end
+
+            def watch_user_login(gateway = Instrumentation.gateway)
+              gateway.watch('appsec.events.user_lifecycle', :appsec) do |stack, kind|
+                context = AppSec.active_context
+
+                next stack.call(kind) unless WATCHED_LOGIN_EVENTS.include?(kind)
+
+                persistent_data = { "server.business_logic.#{kind}" => ARBITRARY_VALUE }
+                result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
+
+                if result.match? || result.derivatives.any?
+                  context.events.push(
+                    AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                  )
+                end
+
+                if result.match?
+                  AppSec::Event.tag_and_keep!(context, result)
+                  AppSec::ActionsHandler.handle(result.actions)
+                end
+
+                stack.call(kind)
               end
             end
           end

--- a/sig/datadog/appsec/monitor/gateway/watcher.rbs
+++ b/sig/datadog/appsec/monitor/gateway/watcher.rbs
@@ -3,9 +3,19 @@ module Datadog
     module Monitor
       module Gateway
         module Watcher
+          ARBITRARY_VALUE: ::String
+
+          EVENT_LOGIN_SUCCESS: ::String
+
+          EVENT_LOGIN_FAILURE: ::String
+
+          WATCHED_LOGIN_EVENTS: ::Array[::String]
+
           def self.watch: () -> untyped
 
-          def self.watch_user_id: (?Datadog::AppSec::Instrumentation::Gateway gateway) -> untyped
+          def self.watch_user_id: (?Instrumentation::Gateway gateway) -> void
+
+          def self.watch_user_login: (?Instrumentation::Gateway gateway) -> void
         end
       end
     end

--- a/spec/datadog/appsec/contrib/integration/rack/session_fingerprint_collection_for_business_events_spec.rb
+++ b/spec/datadog/appsec/contrib/integration/rack/session_fingerprint_collection_for_business_events_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/appsec/spec_helper'
+require 'rack/test'
+
+require 'datadog/tracing'
+require 'datadog/appsec'
+require 'datadog/kit/appsec/events'
+
+RSpec.describe 'Session fingerprint collection for business events' do
+  include Rack::Test::Methods
+
+  before do
+    Datadog.configure do |c|
+      c.tracing.enabled = true
+
+      c.appsec.enabled = true
+      c.appsec.instrument :rack
+
+      c.appsec.waf_timeout = 10_000_000 # in us
+      c.appsec.ip_passlist = []
+      c.appsec.ip_denylist = []
+      c.appsec.user_id_denylist = []
+      c.appsec.ruleset = :recommended
+      c.appsec.api_security.enabled = false
+      c.appsec.api_security.sample_rate = 0.0
+
+      c.remote.enabled = false
+    end
+
+    allow(Datadog::AppSec::Instrumentation).to receive(:gateway).and_return(gateway)
+
+    # NOTE: Don't reach the agent in any way
+    allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
+    allow_any_instance_of(Datadog::Tracing::Transport::Traces::Transport).to receive(:native_events_supported?)
+      .and_return(true)
+
+    Datadog::AppSec::Monitor::Gateway::Watcher.watch
+  end
+
+  after do
+    Datadog.configuration.reset!
+    Datadog.registry[:rack].reset_configuration!
+  end
+
+  let(:gateway) { Datadog::AppSec::Instrumentation::Gateway.new }
+
+  let(:http_service_entry_span) do
+    Datadog::Tracing::Transport::TraceFormatter.format!(trace)
+    spans.find { |s| s.name == 'rack.request' }
+  end
+
+  let(:app) do
+    stack = Rack::Builder.new do
+      use Datadog::Tracing::Contrib::Rack::TraceMiddleware
+      use Datadog::AppSec::Contrib::Rack::RequestMiddleware
+
+      map '/with-track-login-success' do
+        run(
+          lambda do |_env|
+            Datadog::Kit::AppSec::Events.track_login_success(
+              Datadog::Tracing.active_trace, Datadog::Tracing.active_span, user: { id: '42' }
+            )
+
+            [200, { 'Content-Type' => 'text/html' }, ['OK']]
+          end
+        )
+      end
+
+      map '/without-track-login-success' do
+        run ->(_env) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
+      end
+    end
+
+    stack.to_app
+  end
+
+  subject(:response) { last_response }
+
+  context 'when business event was pushed' do
+    before { get('/with-track-login-success') }
+
+    it 'collects session fingerprint' do
+      expect(response).to be_ok
+      expect(http_service_entry_span.tags).to include('_dd.appsec.fp.session' => String)
+    end
+  end
+
+  context 'when business event was not pushed' do
+    before { get('/without-track-login-success') }
+
+    it 'does not collect session fingerprint' do
+      expect(response).to be_ok
+      expect(http_service_entry_span.tags).not_to have_key('_dd.appsec.fp.session')
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Adds handling of business logic events to be able to finish fingerprinting feature.

**Motivation:**

The last bits of fingerprinting is to act on business logic events that produced during sign in via auto-instrumentation or SDK.

**Change log entry**

Yes. AppSec: Add session tracking and fingerprinting support to `devise` and `rails` contribs.

**Additional Notes:**

I would like to restructure integration tests to better separate specifically contrib tests from general logic tests. Hence you would see test in the rack contrib (for now)

Second - we have an issue in libddwaf-rb which converts provided `nil` values into empty strings. Another option is to give a value `invalid` which doesn't make much sense, but it is what it is.

This is what's new in system-tests

<img width="1269" alt="Screenshot 2025-05-13 at 11 59 46" src="https://github.com/user-attachments/assets/dec22bc9-7ef6-4f96-aa3b-06511c6c40f3" />

**How to test the change?**

CI + ST