### PR TITLE
[NO-TICKET] Hide native code for memfd close

### DIFF
--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -210,7 +210,7 @@ module Datadog
           telemetry.emit_closing! unless replacement&.telemetry&.enabled
           telemetry.shutdown!
 
-          Core::ProcessDiscovery._native_close_tracer_memfd(@process_discovery_fd, @logger) if @process_discovery_fd
+          @process_discovery_fd&.shutdown!
         end
 
         # Returns the current state of various components.

--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'datadog/core/process_discovery/tracer_memfd'
+
 module Datadog
   module Core
     # Class used to store tracer metadata in a native file descriptor.
@@ -10,7 +12,9 @@ module Datadog
           return
         end
         metadata = get_metadata(settings)
-        _native_store_tracer_metadata(logger, **metadata)
+        memfd = _native_store_tracer_metadata(logger, **metadata)
+        memfd.logger = logger if memfd
+        memfd
       end
 
       # According to the RFC, runtime_id, service_name, service_env, service_version are optional.

--- a/lib/datadog/core/process_discovery/tracer_memfd.rb
+++ b/lib/datadog/core/process_discovery/tracer_memfd.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Datadog
+  module Core
+    class ProcessDiscovery
+      class TracerMemfd
+        attr_accessor :logger
+
+        def shutdown!
+          ProcessDiscovery._native_close_tracer_memfd(self, logger)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/core/process_discovery/tracer_memfd.rbs
+++ b/sig/datadog/core/process_discovery/tracer_memfd.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module Core
+    class ProcessDiscovery
+      class TracerMemfd
+        attr_accessor logger: Datadog::Core::Logger
+
+        def shutdown!: () -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -28,7 +28,6 @@ require 'datadog/core/transport/http/adapters/net'
 RSpec.describe Datadog::Core::Configuration::Components do
   subject(:components) { described_class.new(settings) }
 
-  # Using a double does not give access to superclass methods like debug
   let(:logger) do
     instance_double(Datadog::Core::Logger).tap do |logger|
       allow(logger).to receive(:debug)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR moves call to native code that was originally located in `core/configuration/components.rb` to `core/process_discovery/tracer_memfd.rb`

**Motivation:**
<!-- What inspired you to submit this pull request? -->
[Comment](https://github.com/DataDog/dd-trace-rb/pull/4649#discussion_r2161162931) on "Enable Service Discovery" PR 

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
CI should still work the same

<!-- Unsure? Have a question? Request a review! -->
