### PR TITLE
[APMAPI-1116] Enable Hands Off Config

### DIFF
--- a/.github/forced-tests-list.json
+++ b/.github/forced-tests-list.json
@@ -1,3 +1,5 @@
 {
-  
+    "PARAMETRIC": [
+        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "files.associations": {
     "*.gemfile": "ruby",
     "Matrixfile": "ruby",
-    "Dockerfile*": "dockerfile"
+    "Dockerfile*": "dockerfile",
+    "__locale": "c",
+    "string": "c",
+    "string_view": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,5 @@
     "*.gemfile": "ruby",
     "Matrixfile": "ruby",
     "Dockerfile*": "dockerfile",
-    "__locale": "c",
-    "string": "c",
-    "string_view": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "files.associations": {
     "*.gemfile": "ruby",
     "Matrixfile": "ruby",
-    "Dockerfile*": "dockerfile",
+    "Dockerfile*": "dockerfile"
   }
 }

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -55,17 +55,12 @@ void library_config_init(VALUE core_module) {
   rb_undef_alloc_func(config_vec_class); // It cannot be created from Ruby code and only serves as an intermediate object for the Ruby GC
 }
 
-// TODO: After libdatadog 17.1 release, delete rb_raise, uncomment code and change `DDTRACE_UNUSED VALUE _klass` by `VALUE klass`
-static VALUE _native_configurator_new(DDTRACE_UNUSED VALUE _klass) {
-  /*
+static VALUE _native_configurator_new(VALUE klass) {
   ddog_Configurator *configurator = ddog_library_configurator_new(false, DDOG_CHARSLICE_C("ruby"));
 
   ddog_library_configurator_with_detect_process_info(configurator);
 
   return TypedData_Wrap_Struct(klass, &configurator_typed_data, configurator);
-  */
-
-  rb_raise(rb_eNotImpError, "TODO: Not in use yet, waiting for libdatadog 17.1");
 }
 
 static VALUE _native_configurator_get(VALUE self) {
@@ -96,8 +91,6 @@ static VALUE _native_configurator_get(VALUE self) {
 
   VALUE local_config_hash = rb_hash_new();
   VALUE fleet_config_hash = rb_hash_new();
-  // TODO: Uncomment next block after libdatadog 17.1 release
-  /*
   for (uintptr_t i = 0; i < config_vec->len; i++) {
     ddog_LibraryConfig config = config_vec->ptr[i];
     VALUE selected_hash;
@@ -111,7 +104,6 @@ static VALUE _native_configurator_get(VALUE self) {
     ddog_CStr name = ddog_library_config_name_to_env(config.name);
     rb_hash_aset(selected_hash, rb_str_new(name.ptr, name.length), rb_str_new(config.value.ptr, config.value.length));
   }
-  */
 
   VALUE result = rb_hash_new();
   rb_hash_aset(result, ID2SYM(rb_intern("local")), local_config_hash);

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -101,8 +101,8 @@ static VALUE _native_configurator_get(VALUE self) {
       selected_hash = fleet_config_hash;
     }
 
-    ddog_CStr name = ddog_library_config_name_to_env(config.name);
-    rb_hash_aset(selected_hash, rb_str_new(name.ptr, name.length), rb_str_new(config.value.ptr, config.value.length));
+    // ddog_CStr name = ddog_library_config_name_to_env(config.name);
+    rb_hash_aset(selected_hash, rb_utf8_str_new_cstr(config.name.ptr), rb_utf8_str_new_cstr(config.value.ptr));
   }
 
   VALUE result = rb_hash_new();

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -101,7 +101,6 @@ static VALUE _native_configurator_get(VALUE self) {
       selected_hash = fleet_config_hash;
     }
 
-    // ddog_CStr name = ddog_library_config_name_to_env(config.name);
     rb_hash_aset(selected_hash, rb_utf8_str_new_cstr(config.name.ptr), rb_utf8_str_new_cstr(config.value.ptr));
   }
 

--- a/lib/datadog/core/configuration/stable_config.rb
+++ b/lib/datadog/core/configuration/stable_config.rb
@@ -14,8 +14,7 @@ module Datadog
         end
 
         def self.configuration
-          # @configuration ||= StableConfig.extract_configuration # TODO: After libdatadog 17.1 release, uncomment this line
-          @configuration ||= {} # TODO: After libdatadog 17.1 release, delete this line
+          @configuration ||= StableConfig.extract_configuration
         end
       end
     end


### PR DESCRIPTION

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Uncomments code related to hands off config. Removes a call to outdated libdatadog API.

This PR relies solely on system-tests as there are no unit tests. It passes all `Test_Stable_Config_Default` system-tests when run locally. See: https://github.com/DataDog/system-tests/pull/4653

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Enable Hands Off Config

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

Yes. Add configuration from local file and from fleet automation.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Once this PR is merged, please merge this one: https://github.com/DataDog/system-tests/pull/4653

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->