### PR TITLE
Retry postgres:alpine docker pulls in system tests

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  SYSTEM_TESTS_REF: 007f43b50f720be299f0dae27f4fcbabdd623591 # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: 7a9ffeb69dcc4db9a3a443d37536ce3d120fd596 # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  SYSTEM_TESTS_REF: 7a9ffeb69dcc4db9a3a443d37536ce3d120fd596 # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: e9fb2335c23a6e6d79ccaf4e993b3dca59649ad5 # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: 7a9ffeb69dcc4db9a3a443d37536ce3d120fd596 # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: e9fb2335c23a6e6d79ccaf4e993b3dca59649ad5 # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: 007f43b50f720be299f0dae27f4fcbabdd623591 # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: 7a9ffeb69dcc4db9a3a443d37536ce3d120fd596 # Automated: This reference is automatically updated.
 
 jobs:
   changes:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Switches system tests reference to https://github.com/DataDog/system-tests/pull/4719 to run our CI against that PR, which retries docker pull in cases when docker pull says the image was not found.

**Motivation:**
Flaky CI
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
You would expect that pulling the image would not end with 'image not found" on the destination (localhost, in this case) as the problem. Might be something within docker racing with itself, such that it does retrieve the image but then fails to see the image in some other code?

This PR also incorporates the fix in https://github.com/DataDog/system-tests/pull/4718.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
I would like this PR  to merged to master and stay in master for a week or so, and observe if the number of failing tests reduces.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
