### PR TITLE
Fix system-tests ref in parametric-tests.yml

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.src }}
       FORCED_TESTS_LIST: ${{ steps.read_forced_tests_list.outputs.FORCED_TESTS_LIST }}
-      ST_REF: ${{ steps.read_forced_tests_list.outputs.ST_REF }}
+      ST_REF: ${{ steps.outputs_branch.outputs.ST_REF }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Fix system-tests ref in parametric-tests.yml

**Motivation:**
<!-- What inspired you to submit this pull request? -->
When trying to change the ref to a system-tests branch for testing purpose, it was still checking out the main branch, which is a bug

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Look at the Parametric Tests GHA, especially the checkout step. It should show the ref that is set in the workflow file instead of just main

<!-- Unsure? Have a question? Request a review! -->
