### PR TITLE
[PROF-11956] Fix profiler stopping due to bug in heap profiling serialization

### DIFF
--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -310,6 +310,10 @@ void start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
       #else
         false
       #endif
+      // If we got really unlucky and an allocation showed up during an update (because it triggered an allocation
+      // directly OR because the GVL got released in the middle of an update), let's skip this sample as well.
+      // See notes on `heap_recorder_update` for details.
+      || heap_recorder->updating
     ) {
     heap_recorder->active_recording = &SKIPPED_RECORD;
     return;
@@ -395,15 +399,28 @@ void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
   heap_recorder_update(heap_recorder, /* full_update: */ false);
 }
 
+// NOTE: This function needs and assumes it gets called with the GVL being held.
+//       But importantly **some of the operations inside `st_object_record_update` may cause a thread switch**,
+//       so we can't assume a single update happens in a single "atomic" step -- other threads may get some running time
+//       in the meanwhile.
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update) {
   if (heap_recorder->updating) {
-    if (full_update) rb_raise(rb_eRuntimeError, "BUG: full_update should not be triggered during another update");
-
-    // If we try to update while another update is still running, short-circuit.
-    // NOTE: This runs while holding the GVL. But since updates may be triggered from GC activity, there's still
-    //       a chance for updates to be attempted concurrently if scheduling gods so determine.
-    heap_recorder->stats_lifetime.updates_skipped_concurrent++;
-    return;
+    if (full_update) {
+      // There's another thread that's already doing an update :(
+      //
+      // Because there's a lock on the `StackRecorder` (see @no_concurrent_serialize_mutex) then it's not possible that
+      // the other update is a full update.
+      // Thus we expect is happening is that the GVL got released by the other thread in the middle of a non-full update
+      // and the scheduler thread decided now was a great time to serialize the profile.
+      //
+      // So, let's yield the time on the current thread until Ruby goes back to the other thread doing the update and
+      // it finishes cleanly.
+      while (heap_recorder->updating) { rb_thread_schedule(); }
+    } else {
+      // Non-full updates are optional, so let's walk away
+      heap_recorder->stats_lifetime.updates_skipped_concurrent++;
+      return;
+    }
   }
 
   if (heap_recorder->object_records_snapshot != NULL) {
@@ -591,6 +608,7 @@ static int st_object_record_entry_free(DDTRACE_UNUSED st_data_t key, st_data_t v
   return ST_DELETE;
 }
 
+// NOTE: Some operations inside this function can cause the GVL to be released! Plan accordingly.
 static int st_object_record_update(st_data_t key, st_data_t value, st_data_t extra_arg) {
   long obj_id = (long) key;
   object_record *record = (object_record*) value;
@@ -616,7 +634,7 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
     return ST_CONTINUE;
   }
 
-  if (!ruby_ref_from_id(LONG2NUM(obj_id), &ref)) {
+  if (!ruby_ref_from_id(LONG2NUM(obj_id), &ref)) { // Note: This function call can cause the GVL to be released
     // Id no longer associated with a valid ref. Need to delete this object record!
     on_committed_object_record_cleanup(recorder, record);
     recorder->stats_last_update.objects_dead++;
@@ -632,7 +650,8 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
   ) {
     // if we were asked to update sizes and this object was not already seen as being frozen,
     // update size again.
-    record->object_data.size = ruby_obj_memsize_of(ref);
+    record->object_data.size = ruby_obj_memsize_of(ref); // Note: This function call can cause the GVL to be released... maybe?
+                                                         //       (With T_DATA for instance, since it can be a custom method supplied by extensions)
     // Check if it's now frozen so we skip a size update next time
     record->object_data.is_frozen = RB_OBJ_FROZEN(ref);
   }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -341,6 +341,12 @@ int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, 
   if (heap_recorder == NULL) {
     return 0;
   }
+  if (heap_recorder->active_recording == &SKIPPED_RECORD) {
+    // Short circuit, in this case there's nothing to be done
+    heap_recorder->active_recording = NULL;
+    return 0;
+  }
+
 
   int exception_state;
   end_heap_allocation_args args = {
@@ -369,6 +375,7 @@ static VALUE end_heap_allocation_recording(VALUE protect_args) {
   heap_recorder->active_recording = NULL;
 
   if (active_recording == &SKIPPED_RECORD) { // special marker when we decided to skip due to sampling
+    // Note: Remember to update the short circuit in end_heap_allocation_recording_with_rb_protect if this logic changes
     return Qnil;
   }
 

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -112,9 +112,7 @@ static VALUE _id2ref_failure(DDTRACE_UNUSED VALUE _unused1, DDTRACE_UNUSED VALUE
   return Qfalse;
 }
 
-// Native wrapper to get an object ref from an id. Returns true on success and
-// writes the ref to the value pointer parameter if !NULL. False if id doesn't
-// reference a valid object (in which case value is not changed).
+// See notes on header for important details
 bool ruby_ref_from_id(VALUE obj_id, VALUE *value) {
   // Call ::ObjectSpace._id2ref natively. It will raise if the id is no longer valid
   // so we need to call it via rb_rescue2

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -70,6 +70,8 @@ NORETURN(void raise_syserr(
 // Native wrapper to get an object ref from an id. Returns true on success and
 // writes the ref to the value pointer parameter if !NULL. False if id doesn't
 // reference a valid object (in which case value is not changed).
+//
+// Note: GVL can be released and other threads may get to run before this method returns
 bool ruby_ref_from_id(size_t id, VALUE *value);
 
 // Native wrapper to get the approximate/estimated current size of the passed

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -538,6 +538,8 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   long heap_iteration_prep_start_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
   // Prepare the iteration on heap recorder we'll be doing outside the GVL. The preparation needs to
   // happen while holding on to the GVL.
+  // NOTE: While rare, it's possible for the GVL to be released inside this function (see comments on `heap_recorder_update`)
+  // and thus don't assume this is an "atomic" step -- other threads may get some running time in the meanwhile.
   heap_recorder_prepare_iteration(state->heap_recorder);
   long heap_iteration_prep_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - heap_iteration_prep_start_time_ns;
 

--- a/lib/datadog/profiling/stack_recorder.rb
+++ b/lib/datadog/profiling/stack_recorder.rb
@@ -23,7 +23,7 @@ module Datadog
         # This isn't something we expect to happen normally, but because it would break the assumptions of the
         # C-level mutexes (that there is a single serializer thread), we add it here as an extra safeguard against it
         # accidentally happening.
-        @no_concurrent_synchronize_mutex = Mutex.new
+        @no_concurrent_serialize_mutex = Mutex.new
 
         self.class._native_initialize(
           self_instance: self,
@@ -60,7 +60,7 @@ module Datadog
       end
 
       def serialize
-        status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_serialize(self) }
+        status, result = @no_concurrent_serialize_mutex.synchronize { self.class._native_serialize(self) }
 
         if status == :ok
           start, finish, encoded_profile, profile_stats = result
@@ -79,7 +79,7 @@ module Datadog
       end
 
       def serialize!
-        status, result = @no_concurrent_synchronize_mutex.synchronize { self.class._native_serialize(self) }
+        status, result = @no_concurrent_serialize_mutex.synchronize { self.class._native_serialize(self) }
 
         if status == :ok
           _start, _finish, encoded_profile = result

--- a/sig/datadog/profiling/stack_recorder.rbs
+++ b/sig/datadog/profiling/stack_recorder.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Profiling
     class StackRecorder
-      @no_concurrent_synchronize_mutex: ::Thread::Mutex
+      @no_concurrent_serialize_mutex: ::Thread::Mutex
 
       def initialize: (
         cpu_time_enabled: bool,

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -593,7 +593,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           end
         end
 
-        it "aren't lost when they happen concurrently with a long serialization" do
+        it "tracks allocations that happen concurrently with a long serialization" do
           described_class::Testing._native_start_fake_slow_heap_serialization(stack_recorder)
 
           test_num_allocated_object = 123


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a rare situation where the profiler would stop during serialization of heap profiling samples with an error message:

```
WARN -- datadog: [datadog] Profiling::Scheduler thread error. Cause: RuntimeError BUG: full_update should not be triggered during another update Location: .../lib/datadog/profiling/stack_recorder.rb:63:in `_native_serialize'
```

This issue happened due to an unexpected thread switch during heap profiling metadata operations.

**Motivation:**

Fix rare heap profiling bug, which is extra important now that we're eclaring it as preview with the next release.


**Change log entry**

Yes. Fix profiler stopping due to bug in heap profiling serialization.

**Additional Notes:**

Understanding this rare bug took some amount of staring at the code and at this assertion.

Interestingly, this bug was not caused by the big refactoring in https://github.com/DataDog/dd-trace-rb/pull/4460 ; in fact, it's very closer in spirit to https://github.com/DataDog/dd-trace-rb/pull/4240 .

(I believe the reason it showed up shortly after #4460 got merged is that this is a numbers game: the more objects that get tracked, the higher the probability of triggering this. Because #4460 raised the number of objects we track by 10x, it made this more likely to happen.)

What happened here is: We were assuming -- because we were inside the profiler's C code and holding the GVL when we called into it -- that the work inside `heap_recorder_update` behaved "atomically".

That is, we assumed that the whole of `heap_recorder_update` got to run, with no other threads running in-between, as we were holding the GVL.

That is, actually, not the case: during `heap_recorder_update` we call `ruby_ref_from_id` and `ruby_obj_memsize_of` both of which can, in rare situations, release the GVL and allow other threads to run for a while. (And currently there's little we could do about this constraint without a bigger redesign of the heap profiler.)

(This is why I claim this is similar to https://github.com/DataDog/dd-trace-rb/pull/4240 -- there's a potential switch point inside the profiler code that we didn't expect, although that one was worse as it introduced a switch point where there couldn't be one for VM correctness.)

Because we assumed the `heap_recorder_update` was atomic, we had this check inside there:

```c
if (heap_recorder->updating) {
  if (full_update) rb_raise(rb_eRuntimeError, "BUG: full_update should not be triggered during another update");
```

That is: We were saying -- if `heap_recorder_update` is atomic, there's no way a second update can start if there's an ongoing one, because by definition the previous one must've finished.

(Interestingly, there was already some comment about this being perhaps a possibility in non-full updates, although when I left that previous comment it didn't occur to me that I was already documenting a clash with the assumptions of this method...).

Having identified there can be concurrency inside `heap_recorder_update`, how is this PR fixing the issue? It turns out it's not as bad as it looks.

There's two sources of concurrency problems here:
1. There's 2+ threads trying to run `heap_recorder_update` concurrently (This caused the error we saw above)
2. There's a thread trying to add a sample at the same time a thread is trying to run `heap_recorder_update` (I suspect this could potentially corrupt the heap recorder state, and in fact I think it may be the source of https://datadoghq.atlassian.net/browse/PROF-10656 )

To fix 1.:
* For non-full updates to `heap_recorder_update` we already skip doing them (since they're optional) -- nothing to do
* There can't be two full updates at the same time as the `@no_concurrent_serialize_mutex` is preventing that -- nothing to do
* So the only remaining situation is when a non-full update started, and switched away to a thread that decided to do full update. The fix here is what we tell Ruby to yield from the current thread trying to do the full update, so that the thread doing the non-full update gets to run and finish its work.

To fix 2. we detect that an update is ongoing in `start_heap_allocation_recording` and skip any samples in that case.

As a final note to better understand this, remember that there is never any **parallelism** here, so we don't need any specific atomics or extra mutexes or whatever. At any point in time, all of the steps being discussed are running with the GVL acquired -- the problem here is that another thread can get to run at one of the specific potential switch points we have.

**How to test the change?**

This is a really good question. This issue has been happening almost daily in our validation environment since https://github.com/DataDog/dd-trace-rb/pull/4460 got merged, so we'll be able to see that profiler will no longer stop reporting data.

But triggering this with unit tests would be... really really hard. 
We'd need invasive surgery to force Ruby to switch in the exact specific situation we need between multiple threads in the middle of our C code.

So I couldn't think of a reasonable way of testing this, other than relying on our end-to-end tests. Suggestions are very welcome.