### PR TITLE
Replace all JSON.fast_generate with JSON.generate

### DIFF
--- a/benchmarks/profiling_http_transport.rb
+++ b/benchmarks/profiling_http_transport.rb
@@ -46,7 +46,7 @@ class ProfilerHttpTransportBenchmark
       code_provenance_data: '', # Random.new(1).bytes(4_000),
       tags_as_array: [],
       internal_metadata: { no_signals_workaround_enabled: false },
-      info_json: JSON.fast_generate({ profiler: { benchmarking: true } }),
+      info_json: JSON.generate({ profiler: { benchmarking: true } }),
     )
   end
 

--- a/lib/datadog/profiling/collectors/code_provenance.rb
+++ b/lib/datadog/profiling/collectors/code_provenance.rb
@@ -42,7 +42,7 @@ module Datadog
         end
 
         def generate_json
-          JSON.fast_generate(v1: seen_libraries.to_a)
+          JSON.generate(v1: seen_libraries.to_a)
         end
 
         private

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -32,7 +32,7 @@ module Datadog
         @code_provenance_file_name = code_provenance_file_name
         @code_provenance_data = code_provenance_data
         @tags_as_array = tags_as_array
-        @internal_metadata_json = JSON.fast_generate(internal_metadata)
+        @internal_metadata_json = JSON.generate(internal_metadata)
         @info_json = info_json
       end
     end

--- a/spec/datadog/profiling/collectors/code_provenance_spec.rb
+++ b/spec/datadog/profiling/collectors/code_provenance_spec.rb
@@ -219,13 +219,13 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
     # end
     #
     # example = Example.new
-    # puts JSON.fast_generate(example)
+    # puts JSON.generate(example)
     #
     # require 'oj'
     # require 'active_support/core_ext/object/json'
     # Oj.mimic_JSON()
     #
-    # puts JSON.fast_generate(example)
+    # puts JSON.generate(example)
     # ```
     #
     # Incorrect output:

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Datadog::Profiling::Flush do
     let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
     let(:internal_metadata) { {no_signals_workaround_enabled: false} }
     let(:info_json) do
-      JSON.fast_generate(
+      JSON.generate(
         {
           application: {
             start_time: "2024-01-24T11:17:22Z"

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
   let(:code_provenance_data) { "the_code_provenance_data" }
   let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
   let(:info_json) do
-    JSON.fast_generate(
+    JSON.generate(
       {
         application: {
           start_time: "2024-01-24T11:17:22Z"


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Replace all `JSON.fast_generate` with `JSON.generate` following `JSON.fast_generate`'s deprecation since [ruby/json v2.11.0](https://github.com/ruby/json/releases/tag/v2.11.0)
Related: https://github.com/DataDog/dd-trace-rb/pull/4602

**Motivation:**
<!-- What inspired you to submit this pull request? -->

After our app updated `ruby/json` to `>= 2.11.0`, Datadog's profillers start to output a lot of warnings to puma/sidekiq logs (once per minute).

```
.../datadog-2.16.0/lib/datadog/profiling/collectors/code_provenance.rb:45: warning: JSON.fast_generate is deprecated and will be removed in json 3.0.0, just use JSON.generate
.../datadog-2.16.0/lib/datadog/profiling/flush.rb:35: warning: JSON.fast_generate is deprecated and will be removed in json 3.0.0, just use JSON.generate
```

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

Yes. Fix triggering "JSON.fast_generate is deprecated" warnings with modern json gem

(Added by @ivoanjo)  
