### PR TITLE
[PROF-12098] Profiler: Enable sample from inside signal handler by default on modern Rubies

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -563,13 +563,16 @@ module Datadog
             # We have not validated it thoroughly with earlier versions, but in practice it should work on Ruby 3.0+
             # (the key change was https://github.com/ruby/ruby/pull/3296).
             #
-            # Enabling this on Ruby 2 is not recommended as it may lead to rare crashes.
+            # Enabling this on Ruby 2 is not recommended as it may cause VM crashes and/or incorrect data.
             #
-            # @default false
+            # @default true on Ruby 3.2.5+ / Ruby 3.3.4+, false on older Rubies
             option :sighandler_sampling_enabled do |o|
               o.type :bool
               o.env 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED'
-              o.default false
+              o.default do
+                Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.5') &&
+                  !(RUBY_VERSION.start_with?('3.3.') && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.3.4'))
+              end
             end
           end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -845,15 +845,45 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       describe '#sighandler_sampling_enabled' do
         subject(:sighandler_sampling_enabled) { settings.profiling.advanced.sighandler_sampling_enabled }
 
-        it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: false
+        context 'on Ruby 3.2.4 and below' do
+          before { stub_const('RUBY_VERSION', '3.2.4') }
+
+          it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: false
+        end
+
+        context 'on Ruby 3.3 < 3.3.4' do
+          before { stub_const('RUBY_VERSION', '3.3.3') }
+
+          it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: false
+        end
+
+        context 'on Ruby 3.2 >= 3.2.5' do
+          before { stub_const('RUBY_VERSION', '3.2.5') }
+
+          it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: true
+        end
+
+        context 'on Ruby 3.3 >= 3.3.4' do
+          before { stub_const('RUBY_VERSION', '3.3.4') }
+
+          it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: true
+        end
+
+        context 'on Ruby 3.4' do
+          before { stub_const('RUBY_VERSION', '3.4.0') }
+
+          it_behaves_like 'a binary setting with', env_variable: 'DD_PROFILING_SIGHANDLER_SAMPLING_ENABLED', default: true
+        end
       end
 
       describe '#sighandler_sampling_enabled=' do
         it 'updates the #sighandler_sampling_enabled setting' do
-          expect { settings.profiling.advanced.sighandler_sampling_enabled = true }
+          default = settings.profiling.advanced.sighandler_sampling_enabled # Default is already tested in the getter
+
+          expect { settings.profiling.advanced.sighandler_sampling_enabled = !default }
             .to change { settings.profiling.advanced.sighandler_sampling_enabled }
-            .from(false)
-            .to(true)
+            .from(default)
+            .to(!default)
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

In https://github.com/DataDog/dd-trace-rb/pull/4785 we added a setting to enable sampling from inside the signal handler, but made it off by default.

The plan was to wait for validation in our test apps before flipping the default. The test apps have now been running for a while with this feature without issue, so we're ready to enable it.

This PR changes the setting to be on by default on Ruby 3.2.5+/3.3.4+.

**Motivation:**

The Ruby versions listed include https://github.com/ruby/ruby/pull/11036 (as well as other prior fixes) and thus it's safe to use this feature, which improves accuracy of profiling data.

See [original PR](https://github.com/DataDog/dd-trace-rb/pull/4785) for more details.

**Change log entry**

Yes. Profiler: Enable sample from inside signal handler by default on modern Rubies

(Note this should not be combined with the entry from https://github.com/DataDog/dd-trace-rb/pull/4785 -- one is about adding the feature, and the other is about enabling it by default only on modern Rubies)

**Additional Notes:**

Out of curiosity, our test apps use Ruby 3.2.5 (GitLab) and 3.3.4 (Rails) so they are exactly at the right versions so they'll start getting the feature on by default.

As mentioned in the comment attached to the setting, we could probably enable this feature on more Ruby versions (all of the 3.x series, potentially) but with more than half of all customer accounts using these modern Rubies, I'm not sure it's worth the extra validation work at this point.

**How to test the change?**

The change includes test coverage. Furthermore, when sampling from the signal handler is enabled, the `signal_handler_prepared_sample` counter added in https://github.com/DataDog/dd-trace-rb/pull/4785 will be non-zero, so this can be used as an extra validation that the feature is enabled for a given profile.