### PR TITLE
switch core to standard from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,12 @@ AllCops:
     # reformatting all of this code to rubocop's demands and then have it
     # be different from telemetry.
     - lib/datadog/core/telemetry/transport/**/*
+    - lib/datadog/di/**/*
+    - lib/datadog/di.rb
+    - spec/datadog/di/**/*
+    - lib/datadog/core/**/*
+    - lib/datadog/core.rb
+    - spec/datadog/core/**/*
   NewCops: disable # Don't allow new cops to be enabled implicitly.
   SuggestExtensions: false # Stop pushing suggestions constantly.
 
@@ -49,12 +55,6 @@ Style:
     - "lib/datadog/appsec/**/*"
     - "spec/datadog/appsec*"
     - "spec/datadog/appsec/**/*"
-    - lib/datadog/di/**/*
-    - lib/datadog/di.rb
-    - spec/datadog/di/**/*
-    - lib/datadog/core/**/*
-    - lib/datadog/core.rb
-    - spec/datadog/core/**/*
 
 Layout:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,9 +29,6 @@ AllCops:
     # reformatting all of this code to rubocop's demands and then have it
     # be different from telemetry.
     - lib/datadog/core/telemetry/transport/**/*
-    - lib/datadog/di/**/*
-    - lib/datadog/di.rb
-    - spec/datadog/di/**/*
   NewCops: disable # Don't allow new cops to be enabled implicitly.
   SuggestExtensions: false # Stop pushing suggestions constantly.
 
@@ -52,6 +49,12 @@ Style:
     - "lib/datadog/appsec/**/*"
     - "spec/datadog/appsec*"
     - "spec/datadog/appsec/**/*"
+    - lib/datadog/di/**/*
+    - lib/datadog/di.rb
+    - spec/datadog/di/**/*
+    - lib/datadog/core/**/*
+    - lib/datadog/core.rb
+    - spec/datadog/core/**/*
 
 Layout:
   Exclude:

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -32,7 +32,6 @@ ignore:
   - ext/libdatadog_api/**/**
   - lib/*
   - lib/datadog/*
-  - lib/datadog/core/**/**
   - lib/datadog/kit/**/**
   - lib/datadog/opentelemetry/**/**
   - lib/datadog/tracing/**/**

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -32,6 +32,7 @@ ignore:
   - ext/libdatadog_api/**/**
   - lib/*
   - lib/datadog/*
+  - lib/datadog/core/vendor/**/**
   - lib/datadog/kit/**/**
   - lib/datadog/opentelemetry/**/**
   - lib/datadog/tracing/**/**

--- a/lib/datadog/core/buffer/random.rb
+++ b/lib/datadog/core/buffer/random.rb
@@ -40,7 +40,7 @@ module Datadog
           add_all!(underflow) unless underflow.nil?
 
           # Iteratively replace items, to ensure pseudo-random replacement.
-          overflow.each { |item| replace!(item) } unless overflow.nil?
+          overflow&.each { |item| replace!(item) }
         end
 
         # Stored items are returned and the local buffer is reset.

--- a/lib/datadog/core/buffer/random.rb
+++ b/lib/datadog/core/buffer/random.rb
@@ -78,7 +78,7 @@ module Datadog
           underflow = nil
           overflow = nil
 
-          overflow_size = @max_size > 0 ? (@items.length + items.length) - @max_size : 0
+          overflow_size = (@max_size > 0) ? (@items.length + items.length) - @max_size : 0
 
           if overflow_size > 0
             # Items will overflow

--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -235,16 +235,14 @@ module Datadog
         end
 
         COMPONENTS_WRITE_LOCK.synchronize do
-          begin
-            yield write_components
-          rescue ThreadError => e
-            logger_without_components.error(
-              'Detected deadlock during datadog initialization. ' \
-              'Please report this at https://github.com/datadog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
-              "\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
-            )
-            nil
-          end
+          yield write_components
+        rescue ThreadError => e
+          logger_without_components.error(
+            'Detected deadlock during datadog initialization. ' \
+            'Please report this at https://github.com/datadog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
+            "\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
+          )
+          nil
         end
       end
 

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -37,8 +37,8 @@ module Datadog
             case adapter
             when Datadog::Core::Configuration::Ext::Agent::HTTP::ADAPTER
               hostname = self.hostname
-              hostname = "[#{hostname}]" if hostname =~ IPV6_REGEXP
-              "#{ssl ? 'https' : 'http'}://#{hostname}:#{port}/"
+              hostname = "[#{hostname}]" if IPV6_REGEXP.match?(hostname)
+              "#{ssl ? "https" : "http"}://#{hostname}:#{port}/"
             when Datadog::Core::Configuration::Ext::Agent::UnixSocket::ADAPTER
               "unix://#{uds_path}"
             else
@@ -158,7 +158,7 @@ module Datadog
               value: settings.agent.timeout_seconds,
             ),
             try_parsing_as_integer(
-              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_TIMEOUT_SECONDS} "\
+              friendly_name: "#{Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_TIMEOUT_SECONDS} " \
                 'environment variable',
               value: ENV[Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_TIMEOUT_SECONDS],
             )
@@ -338,7 +338,7 @@ module Datadog
           log_warning(
             'Configuration mismatch: values differ between ' \
             "#{detected_configurations_in_priority_order
-              .map { |config| "#{config.friendly_name} (#{config.value.inspect})" }.join(' and ')}" \
+              .map { |config| "#{config.friendly_name} (#{config.value.inspect})" }.join(" and ")}" \
             ". Using #{detected_configurations_in_priority_order.first.value.inspect} and ignoring other configuration."
           )
         end

--- a/lib/datadog/core/configuration/agent_settings_resolver.rb
+++ b/lib/datadog/core/configuration/agent_settings_resolver.rb
@@ -344,7 +344,7 @@ module Datadog
         end
 
         def log_warning(message)
-          logger.warn(message) if logger
+          logger&.warn(message)
         end
 
         def http_scheme?(uri)

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -163,20 +163,20 @@ module Datadog
         # and avoid tearing down parts still in use.
         def shutdown!(replacement = nil)
           # Shutdown remote configuration
-          remote.shutdown! if remote
+          remote&.shutdown!
 
           # Shutdown DI after remote, since remote config triggers DI operations.
           dynamic_instrumentation&.shutdown!
 
           # Decommission AppSec
-          appsec.shutdown! if appsec
+          appsec&.shutdown!
 
           # Shutdown the old tracer, unless it's still being used.
           # (e.g. a custom tracer instance passed in.)
           tracer.shutdown! unless replacement && tracer == replacement.tracer
 
           # Shutdown old profiler
-          profiler.shutdown! unless profiler.nil?
+          profiler&.shutdown!
 
           # Shutdown workers
           runtime_metrics.stop(true, close_metrics: false)

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -30,7 +30,7 @@ module Datadog
 
           def build_health_metrics(settings, logger, telemetry)
             settings = settings.health_metrics
-            options = { enabled: settings.enabled }
+            options = {enabled: settings.enabled}
             options[:statsd] = settings.statsd unless settings.statsd.nil?
 
             Core::Diagnostics::Health::Metrics.new(telemetry: telemetry, logger: logger, **options)
@@ -44,7 +44,7 @@ module Datadog
           end
 
           def build_runtime_metrics(settings, logger, telemetry)
-            options = { enabled: settings.runtime_metrics.enabled }
+            options = {enabled: settings.runtime_metrics.enabled}
             options[:statsd] = settings.runtime_metrics.statsd unless settings.runtime_metrics.statsd.nil?
             options[:services] = [settings.service] unless settings.service.nil?
             options[:experimental_runtime_id_enabled] = settings.runtime_metrics.experimental_runtime_id_enabled
@@ -194,14 +194,14 @@ module Datadog
             health_metrics.statsd
           ].compact.uniq
 
-          new_statsd =  if replacement
-                          [
-                            replacement.runtime_metrics.metrics.statsd,
-                            replacement.health_metrics.statsd
-                          ].compact.uniq
-                        else
-                          []
-                        end
+          new_statsd = if replacement
+            [
+              replacement.runtime_metrics.metrics.statsd,
+              replacement.health_metrics.statsd
+            ].compact.uniq
+          else
+            []
+          end
 
           unused_statsd = (old_statsd - (old_statsd & new_statsd))
           unused_statsd.each(&:close)

--- a/lib/datadog/core/configuration/option.rb
+++ b/lib/datadog/core/configuration/option.rb
@@ -142,14 +142,14 @@ module Datadog
 
         def reset
           @value = if definition.resetter
-                     # Don't change @is_set to false; custom resetters are
-                     # responsible for changing @value back to a good state.
-                     # Setting @is_set = false would cause a default to be applied.
-                     context_exec(@value, &definition.resetter)
-                   else
-                     @is_set = false
-                     nil
-                   end
+            # Don't change @is_set to false; custom resetters are
+            # responsible for changing @value back to a good state.
+            # Setting @is_set = false would cause a default to be applied.
+            context_exec(@value, &definition.resetter)
+          else
+            @is_set = false
+            nil
+          end
 
           # Reset back to the lowest precedence, to allow all `set`s to succeed right after a reset.
           @precedence_set = Precedence::DEFAULT
@@ -227,20 +227,20 @@ module Datadog
 
           unless valid_type
             raise_error = if @definition.type_options[:nilable]
-                            !value.is_a?(NilClass)
-                          else
-                            true
-                          end
+              !value.is_a?(NilClass)
+            else
+              true
+            end
           end
 
           if raise_error
             error_msg = if @definition.type_options[:nilable]
-                          "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a "\
-                          "#{@definition.type} or `nil`, but a `#{value.class}` was provided (#{value.inspect})."\
-                        else
-                          "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a "\
-                          "#{@definition.type}, but a `#{value.class}` was provided (#{value.inspect})."\
-                        end
+              "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a " \
+              "#{@definition.type} or `nil`, but a `#{value.class}` was provided (#{value.inspect})." \
+            else
+              "The setting `#{@definition.name}` inside your app's `Datadog.configure` block expects a " \
+              "#{@definition.type}, but a `#{value.class}` was provided (#{value.inspect})." \
+            end
 
             error_msg = "#{error_msg} Please update your `configure` block. "
 

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -111,7 +111,7 @@ module Datadog
 
           def type(value, nilable: false)
             @type = value
-            @type_options = { nilable: nilable }
+            @type_options = {nilable: nilable}
 
             value
           end
@@ -156,7 +156,7 @@ module Datadog
             if !@default.nil? && @default_proc
               raise InvalidOptionError,
                 'Using `default` and `default_proc` is not allowed. Please use one or the other.' \
-                                'If you want to store a block as the default value use `default_proc`'\
+                                'If you want to store a block as the default value use `default_proc`' \
                                 ' otherwise use `default`'
             end
           end

--- a/lib/datadog/core/configuration/option_definition.rb
+++ b/lib/datadog/core/configuration/option_definition.rb
@@ -71,11 +71,11 @@ module Datadog
             validate_options!
           end
 
-          def env(value)
+          def env(value) # standard:disable Style/TrivialAccessors
             @env = value
           end
 
-          def deprecated_env(value)
+          def deprecated_env(value) # standard:disable Style/TrivialAccessors
             @deprecated_env = value
           end
 

--- a/lib/datadog/core/configuration/options.rb
+++ b/lib/datadog/core/configuration/options.rb
@@ -18,7 +18,7 @@ module Datadog
         module ClassMethods
           def options
             # Allows for class inheritance of option definitions
-            @options ||= superclass <= Options ? superclass.options.dup : {}
+            @options ||= (superclass <= Options) ? superclass.options.dup : {}
           end
 
           protected

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -137,7 +137,7 @@ module Datadog
             o.after_set do |enabled|
               # Enable rich debug print statements.
               # We do not need to unnecessarily load 'pp' unless in debugging mode.
-              require 'pp' if enabled
+              require 'pp' if enabled # standard:disable Lint/RedundantRequireStatement
             end
           end
 

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -18,7 +18,7 @@ module Datadog
     module Configuration
       # Global configuration settings for the Datadog library.
       # @public_api
-      # rubocop:disable Metrics/BlockLength
+      # standard:disable Metrics/BlockLength
       class Settings
         include Base
 
@@ -995,7 +995,7 @@ module Datadog
         #       Keep this extension here for now to keep things working.
         extend Datadog::Tracing::Configuration::Settings
       end
-      # rubocop:enable Metrics/BlockLength
+      # standard:enable Metrics/BlockLength
     end
   end
 end

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -123,7 +123,7 @@ module Datadog
           # @return [Boolean]
           option :debug do |o|
             o.env [Datadog::Core::Configuration::Ext::Diagnostics::ENV_DEBUG_ENABLED,
-                   Datadog::Core::Configuration::Ext::Diagnostics::ENV_OTEL_LOG_LEVEL]
+              Datadog::Core::Configuration::Ext::Diagnostics::ENV_OTEL_LOG_LEVEL]
             o.default false
             o.type :bool
             o.env_parser do |value|
@@ -454,7 +454,7 @@ module Datadog
               o.after_set do |_, _, precedence|
                 unless precedence == Datadog::Core::Configuration::Option::Precedence::DEFAULT
                   Core.log_deprecation(key: :experimental_crash_tracking_enabled) do
-                    'The profiling.advanced.experimental_crash_tracking_enabled setting has been deprecated for removal '\
+                    'The profiling.advanced.experimental_crash_tracking_enabled setting has been deprecated for removal ' \
                     'and no longer does anything. Please remove it from your Datadog.configure block.'
                   end
                 end
@@ -641,11 +641,11 @@ module Datadog
                 val ||= ''
                 # maps OpenTelemetry semantic attributes to Datadog tags
                 key = case key.downcase
-                      when 'deployment.environment' then 'env'
-                      when 'service.version' then 'version'
-                      when 'service.name' then 'service'
-                      else key
-                      end
+                when 'deployment.environment' then 'env'
+                when 'service.version' then 'version'
+                when 'service.name' then 'service'
+                else key
+                end
                 result[key] = val unless key.empty?
               end
             end

--- a/lib/datadog/core/encoding.rb
+++ b/lib/datadog/core/encoding.rb
@@ -54,7 +54,7 @@ module Datadog
         end
 
         def join(encoded_data)
-          "[#{encoded_data.join(',')}]"
+          "[#{encoded_data.join(",")}]"
         end
       end
 

--- a/lib/datadog/core/environment/cgroup.rb
+++ b/lib/datadog/core/environment/cgroup.rb
@@ -23,20 +23,18 @@ module Datadog
 
         def descriptors(process = 'self')
           [].tap do |descriptors|
-            begin
-              filepath = "/proc/#{process}/cgroup"
+            filepath = "/proc/#{process}/cgroup"
 
-              if File.exist?(filepath)
-                File.foreach("/proc/#{process}/cgroup") do |line|
-                  line = line.strip
-                  descriptors << parse(line) unless line.empty?
-                end
+            if File.exist?(filepath)
+              File.foreach("/proc/#{process}/cgroup") do |line|
+                line = line.strip
+                descriptors << parse(line) unless line.empty?
               end
-            rescue StandardError => e
-              Datadog.logger.error(
-                "Error while parsing cgroup. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
-              )
             end
+          rescue => e
+            Datadog.logger.error(
+              "Error while parsing cgroup. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+            )
           end
         end
 

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -37,52 +37,50 @@ module Datadog
 
         def descriptor
           @descriptor ||= Descriptor.new.tap do |descriptor|
-            begin
-              Cgroup.descriptors.each do |cgroup_descriptor|
-                # Parse container data from cgroup descriptor
-                path = cgroup_descriptor.path
-                next if path.nil?
+            Cgroup.descriptors.each do |cgroup_descriptor|
+              # Parse container data from cgroup descriptor
+              path = cgroup_descriptor.path
+              next if path.nil?
 
-                # Split path into parts
-                parts = path.split('/')
-                parts.shift # Remove leading empty part
+              # Split path into parts
+              parts = path.split('/')
+              parts.shift # Remove leading empty part
 
-                # Read info from path
-                next if parts.empty?
+              # Read info from path
+              next if parts.empty?
 
-                platform = parts[0][PLATFORM_REGEX, :platform]
-                container_id, task_uid = nil
+              platform = parts[0][PLATFORM_REGEX, :platform]
+              container_id, task_uid = nil
 
-                case parts.length
-                when 0..1
-                  next
-                when 2
-                  container_id = parts[-1][CONTAINER_REGEX, :container] \
-                                || parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
+              case parts.length
+              when 0..1
+                next
+              when 2
+                container_id = parts[-1][CONTAINER_REGEX, :container] \
+                              || parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
+              else
+                if (container_id = parts[-1][CONTAINER_REGEX, :container])
+                  task_uid = parts[-2][POD_REGEX, :pod] || parts[1][POD_REGEX, :pod]
                 else
-                  if (container_id = parts[-1][CONTAINER_REGEX, :container])
-                    task_uid = parts[-2][POD_REGEX, :pod] || parts[1][POD_REGEX, :pod]
-                  else
-                    container_id = parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
-                  end
+                  container_id = parts[-1][FARGATE_14_CONTAINER_REGEX, :container]
                 end
-
-                # If container ID wasn't found, ignore.
-                # Path might describe a non-container environment.
-                next if container_id.nil?
-
-                descriptor.platform = platform
-                descriptor.container_id = container_id
-                descriptor.task_uid = task_uid
-
-                break
               end
-            rescue StandardError => e
-              Datadog.logger.error(
-                "Error while parsing container info. Cause: #{e.class.name} #{e.message} " \
-                "Location: #{Array(e.backtrace).first}"
-              )
+
+              # If container ID wasn't found, ignore.
+              # Path might describe a non-container environment.
+              next if container_id.nil?
+
+              descriptor.platform = platform
+              descriptor.container_id = container_id
+              descriptor.task_uid = task_uid
+
+              break
             end
+          rescue => e
+            Datadog.logger.error(
+              "Error while parsing container info. Cause: #{e.class.name} #{e.message} " \
+              "Location: #{Array(e.backtrace).first}"
+            )
           end
         end
       end

--- a/lib/datadog/core/environment/ext.rb
+++ b/lib/datadog/core/environment/ext.rb
@@ -9,11 +9,11 @@ module Datadog
       module Ext
         # e.g for CRuby '3.0.1', for JRuby '9.2.19.0', for TruffleRuby '21.1.0'
         ENGINE_VERSION = if defined?(RUBY_ENGINE_VERSION)
-                           RUBY_ENGINE_VERSION
-                         else
-                           # CRuby < 2.3 doesn't support RUBY_ENGINE_VERSION
-                           RUBY_VERSION
-                         end
+          RUBY_ENGINE_VERSION
+        else
+          # CRuby < 2.3 doesn't support RUBY_ENGINE_VERSION
+          RUBY_VERSION
+        end
 
         ENV_API_KEY = 'DD_API_KEY'
         ENV_ENVIRONMENT = 'DD_ENV'
@@ -26,7 +26,7 @@ module Datadog
         FALLBACK_SERVICE_NAME =
           begin
             File.basename($PROGRAM_NAME, '.*')
-          rescue StandardError
+          rescue
             'ruby'
           end.freeze
 

--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -67,12 +67,12 @@ module Datadog
 
           rest.split('.').tap do |segments|
             if segments.length >= 4
-              pre   = "-#{segments.shift}"
-              build = "+#{segments.join('.')}"
+              pre = "-#{segments.shift}"
+              build = "+#{segments.join(".")}"
             elsif segments.length == 1
               pre = "-#{segments.shift}"
             else
-              build = "+#{segments.join('.')}"
+              build = "+#{segments.join(".")}"
             end
           end
 

--- a/lib/datadog/core/environment/platform.rb
+++ b/lib/datadog/core/environment/platform.rb
@@ -13,18 +13,18 @@ module Datadog
 
         # @return [String] ISA of host; `uname -m`
         def architecture
-          Identity.lang_version >= '2.2' ? Etc.uname[:machine] : Gem::Platform.local.cpu
+          (Identity.lang_version >= '2.2') ? Etc.uname[:machine] : Gem::Platform.local.cpu
         end
 
         # @return [String] name of host; `uname -n`
         def hostname
-          Identity.lang_version >= '2.2' ? Etc.uname[:nodename] : nil
+          (Identity.lang_version >= '2.2') ? Etc.uname[:nodename] : nil
         end
 
         # System name, normally `Linux` or `Darwin` (but 'Mac OS X' on JRuby);
         # @return [String] name of kernel; `uname -s`.
         def kernel_name
-          Identity.lang_version >= '2.2' ? Etc.uname[:sysname] : Gem::Platform.local.os.capitalize
+          (Identity.lang_version >= '2.2') ? Etc.uname[:sysname] : Gem::Platform.local.os.capitalize
         end
 
         # @return [String] kernel release; `uname -r`

--- a/lib/datadog/core/error.rb
+++ b/lib/datadog/core/error.rb
@@ -34,7 +34,7 @@ module Datadog
         # but it's around 3x faster in our benchmark test
         # at `error_spec.rb`.
         def full_backtrace(ex)
-          backtrace = String.new
+          backtrace = +''
           backtrace_for(ex, backtrace)
 
           # Avoid circular causes

--- a/lib/datadog/core/logger.rb
+++ b/lib/datadog/core/logger.rb
@@ -28,7 +28,7 @@ module Datadog
 
         if message.nil?
           if block
-            super(severity, message, progname) do
+            super do
               "[#{self.progname}] #{where}#{yield}"
             end
           else
@@ -39,7 +39,7 @@ module Datadog
         end
       end
 
-      alias log add
+      alias_method :log, :add
     end
   end
 end

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -173,7 +173,7 @@ module Datadog
         end
 
         def close
-          @statsd.close if @statsd && @statsd.respond_to?(:close)
+          @statsd.close if @statsd&.respond_to?(:close)
         end
 
         private
@@ -185,10 +185,8 @@ module Datadog
             defined?(Datadog::Statsd::VERSION) &&
               Datadog::Statsd::VERSION &&
               Gem::Version.new(Datadog::Statsd::VERSION)
-          ) || (
-            Gem.loaded_specs['dogstatsd-ruby'] &&
-              Gem.loaded_specs['dogstatsd-ruby'].version
-          )
+          ) ||
+            Gem.loaded_specs['dogstatsd-ruby']&.version
         end
 
         IGNORED_STATSD_ONLY_ONCE = Utils::OnlyOnce.new

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -75,10 +75,10 @@ module Datadog
           #
           # Versions < 5.0 are always single-threaded, but do not have the kwarg option.
           options = if dogstatsd_version >= Gem::Version.new('5.2')
-                      { single_thread: true }
-                    else
-                      {}
-                    end
+            {single_thread: true}
+          else
+            {}
+          end
 
           Datadog::Statsd.new(default_hostname, default_port, **options)
         end
@@ -99,7 +99,7 @@ module Datadog
           raise ArgumentError if value.nil?
 
           statsd.count(stat, value, metric_options(options))
-        rescue StandardError => e
+        rescue => e
           logger.error(
             "Failed to send count stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
@@ -113,7 +113,7 @@ module Datadog
           raise ArgumentError if value.nil?
 
           statsd.distribution(stat, value, metric_options(options))
-        rescue StandardError => e
+        rescue => e
           logger.error(
             "Failed to send distribution stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
@@ -126,7 +126,7 @@ module Datadog
           options = yield if block_given?
 
           statsd.increment(stat, metric_options(options))
-        rescue StandardError => e
+        rescue => e
           logger.error(
             "Failed to send increment stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
@@ -140,7 +140,7 @@ module Datadog
           raise ArgumentError if value.nil?
 
           statsd.gauge(stat, value, metric_options(options))
-        rescue StandardError => e
+        rescue => e
           logger.error(
             "Failed to send gauge stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"
           )
@@ -159,7 +159,7 @@ module Datadog
               finished = Utils::Time.get_time
               distribution(stat, ((finished - start) * 1000), options)
             end
-          rescue StandardError => e
+          rescue => e
             # TODO: Likely to be redundant, since `distribution` handles its own errors.
             logger.error(
               "Failed to send time stat. Cause: #{e.class.name} #{e.message} Source: #{Array(e.backtrace).first}"

--- a/lib/datadog/core/metrics/logging.rb
+++ b/lib/datadog/core/metrics/logging.rb
@@ -17,25 +17,25 @@ module Datadog
               l.progname = nil
               l.formatter = proc do |_severity, datetime, _progname, msg|
                 stat = JSON.parse(msg[3..-1]) # Trim off leading progname...
-                "#{JSON.dump(timestamp: datetime.to_i, message: 'Metric sent.', metric: stat)}\n"
+                "#{JSON.dump(timestamp: datetime.to_i, message: "Metric sent.", metric: stat)}\n"
               end
             end
           end
 
           def count(stat, value, options = nil)
-            logger.info({ stat: stat, type: :count, value: value, options: options }.to_json)
+            logger.info({stat: stat, type: :count, value: value, options: options}.to_json)
           end
 
           def distribution(stat, value, options = nil)
-            logger.info({ stat: stat, type: :distribution, value: value, options: options }.to_json)
+            logger.info({stat: stat, type: :distribution, value: value, options: options}.to_json)
           end
 
           def increment(stat, options = nil)
-            logger.info({ stat: stat, type: :increment, options: options }.to_json)
+            logger.info({stat: stat, type: :increment, options: options}.to_json)
           end
 
           def gauge(stat, value, options = nil)
-            logger.info({ stat: stat, type: :gauge, value: value, options: options }.to_json)
+            logger.info({stat: stat, type: :gauge, value: value, options: options}.to_json)
           end
         end
       end

--- a/lib/datadog/core/rate_limiter.rb
+++ b/lib/datadog/core/rate_limiter.rb
@@ -13,13 +13,15 @@ module Datadog
       # to be side-effect free.
       #
       # @return [Boolean] whether a resource conforms with the current limit
-      def allow?(size = 1); end
+      def allow?(size = 1)
+      end
 
       # The effective rate limiting ratio based on
       # recent calls to `allow?`.
       #
       # @return [Float] recent allowance ratio
-      def effective_rate; end
+      def effective_rate
+      end
     end
 
     # Implementation of the Token Bucket metering algorithm

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -11,6 +11,7 @@ module Datadog
       # Client communicates with the agent and sync remote configuration
       class Client
         class TransportError < StandardError; end
+
         class SyncError < StandardError; end
 
         attr_reader :transport, :repository, :id, :dispatcher, :logger
@@ -134,10 +135,10 @@ module Datadog
             "ruby.runtime.engine.name:#{RUBY_ENGINE}",
             "ruby.runtime.engine.version:#{ruby_engine_version}",
             "ruby.rubygems.platform.local:#{Gem::Platform.local}",
-            "ruby.gem.libddwaf.version:#{gem_spec('libddwaf').version}",
-            "ruby.gem.libddwaf.platform:#{gem_spec('libddwaf').platform}",
-            "ruby.gem.libdatadog.version:#{gem_spec('libdatadog').version}",
-            "ruby.gem.libdatadog.platform:#{gem_spec('libdatadog').platform}",
+            "ruby.gem.libddwaf.version:#{gem_spec("libddwaf").version}",
+            "ruby.gem.libddwaf.platform:#{gem_spec("libddwaf").platform}",
+            "ruby.gem.libdatadog.version:#{gem_spec("libdatadog").version}",
+            "ruby.gem.libdatadog.platform:#{gem_spec("libdatadog").platform}",
           ]
 
           if (git_repository_url = Core::Environment::Git.git_repository_url)
@@ -202,37 +203,37 @@ module Datadog
           return @native_platform unless @native_platform.nil?
 
           os = if RUBY_ENGINE == 'jruby'
-                 os_name = java.lang.System.get_property('os.name')
+            os_name = java.lang.System.get_property('os.name')
 
-                 case os_name
-                 when /linux/i then 'linux'
-                 when /mac/i   then 'darwin'
-                 else os_name
-                 end
-               else
-                 Gem::Platform.local.os
-               end
+            case os_name
+            when /linux/i then 'linux'
+            when /mac/i then 'darwin'
+            else os_name
+            end
+          else
+            Gem::Platform.local.os
+          end
 
           version = if os != 'linux'
-                      nil
-                    elsif RUBY_PLATFORM =~ /linux-(.+)$/
-                      # Old rubygems don't handle non-gnu linux correctly
-                      Regexp.last_match(1)
-                    else
-                      'gnu'
-                    end
+            nil
+          elsif RUBY_PLATFORM =~ /linux-(.+)$/
+            # Old rubygems don't handle non-gnu linux correctly
+            Regexp.last_match(1)
+          else
+            'gnu'
+          end
 
           cpu = if RUBY_ENGINE == 'jruby'
-                  os_arch = java.lang.System.get_property('os.arch')
+            os_arch = java.lang.System.get_property('os.arch')
 
-                  case os_arch
-                  when 'amd64' then 'x86_64'
-                  when 'aarch64' then os == 'darwin' ? 'arm64' : 'aarch64'
-                  else os_arch
-                  end
-                else
-                  Gem::Platform.local.cpu
-                end
+            case os_arch
+            when 'amd64' then 'x86_64'
+            when 'aarch64' then (os == 'darwin') ? 'arm64' : 'aarch64'
+            else os_arch
+            end
+          else
+            Gem::Platform.local.cpu
+          end
 
           @native_platform = [cpu, os, version].compact.join('-')
         end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -119,7 +119,7 @@ module Datadog
           end
         end
 
-        def payload # rubocop:disable Metrics/MethodLength
+        def payload # standard:disable Metrics/MethodLength
           state = repository.state
 
           client_tracer_tags = [

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -42,7 +42,7 @@ module Datadog
               logger.error do
                 "remote worker client sync error: #{e.message} location: #{Array(e.backtrace).first}. skipping sync"
               end
-            rescue StandardError => e
+            rescue => e
               # In case of unexpected errors, reset the negotiation object
               # given external conditions have changed and the negotiation
               # negotiation object stores error logging state that should be reset.
@@ -50,7 +50,7 @@ module Datadog
 
               # Transient errors due to network or agent. Logged the error but not via telemetry
               logger.error do
-                "remote worker error: #{e.class.name} #{e.message} location: #{Array(e.backtrace).first}. "\
+                "remote worker error: #{e.class.name} #{e.message} location: #{Array(e.backtrace).first}. " \
                 'resetting client state'
               end
 

--- a/lib/datadog/core/remote/configuration/digest.rb
+++ b/lib/datadog/core/remote/configuration/digest.rb
@@ -29,13 +29,13 @@ module Datadog
           class << self
             def hexdigest(type, data)
               d = case type
-                  when :sha256
-                    ::Digest::SHA256.new
-                  when :sha512
-                    ::Digest::SHA512.new
-                  else
-                    raise InvalidHashTypeError, type
-                  end
+              when :sha256
+                ::Digest::SHA256.new
+              when :sha512
+                ::Digest::SHA512.new
+              else
+                raise InvalidHashTypeError, type
+              end
 
               while (buf = data.read(DIGEST_CHUNK))
                 d.update(buf)

--- a/lib/datadog/core/remote/configuration/path.rb
+++ b/lib/datadog/core/remote/configuration/path.rb
@@ -30,7 +30,7 @@ module Datadog
 
               raise ParseError, "could not parse: #{path.inspect}" if m.nil?
 
-              org_id = m['org_id'] ? m['org_id'].to_i : nil
+              org_id = m['org_id']&.to_i
 
               source = m['source']
               raise ParseError, 'missing source value' unless source

--- a/lib/datadog/core/remote/transport/http/client.rb
+++ b/lib/datadog/core/remote/transport/http/client.rb
@@ -28,7 +28,7 @@ module Datadog
 
               # Get responses from API
               yield(api, env)
-            rescue StandardError => e
+            rescue => e
               message =
                 "Internal error during #{self.class.name} request. Cause: #{e.class.name} #{e.message} " \
                   "Location: #{Array(e.backtrace).first}"

--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -231,7 +231,7 @@ module Datadog
                   env.body = env.request.parcel.data
 
                   # Query for response
-                  http_response = super(env, &block)
+                  http_response = super
 
                   response_options = {}
 

--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -21,7 +21,7 @@ module Datadog
               include Datadog::Core::Transport::HTTP::Response
               include Core::Remote::Transport::Config::Response
 
-              def initialize(http_response, options = {}) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+              def initialize(http_response, options = {}) # standard:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
                 super(http_response)
 
                 raise AgentErrorResponse.new(http_response.code, http_response.payload) if http_response.code != 200

--- a/lib/datadog/core/remote/transport/http/negotiation.rb
+++ b/lib/datadog/core/remote/transport/http/negotiation.rb
@@ -79,7 +79,7 @@ module Datadog
 
                 def call(env, &block)
                   # Query for response
-                  http_response = super(env, &block)
+                  http_response = super
 
                   # Process the response
                   body = JSON.parse(http_response.payload, symbolize_names: true) if http_response.ok?

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -96,7 +96,7 @@ module Datadog
 
         def try_flush
           yield
-        rescue StandardError => e
+        rescue => e
           Datadog.logger.warn("Error while sending runtime metric. Cause: #{e.class.name} #{e.message}")
         end
 

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -147,7 +147,7 @@ module Datadog
           gauge(metric_name, metric_value) if metric_value
         end
 
-        # rubocop:disable Metrics/MethodLength
+        # standard:disable Metrics/MethodLength
         def flush_yjit_stats
           # Only on Ruby >= 3.2
           try_flush do
@@ -195,7 +195,7 @@ module Datadog
             end
           end
         end
-        # rubocop:enable Metrics/MethodLength
+        # standard:enable Metrics/MethodLength
       end
     end
   end

--- a/lib/datadog/core/telemetry/component.rb
+++ b/lib/datadog/core/telemetry/component.rb
@@ -60,25 +60,25 @@ module Datadog
           return unless @enabled
 
           @transport = if settings.telemetry.agentless_enabled
-                         agent_settings = Core::Configuration::AgentlessSettingsResolver.call(
-                           settings,
-                           host_prefix: 'instrumentation-telemetry-intake',
-                           url_override: settings.telemetry.agentless_url_override,
-                           url_override_source: 'c.telemetry.agentless_url_override',
-                           logger: logger,
-                         )
-                         Telemetry::Transport::HTTP.agentless_telemetry(
-                           agent_settings: agent_settings,
-                           logger: logger,
-                           # api_key should have already validated to be
-                           # not nil by +build+ method above.
-                           api_key: settings.api_key,
-                         )
-                       else
-                         Telemetry::Transport::HTTP.agent_telemetry(
-                           agent_settings: agent_settings, logger: logger,
-                         )
-                       end
+            agent_settings = Core::Configuration::AgentlessSettingsResolver.call(
+              settings,
+              host_prefix: 'instrumentation-telemetry-intake',
+              url_override: settings.telemetry.agentless_url_override,
+              url_override_source: 'c.telemetry.agentless_url_override',
+              logger: logger,
+            )
+            Telemetry::Transport::HTTP.agentless_telemetry(
+              agent_settings: agent_settings,
+              logger: logger,
+              # api_key should have already validated to be
+              # not nil by +build+ method above.
+              api_key: settings.api_key,
+            )
+          else
+            Telemetry::Transport::HTTP.agent_telemetry(
+              agent_settings: agent_settings, logger: logger,
+            )
+          end
 
           @worker = Telemetry::Worker.new(
             enabled: @enabled,

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -34,7 +34,13 @@ module Datadog
           logger.debug { "Telemetry sent for event `#{event.type}` (response code: #{res.code})" }
           res
         rescue => e
-          logger.debug { "Unable to send telemetry request for event `#{event.type rescue 'unknown'}`: #{e}" }
+          logger.debug {
+            "Unable to send telemetry request for event `#{begin
+              event.type
+            rescue
+              "unknown"
+            end}`: #{e}"
+          }
           Core::Transport::InternalErrorResponse.new(e)
         end
 

--- a/lib/datadog/core/telemetry/event/app_client_configuration_change.rb
+++ b/lib/datadog/core/telemetry/event/app_client_configuration_change.rb
@@ -21,7 +21,7 @@ module Datadog
           end
 
           def payload
-            { configuration: configuration }
+            {configuration: configuration}
           end
 
           def configuration
@@ -53,7 +53,7 @@ module Datadog
             other.is_a?(AppClientConfigurationChange) && other.changes == @changes && other.origin == @origin
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [self.class, @changes, @origin].hash

--- a/lib/datadog/core/telemetry/event/app_dependencies_loaded.rb
+++ b/lib/datadog/core/telemetry/event/app_dependencies_loaded.rb
@@ -13,7 +13,7 @@ module Datadog
           end
 
           def payload
-            { dependencies: dependencies }
+            {dependencies: dependencies}
           end
 
           private

--- a/lib/datadog/core/telemetry/event/app_integrations_change.rb
+++ b/lib/datadog/core/telemetry/event/app_integrations_change.rb
@@ -13,7 +13,7 @@ module Datadog
           end
 
           def payload
-            { integrations: integrations }
+            {integrations: integrations}
           end
 
           private

--- a/lib/datadog/core/telemetry/event/app_integrations_change.rb
+++ b/lib/datadog/core/telemetry/event/app_integrations_change.rb
@@ -25,7 +25,7 @@ module Datadog
 
               is_enabled = is_instrumented && integration.klass.patcher.patch_successful
 
-              version = integration.klass.class.version ? integration.klass.class.version.to_s : nil
+              version = integration.klass.class.version&.to_s
 
               res = {
                 name: integration.name.to_s,

--- a/lib/datadog/core/telemetry/event/app_started.rb
+++ b/lib/datadog/core/telemetry/event/app_started.rb
@@ -66,8 +66,8 @@ module Datadog
             tracing.sampling.rate_limit
           ].freeze
 
-          # rubocop:disable Metrics/AbcSize
-          # rubocop:disable Metrics/MethodLength
+          # standard:disable Metrics/AbcSize
+          # standard:disable Metrics/MethodLength
           def configuration
             config = Datadog.configuration
             seq_id = Event.configuration_sequence.next
@@ -133,8 +133,8 @@ module Datadog
             list.reject! { |entry| entry[:value].nil? }
             list
           end
-          # rubocop:enable Metrics/AbcSize
-          # rubocop:enable Metrics/MethodLength
+          # standard:enable Metrics/AbcSize
+          # standard:enable Metrics/MethodLength
 
           def agent_transport(config)
             adapter = Core::Configuration::AgentSettingsResolver.call(config).adapter

--- a/lib/datadog/core/telemetry/event/base.rb
+++ b/lib/datadog/core/telemetry/event/base.rb
@@ -27,7 +27,7 @@ module Datadog
           end
 
           # @see #==
-          alias eql? ==
+          alias_method :eql?, :==
 
           # @see #==
           def hash

--- a/lib/datadog/core/telemetry/event/generate_metrics.rb
+++ b/lib/datadog/core/telemetry/event/generate_metrics.rb
@@ -31,7 +31,7 @@ module Datadog
             other.is_a?(GenerateMetrics) && other.namespace == @namespace && other.metric_series == @metric_series
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [self.class, @namespace, @metric_series].hash

--- a/lib/datadog/core/telemetry/event/log.rb
+++ b/lib/datadog/core/telemetry/event/log.rb
@@ -64,7 +64,7 @@ module Datadog
               other.level == @level && other.stack_trace == @stack_trace && other.count == @count
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [self.class, @message, @level, @stack_trace, @count].hash

--- a/lib/datadog/core/telemetry/event/message_batch.rb
+++ b/lib/datadog/core/telemetry/event/message_batch.rb
@@ -30,7 +30,7 @@ module Datadog
             other.is_a?(MessageBatch) && other.events == @events
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [self.class, @events].hash

--- a/lib/datadog/core/telemetry/logger.rb
+++ b/lib/datadog/core/telemetry/logger.rb
@@ -35,7 +35,7 @@ module Datadog
             # The downside is: this leaves us unable to report telemetry during component initialization.
             components = Datadog.send(:components, allow_initialization: false)
 
-            if components && components.telemetry
+            if components&.telemetry
               components.telemetry
             else
               Datadog.logger.warn(

--- a/lib/datadog/core/telemetry/metric.rb
+++ b/lib/datadog/core/telemetry/metric.rb
@@ -20,7 +20,7 @@ module Datadog
           end
 
           def id
-            @id ||= "#{type}::#{name}::#{tags.join(',')}"
+            @id ||= "#{type}::#{name}::#{tags.join(",")}"
           end
 
           def track(value)
@@ -47,7 +47,7 @@ module Datadog
               values == other.values && tags == other.tags && common == other.common && type == other.type
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [self.class, name, values, tags, common, type].hash
@@ -88,7 +88,7 @@ module Datadog
             super && interval == other.interval
           end
 
-          alias eql? ==
+          alias_method :eql?, :==
 
           def hash
             [super, interval].hash

--- a/lib/datadog/core/telemetry/transport/http/telemetry.rb
+++ b/lib/datadog/core/telemetry/transport/http/telemetry.rb
@@ -64,11 +64,11 @@ module Datadog
                   super
                 end
 
-                def headers(request_type:, api_version: 'v2', api_key:)
+                def headers(request_type:, api_key:, api_version: 'v2')
                   {
                     Core::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST => '1',
                     # Provided by encoder
-                    #'Content-Type' => 'application/json',
+                    # 'Content-Type' => 'application/json',
                     'DD-Telemetry-API-Version' => api_version,
                     'DD-Telemetry-Request-Type' => request_type,
                     'DD-Client-Library-Language' => Core::Environment::Ext::LANG,

--- a/lib/datadog/core/telemetry/transport/telemetry.rb
+++ b/lib/datadog/core/telemetry/transport/telemetry.rb
@@ -14,7 +14,6 @@ module Datadog
           end
 
           class Request < Datadog::Core::Transport::Request
-
             attr_reader :request_type
             attr_reader :api_key
 

--- a/lib/datadog/core/transport/http/adapters/test.rb
+++ b/lib/datadog/core/transport/http/adapters/test.rb
@@ -38,7 +38,8 @@ module Datadog
               @status = status
             end
 
-            def url; end
+            def url
+            end
 
             # Response for test adapter
             class Response

--- a/lib/datadog/core/transport/http/builder.rb
+++ b/lib/datadog/core/transport/http/builder.rb
@@ -41,19 +41,19 @@ module Datadog
 
           def adapter(config, *args, **kwargs)
             @default_adapter = case config
-                               when Core::Configuration::AgentSettingsResolver::AgentSettings
-                                 registry_klass = REGISTRY.get(config.adapter)
-                                 raise UnknownAdapterError, config.adapter if registry_klass.nil?
+            when Core::Configuration::AgentSettingsResolver::AgentSettings
+              registry_klass = REGISTRY.get(config.adapter)
+              raise UnknownAdapterError, config.adapter if registry_klass.nil?
 
-                                 registry_klass.build(config)
-                               when Symbol
-                                 registry_klass = REGISTRY.get(config)
-                                 raise UnknownAdapterError, config if registry_klass.nil?
+              registry_klass.build(config)
+            when Symbol
+              registry_klass = REGISTRY.get(config)
+              raise UnknownAdapterError, config if registry_klass.nil?
 
-                                 registry_klass.new(*args, **kwargs)
-                               else
-                                 config
-                               end
+              registry_klass.new(*args, **kwargs)
+            else
+              config
+            end
           end
 
           def headers(values = {})

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -51,13 +51,13 @@ module Datadog
           def fork
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
-                            proc do
-                              AtForkMonkeyPatch.run_at_fork_blocks(:child)
+              proc do
+                AtForkMonkeyPatch.run_at_fork_blocks(:child)
 
-                              # Invoke original block
-                              yield
-                            end
-                          end
+                # Invoke original block
+                yield
+              end
+            end
 
             # Start fork
             # If a block is provided, use the wrapped version.

--- a/lib/datadog/core/utils/duration.rb
+++ b/lib/datadog/core/utils/duration.rb
@@ -7,42 +7,42 @@ module Datadog
       module Duration
         def self.call(value, base: :s)
           cast = if value.include?('.')
-                   method(:Float)
-                 else
-                   method(:Integer)
-                 end
+            method(:Float)
+          else
+            method(:Integer)
+          end
 
           scale = case base
-                  when :s
-                    1_000_000_000
-                  when :ms
-                    1_000_000
-                  when :us
-                    1000
-                  when :ns
-                    1
-                  else
-                    raise ArgumentError, "invalid base: #{base.inspect}"
-                  end
+          when :s
+            1_000_000_000
+          when :ms
+            1_000_000
+          when :us
+            1000
+          when :ns
+            1
+          else
+            raise ArgumentError, "invalid base: #{base.inspect}"
+          end
 
           result = case value
-                   when /^(\d+(?:\.\d+)?)h$/
-                     cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 * 60 / scale
-                   when /^(\d+(?:\.\d+)?)m$/
-                     cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 / scale
-                   when /^(\d+(?:\.\d+)?)s$/
-                     cast.call(Regexp.last_match(1)) * 1_000_000_000 / scale
-                   when /^(\d+(?:\.\d+)?)ms$/
-                     cast.call(Regexp.last_match(1)) * 1_000_000 / scale
-                   when /^(\d+(?:\.\d+)?)us$/
-                     cast.call(Regexp.last_match(1)) * 1_000 / scale
-                   when /^(\d+(?:\.\d+)?)ns$/
-                     cast.call(Regexp.last_match(1)) / scale
-                   when /^(\d+(?:\.\d+)?)$/
-                     cast.call(Regexp.last_match(1))
-                   else
-                     raise ArgumentError, "invalid duration: #{value.inspect}"
-                   end
+          when /^(\d+(?:\.\d+)?)h$/
+            cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 * 60 / scale
+          when /^(\d+(?:\.\d+)?)m$/
+            cast.call(Regexp.last_match(1)) * 1_000_000_000 * 60 / scale
+          when /^(\d+(?:\.\d+)?)s$/
+            cast.call(Regexp.last_match(1)) * 1_000_000_000 / scale
+          when /^(\d+(?:\.\d+)?)ms$/
+            cast.call(Regexp.last_match(1)) * 1_000_000 / scale
+          when /^(\d+(?:\.\d+)?)us$/
+            cast.call(Regexp.last_match(1)) * 1_000 / scale
+          when /^(\d+(?:\.\d+)?)ns$/
+            cast.call(Regexp.last_match(1)) / scale
+          when /^(\d+(?:\.\d+)?)$/
+            cast.call(Regexp.last_match(1))
+          else
+            raise ArgumentError, "invalid duration: #{value.inspect}"
+          end
           # @type var result: Numeric
           result.round
         end

--- a/lib/datadog/core/utils/forking.rb
+++ b/lib/datadog/core/utils/forking.rb
@@ -47,12 +47,12 @@ module Datadog
           # This wrapper prevents this by initializing the fork PID when the object is created.
           if RUBY_VERSION >= '3'
             def initialize(*args, **kwargs, &block)
-              super(*args, **kwargs, &block)
+              super
               update_fork_pid!
             end
           else
             def initialize(*args, &block)
-              super(*args, &block)
+              super
               update_fork_pid!
             end
           end

--- a/lib/datadog/core/utils/network.rb
+++ b/lib/datadog/core/utils/network.rb
@@ -52,10 +52,10 @@ module Datadog
             return unless ip
 
             clean_ip = if likely_ipv4?(ip)
-                         strip_ipv4_port(ip)
-                       else
-                         strip_zone_specifier(strip_ipv6_port(ip))
-                       end
+              strip_ipv4_port(ip)
+            else
+              strip_zone_specifier(strip_ipv6_port(ip))
+            end
 
             begin
               IPAddr.new(clean_ip)

--- a/lib/datadog/core/utils/network.rb
+++ b/lib/datadog/core/utils/network.rb
@@ -32,7 +32,7 @@ module Datadog
           def stripped_ip_from_request_headers(headers, ip_headers_to_check: DEFAULT_IP_HEADERS_NAMES)
             ip = ip_header(headers, ip_headers_to_check)
 
-            ip ? ip.to_s : nil
+            ip&.to_s
           end
 
           # @param [String] IP value.
@@ -40,7 +40,7 @@ module Datadog
           # @return [nil] when no valid IP value found.
           def stripped_ip(ip)
             ip = ip_to_ipaddr(ip)
-            ip ? ip.to_s : nil
+            ip&.to_s
           end
 
           private

--- a/lib/datadog/core/utils/time.rb
+++ b/lib/datadog/core/utils/time.rb
@@ -35,7 +35,11 @@ module Datadog
             # Avoid method redefinition warning.
             # `rescue nil` is added in case customers remove the method
             # themselves to squelch the warning.
-            remove_method(:now) rescue nil
+            begin
+              remove_method(:now)
+            rescue
+              nil
+            end
           end
           define_singleton_method(:now, &block)
         end
@@ -53,7 +57,11 @@ module Datadog
             # Avoid method redefinition warning
             # `rescue nil` is added in case customers remove the method
             # themselves to squelch the warning.
-            remove_method(:get_time) rescue nil
+            begin
+              remove_method(:get_time)
+            rescue
+              nil
+            end
           end
           define_singleton_method(:get_time, &block)
         end

--- a/lib/datadog/core/vendor/multipart-post/multipart/post/composite_read_io.rb
+++ b/lib/datadog/core/vendor/multipart-post/multipart/post/composite_read_io.rb
@@ -108,7 +108,7 @@ module Datadog
             end
 
             def respond_to?(meth, include_all = false)
-              @io.respond_to?(meth, include_all) || super(meth, include_all)
+              @io.respond_to?(meth, include_all) || super
             end
           end
         end

--- a/lib/datadog/core/vendor/multipart-post/multipart/post/multipartable.rb
+++ b/lib/datadog/core/vendor/multipart-post/multipart/post/multipartable.rb
@@ -28,29 +28,29 @@ module Datadog
               "--#{SecureRandom.uuid}"
             end
 
-            def initialize(path, params, headers={}, boundary = Multipartable.secure_boundary)
+            def initialize(path, params, headers = {}, boundary = Multipartable.secure_boundary)
               headers = headers.clone # don't want to modify the original variable
               parts_headers = headers.delete(:parts) || {}
               super(path, headers)
-              parts = params.map do |k,v|
+              parts = params.map do |k, v|
                 case v
                 when Array
-                  v.map {|item| Parts::Part.new(boundary, "#{k}[]", item, parts_headers[k]) }
+                  v.map { |item| Parts::Part.new(boundary, "#{k}[]", item, parts_headers[k]) }
                 else
                   Parts::Part.new(boundary, k, v, parts_headers[k])
                 end
               end.flatten
               parts << Parts::EpiloguePart.new(boundary)
-              ios = parts.map {|p| p.to_io }
-              self.set_content_type(headers["Content-Type"] || "multipart/form-data",
-                                    { "boundary" => boundary })
-              self.content_length = parts.inject(0) {|sum,i| sum + i.length }
+              ios = parts.map { |p| p.to_io }
+              set_content_type(headers["Content-Type"] || "multipart/form-data",
+                {"boundary" => boundary})
+              self.content_length = parts.inject(0) { |sum, i| sum + i.length }
               self.body_stream = CompositeReadIO.new(*ios)
 
               @boundary = boundary
             end
 
-            attr :boundary
+            attr_reader :boundary
           end
         end
       end

--- a/lib/datadog/core/vendor/multipart-post/multipart/post/parts.rb
+++ b/lib/datadog/core/vendor/multipart-post/multipart/post/parts.rb
@@ -58,7 +58,7 @@ module Datadog
                 part = ''
                 part << "--#{boundary}\r\n"
                 part << "Content-ID: #{headers["Content-ID"]}\r\n" if headers["Content-ID"]
-                part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"
+                part << "Content-Disposition: form-data; name=\"#{name}\"\r\n"
                 part << "Content-Type: #{headers["Content-Type"]}\r\n" if headers["Content-Type"]
                 part << "\r\n"
                 part << "#{value}\r\n"
@@ -76,9 +76,9 @@ module Datadog
               # @param io [IO]
               # @param headers [Hash]
               def initialize(boundary, name, io, headers = {})
-                file_length = io.respond_to?(:length) ?  io.length : File.size(io.local_path)
+                file_length = io.respond_to?(:length) ? io.length : File.size(io.local_path)
                 @head = build_head(boundary, name, io.original_filename, io.content_type, file_length,
-                                  io.respond_to?(:opts) ? io.opts.merge(headers) : headers)
+                  io.respond_to?(:opts) ? io.opts.merge(headers) : headers)
                 @foot = "\r\n"
                 @length = @head.bytesize + file_length + @foot.length
                 @io = CompositeReadIO.new(StringIO.new(@head), io, StringIO.new(@foot))
@@ -98,16 +98,16 @@ module Datadog
 
                 part = ''
                 part << "--#{boundary}\r\n"
-                part << "Content-Disposition: #{content_disposition}; name=\"#{name.to_s}\"; filename=\"#{filename}\"\r\n"
+                part << "Content-Disposition: #{content_disposition}; name=\"#{name}\"; filename=\"#{filename}\"\r\n"
                 part << "Content-Length: #{content_len}\r\n"
                 if content_id = opts.delete("Content-ID")
                   part << "Content-ID: #{content_id}\r\n"
                 end
 
-                if opts["Content-Type"] != nil
-                  part <<  "Content-Type: " + opts["Content-Type"] + "\r\n"
+                part << if !opts["Content-Type"].nil?
+                  "Content-Type: " + opts["Content-Type"] + "\r\n"
                 else
-                  part << "Content-Type: #{type}\r\n"
+                  "Content-Type: #{type}\r\n"
                 end
 
                 part << "Content-Transfer-Encoding: #{trans_encoding}\r\n"

--- a/lib/datadog/core/worker.rb
+++ b/lib/datadog/core/worker.rb
@@ -12,7 +12,7 @@ module Datadog
       end
 
       def perform(*args)
-        task.call(*args) unless task.nil?
+        task&.call(*args)
       end
 
       protected

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -154,16 +154,15 @@ module Datadog
             Datadog.logger.debug { "Starting thread for: #{self}" }
 
             @worker = ::Thread.new do
-              begin
-                yield
-              # rubocop:disable Lint/RescueException
-              rescue Exception => e
-                @error = e
-                Datadog.logger.debug(
-                  "Worker thread error. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
-                )
-                raise
-              end
+              yield
+            # rubocop:disable Lint/RescueException
+            rescue Exception => e
+              @error = e
+              Datadog.logger.debug(
+                "Worker thread error. Cause: #{e.class.name} #{e.message} Location: #{Array(e.backtrace).first}"
+              )
+              raise
+
               # rubocop:enable Lint/RescueException
             end
             @worker.name = self.class.name


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Switches core to use standard instead of rubocop

**Motivation:**
We decided to standardize on standard
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
