### PR TITLE
Add assertions to error tracking component test to troubleshoot failures

### DIFF
--- a/spec/datadog/error_tracking/component_spec.rb
+++ b/spec/datadog/error_tracking/component_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Datadog::ErrorTracking::Component do
 
     shared_examples 'span event validation' do
       it 'has the expected span events' do
+        expect(spans.length).to eq(expected_exceptions.length)
         expected_exceptions.each_with_index do |events_per_span, i|
           expect(spans[i].events.length).to eq(events_per_span.length)
           unless events_per_span.empty?
@@ -232,6 +233,7 @@ RSpec.describe Datadog::ErrorTracking::Component do
       end
 
       it 'has the correct span names' do
+        expect(spans.length).to eq(2)
         expect(spans[0].name).to eq('child_span')
         expect(spans[1].name).to eq('parent_span')
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds additional assertions to get more debugging information when error tracking tests fail

**Motivation:**
I've seen the following failures in a PR last week:
```


  1) Datadog::ErrorTracking::Component use ErrorTracking component global feature when number of span events is over limit has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:206
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  2) Datadog::ErrorTracking::Component use ErrorTracking component global feature with multiple begin-rescue blocks has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:126
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  3) Datadog::ErrorTracking::Component use ErrorTracking component global feature when an exception is handled multiple times has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:146
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  4) Datadog::ErrorTracking::Component use ErrorTracking component global feature when an exception is handled in the parent_span has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:239
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  5) Datadog::ErrorTracking::Component use ErrorTracking component global feature when an exception is handled in the parent_span has the correct span names
     Failure/Error: expect(spans[0].name).to eq('child_span')

     NoMethodError:
       undefined method `name' for nil:NilClass
     # ./spec/datadog/error_tracking/component_spec.rb:235:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  6) Datadog::ErrorTracking::Component use ErrorTracking component global feature when an exception is handled multiple times with different types has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:169
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  7) Datadog::ErrorTracking::Component use ErrorTracking component global feature when an exception is handled then raised has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:188
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'

  8) Datadog::ErrorTracking::Component use ErrorTracking component global feature with a simple begin-rescue block has the expected span events
     Failure/Error: expect(spans[i].events.length).to eq(events_per_span.length)

     NoMethodError:
       undefined method `events' for nil:NilClass
     Shared Example Group: "span event validation" called from ./spec/datadog/error_tracking/component_spec.rb:100
     # ./spec/datadog/error_tracking/component_spec.rb:74:in `block (5 levels) in <top (required)>'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `each_with_index'
     # ./spec/datadog/error_tracking/component_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:266:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:151:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
```
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
N/A
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
