### PR TITLE
Bump to version 2.18.0

### DIFF
--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  SYSTEM_TESTS_REF: bdd462533169d3ae2d6e47a3d455e9f8553d80a3 # Automated: Can be updated by .github/workflows/update-system-tests.yml
+  SYSTEM_TESTS_REF: 316900e2a7466555951a341e6f2bedd4bf261097 # Automated: Can be updated by .github/workflows/update-system-tests.yml
 
 jobs:
   changes:

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  SYSTEM_TESTS_REF: 41b4d2ab45583fd444d37032e94dcd471d81388c # Automated: Can be updated by .github/workflows/update-system-tests.yml
+  SYSTEM_TESTS_REF: bdd462533169d3ae2d6e47a3d455e9f8553d80a3 # Automated: Can be updated by .github/workflows/update-system-tests.yml
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: bdd462533169d3ae2d6e47a3d455e9f8553d80a3 # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: 316900e2a7466555951a341e6f2bedd4bf261097 # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   REPO: ghcr.io/datadog/dd-trace-rb
-  SYSTEM_TESTS_REF: 41b4d2ab45583fd444d37032e94dcd471d81388c # Automated: This reference is automatically updated.
+  SYSTEM_TESTS_REF: bdd462533169d3ae2d6e47a3d455e9f8553d80a3 # Automated: This reference is automatically updated.
 
 jobs:
   changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+## [2.18.0] - 2025-07-03
+
+### Added
+
+* AppSec: Add API Security with new sampling algorithm to the Rack, Rails, Sinatra and Grape frameworks ([#4699][])
+* Core: Add support for tracer configuration through Fleet Automation ([#4651][])
+* Tracing: Add Rails view render times and database query times to the spans, when available ([#4697][])
+* Core: Add Service Discovery capability, enabling the tracer to reliably determine which process are instrumented
+
+### Changed
+
+* AppSec: Enable API Security feature by default ([#4756][])
+* AppSec: Improve overall threat detection ([#4757][])
+* AppSec: Deprecate `config.appsec.ip_passlist`, `config.appsec.ip_denylist`, and `config.appsec.user_id_denylist` ([#4757][])
+* Profiling: Graduate Heap Profiling from alpha to preview ([#4401][], [#4460][])
+* Dynamic Instrumentation: Add instance variable capture to method and line probes ([#4668][])
+* Profiling: Add capturing of native filenames in backtraces ([#4745][])
+* Profiling: Clean up profiler logging ([#4728][])
+Tracing: Add support for `DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED` to tag runtime metrics with the current runtime ID, allowing correlation across processes ([#4718][])
+* Tracing: Improve performance of `http.route` tag computation for Rails ([#4688][])
+
+### Fixed
+
+* AppSec: Fix authenticated users tracking in anonymization mode for Devise ([#4731][])
+* Dynamic Instrumentation: Fix source code display in live debugger ([#4743][])
+* Profiling: Fix profiler stopping due to bug in heap profiling serialization ([#4721][])
+
 ## [2.17.0] - 2025-06-02
 
 ### Added
@@ -3241,7 +3268,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.17.0...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.18.0...master
+[2.18.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.17.0...v2.18.0
 [2.17.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.16.0...v2.17.0
 [2.16.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.14.0...v2.15.0
@@ -4745,6 +4773,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#4391]: https://github.com/DataDog/dd-trace-rb/issues/4391
 [#4398]: https://github.com/DataDog/dd-trace-rb/issues/4398
 [#4399]: https://github.com/DataDog/dd-trace-rb/issues/4399
+[#4401]: https://github.com/DataDog/dd-trace-rb/issues/4401
 [#4403]: https://github.com/DataDog/dd-trace-rb/issues/4403
 [#4406]: https://github.com/DataDog/dd-trace-rb/issues/4406
 [#4411]: https://github.com/DataDog/dd-trace-rb/issues/4411
@@ -4755,6 +4784,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#4433]: https://github.com/DataDog/dd-trace-rb/issues/4433
 [#4437]: https://github.com/DataDog/dd-trace-rb/issues/4437
 [#4455]: https://github.com/DataDog/dd-trace-rb/issues/4455
+[#4460]: https://github.com/DataDog/dd-trace-rb/issues/4460
 [#4473]: https://github.com/DataDog/dd-trace-rb/issues/4473
 [#4493]: https://github.com/DataDog/dd-trace-rb/issues/4493
 [#4497]: https://github.com/DataDog/dd-trace-rb/issues/4497
@@ -4787,14 +4817,27 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#4616]: https://github.com/DataDog/dd-trace-rb/issues/4616
 [#4625]: https://github.com/DataDog/dd-trace-rb/issues/4625
 [#4644]: https://github.com/DataDog/dd-trace-rb/issues/4644
+[#4651]: https://github.com/DataDog/dd-trace-rb/issues/4651
 [#4653]: https://github.com/DataDog/dd-trace-rb/issues/4653
 [#4656]: https://github.com/DataDog/dd-trace-rb/issues/4656
 [#4665]: https://github.com/DataDog/dd-trace-rb/issues/4665
+[#4668]: https://github.com/DataDog/dd-trace-rb/issues/4668
 [#4669]: https://github.com/DataDog/dd-trace-rb/issues/4669
 [#4672]: https://github.com/DataDog/dd-trace-rb/issues/4672
 [#4673]: https://github.com/DataDog/dd-trace-rb/issues/4673
 [#4678]: https://github.com/DataDog/dd-trace-rb/issues/4678
 [#4679]: https://github.com/DataDog/dd-trace-rb/issues/4679
+[#4688]: https://github.com/DataDog/dd-trace-rb/issues/4688
+[#4697]: https://github.com/DataDog/dd-trace-rb/issues/4697
+[#4699]: https://github.com/DataDog/dd-trace-rb/issues/4699
+[#4718]: https://github.com/DataDog/dd-trace-rb/issues/4718
+[#4721]: https://github.com/DataDog/dd-trace-rb/issues/4721
+[#4728]: https://github.com/DataDog/dd-trace-rb/issues/4728
+[#4731]: https://github.com/DataDog/dd-trace-rb/issues/4731
+[#4743]: https://github.com/DataDog/dd-trace-rb/issues/4743
+[#4745]: https://github.com/DataDog/dd-trace-rb/issues/4745
+[#4756]: https://github.com/DataDog/dd-trace-rb/issues/4756
+[#4757]: https://github.com/DataDog/dd-trace-rb/issues/4757
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Tracing: Add support for `DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED` to tag runtime 
 ### Fixed
 
 * AppSec: Fix authenticated users tracking in anonymization mode for Devise ([#4731][])
-* Dynamic Instrumentation: Fix source code display in live debugger ([#4743][])
+* Dynamic Instrumentation: Fix source code display in dynamic instrumentation/live debugger ([#4743][])
 * Profiling: Fix profiler stopping due to bug in heap profiling serialization ([#4721][])
 
 ## [2.17.0] - 2025-06-02

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_faraday_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_faraday_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_faraday_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_faraday_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_karafka_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_karafka_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_karafka_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_faraday_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -57,7 +57,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -57,7 +57,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -57,7 +57,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -54,7 +54,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -57,7 +57,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_app.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_excon_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog (2.17.0)
+    datadog (2.18.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)

--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -3,7 +3,7 @@
 module Datadog
   module VERSION
     MAJOR = 2
-    MINOR = 17
+    MINOR = 18
     PATCH = 0
     PRE = nil
     BUILD = nil


### PR DESCRIPTION
### Added

* AppSec: Add API Security with new sampling algorithm to the Rack, Rails, Sinatra and Grape frameworks (#4699)
* Core: Add support for tracer configuration through Fleet Automation (#4651)
* Tracing: Add Rails view render times and database query times to the spans, when available (#4697)
* Core: Add Service Discovery capability, enabling the tracer to reliably determine which process are instrumented

### Changed

* AppSec: Enable API Security feature by default (#4756)
* AppSec: Improve overall threat detection (#4757)
* AppSec: Deprecate `config.appsec.ip_passlist`, `config.appsec.ip_denylist`, and `config.appsec.user_id_denylist` (#4757)
* Profiling: Graduate Heap Profiling from alpha to preview (#4401, #4460)
* Dynamic Instrumentation: Add instance variable capture to method and line probes (#4668)
* Profiling: Add capturing of native filenames in backtraces (#4745)
* Profiling: Clean up profiler logging (#4728)
Tracing: Add support for `DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED` to tag runtime metrics with the current runtime ID, allowing correlation across processes (#4718)
* Tracing: Improve performance of `http.route` tag computation for Rails (#4688)

### Fixed

* AppSec: Fix authenticated users tracking in anonymization mode for Devise (#4731)
* Dynamic Instrumentation: Fix source code display in dynamic instrumentation/live debugger (#4743)
* Profiling: Fix profiler stopping due to bug in heap profiling serialization (#4721)
