### PR TITLE
Pin datadog-ci with 3.7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     container:
-      image: datadog/ci
+      image: datadog/ci:v3.7.1
       credentials:
         username: "${{ secrets.DOCKERHUB_USERNAME }}"
         password: "${{ secrets.DOCKERHUB_TOKEN }}"


### PR DESCRIPTION
**What does this PR do?**

Pin version with 3.7.1

**Motivation:**

Latest 3.8.0 is broken with: https://github.com/DataDog/dd-trace-rb/actions/runs/15631277859/job/44037031912?pr=4732

**Change log entry**
None.