### PR TITLE
Fix no-op specs

### DIFF
--- a/spec/datadog/tracing/metadata/errors_spec.rb
+++ b/spec/datadog/tracing/metadata/errors_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Datadog::Tracing::Metadata::Errors do
     end
   end
 
-  Array(['set_error', 'set_error_tags']) do |method_name|
+  ['set_error', 'set_error_tags'].each do |method_name|
     describe "##{method_name}" do
-      subject(:error_setter) { test_object.send(method_name) }
+      subject(:error_setter) { test_object.send(method_name, error) }
 
       let(:error) { RuntimeError.new('oops') }
       let(:backtrace) { %w[method1 method2 method3] }


### PR DESCRIPTION
**Motivation:**

The tests are noop. 

```
$ bundle exec rspec spec/datadog/tracing/metadata/errors_spec.rb

Finished in 0.00117 seconds (files took 0.66045 seconds to load)
0 examples, 0 failures
```

**What does this PR do?**

- Fix no-op block syntax
- Fix ArgumentError for subject without passing an argument.

**Change log entry**
None.

