### PR TITLE
[NO-TICKET] Remove "test-asan" profiler check due to flakiness

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -27,29 +27,11 @@ jobs:
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
       - run: gem update --system 3.5.23 # TODO: This is a workaround for a buggy rubygems in 3.4.0-preview2; remove once stable version 3.4 is out
       - run: bundle exec rake compile spec:profiling:memcheck
-  test-asan:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # Adds 3.4-asan builds
-        with:
-          ruby-version: 3.4-asan
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          bundler: latest
-          cache-version: v2 # bump this to invalidate cache
-      - run: bundle exec rake spec:profiling:main
-        env:
-          RUBY_FREE_AT_EXIT: 1
-          LSAN_OPTIONS: verbosity=0:log_threads=1:suppressions=${{ github.workspace }}/suppressions/lsan.supp
-          ASAN_OPTIONS: detect_leaks=1
 
   complete:
     name: Test for memory leaks (complete)
     runs-on: ubuntu-24.04
     needs:
       - test-memcheck
-      - test-asan
     steps:
       - run: echo "DONE!"


### PR DESCRIPTION
**What does this PR do?**

This PR removes the `test-asan` step in CI as it's currently flaky and I wasn't able to debug the issue or skip it.

This run
https://github.com/DataDog/dd-trace-rb/actions/runs/15112212122/job/42474072954?pr=4664 shows this step failing:

```
Randomized with seed 3003
......................................................1.8.1
==2610==Running thread 2303 was not suspended. False leaks are possible.
==2610==Running thread 2304 was not suspended. False leaks are possible.
==2610==Processing thread 2606.
==2610==Stack at 0x7fff7be8d000-0x7fff7ce8d000 (SP = 0x7fff7ce81630).
==2610==TLS at 0x7f0d63c88b80-0x7f0d63c89cc0.
==2610==DTLS 5 at 0x512000597940-0x512000597a78.
==2610==DTLS 6 at 0x5020000d0e30-0x5020000d0e38.
==2615==Running thread 2303 was not suspended. False leaks are possible.
==2615==Running thread 2304 was not suspended. False leaks are possible.
==2615==Processing thread 2611.
==2615==Stack at 0x7fff7be8d000-0x7fff7ce8d000 (SP = 0x7fff7ce80cb0).
==2615==TLS at 0x7f0d63c88b80-0x7f0d63c89cc0.
==2615==DTLS 5 at 0x512000597940-0x512000597a78.
==2615==DTLS 6 at 0x5020000d0e30-0x5020000d0e38.
=================================================================
==2298==ERROR: AddressSanitizer: use-after-poison on address 0x7f0d48ea00e8 at pc 0x555ee334c0a6 bp 0x7fff7ce80680 sp 0x7fff7ce7fe40
READ of size 83 at 0x7f0d48ea00e8 thread T0
    #0 0x555ee334c0a5 in __asan_memcpy (/home/runner/.rubies/ruby-3.4-asan/bin/ruby+0xc50a5) (BuildId: 0436b55d43125d84e3c30c1e201ade3c92f23140)
    #1 0x7f0d634b3855 in memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10
    #2 0x7f0d634b3855 in ruby_nonempty_memcpy /home/runner/work/ruby-dev-builder/ruby-dev-builder/./include/ruby/internal/memory.h:671:16
    #3 0x7f0d634b3855 in ruby__sfvwrite /home/runner/work/ruby-dev-builder/ruby-dev-builder/sprintf.c:1083:9
    #4 0x7f0d634b2dd1 in BSD__sprint /home/runner/work/ruby-dev-builder/ruby-dev-builder/./vsnprintf.c:318:8
    #5 0x7f0d634b286e in BSD_vfprintf /home/runner/work/ruby-dev-builder/ruby-dev-builder/./vsnprintf.c:1215:3
    #6 0x7f0d634afced in ruby_vsprintf0 /home/runner/work/ruby-dev-builder/ruby-dev-builder/sprintf.c:1164:5
    #7 0x7f0d634b03ee in rb_str_vcatf /home/runner/work/ruby-dev-builder/ruby-dev-builder/sprintf.c:1234:5
    #8 0x7f0d634af198 in rb_str_catf /home/runner/work/ruby-dev-builder/ruby-dev-builder/sprintf.c:1245:11
    #9 0x7f0d636519e2 in location_format /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:456:9
    #10 0x7f0d636519e2 in location_to_str /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:487:12
    #11 0x7f0d6364ccc7 in location_to_str_dmyarg /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:783:12
    #12 0x7f0d6364ccc7 in backtrace_collect /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:774:28
    #13 0x7f0d6364ccc7 in backtrace_to_str_ary /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:792:9
    #14 0x7f0d6364ccc7 in ec_backtrace_to_ary /home/runner/work/ruby-dev-builder/ruby-dev-builder/vm_backtrace.c:1277:13
    #15 0x7f0d6362b19e in vm_call_cfunc_with_frame_ /home/runner/work/ruby-dev-builder/ruby-dev-builder/./vm_insnhelper.c:3794:11
    #16 0x7f0d635c0f63 in vm_sendish /home/runner/work/ruby-dev-builder/ruby-dev-builder/./vm_callinfo.h
    #17 0x7f0d635cc606 in vm_exec_core /home/runner/work/ruby-dev-builder/ruby-dev-builder/insns.def:898:11

...etc...

Address 0x7f0d48ea00e8 is a wild pointer inside of access range of size 0x000000000053.
SUMMARY: AddressSanitizer: use-after-poison (/home/runner/.rubies/ruby-3.4-asan/bin/ruby+0xc50a5) (BuildId: 0436b55d43125d84e3c30c1e201ade3c92f23140) in __asan_memcpy
Shadow bytes around the buggy address:
  0x7f0d48e9fe00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48e9fe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48e9ff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48e9ff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48ea0000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7f0d48ea0080: 00 00 00 00 00 00 00 00 00 00 f7 f7 f7[f7]f7 f7
  0x7f0d48ea0100: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x7f0d48ea0180: f7 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48ea0200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48ea0280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f0d48ea0300: 00 00 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2298==ABORTING
/home/runner/work/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:280: [BUG] ASAN error
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0079 p:---- s:0392 e:000391 CFUNC  :caller
c:0078 p:0003 s:0388 e:000387 METHOD /home/runner/work/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:280 [FINISH]
c:0077 p:---- s:0381 e:000380 CFUNC  :new
c:0076 p:0008 s:0376 e:000375 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/spec/datadog/profiling/collectors/thread_context_spec.rb:33
c:0075 p:0005 s:0372 e:000371 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:34
c:0074 p:0009 s:0369 e:000365 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:17 [FINISH]
c:0073 p:---- s:0363 e:000362 CFUNC  :fetch
c:0072 p:0009 s:0358 e:000357 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:17
c:0071 p:0006 s:0355 e:000354 METHOD /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-support-3.13.3/lib/rspec/support/reentrant_mutex.
c:0070 p:0006 s:0351 e:000350 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:17 [FINISH]
c:0069 p:---- s:0348 e:000347 CFUNC  :fetch
c:0068 p:0008 s:0343 e:000342 METHOD /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:17
c:0067 p:0008 s:0338 e:000337 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/memoized_helpers.rb:34
c:0066 p:0024 s:0334 e:000331 BLOCK  /home/runner/work/dd-trace-rb/dd-trace-rb/spec/datadog/profiling/collectors/thread_context_spec.rb:10 [FINISH]
c:0065 p:---- s:0329 e:000328 CFUNC  :instance_exec
c:0064 p:0013 s:0324 e:000323 METHOD /home/runner/work/dd-trace-rb/dd-trace-rb/vendor/bundle/ruby/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457

...etc...
```

On a second run, with no changes, this same spec passed: https://github.com/DataDog/dd-trace-rb/actions/runs/15112212122?pr=4664

**Motivation:**

Avoid having flaky CI.

**Change log entry**

None.

**Additional Notes:**

This is not the first time we had CI flakiness due to this check, and for a while it was running fine with the upstream "3.4-asan" builds.

I plan on trying again once Ruby 3.5 is out.

**How to test the change?**

Validate the "test-memory-leaks" workflow no longer runs `test-asan`.