### PR TITLE
Fix Anonymizer call

### DIFF
--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -92,7 +92,7 @@ module Datadog
             return if value.nil?
             return value.to_s unless anonymize?
 
-            Anonymizer.anonimyze(value.to_s)
+            Anonymizer.anonymize(value.to_s)
           end
 
           def anonymize?


### PR DESCRIPTION
## Summary
- fix method name in Devise tracking middleware

## Testing
- `bundle exec rake spec:appsec:devise` *(fails: Could not find gem 'benchmark-ips (~> 2.8)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_b_684be3832e94832c922dd38b0672760e