### PR TITLE
Fix mistyped method call in AppSec devise contrib

### DIFF
--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -92,7 +92,7 @@ module Datadog
             return if value.nil?
             return value.to_s unless anonymize?
 
-            Anonymizer.anonimyze(value.to_s)
+            Anonymizer.anonymize(value.to_s)
           end
 
           def anonymize?


### PR DESCRIPTION
**What does this PR do?**

Fix a mistype

**Motivation:**

It will cause errors in anonymization mode

**Change log entry**

Yes. AppSec: Fix authenticated users tracking in anonymization mode for `devise` contrib.

**Additional Notes:**

No

**How to test the change?**

CI