### PR TITLE
[PROF-12098] Profiler: Allow sampling from inside the signal handler to improve accuracy

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -102,6 +102,7 @@ typedef struct {
   bool allocation_counting_enabled;
   bool gvl_profiling_enabled;
   bool skip_idle_samples_for_testing;
+  bool sighandler_sampling_enabled;
   VALUE self_instance;
   VALUE thread_context_collector_instance;
   VALUE idle_sampling_helper_instance;
@@ -358,6 +359,7 @@ static VALUE _native_new(VALUE klass) {
   state->allocation_counting_enabled = false;
   state->gvl_profiling_enabled = false;
   state->skip_idle_samples_for_testing = false;
+  state->sighandler_sampling_enabled = false;
   state->thread_context_collector_instance = Qnil;
   state->idle_sampling_helper_instance = Qnil;
   state->owner_thread = Qnil;
@@ -400,6 +402,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   VALUE allocation_counting_enabled = rb_hash_fetch(options, ID2SYM(rb_intern("allocation_counting_enabled")));
   VALUE gvl_profiling_enabled = rb_hash_fetch(options, ID2SYM(rb_intern("gvl_profiling_enabled")));
   VALUE skip_idle_samples_for_testing = rb_hash_fetch(options, ID2SYM(rb_intern("skip_idle_samples_for_testing")));
+  VALUE sighandler_sampling_enabled = rb_hash_fetch(options, ID2SYM(rb_intern("sighandler_sampling_enabled")));
 
   ENFORCE_BOOLEAN(gc_profiling_enabled);
   ENFORCE_BOOLEAN(no_signals_workaround_enabled);
@@ -409,6 +412,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   ENFORCE_BOOLEAN(allocation_counting_enabled);
   ENFORCE_BOOLEAN(gvl_profiling_enabled);
   ENFORCE_BOOLEAN(skip_idle_samples_for_testing)
+  ENFORCE_BOOLEAN(sighandler_sampling_enabled)
 
   cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(self_instance, cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
@@ -420,6 +424,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   state->allocation_counting_enabled = (allocation_counting_enabled == Qtrue);
   state->gvl_profiling_enabled = (gvl_profiling_enabled == Qtrue);
   state->skip_idle_samples_for_testing = (skip_idle_samples_for_testing == Qtrue);
+  state->sighandler_sampling_enabled = (sighandler_sampling_enabled == Qtrue);
 
   double total_overhead_target_percentage = NUM2DBL(dynamic_sampling_rate_overhead_target_percentage);
   if (!state->allocation_profiling_enabled) {

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -598,13 +598,14 @@ void record_placeholder_stack(
   );
 }
 
-void prepare_sample_thread(VALUE thread, sampling_buffer *buffer) {
+bool prepare_sample_thread(VALUE thread, sampling_buffer *buffer) {
   // Since this can get called from inside a signal handler, we don't want to touch the buffer if
   // the thread was actually in the middle of marking it.
-  if (buffer->is_marking) return;
+  if (buffer->is_marking) return false;
 
   buffer->pending_sample = true;
   buffer->pending_sample_result = ddtrace_rb_profile_frames(thread, 0, buffer->max_frames, buffer->stack_buffer);
+  return true;
 }
 
 uint16_t sampling_buffer_check_max_frames(int max_frames) {

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -14,6 +14,7 @@ typedef struct {
   ddog_prof_Location *locations;
   frame_info *stack_buffer;
   bool pending_sample;
+  bool is_marking; // Used to avoid recording a sample when marking
   int pending_sample_result;
 } sampling_buffer;
 

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -33,7 +33,7 @@ void record_placeholder_stack(
   sample_labels labels,
   ddog_CharSlice placeholder_stack
 );
-void prepare_sample_thread(VALUE thread, sampling_buffer *buffer);
+bool prepare_sample_thread(VALUE thread, sampling_buffer *buffer);
 
 uint16_t sampling_buffer_check_max_frames(int max_frames);
 void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames, ddog_prof_Location *locations);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -10,7 +10,7 @@ void thread_context_collector_sample(
   long current_monotonic_wall_time_ns,
   VALUE profiler_overhead_stack_thread
 );
-void thread_context_collector_prepare_sample_inside_signal_handler(VALUE self_instance);
+__attribute__((warn_unused_result)) bool thread_context_collector_prepare_sample_inside_signal_handler(VALUE self_instance);
 void thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight, VALUE new_object);
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -72,7 +72,7 @@ NORETURN(void raise_syserr(
 // reference a valid object (in which case value is not changed).
 //
 // Note: GVL can be released and other threads may get to run before this method returns
-bool ruby_ref_from_id(size_t id, VALUE *value);
+bool ruby_ref_from_id(VALUE obj_id, VALUE *value);
 
 // Native wrapper to get the approximate/estimated current size of the passed
 // object.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -554,6 +554,16 @@ module Datadog
               o.env 'DD_PROFILING_NATIVE_FILENAMES_ENABLED'
               o.default true
             end
+
+            # Controls if the profiler should sample directly from the signal handler.
+            # TODO: Change default on Rubies that support it, explain better how this works.
+            #
+            # @default false
+            option :sighandler_sampling_enabled do |o|
+              o.type :bool
+              o.env 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED'
+              o.default false
+            end
           end
 
           # @public_api

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -556,7 +556,14 @@ module Datadog
             end
 
             # Controls if the profiler should sample directly from the signal handler.
-            # TODO: Change default on Rubies that support it, explain better how this works.
+            # Sampling directly from the signal handler improves accuracy of the data collected.
+            #
+            # We recommend using this setting with Ruby 3.2.5+ / Ruby 3.3.4+ and above
+            # as they include additional safety measures added in https://github.com/ruby/ruby/pull/11036.
+            # We have not validated it thoroughly with earlier versions, but in practice it should work on Ruby 3.0+
+            # (the key change was https://github.com/ruby/ruby/pull/3296).
+            #
+            # Enabling this on Ruby 2 is not recommended as it may lead to rare crashes.
             #
             # @default false
             option :sighandler_sampling_enabled do |o|

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -23,6 +23,7 @@ module Datadog
           allocation_profiling_enabled:,
           allocation_counting_enabled:,
           gvl_profiling_enabled:,
+          sighandler_sampling_enabled:,
           # **NOTE**: This should only be used for testing; disabling the dynamic sampling rate will increase the
           # profiler overhead!
           dynamic_sampling_rate_enabled: true,
@@ -49,6 +50,7 @@ module Datadog
             allocation_profiling_enabled: allocation_profiling_enabled,
             allocation_counting_enabled: allocation_counting_enabled,
             gvl_profiling_enabled: gvl_profiling_enabled,
+            sighandler_sampling_enabled: sighandler_sampling_enabled,
             skip_idle_samples_for_testing: skip_idle_samples_for_testing,
           )
           @worker_thread = nil

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -67,6 +67,7 @@ module Datadog
           allocation_profiling_enabled: allocation_profiling_enabled,
           allocation_counting_enabled: settings.profiling.advanced.allocation_counting_enabled,
           gvl_profiling_enabled: enable_gvl_profiling?(settings, logger),
+          sighandler_sampling_enabled: settings.profiling.advanced.sighandler_sampling_enabled,
         )
 
         internal_metadata = {

--- a/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
+++ b/sig/datadog/profiling/collectors/cpu_and_wall_time_worker.rbs
@@ -17,6 +17,7 @@ module Datadog
           allocation_profiling_enabled: bool,
           allocation_counting_enabled: bool,
           gvl_profiling_enabled: bool,
+          sighandler_sampling_enabled: bool,
           ?skip_idle_samples_for_testing: false,
         ) -> void
 
@@ -31,6 +32,7 @@ module Datadog
           allocation_profiling_enabled: bool,
           allocation_counting_enabled: bool,
           gvl_profiling_enabled: bool,
+          sighandler_sampling_enabled: bool,
           skip_idle_samples_for_testing: bool,
         ) -> true
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -841,6 +841,21 @@ RSpec.describe Datadog::Core::Configuration::Settings do
             .to(false)
         end
       end
+
+      describe '#sighandler_sampling_enabled' do
+        subject(:sighandler_sampling_enabled) { settings.profiling.advanced.sighandler_sampling_enabled }
+
+        it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: false
+      end
+
+      describe '#sighandler_sampling_enabled=' do
+        it 'updates the #sighandler_sampling_enabled setting' do
+          expect { settings.profiling.advanced.sighandler_sampling_enabled = true }
+            .to change { settings.profiling.advanced.sighandler_sampling_enabled }
+            .from(false)
+            .to(true)
+        end
+      end
     end
 
     describe '#upload' do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1039,7 +1039,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         start
 
-        loop_until { cpu_and_wall_time_worker.stats.fetch(:signal_handler_enqueued_sample) >= 20 }
+        loop_until(timeout_seconds: 60) { cpu_and_wall_time_worker.stats.fetch(:signal_handler_enqueued_sample) >= 20 }
 
         cpu_and_wall_time_worker.stop
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:stack_recorder_options) { {} }
   let(:allocation_counting_enabled) { false }
   let(:gvl_profiling_enabled) { false }
+  let(:sighandler_sampling_enabled) { false }
   let(:worker_settings) do
     {
       gc_profiling_enabled: gc_profiling_enabled,
@@ -32,6 +33,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       allocation_profiling_enabled: allocation_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
       gvl_profiling_enabled: gvl_profiling_enabled,
+      sighandler_sampling_enabled: sighandler_sampling_enabled,
       **options
     }
   end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1021,7 +1021,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
     end
 
-    describe "sampling from signal handler" do
+    describe "sampling from signal handler", :memcheck_valgrind_skip do
       let(:options) { {dynamic_sampling_rate_enabled: false} }
 
       let(:sample_count) do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1039,7 +1039,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         start
 
-        loop_until(timeout_seconds: 60) { cpu_and_wall_time_worker.stats.fetch(:signal_handler_enqueued_sample) >= 20 }
+        loop_until { cpu_and_wall_time_worker.stats.fetch(:signal_handler_enqueued_sample) >= 20 }
 
         cpu_and_wall_time_worker.stop
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe Datadog::Profiling::Component do
           expect(settings.profiling.advanced)
             .to receive(:allocation_counting_enabled).and_return(:allocation_counting_enabled_config)
           expect(described_class).to receive(:enable_gvl_profiling?).and_return(:gvl_profiling_result)
+          expect(settings.profiling.advanced)
+            .to receive(:sighandler_sampling_enabled).and_return(:sighandler_sampling_enabled_config)
 
           expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with(
             gc_profiling_enabled: anything,
@@ -136,6 +138,7 @@ RSpec.describe Datadog::Profiling::Component do
             allocation_profiling_enabled: false,
             allocation_counting_enabled: :allocation_counting_enabled_config,
             gvl_profiling_enabled: :gvl_profiling_result,
+            sighandler_sampling_enabled: :sighandler_sampling_enabled_config,
           )
 
           build_profiler_component


### PR DESCRIPTION
**What does this PR do?**

This PR picks up from where https://github.com/DataDog/dd-trace-rb/pull/4750 left off and finishes the new "sample from inside the signal handler" feature.

Most of the preparation work was already included in the prior PR so this PR:
* Adds a new setting `c.profiling.advanced.sighandler_sampling_enabled` / `DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED` environment variable
* Uses this setting to decide when to use `thread_context_collector_prepare_sample_inside_signal_handler`
* ...and it sprinkles a few compiler barriers to make sure we get a consistent view of the state of the profiler from inside the signal handler.

**Motivation:**

On older Ruby versions, the profiler wasn't able to sample from inside the signal handler. This is no longer the case since https://github.com/ruby/ruby/pull/3296 and https://github.com/ruby/ruby/pull/11036. Sampling from inside the signal handler increases profiler accuracy, and thus we want to start doing it on Rubies where it is safe to do so.

**Change log entry**

Yes. Profiler: Allow sampling from inside the signal handler to improve accuracy

**Additional Notes:**

In its current form, the feature is disabled by default. I'm still validating it in our testing environments, and I plan to submit a follow-up PR to enable it by default on Ruby 3.2.5+/3.3.4+ once validation finishes.

**How to test the change?**

I've added test coverage on this PR. Furthermore, here's a tiny worst-case reproducer that can show the difference quite clearly:

```ruby
def empty_method # gets 100% blame
end

def slow_method
  x = "h" + "e" + "l" + "l" + "o" + "," # Line 5
  x += "w" + "o" + "r" + "l" + "d"      # Line 6
  empty_method                          # Line 7
end

10000000.times do
  slow_method
end
```

Here's how this testcase looks without sampling from the signal handler:

| |
|-|
| ![image](https://github.com/user-attachments/assets/c3a27fff-060a-4609-b585-e537ffd25c3c) |

And here's how it looks with the feature enabled:
| |
|-|
| ![image](https://github.com/user-attachments/assets/5714badc-7440-4202-a5ef-592e6f66d1d1) |

You can see how the cpu-time gets correctly attributed to lines 5 and 6 with this change.