### PR TITLE
Fix sampling rules and sample rate reporting in environment logger

### DIFF
--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -84,7 +84,9 @@ module Datadog
           # @return [Numeric, nil] tracer sample rate configured
           def sample_rate
             sampler = Datadog.configuration.tracing.sampler
-            return nil unless sampler
+            unless sampler
+              return Datadog.configuration.tracing.sampling.default_rate rescue nil
+            end
 
             sampler.sample_rate(nil) rescue nil
           end
@@ -97,6 +99,11 @@ module Datadog
           # @return [Hash, nil] sample rules configured
           def sampling_rules
             sampler = Datadog.configuration.tracing.sampler
+
+            unless sampler
+              return Datadog.configuration.tracing.sampling.rules rescue nil
+            end
+
             return nil unless sampler.is_a?(Tracing::Sampling::PrioritySampler) &&
               sampler.priority_sampler.is_a?(Tracing::Sampling::RuleSampler)
 
@@ -109,6 +116,8 @@ module Datadog
                 sample_rate: rule.sampler.sample_rate(nil)
               }
             end.compact
+          rescue
+            nil
           end
 
           # Concatenated list of integrations activated, with their gem version.


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
- Check `tracing.sampling.default_rate` as fallback for sample_rate  
- Resolve null sampling_rules in diagnostic logs when sampler is unavailable by check `tracing.sampling.rules` when no sampler is configured

**Motivation:**
<!-- What inspired you to submit this pull request? -->
The `sample_rate` and `sampling_rules` are null even we configured via env var or `Datadog.configure`.

- https://github.com/DataDog/dd-trace-rb/blob/9266d0a37e8c22cf569496f6778fa8ec4660c2b9/docs/GettingStarted.md?plain=1#L2103
- https://github.com/DataDog/dd-trace-rb/blob/9266d0a37e8c22cf569496f6778fa8ec4660c2b9/docs/GettingStarted.md?plain=1#L2105

Before:

```log
app-1  | I, [2025-07-01T08:14:36.550791 #1]  INFO -- datadog: [datadog] (/usr/local/bundle/gems/datadog-2.17.0/lib/datadog/core/diagnostics/environment_logger.rb:15:in 'Datadog::Core::Diagnostics::EnvironmentLogging#log_configuration!') DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":"http://agent:8126?timeout=30","analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"integrations_loaded":null,"partial_flushing_enabled":false}
```

After:

```log
app-1  | I, [2025-07-01T08:16:06.774422 #1]  INFO -- datadog: [datadog] (/usr/local/bundle/gems/datadog-2.17.0/lib/datadog/core/diagnostics/environment_logger.rb:15:in 'Datadog::Core::Diagnostics::EnvironmentLogging#log_configuration!') DATADOG CONFIGURATION - TRACING - {"enabled":true,"agent_url":"http://agent:8126?timeout=30","analytics_enabled":false,"sample_rate":0.33,"sampling_rules":"[{\"service\":\"my-ruby-app\",\"sample_rate\":0.22}]","integrations_loaded":null,"partial_flushing_enabled":false}
```

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<details>

<summary>You can reproduce this issue with the following files.</summary>

`app.rb`

```ruby
#!/usr/bin/env ruby

require 'datadog'

Datadog.configure do |c|
  c.service = 'my-ruby-app'
  c.tracing.sampling.default_rate = 0.33
  c.tracing.sampling.rules = [
    {
      service: "my-ruby-app",
      sample_rate: 0.22
    }
].to_json
end

def main
  Datadog::Tracing.trace('do_something') do |root_span|
    puts "Do Something"
  end
end

begin
  main
rescue => e
  puts "Error: #{e.message}"
  puts e.backtrace
  exit 1
end 
```

`Gemfile`

```gemfile
source 'https://rubygems.org'

gem 'datadog', '~> 2.17'
```

`Dockerfile`

```dockerfile
FROM ruby:3
WORKDIR /app
COPY Gemfile Gemfile.lock .
RUN bundle install
COPY app.rb .
CMD ["ruby", "app.rb"]
```

`docker-compose.yaml`

```yaml
services:
  agent:
    image: datadog/agent:7
    volumes:
      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
      - /proc/:/host/proc/:ro
      - /var/run/docker.sock:/var/run/docker.sock:ro
    pid: host
    cgroup: host
    environment:
      - DD_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      - DD_APM_ENABLED=true
      - DD_APM_NON_LOCAL_TRAFFIC=true
  app:
    build:
      context: .
    volumes: 
     # To test updated code.
      - ./environment_logger.rb:/usr/local/bundle/gems/datadog-2.17.0/lib/datadog/tracing/diagnostics/environment_logger.rb
    depends_on:
      - agent
    environment:
      - DD_AGENT_HOST=agent
      - DD_TRACE_DEBUG=true
```

</details>

<!-- Unsure? Have a question? Request a review! -->
