### PR TITLE
DEBUG-3573 improve telemetry event tests

### DIFF
--- a/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
         end
       end
 
+      after do
+        Datadog.configuration.reset!
+      end
+
       it 'includes sca enablement configuration' do
         is_expected.to eq(
           configuration:

--- a/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
@@ -4,12 +4,11 @@ require 'datadog/core/telemetry/event/app_client_configuration_change'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
-  let(:event) { event_class.new(changes, origin) }
+  let(:event) { described_class.new(changes, origin) }
   let(:changes) { { name => value } }
   let(:origin) { double('origin') }
   let(:name) { 'key' }
@@ -50,8 +49,8 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
 
   it 'all events to be the same' do
     events =     [
-      event_class.new({ 'key' => 'value' }, 'origin'),
-      event_class.new({ 'key' => 'value' }, 'origin'),
+      described_class.new({ 'key' => 'value' }, 'origin'),
+      described_class.new({ 'key' => 'value' }, 'origin'),
     ]
 
     expect(events.uniq).to have(1).item
@@ -59,11 +58,11 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
 
   it 'all events to be different' do
     events =     [
-      event_class.new({ 'key' => 'value' }, 'origin'),
-      event_class.new({ 'key' => 'value' }, 'origin2'),
-      event_class.new({ 'key' => 'value2' }, 'origin'),
-      event_class.new({ 'key2' => 'value' }, 'origin'),
-      event_class.new({}, 'origin'),
+      described_class.new({ 'key' => 'value' }, 'origin'),
+      described_class.new({ 'key' => 'value' }, 'origin2'),
+      described_class.new({ 'key' => 'value2' }, 'origin'),
+      described_class.new({ 'key2' => 'value' }, 'origin'),
+      described_class.new({}, 'origin'),
     ]
 
     expect(events.uniq).to eq(events)

--- a/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_client_configuration_change_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   let(:event) { described_class.new(changes, origin) }
   let(:changes) { { name => value } }
   let(:origin) { double('origin') }
@@ -18,32 +16,36 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClientConfigurationChange do
     allow_any_instance_of(Datadog::Core::Utils::Sequence).to receive(:next).and_return(id)
   end
 
-  it 'has a list of client configurations' do
-    is_expected.to eq(
-      configuration: [{
-        name: name,
-        value: value,
-        origin: origin,
-        seq_id: id
-      }]
-    )
-  end
+  describe '.payload' do
+    subject(:payload) { event.payload }
 
-  context 'with env_var state configuration' do
-    before do
-      Datadog.configure do |c|
-        c.appsec.sca_enabled = false
-      end
+    it 'has a list of client configurations' do
+      is_expected.to eq(
+        configuration: [{
+          name: name,
+          value: value,
+          origin: origin,
+          seq_id: id
+        }]
+      )
     end
 
-    it 'includes sca enablement configuration' do
-      is_expected.to eq(
-        configuration:
-        [
-          { name: name, value: value, origin: origin, seq_id: id },
-          { name: 'appsec.sca_enabled', value: false, origin: 'code', seq_id: id }
-        ]
-      )
+    context 'with env_var state configuration' do
+      before do
+        Datadog.configure do |c|
+          c.appsec.sca_enabled = false
+        end
+      end
+
+      it 'includes sca enablement configuration' do
+        is_expected.to eq(
+          configuration:
+          [
+            { name: name, value: value, origin: origin, seq_id: id },
+            { name: 'appsec.sca_enabled', value: false, origin: 'code', seq_id: id }
+          ]
+        )
+      end
     end
   end
 

--- a/spec/datadog/core/telemetry/event/app_closing_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_closing_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppClosing do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   it_behaves_like 'telemetry event with no attributes'
 
-  it 'has no payload' do
-    is_expected.to eq({})
+  describe '.payload' do
+    subject(:payload) { event.payload }
+
+    it 'is empty' do
+      is_expected.to eq({})
+    end
   end
 end

--- a/spec/datadog/core/telemetry/event/app_closing_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_closing_spec.rb
@@ -4,11 +4,10 @@ require 'datadog/core/telemetry/event/app_closing'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppClosing do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
   it_behaves_like 'telemetry event with no attributes'
 
   it 'has no payload' do

--- a/spec/datadog/core/telemetry/event/app_dependencies_loaded_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_dependencies_loaded_spec.rb
@@ -4,11 +4,10 @@ require 'datadog/core/telemetry/event/app_dependencies_loaded'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppDependenciesLoaded do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
   it_behaves_like 'telemetry event with no attributes'
 
   it 'all have name and Ruby gem version' do

--- a/spec/datadog/core/telemetry/event/app_dependencies_loaded_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_dependencies_loaded_spec.rb
@@ -6,17 +6,19 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppDependenciesLoaded do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   it_behaves_like 'telemetry event with no attributes'
 
-  it 'all have name and Ruby gem version' do
-    is_expected.to match(dependencies: all(match(name: kind_of(String), version: kind_of(String))))
-  end
+  describe '.payload' do
+    subject(:payload) { event.payload }
 
-  it 'has a known gem with expected version' do
-    is_expected.to match(
-      dependencies: include(name: 'datadog', version: Datadog::Core::Environment::Identity.gem_datadog_version)
-    )
+    it 'all have name and Ruby gem version' do
+      is_expected.to match(dependencies: all(match(name: kind_of(String), version: kind_of(String))))
+    end
+
+    it 'has a known gem with expected version' do
+      is_expected.to match(
+        dependencies: include(name: 'datadog', version: Datadog::Core::Environment::Identity.gem_datadog_version)
+      )
+    end
   end
 end

--- a/spec/datadog/core/telemetry/event/app_heartbeat_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_heartbeat_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppHeartbeat do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   it_behaves_like 'telemetry event with no attributes'
 
-  it 'has no payload' do
-    is_expected.to eq({})
+  describe '.payload' do
+    subject(:payload) { event.payload }
+
+    it 'is empty' do
+      is_expected.to eq({})
+    end
   end
 end

--- a/spec/datadog/core/telemetry/event/app_heartbeat_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_heartbeat_spec.rb
@@ -4,11 +4,10 @@ require 'datadog/core/telemetry/event/app_heartbeat'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppHeartbeat do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
   it_behaves_like 'telemetry event with no attributes'
 
   it 'has no payload' do

--- a/spec/datadog/core/telemetry/event/app_integrations_change_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_integrations_change_spec.rb
@@ -4,11 +4,10 @@ require 'datadog/core/telemetry/event/app_integrations_change'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppIntegrationsChange do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
   it_behaves_like 'telemetry event with no attributes'
 
   it 'all have name and compatibility' do

--- a/spec/datadog/core/telemetry/event/app_integrations_change_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_integrations_change_spec.rb
@@ -6,51 +6,53 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppIntegrationsChange do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   it_behaves_like 'telemetry event with no attributes'
 
-  it 'all have name and compatibility' do
-    is_expected.to match(integrations: all(include(name: kind_of(String), compatible: boolean)))
-  end
+  describe '.payload' do
+    subject(:payload) { event.payload }
 
-  context 'with an instrumented integration' do
-    context 'that applied' do
-      before do
-        Datadog.configure do |c|
-          c.tracing.instrument :http
-        end
-      end
-      it 'has a list of integrations' do
-        is_expected.to match(
-          integrations: include(
-            name: 'http',
-            version: RUBY_VERSION,
-            compatible: true,
-            enabled: true
-          )
-        )
-      end
+    it 'all have name and compatibility' do
+      is_expected.to match(integrations: all(include(name: kind_of(String), compatible: boolean)))
     end
 
-    context 'that failed to apply' do
-      before do
-        raise 'pg is loaded! This test requires integration that does not have its gem loaded' if Gem.loaded_specs['pg']
-
-        Datadog.configure do |c|
-          c.tracing.instrument :pg
+    context 'with an instrumented integration' do
+      context 'that applied' do
+        before do
+          Datadog.configure do |c|
+            c.tracing.instrument :http
+          end
+        end
+        it 'has a list of integrations' do
+          is_expected.to match(
+            integrations: include(
+              name: 'http',
+              version: RUBY_VERSION,
+              compatible: true,
+              enabled: true
+            )
+          )
         end
       end
 
-      it 'has a list of integrations' do
-        is_expected.to match(
-          integrations: include(
-            name: 'pg',
-            compatible: false,
-            enabled: false,
-            error: 'Available?: false, Loaded? false, Compatible? false, Patchable? false',
+      context 'that failed to apply' do
+        before do
+          raise 'pg is loaded! This test requires integration that does not have its gem loaded' if Gem.loaded_specs['pg']
+
+          Datadog.configure do |c|
+            c.tracing.instrument :pg
+          end
+        end
+
+        it 'has a list of integrations' do
+          is_expected.to match(
+            integrations: include(
+              name: 'pg',
+              compatible: false,
+              enabled: false,
+              error: 'Available?: false, Loaded? false, Compatible? false, Patchable? false',
+            )
           )
-        )
+        end
       end
     end
   end

--- a/spec/datadog/core/telemetry/event/app_started_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_started_spec.rb
@@ -4,7 +4,7 @@ require 'datadog/core/telemetry/event/app_started'
 
 RSpec.describe Datadog::Core::Telemetry::Event::AppStarted do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
@@ -57,7 +57,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppStarted do
       profiler: hash_including(enabled: false),
     }
   end
-  let(:event_class) { described_class }
   before do
     allow_any_instance_of(Datadog::Core::Utils::Sequence).to receive(:next).and_return(id)
 

--- a/spec/datadog/core/telemetry/event/app_started_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_started_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppStarted do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   let(:logger) do
     stub_const('MyLogger', Class.new(::Logger)).new(nil)
   end
@@ -88,57 +86,61 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppStarted do
     array.map { |name, value| { name: name, origin: 'env_var', seq_id: id, value: value } }
   end
 
-  it do
-    is_expected.to match(
-      products: expected_products,
-      configuration: contain_code_configuration(
-        *default_code_configuration
-      ),
-      install_signature: expected_install_signature,
-    )
-  end
+  describe '.payload' do
+    subject(:payload) { event.payload }
 
-  context 'with git/SCI environment variables set' do
-    with_env 'DD_GIT_REPOSITORY_URL' => 'https://github.com/datadog/hello',
-      'DD_GIT_COMMIT_SHA' => '1234hash'
-
-    before do
-      # Reset global cache so that we get our values back
-      Datadog::Core::Environment::Git.reset_for_tests
-    end
-
-    after do
-      # Do not use our values in other tests
-      Datadog::Core::Environment::Git.reset_for_tests
-    end
-
-    it 'reports git/SCI values to telemetry' do
+    it do
       is_expected.to match(
         products: expected_products,
-        configuration: contain_env_configuration(
-          ['DD_GIT_REPOSITORY_URL', 'https://github.com/datadog/hello'],
-          ['DD_GIT_COMMIT_SHA', '1234hash'],
-        ) + contain_code_configuration(
+        configuration: contain_code_configuration(
           *default_code_configuration
         ),
         install_signature: expected_install_signature,
       )
     end
-  end
 
-  context 'with nil configurations' do
-    before do
-      Datadog.configure do |c|
-        c.logger.instance = nil
+    context 'with git/SCI environment variables set' do
+      with_env 'DD_GIT_REPOSITORY_URL' => 'https://github.com/datadog/hello',
+        'DD_GIT_COMMIT_SHA' => '1234hash'
+
+      before do
+        # Reset global cache so that we get our values back
+        Datadog::Core::Environment::Git.reset_for_tests
+      end
+
+      after do
+        # Do not use our values in other tests
+        Datadog::Core::Environment::Git.reset_for_tests
+      end
+
+      it 'reports git/SCI values to telemetry' do
+        is_expected.to match(
+          products: expected_products,
+          configuration: contain_env_configuration(
+            ['DD_GIT_REPOSITORY_URL', 'https://github.com/datadog/hello'],
+            ['DD_GIT_COMMIT_SHA', '1234hash'],
+          ) + contain_code_configuration(
+            *default_code_configuration
+          ),
+          install_signature: expected_install_signature,
+        )
       end
     end
 
-    it 'removes empty configurations from payload' do
-      is_expected.to_not match(
-        configuration: include(
-          { name: 'logger.instance', origin: anything, seq_id: anything, value: anything }
+    context 'with nil configurations' do
+      before do
+        Datadog.configure do |c|
+          c.logger.instance = nil
+        end
+      end
+
+      it 'removes empty configurations from payload' do
+        is_expected.to_not match(
+          configuration: include(
+            { name: 'logger.instance', origin: anything, seq_id: anything, value: anything }
+          )
         )
-      )
+      end
     end
   end
 end

--- a/spec/datadog/core/telemetry/event/distributions_spec.rb
+++ b/spec/datadog/core/telemetry/event/distributions_spec.rb
@@ -5,12 +5,11 @@ require 'datadog/core/telemetry/metric'
 
 RSpec.describe Datadog::Core::Telemetry::Event::Distributions do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
-  let(:event) { event_class.new(namespace, metrics) }
+  let(:event) { described_class.new(namespace, metrics) }
 
   let(:namespace) { 'general' }
   let(:metric_name) { 'request_duration' }

--- a/spec/datadog/core/telemetry/event/distributions_spec.rb
+++ b/spec/datadog/core/telemetry/event/distributions_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::Distributions do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   let(:event) { described_class.new(namespace, metrics) }
 
   let(:namespace) { 'general' }
@@ -20,12 +18,16 @@ RSpec.describe Datadog::Core::Telemetry::Event::Distributions do
 
   let(:expected_metric_series) { [metric.to_h] }
 
-  it do
-    is_expected.to eq(
-      {
-        namespace: namespace,
-        series: expected_metric_series
-      }
-    )
+  describe '.payload' do
+    subject(:payload) { event.payload }
+
+    it do
+      is_expected.to eq(
+        {
+          namespace: namespace,
+          series: expected_metric_series
+        }
+      )
+    end
   end
 end

--- a/spec/datadog/core/telemetry/event/generate_metrics_spec.rb
+++ b/spec/datadog/core/telemetry/event/generate_metrics_spec.rb
@@ -5,12 +5,11 @@ require 'datadog/core/telemetry/metric'
 
 RSpec.describe Datadog::Core::Telemetry::Event::GenerateMetrics do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
-  let(:event) { event_class.new(namespace, metrics) }
+  let(:event) { described_class.new(namespace, metrics) }
 
   let(:namespace) { 'general' }
   let(:metric_name) { 'request_count' }
@@ -32,8 +31,8 @@ RSpec.describe Datadog::Core::Telemetry::Event::GenerateMetrics do
 
   it 'all events to be the same' do
     events =     [
-      event_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
-      event_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
+      described_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
+      described_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
     ]
 
     expect(events.uniq).to have(1).item
@@ -41,10 +40,10 @@ RSpec.describe Datadog::Core::Telemetry::Event::GenerateMetrics do
 
   it 'all events to be different' do
     events =     [
-      event_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
-      event_class.new('nospace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
-      event_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '2' })]),
-      event_class.new('namespace', []),
+      described_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
+      described_class.new('nospace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '1' })]),
+      described_class.new('namespace', [Datadog::Core::Telemetry::Metric::Count.new('name', tags: { val: '2' })]),
+      described_class.new('namespace', []),
 
     ]
 

--- a/spec/datadog/core/telemetry/event/generate_metrics_spec.rb
+++ b/spec/datadog/core/telemetry/event/generate_metrics_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::GenerateMetrics do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   let(:event) { described_class.new(namespace, metrics) }
 
   let(:namespace) { 'general' }
@@ -20,13 +18,17 @@ RSpec.describe Datadog::Core::Telemetry::Event::GenerateMetrics do
 
   let(:expected_metric_series) { [metric.to_h] }
 
-  it do
-    is_expected.to eq(
-      {
-        namespace: namespace,
-        series: expected_metric_series
-      }
-    )
+  describe '.payload' do
+    subject(:payload) { event.payload }
+
+    it do
+      is_expected.to eq(
+        {
+          namespace: namespace,
+          series: expected_metric_series
+        }
+      )
+    end
   end
 
   it 'all events to be the same' do

--- a/spec/datadog/core/telemetry/event/log_spec.rb
+++ b/spec/datadog/core/telemetry/event/log_spec.rb
@@ -6,34 +6,35 @@ RSpec.describe Datadog::Core::Telemetry::Event::Log do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
+  describe '.payload' do
 
-  it do
-    event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :error)
-    expect(event.type).to eq('logs')
-    expect(event.payload).to eq(
-      {
-        logs: [{
-          message: 'Hi',
-          level: 'ERROR',
-          count: 1
-        }]
-      }
-    )
-  end
+    it do
+      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :error)
+      expect(event.type).to eq('logs')
+      expect(event.payload).to eq(
+        {
+          logs: [{
+            message: 'Hi',
+            level: 'ERROR',
+            count: 1
+          }]
+        }
+      )
+    end
 
-  it do
-    event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :warn)
-    expect(event.type).to eq('logs')
-    expect(event.payload).to eq(
-      {
-        logs: [{
-          message: 'Hi',
-          level: 'WARN',
-          count: 1
-        }]
-      }
-    )
+    it do
+      event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :warn)
+      expect(event.type).to eq('logs')
+      expect(event.payload).to eq(
+        {
+          logs: [{
+            message: 'Hi',
+            level: 'WARN',
+            count: 1
+          }]
+        }
+      )
+    end
   end
 
   it do

--- a/spec/datadog/core/telemetry/event/log_spec.rb
+++ b/spec/datadog/core/telemetry/event/log_spec.rb
@@ -4,11 +4,9 @@ require 'datadog/core/telemetry/event/log'
 
 RSpec.describe Datadog::Core::Telemetry::Event::Log do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
-
-  let(:event_class) { described_class }
 
   it do
     event = Datadog::Core::Telemetry::Event::Log.new(message: 'Hi', level: :error)
@@ -46,8 +44,8 @@ RSpec.describe Datadog::Core::Telemetry::Event::Log do
 
   it 'all events to be the same' do
     events =     [
-      event_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
-      event_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
+      described_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
+      described_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
     ]
 
     expect(events.uniq).to have(1).item
@@ -55,11 +53,11 @@ RSpec.describe Datadog::Core::Telemetry::Event::Log do
 
   it 'all events to be different' do
     events =     [
-      event_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
-      event_class.new(message: 'Yo', level: :warn, stack_trace: 'stack trace', count: 1),
-      event_class.new(message: 'Hi', level: :error, stack_trace: 'stack trace', count: 1),
-      event_class.new(message: 'Hi', level: :warn, stack_trace: 'stack&trace', count: 1),
-      event_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 2),
+      described_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 1),
+      described_class.new(message: 'Yo', level: :warn, stack_trace: 'stack trace', count: 1),
+      described_class.new(message: 'Hi', level: :error, stack_trace: 'stack trace', count: 1),
+      described_class.new(message: 'Hi', level: :warn, stack_trace: 'stack&trace', count: 1),
+      described_class.new(message: 'Hi', level: :warn, stack_trace: 'stack trace', count: 2),
     ]
 
     expect(events.uniq).to eq(events)

--- a/spec/datadog/core/telemetry/event/message_batch_spec.rb
+++ b/spec/datadog/core/telemetry/event/message_batch_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Datadog::Core::Telemetry::Event::MessageBatch do
   let(:id) { double('seq_id') }
   let(:event) { described_class.new }
 
-  subject(:payload) { event.payload }
-
   let(:event) { described_class.new(events) }
 
   let(:events) do
@@ -17,18 +15,22 @@ RSpec.describe Datadog::Core::Telemetry::Event::MessageBatch do
     ]
   end
 
-  it do
-    is_expected.to eq(
-      [
-        {
-          request_type: 'app-closing',
-          payload: {}
-        },
-        {
-          request_type: 'app-heartbeat',
-          payload: {}
-        }
-      ]
-    )
+  describe '.payload' do
+    subject(:payload) { event.payload }
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            request_type: 'app-closing',
+            payload: {}
+          },
+          {
+            request_type: 'app-heartbeat',
+            payload: {}
+          }
+        ]
+      )
+    end
   end
 end

--- a/spec/datadog/core/telemetry/event/message_batch_spec.rb
+++ b/spec/datadog/core/telemetry/event/message_batch_spec.rb
@@ -4,12 +4,11 @@ require 'datadog/core/telemetry/event/message_batch'
 
 RSpec.describe Datadog::Core::Telemetry::Event::MessageBatch do
   let(:id) { double('seq_id') }
-  let(:event) { event_class.new }
+  let(:event) { described_class.new }
 
   subject(:payload) { event.payload }
 
-  let(:event_class) { described_class }
-  let(:event) { event_class.new(events) }
+  let(:event) { described_class.new(events) }
 
   let(:events) do
     [

--- a/spec/support/telemetry_helpers.rb
+++ b/spec/support/telemetry_helpers.rb
@@ -17,8 +17,8 @@ module TelemetryHelpers
 
   RSpec.shared_examples 'telemetry event with no attributes' do
     it 'all event instances to the same' do
-      event1 = event_class.new
-      event2 = event_class.new
+      event1 = described_class.new
+      event2 = described_class.new
       expect(event1).to eq(event2)
       expect(event1.hash).to eq(event2.hash)
     end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Addresses review feedback in https://github.com/DataDog/dd-trace-rb/pull/4685:
. removed `event_class` alias that no longer has logic
. added `describe payload` blocks to clarify what the subject is for those tests
. added a configuration reset after the test that enables SCA

**Motivation:**
Review comments in https://github.com/DataDog/dd-trace-rb/pull/4685
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing tests
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
