### PR TITLE
fix(mysql): prevent `db.name` from being empty

### DIFF
--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -93,10 +93,10 @@ module Datadog
               return if database.nil? || database.empty?
 
               span.set_tag(Contrib::Ext::DB::TAG_INSTANCE, database)
+              span.set_tag(Ext::TAG_DB_NAME, database)
             end
 
             def set_span_tags(span, query_options)
-              span.set_tag(Ext::TAG_DB_NAME, query_options[:database])
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, query_options[:host])
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, query_options[:port])
               span.set_tag(Tracing::Metadata::Ext::TAG_PEER_HOSTNAME, query_options[:host])

--- a/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/mysql2/patcher_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'Mysql2::Client patcher' do
             query
 
             expect(span.get_tag('db.instance')).to be_nil
-            expect(span.get_tag('mysql2.db.name')).to eq('')
+            expect(span.get_tag('mysql2.db.name')).to be_nil
           end
         end
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

Some queries to mysql DBs have an empty database name field due to it not being a mandatory parameter. For these cases, we are setting the db.name tag to be empty and creating an empty string inferred service.

**What does this PR do?**
Prevents `db.name` tag from being empty. This is a peer tag which intake will use to set inferred service. If empty, then inferred service will appear empty. This fix prevents that. 

**Change log entry**
Yes. The mysql integration now only sets the `db.name` tag if there is a valid value

**How to test the change?**
All changes have tests. There are queries with an empty DB name and the results are now as expected
