### PR TITLE
[NO-TICKET] Enable forcing parametric tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -14,12 +14,17 @@ on: # yamllint disable-line rule:truthy
 # Default permissions for all jobs
 permissions: {}
 
+env:
+  SYSTEM_TESTS_REF: 'main' # This must always be set to `main` on dd-trace-rb's master branch
+
 jobs:
   changes:
     name: Changes
     runs-on: ubuntu-24.04
     outputs:
       changes: ${{ steps.changes.outputs.src }}
+      FORCED_TESTS_LIST: ${{ steps.read_forced_tests_list.outputs.FORCED_TESTS_LIST }}
+      ST_REF: ${{ steps.read_forced_tests_list.outputs.ST_REF }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,6 +36,7 @@ jobs:
         with:
           filters: |
             src:
+              - '.github/forced-tests-list.json'
               - '.github/workflows/**'
               - 'lib/**'
               - 'ext/**'
@@ -39,6 +45,20 @@ jobs:
               - '*.gemfile'
               - 'lib-injection/**'
               - 'tasks/**'
+      - name: Read forced-tests-list.json file
+        id: read_forced_tests_list
+        run: |
+          {
+            printf "FORCED_TESTS_LIST<<EOF\n"
+            cat .github/forced-tests-list.json
+            printf "\nEOF\n"
+          } >> "$GITHUB_OUTPUT"
+      # This may feel useless but we cannot access env in `with` block in parametric job, while we can access needs.changes.output
+      - name: Outputs branch
+        id: outputs_branch
+        env:
+          SYSTEM_TESTS_REF: ${{ env.SYSTEM_TESTS_REF }}
+        run: echo "ST_REF=${SYSTEM_TESTS_REF}" >> "$GITHUB_OUTPUT"
 
   build-artifacts:
     needs:
@@ -60,17 +80,37 @@ jobs:
           path: binaries/
 
   parametric:
+    name: Parametric Tests (with force tests)
     needs:
       - build-artifacts
       - changes
-    if: ${{ needs.changes.outputs.changes == 'true' }}
-    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
+    if: ${{ needs.changes.outputs.changes == 'true' && needs.changes.outputs.FORCED_TESTS_LIST && !(fromJSON(needs.changes.outputs.FORCED_TESTS_LIST)['PARAMETRIC'] == null) }}
     secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
+
     with:
       library: ruby
       binaries_artifact: system_tests_binaries
       job_count: 8
       job_matrix: "[1,2,3,4,5,6,7,8]"
+      ref: ${{ needs.changes.outputs.ST_REF }}
+      force_execute_tests: ${{ toJSON(fromJSON(needs.changes.outputs.FORCED_TESTS_LIST)['PARAMETRIC'])}}
+
+  parametric-without-force-tests:
+    name: Parametric Tests (without force tests)
+    needs:
+      - build-artifacts
+      - changes
+    if: ${{ needs.changes.outputs.changes == 'true' && !(needs.changes.outputs.FORCED_TESTS_LIST && !(fromJSON(needs.changes.outputs.FORCED_TESTS_LIST)['PARAMETRIC'] == null)) }}
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: DataDog/system-tests/.github/workflows/run-parametric.yml@main
+
+    with:
+      library: ruby
+      binaries_artifact: system_tests_binaries
+      job_count: 8
+      job_matrix: "[1,2,3,4,5,6,7,8]"
+      ref: ${{ needs.changes.outputs.ST_REF }}
 
   complete:
     name: Parametric Tests (complete)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
It adds support for PARAMETRIC scenario in forced-tests-list.json

**Motivation:**
<!-- What inspired you to submit this pull request? -->
I needed to force execute some parametric tests for StableConfig and ProcessDiscovery

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
