### PR TITLE
[NO-TICKET] Force-enable ST stable config phase 1 instead of whole class

### DIFF
--- a/.github/forced-tests-list.json
+++ b/.github/forced-tests-list.json
@@ -1,6 +1,9 @@
 {
     "PARAMETRIC": [
-        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default",
+        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence",
+        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_invalid_files",
+        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_unknown_key_skipped",
+        "tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_default_config",
         "tests/parametric/test_process_discovery.py"
     ]
 }

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: ruby-enable-remote-config-rule-changes-tests # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: a8d5055e91531faf069e784b6810ec28cdc284a1 # Automated: This reference is automatically updated.
 
 jobs:
   changes:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Force enable system-tests specific to stable config phase 1 instead of the whole class

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Phase 2 tests are also in this class and they are not passing

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Ci should be green but it was already. But once this is merged, it should also be green when updating the system-tests ref in the future.

<!-- Unsure? Have a question? Request a review! -->
