### PR TITLE
DEBUG-3573 Report state of dynamic instrumentation to telemetry

### DIFF
--- a/lib/datadog.rb
+++ b/lib/datadog.rb
@@ -7,7 +7,5 @@ require_relative 'datadog/tracing/contrib'
 # Load other products (must follow tracing)
 require_relative 'datadog/profiling'
 require_relative 'datadog/appsec'
-# Line probes will not work on Ruby < 2.6 because of lack of :script_compiled
-# trace point. Only load DI on supported Ruby versions.
-require_relative 'datadog/di' if RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby'
+require_relative 'datadog/di'
 require_relative 'datadog/kit'

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -90,6 +90,7 @@ module Datadog
           end
 
           TARGET_OPTIONS = %w[
+            dynamic_instrumentation.enabled
             logger.level
             profiling.advanced.code_provenance_enabled
             profiling.advanced.endpoint.collection.enabled

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -74,10 +74,9 @@ module Datadog
               profiler: {
                 enabled: Datadog::Profiling.enabled?,
               },
-              # DEV: Not implemented yet
-              # dynamic_instrumentation: {
-              #   enabled: true,
-              # }
+              dynamic_instrumentation: {
+                enabled: defined?(Datadog::DI) && Datadog::DI.enabled?,
+              }
             }
 
             if (unsupported_reason = Datadog::Profiling.unsupported_reason)

--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -75,7 +75,7 @@ module Datadog
                 enabled: Datadog::Profiling.enabled?,
               },
               dynamic_instrumentation: {
-                enabled: defined?(Datadog::DI) && Datadog::DI.enabled?,
+                enabled: defined?(Datadog::DI) && Datadog::DI.respond_to?(:enabled?) && Datadog::DI.enabled?,
               }
             }
 

--- a/lib/datadog/di.rb
+++ b/lib/datadog/di.rb
@@ -1,24 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'di/logger'
-require_relative 'di/base'
-require_relative 'di/error'
-require_relative 'di/code_tracker'
-require_relative 'di/component'
 require_relative 'di/configuration'
 require_relative 'di/extensions'
-require_relative 'di/instrumenter'
-require_relative 'di/probe'
-require_relative 'di/probe_builder'
-require_relative 'di/probe_manager'
-require_relative 'di/probe_notification_builder'
-require_relative 'di/probe_notifier_worker'
-require_relative 'di/redactor'
 require_relative 'di/remote'
-require_relative 'di/serializer'
-#require_relative 'di/transport'
-require_relative 'di/transport/http'
-require_relative 'di/utils'
 
 module Datadog
   # Namespace for Datadog dynamic instrumentation.
@@ -52,19 +36,8 @@ module Datadog
   end
 end
 
-if %w(1 true).include?(ENV['DD_DYNAMIC_INSTRUMENTATION_ENABLED']) # steep:ignore
-  # For initial release of Dynamic Instrumentation, activate code tracking
-  # only if DI is explicitly requested in the environment.
-  # Code tracking is required for line probes to work; see the comments
-  # above for the implementation of the method.
-  #
-  # If DI is enabled programmatically, the application can (and must,
-  # for line probes to work) activate tracking in an initializer.
-  # We seem to have Datadog.logger here already
-  Datadog.logger.debug("di: activating code tracking")
-  Datadog::DI.activate_tracking
-end
-
-require_relative 'di/contrib'
-
-Datadog::DI::Contrib.load_now_or_later
+# Line probes will not work on Ruby < 2.6 because of lack of :script_compiled
+# trace point. Activate DI automatically on supported Ruby versions but
+# always load its settings so that, for example, turning DI off when
+# we are on Ruby 2.5 does not produce exceptions.
+require_relative 'di/boot' if RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby'

--- a/lib/datadog/di/boot.rb
+++ b/lib/datadog/di/boot.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'logger'
+require_relative 'base'
+require_relative 'error'
+require_relative 'code_tracker'
+require_relative 'component'
+require_relative 'instrumenter'
+require_relative 'probe'
+require_relative 'probe_builder'
+require_relative 'probe_manager'
+require_relative 'probe_notification_builder'
+require_relative 'probe_notifier_worker'
+require_relative 'redactor'
+require_relative 'serializer'
+require_relative 'transport/http'
+require_relative 'utils'
+
+if %w(1 true yes).include?(ENV['DD_DYNAMIC_INSTRUMENTATION_ENABLED']) # steep:ignore
+  # For initial release of Dynamic Instrumentation, activate code tracking
+  # only if DI is explicitly requested in the environment.
+  # Code tracking is required for line probes to work; see the comments
+  # above for the implementation of the method.
+  #
+  # If DI is enabled programmatically, the application can (and must,
+  # for line probes to work) activate tracking in an initializer.
+  # We seem to have Datadog.logger here already
+  Datadog.logger.debug("di: activating code tracking")
+  Datadog::DI.activate_tracking
+end
+
+require_relative 'contrib'
+
+Datadog::DI::Contrib.load_now_or_later

--- a/lib/datadog/di/boot.rb
+++ b/lib/datadog/di/boot.rb
@@ -16,7 +16,7 @@ require_relative 'serializer'
 require_relative 'transport/http'
 require_relative 'utils'
 
-if %w(1 true yes).include?(ENV['DD_DYNAMIC_INSTRUMENTATION_ENABLED']) # steep:ignore
+if %w[1 true yes].include?(ENV['DD_DYNAMIC_INSTRUMENTATION_ENABLED']) # steep:ignore
   # For initial release of Dynamic Instrumentation, activate code tracking
   # only if DI is explicitly requested in the environment.
   # Code tracking is required for line probes to work; see the comments

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -18,6 +18,8 @@ module Datadog
         PRODUCT = 'LIVE_DEBUGGING'
 
         def products
+          # TODO: do not send our product on unsupported runtimes
+          # (Ruby 2.5 / JRuby)
           [PRODUCT]
         end
 

--- a/sig/datadog/di.rbs
+++ b/sig/datadog/di.rbs
@@ -1,6 +1,7 @@
 module Datadog
   module DI
     def self.component: () -> Component?
+    def self.enabled?: () -> bool
     
   end
 end

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Datadog::Core::Telemetry::Event do
           ['DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED', true],
           ['DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED', false],
           ['DD_TRACE_PEER_SERVICE_MAPPING', 'foo:bar'],
+          ['dynamic_instrumentation.enabled', false],
           ['logger.level', 0],
           ['profiling.advanced.code_provenance_enabled', true],
           ['profiling.advanced.endpoint.collection.enabled', true],

--- a/spec/datadog/core/telemetry/event_spec.rb
+++ b/spec/datadog/core/telemetry/event_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe Datadog::Core::Telemetry::Event do
           appsec: {
             enabled: false,
           },
+          dynamic_instrumentation: {
+            enabled: false,
+          },
           profiler: hash_including(enabled: false),
         },
         configuration: contain_configuration(

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe 'Telemetry integration tests' do
 
     let(:expected_products_hash) do
       {
-        'appsec' => { 'enabled' => false },
-        'profiler' => { 'enabled' => false },
+        'appsec' => {'enabled' => false},
+        'dynamic_instrumentation' => {'enabled' => false},
+        'profiler' => {'enabled' => false},
       }
     end
 

--- a/spec/datadog/core/telemetry/integration/telemetry_spec.rb
+++ b/spec/datadog/core/telemetry/integration/telemetry_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe 'Telemetry integration tests' do
 
     let(:expected_products_hash) do
       {
-        'appsec' => {'enabled' => false},
-        'dynamic_instrumentation' => {'enabled' => false},
-        'profiler' => {'enabled' => false},
+        'appsec' => { 'enabled' => false },
+        'dynamic_instrumentation' => { 'enabled' => false },
+        'profiler' => { 'enabled' => false },
       }
     end
 

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -1,4 +1,5 @@
 require 'datadog/di'
+require 'datadog/di/code_tracker'
 require "datadog/di/spec_helper"
 
 RSpec.describe Datadog::DI::CodeTracker do

--- a/spec/datadog/di/integration/probe_notifier_worker_spec.rb
+++ b/spec/datadog/di/integration/probe_notifier_worker_spec.rb
@@ -1,11 +1,14 @@
 require "datadog/di/spec_helper"
 require 'datadog/di'
+require "datadog/di/probe_notifier_worker"
 
 # standard tries to wreck regular expressions in this fiel
 # rubocop:disable Style/PercentLiteralDelimiters
 # rubocop:disable Layout/LineContinuationSpacing
 
 RSpec.describe Datadog::DI::ProbeNotifierWorker do
+  di_test
+
   let(:worker) do
     described_class.new(settings, logger, agent_settings: agent_settings)
   end

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'loading of products' do
   end
 end
 
-RSpec.describe 'load core only and configure library' do
+RSpec.describe 'load core only and configure library with no settings' do
   let(:code) do
     <<-E
       if defined?(Datadog)
@@ -71,6 +71,31 @@ RSpec.describe 'load core only and configure library' do
     E
   end
 
+  it 'configures successfully' do
+    rv = system("ruby -e #{Shellwords.shellescape(code)}")
+    expect(rv).to be true
+  end
+end
+
+RSpec.describe 'load datadog and enable dynamic instrumentation' do
+  let(:code) do
+    <<-E
+      if defined?(Datadog)
+        unless Datadog.constants == [:VERSION]
+          exit 1
+        end
+      end
+
+      require 'datadog'
+
+      Datadog.configure do |c|
+        c.dynamic_instrumentation.enabled = true
+      end
+    E
+  end
+
+  # DI is not available in all environments, however asking for it to be
+  # turned on should not produce exceptions.
   it 'configures successfully' do
     rv = system("ruby -e #{Shellwords.shellescape(code)}")
     expect(rv).to be true


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adds the enabled status of dynamic instrumentation to telemetry app-started event
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Reporting of DI status is required for DI UI to work correctly as well as for internal DI monitoring/troubleshooting tools
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
To make DI always reportable via telemetry I had to make its configuration defined on all Ruby runtimes including the ones where the product itself does not work (Ruby 2.5, JRuby). Additional loading test was added to verify ability to set DI configuration options on all runtimes; this test mirrors failures I've gotten on rails42 and rails50 system test configurations which use Ruby 2.5 once I started sending DI status to telemetry.

**How to test the change?**
Unit tests  + system tests enabled in https://github.com/DataDog/system-tests/pull/4656
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
