### PR TITLE
[NO-TICKET] Minor: Enable native filenames benchmark

### DIFF
--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -48,20 +48,19 @@ class ProfilerSampleLoopBenchmark
     collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder)
 
     if mode == :native
-      # TODO: REMOVE THIS AFTER MERGING PR (IT BREAKS ADDING THIS BENCHMARK IN CI)
-      # if !Datadog::Profiling::Collectors::Stack._native_filenames_available?
-      #   if OS.linux?
-      #     raise 'Native filenames are not available. This is not expected on Linux!'
-      #   else
-      #     puts "Skipping benchmarking native_frames, not supported outside of Linux"
-      #     return
-      #   end
-      # end
-      #
-      # collector_without_native_filenames = Datadog::Profiling::Collectors::ThreadContext.for_testing(
-      #   recorder: @recorder,
-      #   native_filenames_enabled: false
-      # )
+      if !Datadog::Profiling::Collectors::Stack._native_filenames_available?
+        if OS.linux?
+          raise 'Native filenames are not available. This is not expected on Linux!'
+        else
+          puts "Skipping benchmarking native_frames, not supported outside of Linux"
+          return
+        end
+      end
+
+      collector_without_native_filenames = Datadog::Profiling::Collectors::ThreadContext.for_testing(
+        recorder: @recorder,
+        native_filenames_enabled: false
+      )
       collector_without_native_filenames = collector
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR enables the native filenames benchmark that was added in https://github.com/DataDog/dd-trace-rb/pull/4745 but not enable [because of](https://github.com/DataDog/dd-trace-rb/pull/4745#discussion_r2167144621):

> So... our current benchmarking setup is... weird in this regard.
>
> Specifically, it checks out this branch, runs the benchmarks, and then it copies the benchmarks to a temp folder, and then checks out master, and runs the benchmarks from this branch with master.
>
> That's.... cool if you add a new benchmark for something, and then modify some existing code to make things faster, and boom, in your PR you can see the before/after right away.
>
> But whenever the benchmark is not backwards-compatible with master (e.g. some new arguments get added, classes get changed, etc), then this completely breaks, since master doesn't really have the ability to run the benchmark without the other changes.
>
> So yeah, fixing our benchmarks integration aside, the workaround is to just comment the backwards-incompatible changes (or the whole benchmark), get it in master first, and then in a follow-up PR it can be enabled (since by then master will be able to run the benchmark).

**Motivation:**

Actually enable the new benchmark.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

Check CI results, benchmark should be there!