### PR TITLE
Remove GHCR publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,22 +156,6 @@ deploy_to_reliability_env:
   needs:
     - save_versions
 
-publish-to-ghcr:
-  extends: .base-packaging-job
-  needs:
-    - job: create-multiarch-lib-injection-image
-  rules:
-    - if: $SKIP_SHARED_PIPELINE == "true"
-      when: never
-    - when: on_success
-  script:
-    - export GHCR_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.$CI_PROJECT_NAME.gh_ghcr_token --with-decryption --query "Parameter.Value" --out text)
-    - echo $GHCR_TOKEN | docker login ghcr.io/datadog --username uploader --password-stdin
-    - crane copy ${INTERNAL_K8S_REGISTRY_BASE}/dd-lib-ruby-init:glci${CI_PIPELINE_ID} ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:glci${CI_PIPELINE_ID}
-    - crane copy ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:glci${CI_PIPELINE_ID} ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:${CI_COMMIT_SHA}
-    - crane copy ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:glci${CI_PIPELINE_ID} ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:glci${CI_PIPELINE_ID}-g${CI_COMMIT_SHA}
-    - if [[ "$CI_COMMIT_BRANCH" == "master" ]]; then crane tag ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:glci${CI_PIPELINE_ID} ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:latest_snapshot; fi
-
 # Currently, the job is implemented with polling mechanism.
 #
 # Due to the constraints of Github workflow dispatch endpoint, it does not return the workflow run id.
@@ -182,7 +166,7 @@ vaccine:
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:v68058725-73f34e7-2025.06-1
   tags: ["arch:amd64"]
   stage: vaccine
-  needs: [create-multiarch-lib-injection-image, publish-to-ghcr]
+  needs: [create-multiarch-lib-injection-image]
 
   id_tokens:
     DDOCTOSTS_ID_TOKEN:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Remove GHCR publishing in the build pipeline.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
GHCR publishing introduced in #4732 was intended to be temporary until Vaccine changes were merged. The vaccine changes were merged so publishing to ghcr is no longer needed. Additionally, the job will break when Classic PATs are deprecated.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
