### PR TITLE
Skip telemetry integration tests using any_instance_of on JRuby 9.2

### DIFF
--- a/spec/datadog/core/telemetry/integration/full_integration_spec.rb
+++ b/spec/datadog/core/telemetry/integration/full_integration_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Telemetry full integration tests' do
   end
 
   context 'when Datadog.configure is used and dependency collection is enabled' do
+    skip_any_instance_on_buggy_jruby
 
     before do
       Datadog.send(:reset!)
@@ -115,6 +116,7 @@ RSpec.describe 'Telemetry full integration tests' do
   end
 
   context 'when Datadog.configure is used and dynamic instrumentation is enabled' do
+    skip_any_instance_on_buggy_jruby
 
     before do
       Datadog.send(:reset!)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
   config.include TracerHelpers
   config.include TestHelpers::RSpec::Integration, :integration
   config.include HttpServerHelpers
+  config.extend  PlatformHelpers::ClassMethods
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -76,7 +76,7 @@ module PlatformHelpers
       before do
         if PlatformHelpers.jruby? && !PlatformHelpers.ruby_version_matches?('>= 2.6')
           # See: https://github.com/rspec/rspec-mocks/issues/1338
-          skip "any_instance expectations are broken on JRuby 9.2"
+          skip 'any_instance expectations are broken on JRuby 9.2'
         end
       end
     end

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -70,4 +70,15 @@ module PlatformHelpers
   def supports_fork?
     Process.respond_to?(:fork)
   end
+
+  module ClassMethods
+    def skip_any_instance_on_buggy_jruby
+      before do
+        if PlatformHelpers.jruby? && !PlatformHelpers.ruby_version_matches?('>= 2.6')
+          # See: https://github.com/rspec/rspec-mocks/issues/1338
+          skip "any_instance expectations are broken on JRuby 9.2"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Skips telemetry integration tests making use of `any_instance_of` on JRuby 9.2.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

The tests are failing with the following error:

```
2025-06-02T18:44:11.0859185Z Datadog::Core::Telemetry::Worker
2025-06-02T18:44:11.0865028Z   #stop
2025-06-02T18:44:11.1007491Z warning: thread "Datadog::Core::Telemetry::Worker (Ruby-0-Thread-1529@Datadog::Core::Telemetry::Worker: /__w/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:290)" terminated with exception (report_on_exception is true):
2025-06-02T18:44:11.1008845Z NoMethodError: undefined method `send_event' for #<Datadog::Core::Telemetry::Worker:0x1a61064d>
2025-06-02T18:44:11.1009429Z       started! at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/telemetry/worker.rb:183
2025-06-02T18:44:11.1009967Z            run at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/utils/only_once_successful.rb:44
2025-06-02T18:44:11.1010411Z    synchronize at org/jruby/ext/thread/Mutex.java:164
2025-06-02T18:44:11.1010839Z            run at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/utils/only_once_successful.rb:41
2025-06-02T18:44:11.1011341Z       started! at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/telemetry/worker.rb:182
2025-06-02T18:44:11.1012142Z        perform at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/telemetry/worker.rb:139
2025-06-02T18:44:11.1012633Z        perform at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/queue.rb:16
2025-06-02T18:44:11.1013133Z        perform at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/interval_loop.rb:27
2025-06-02T18:44:11.1013680Z   perform_loop at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/interval_loop.rb:116
2025-06-02T18:44:11.1014115Z           loop at org/jruby/RubyKernel.java:1442
2025-06-02T18:44:11.1014558Z   perform_loop at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/interval_loop.rb:112
2025-06-02T18:44:11.1015216Z        perform at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/interval_loop.rb:24
2025-06-02T18:44:11.1015713Z        perform at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/async.rb:27
2025-06-02T18:44:11.1016192Z   start_worker at /__w/dd-trace-rb/dd-trace-rb/lib/datadog/core/workers/async.rb:157
2025-06-02T18:44:11.1016933Z     initialize at /__w/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:286
2025-06-02T18:44:16.1004657Z     flushes events and stops the worker (FAILED - 1)
```

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

The issue appears to be https://github.com/rspec/rspec-mocks/issues/1338, and it appears to only affect JRuby 9.2.

I reduced it to the following test:

```
# frozen_string_literal: true

require 'spec_helper'

require 'datadog/core/telemetry/component'

RSpec.describe 'Telemetry full integration tests' do

  let(:ok_response) do
    double(Datadog::Core::Transport::HTTP::Adapters::Net::Response).tap do |response|
      expect(response).to receive(:ok?).and_return(true).at_least(:once)
    end
  end

  it 'sends dependencies once' do
    events = []
    allow_any_instance_of(Datadog::Core::Telemetry::Worker).to receive(:send_event) do |_, event|
      events << event
      ok_response
    end
  end

  # Ideally this test would start with a completely virgin state and
  # the first configurtion would be via the auto_instrument require.
  it 'sends dynamic instrumentation state on each configuration' do
    events = []
    allow_any_instance_of(Datadog::Core::Telemetry::Worker).to receive(:send_event) do |_, event|
      events << event
      ok_response
    end
  end

  let(:worker) do
    Datadog::Core::Telemetry::Worker.new(
      enabled: true,
      heartbeat_interval_seconds: 1,
      metrics_aggregation_interval_seconds: 1,
      emitter: emitter,
      metrics_manager: metrics_manager,
      dependency_collection: false,
      logger: logger,
    )
  end
  let(:emitter) { instance_double(Datadog::Core::Telemetry::Emitter) }
  let(:metrics_manager) { instance_double(Datadog::Core::Telemetry::MetricsManager, flush!: [], disable!: nil) }
  let(:logger) { logger_allowing_debug }
  let(:initial_event) do
    Datadog::Core::Telemetry::Event::AppStarted.new
  end

  describe '#stop' do
    it 'flushes events and stops the worker' do
      worker.start(initial_event)

      worker.stop(true)

    end
  end
end
```

Running it with
```
 DD_TRACE_DEBUG=1 bs spec/datadog/core/telemetry/integration/full_integration_spec.rb --order defined -fd
```

... reproduces the issue under jruby 9.2 and not under 9.3.


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
