### PR TITLE
[PROF-11809] Fix profiler compatibility with ruby-head (3.5)

### DIFF
--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -131,6 +131,9 @@ end
 
 have_func "malloc_stats"
 
+# On Ruby 3.5, we can't ask the object_id from IMEMOs (https://github.com/ruby/ruby/pull/13347)
+$defs << "-DNO_IMEMO_OBJECT_ID" unless RUBY_VERSION < "3.5"
+
 # On Ruby 2.5 and 3.3, this symbol was not visible. It is on 2.6 to 3.2, as well as 3.4+
 $defs << "-DNO_RB_OBJ_INFO" if RUBY_VERSION.start_with?("2.5", "3.3")
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -314,7 +314,14 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     rb_raise(rb_eRuntimeError, "Detected consecutive heap allocation recording starts without end.");
   }
 
-  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) {
+  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate ||
+      #ifdef NO_IMEMO_OBJECT_ID
+        // On Ruby 3.5, we can't ask the object_id from IMEMOs (https://github.com/ruby/ruby/pull/13347)
+        RB_BUILTIN_TYPE(new_obj) == RUBY_T_IMEMO
+      #else
+        false
+      #endif
+    ) {
     heap_recorder->active_recording = &SKIPPED_RECORD;
     return;
   }


### PR DESCRIPTION
**What does this PR do?**

This PR fixes three issues in the profiler when used with latest ruby-head:

1. It's no longer possible to ask the object_id from a T_IMEMO object. This showed up as a Ruby VM crash with an error message "T_IMEMO can't have an object_id". (See https://github.com/ruby/ruby/pull/13347 for the upstream change)

2. Creating new instances of a class is now inlined into the caller, and there is no longer a frame to represent the new. This broke some of our tests that expected the stack from allocating an object to have the `new` at the top. (See https://github.com/ruby/ruby/pull/13080 for the upstream change)

3. Object ids now count towards the size of objects. This broke some of our tests that asserted on size of profiled objects. (See https://github.com/ruby/ruby/pull/13159 for the upstream change)

**Motivation:**

Fix support for Ruby 3.5.

**Change log entry**

Yes. Fix profiler compatibility with ruby-head (3.5)

**Additional Notes:**

N/A

**How to test the change?**

I've updated our specs to cover these changes. Unfortunately, we don't yet test with Ruby 3.5 in CI, so you'll have to test manually if you want to see the fixes working with 3.5.

(Note that these changes showed up after 3.5.0-preview1, so testing on -preview1 is not enough)
