### PR TITLE
[NO-TICKET] Fix profiling scheduler reporting corner case during shutdown

### DIFF
--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -37,6 +37,7 @@ module Datadog
         @exporter = exporter
         @transport = transport
         @profiler_failed = false
+        @stop_requested = false
 
         # Workers::Async::Thread settings
         self.fork_policy = fork_policy
@@ -88,7 +89,7 @@ module Datadog
       end
 
       def work_pending?
-        !profiler_failed && exporter.can_flush?
+        !profiler_failed && exporter.can_flush? && (run_loop? || !stop_requested?)
       end
 
       def reset_after_fork
@@ -138,7 +139,13 @@ module Datadog
           Datadog::Core::Telemetry::Logger.report(e, description: "Unable to report profile")
         end
 
+        @stop_requested = !run_loop?
+
         true
+      end
+
+      def stop_requested?
+        @stop_requested
       end
     end
   end

--- a/spec/datadog/profiling/scheduler_spec.rb
+++ b/spec/datadog/profiling/scheduler_spec.rb
@@ -271,4 +271,33 @@ RSpec.describe Datadog::Profiling::Scheduler do
       reset_after_fork
     end
   end
+
+  describe "#stop" do
+    let(:flush) { instance_double(Datadog::Profiling::Flush) }
+    let(:interval) { 1 }
+
+    before { allow(transport).to receive(:export) }
+
+    context "when exporter has data to flush" do
+      before do
+        allow(exporter).to receive(:can_flush?).and_return(true)
+        allow(exporter).to receive(:flush).and_return(flush)
+      end
+
+      # This test validates the behavior of the @stop_requested flag.
+      #
+      # Specifically, the looping behavior we get from the core helpers will keep on trying to flush
+      # while work_pending? is true. Because work_pending? used to keep on returning true while
+      # exporter.can_flush? was true, this would cause the loop keep running.
+      #
+      # This was fixed by the introduction of @stop_requested, which ensures that we "remember"
+      # when an export was done but a stop was requested.
+      it "flushes the data and stops the loop" do
+        scheduler.start
+        wait_for { scheduler.run_loop? }.to be true
+
+        expect(scheduler.stop).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a weird corner case in the profiling scheduler class that happened when the scheduler was being shutdown / stopped.

Specifically, if reporting a given profile to the backend took longer than `Exporter::PROFILE_DURATION_THRESHOLD_SECONDS`, then the exporter would keep on returning `exporter.can_flush? == true`.

This caused the scheduler to get "stuck" in a loop trying to report profiles again and again, until one of the reports was fast enough so that `exporter.can_flush? == false`.

In practice, this wouldn't actually happen because during shutdown, the `stop` operation gets called with `force_stop = true` (in workers/polling.rb) and thus the scheduler would be terminated "the hard way" after `DEFAULT_SHUTDOWN_TIMEOUT`, which is set to 1 second.

**Motivation:**

Even though this wouldn't happen in practice, it was a footgun locked and loaded.

This footgun actually hit me while I was doing some unrelated experiments and raised `DEFAULT_SHUTDOWN_TIMEOUT` to test something out.

So I decided to disarm the footgun and add test coverage for it ;)

**Change log entry**

Yes. Fix profiling scheduler reporting corner case during shutdown.

**Additional Notes:**

N/A

**How to test the change?**

I've added test coverage for the change. If you want to test it manually, try setting `Exporter::PROFILE_DURATION_THRESHOLD_SECONDS` to a really low value, such as 0.01 and observe what happens on app shutdown.