### PR TITLE
DEBUG-3573 Change telemetry event class into module

### DIFF
--- a/lib/datadog/core/telemetry/event.rb
+++ b/lib/datadog/core/telemetry/event.rb
@@ -7,7 +7,7 @@ module Datadog
   module Core
     module Telemetry
       # Collection of telemetry events
-      class Event
+      module Event
         extend Core::Utils::Forking
 
         # returns sequence that increments every time the configuration changes

--- a/lib/datadog/core/telemetry/event/app_client_configuration_change.rb
+++ b/lib/datadog/core/telemetry/event/app_client_configuration_change.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-client-configuration-change' event
         class AppClientConfigurationChange < Base
           attr_reader :changes, :origin

--- a/lib/datadog/core/telemetry/event/app_closing.rb
+++ b/lib/datadog/core/telemetry/event/app_closing.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-closing' event
         class AppClosing < Base
           def type

--- a/lib/datadog/core/telemetry/event/app_dependencies_loaded.rb
+++ b/lib/datadog/core/telemetry/event/app_dependencies_loaded.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-dependencies-loaded' event
         class AppDependenciesLoaded < Base
           def type

--- a/lib/datadog/core/telemetry/event/app_heartbeat.rb
+++ b/lib/datadog/core/telemetry/event/app_heartbeat.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-heartbeat' event
         class AppHeartbeat < Base
           def type

--- a/lib/datadog/core/telemetry/event/app_integrations_change.rb
+++ b/lib/datadog/core/telemetry/event/app_integrations_change.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-integrations-change' event
         class AppIntegrationsChange < Base
           def type

--- a/lib/datadog/core/telemetry/event/app_started.rb
+++ b/lib/datadog/core/telemetry/event/app_started.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'app-started' event
         class AppStarted < Base
           def type

--- a/lib/datadog/core/telemetry/event/base.rb
+++ b/lib/datadog/core/telemetry/event/base.rb
@@ -3,7 +3,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Base class for all Telemetry V2 events.
         class Base
           # The type of the event.

--- a/lib/datadog/core/telemetry/event/distributions.rb
+++ b/lib/datadog/core/telemetry/event/distributions.rb
@@ -5,7 +5,7 @@ require_relative 'generate_metrics'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'distributions' event
         class Distributions < GenerateMetrics
           def type

--- a/lib/datadog/core/telemetry/event/generate_metrics.rb
+++ b/lib/datadog/core/telemetry/event/generate_metrics.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'generate-metrics' event
         class GenerateMetrics < Base
           attr_reader :namespace, :metric_series

--- a/lib/datadog/core/telemetry/event/log.rb
+++ b/lib/datadog/core/telemetry/event/log.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'logs' event.
         # Logs with the same content are deduplicated at flush time.
         class Log < Base

--- a/lib/datadog/core/telemetry/event/message_batch.rb
+++ b/lib/datadog/core/telemetry/event/message_batch.rb
@@ -3,7 +3,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         # Telemetry class for the 'message-batch' event.
         class MessageBatch < Base
           attr_reader :events

--- a/sig/datadog/core/telemetry/event.rbs
+++ b/sig/datadog/core/telemetry/event.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         extend Core::Utils::Forking
 
         self.@sequence: Datadog::Core::Utils::Sequence

--- a/sig/datadog/core/telemetry/event/app_client_configuration_change.rbs
+++ b/sig/datadog/core/telemetry/event/app_client_configuration_change.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppClientConfigurationChange < Base
           @changes: untyped
 

--- a/sig/datadog/core/telemetry/event/app_closing.rbs
+++ b/sig/datadog/core/telemetry/event/app_closing.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppClosing < Base
           def type: () -> "app-closing"
         end

--- a/sig/datadog/core/telemetry/event/app_dependencies_loaded.rbs
+++ b/sig/datadog/core/telemetry/event/app_dependencies_loaded.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppDependenciesLoaded < Base
           def type: () -> "app-dependencies-loaded"
 

--- a/sig/datadog/core/telemetry/event/app_heartbeat.rbs
+++ b/sig/datadog/core/telemetry/event/app_heartbeat.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppHeartbeat < Base
           def type: () -> "app-heartbeat"
         end

--- a/sig/datadog/core/telemetry/event/app_integrations_change.rbs
+++ b/sig/datadog/core/telemetry/event/app_integrations_change.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppIntegrationsChange < Base
           def type: () -> "app-integrations-change"
 

--- a/sig/datadog/core/telemetry/event/app_started.rbs
+++ b/sig/datadog/core/telemetry/event/app_started.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class AppStarted < Base
           def type: () -> "app-started"
 

--- a/sig/datadog/core/telemetry/event/base.rbs
+++ b/sig/datadog/core/telemetry/event/base.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class Base
           def payload: () -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
           def type: -> String

--- a/sig/datadog/core/telemetry/event/distributions.rbs
+++ b/sig/datadog/core/telemetry/event/distributions.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class Distributions < GenerateMetrics
           def type: () -> "distributions"
         end

--- a/sig/datadog/core/telemetry/event/generate_metrics.rbs
+++ b/sig/datadog/core/telemetry/event/generate_metrics.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class GenerateMetrics < Base
           @namespace: untyped
 

--- a/sig/datadog/core/telemetry/event/log.rbs
+++ b/sig/datadog/core/telemetry/event/log.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class Log < Base
           @message: untyped
 

--- a/sig/datadog/core/telemetry/event/message_batch.rbs
+++ b/sig/datadog/core/telemetry/event/message_batch.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     module Telemetry
-      class Event
+      module Event
         class MessageBatch < Base
           @events: Array[Datadog::Core::Telemetry::Event::Base]
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes `Datadog::Core::Telemetry::Event` to be a module instead of a class

**Motivation:**
https://github.com/DataDog/dd-trace-rb/pull/4671 split the individual event classes, and now it is clear that the `Event` container itself doesn't have any code and should be a module for namespacing.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
N/A
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing unit tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
