### PR TITLE
Auto update system tests

### DIFF
--- a/.github/scripts/update_reference.rb
+++ b/.github/scripts/update_reference.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# This script updates the reference in a YAML file.
+
+target = ENV.fetch('TARGET')
+puts "Target: #{target}"
+
+ref  = ENV.fetch('REF')
+puts "Ref: #{ref}"
+
+pattern_string = ENV.fetch('PATTERN')
+clean_pattern = pattern_string.gsub(/^\/|\/$/,'')
+pattern = Regexp.new(clean_pattern)
+puts "Pattern: #{pattern}"
+
+# Read file, update, write back
+content = File.read(target)
+updated_content = content.gsub(pattern) { "#{$1}#{ref}#{$3}" }
+File.write(target, updated_content)
+
+# Report result
+if content != updated_content
+  puts "✓ Updated references in #{target}"
+else
+  puts "No references found in #{target}"
+end

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  SYSTEM_TESTS_REF: 'main' # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: 'main' # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: main # This must always be set to `main` on dd-trace-rb's master branch
+  SYSTEM_TESTS_REF: main # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/update-system-tests.yml
+++ b/.github/workflows/update-system-tests.yml
@@ -1,0 +1,74 @@
+name: Update System Tests
+
+on: # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Reference to be updated (commit hash, branch, or tag)
+        required: false
+        type: string
+      dry-run:
+        description: Skip PR creation and only show changes
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default permissions for all jobs
+permissions: {}
+
+jobs:
+  update-system-tests:
+    name: "Update System Tests"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true
+
+      - name: Checkout System Test
+        id: system-test-ref
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "DataDog/system-tests"
+          path: system-tests
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref || '' }}
+
+      - run: .github/scripts/update_reference.rb
+        env:
+          TARGET: ".github/workflows/system-tests.yml"
+          PATTERN: '(\s*SYSTEM_TESTS_REF:\s+)(\S+)(\s+# Automated:.*)'
+          REF: ${{ steps.system-test-ref.outputs.commit }}
+
+      - run: .github/scripts/update_reference.rb
+        env:
+          TARGET: ".github/workflows/parametric-tests.yml"
+          PATTERN: '(\s*SYSTEM_TESTS_REF:\s+)(\S+)(\s+# Automated:.*)'
+          REF: ${{ steps.system-test-ref.outputs.commit }}
+
+      - run: git diff --color=always
+
+      - name: Create Pull Request
+        if: ${{ github.event.inputs.dry-run == false }}
+        id: cpr
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GHA_PAT }}
+          branch: auto-generate/update-system-tests
+          title: '[🤖] Update System Tests'
+          base: master
+          labels: dev/internal
+          commit-message: "[🤖] Update System Tests: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          delete-branch: true
+          add-paths: |
+            .github/
+          body: |
+            _This is an auto-generated PR from [here](https://github.com/DataDog/dd-trace-rb/blob/master/.github/workflows/yoga.yml)
+            The PR updates the system tests (Updated to commit: ${{ steps.system-test-ref.outputs.commit }})
+            Please review the changes and merge when ready


### PR DESCRIPTION
**Motivation:**

Pointing at system tests `main` branch creates inconsistent result.

**What does this PR do?**

An workflow to automate the update process with a pinned version 

For testing, it creates: https://github.com/DataDog/dd-trace-rb/pull/4701

**Change log entry**
None.