### PR TITLE
[NO-TICKET] Add more context to profiling specs that failed in test-asan

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -675,7 +675,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           it "only keeps track of some allocations" do
             # By only sampling every 2nd allocation we only track the odd objects which means our array
             # should be the only heap sample captured (string is index 0, array is index 1, hash is 4)
-            expect(heap_samples.size).to eq(1)
+            expect(heap_samples.size)
+              .to eq(1), "Expected one heap sample, got #{heap_samples.size}; heap_samples is #{heap_samples}"
 
             heap_sample = heap_samples.first
             expect(heap_sample.labels[:"allocation class"]).to eq("Array")


### PR DESCRIPTION
**What does this PR do?**

This PR adds more context and validation to two tests that we've seen failing in test-asan CI:

* https://github.com/DataDog/dd-trace-rb/actions/runs/14973937437/job/42061305617?pr=4638
* https://github.com/DataDog/dd-trace-rb/actions/runs/14697248627/job/41240596719?pr=4588 (same as above)
* https://github.com/DataDog/dd-trace-rb/actions/runs/14783286431/job/41506701640?pr=4619

It's not clear to me exactly what's wrong and why they are failing, so I'm adding more details so I can debug the issue the next time it happens.

**Motivation:**

Always aim to have zero flaky specs.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

These extra assertions/info will only show up when the tests fail again -- for now all we can validate is that CI is still green with them.