### PR TITLE
[NO-TICKET] Profiling: Add workaround for Ruby VM bug

### DIFF
--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -445,6 +445,12 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
     // support sampling any thread (including the current) passed as an argument
     rb_thread_t *th = thread_struct_from_object(thread);
     const rb_execution_context_t *ec = th->ec;
+
+    // As of this writing, we don't support profiling with MN enabled, and this only happens in that mode, but as we
+    // probably want to experiment with it in the future, I've decided to import https://github.com/ruby/ruby/pull/9310
+    // here.
+    if (ec == NULL) return 0;
+
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
     #ifndef NO_JIT_RETURN
       const rb_control_frame_t *top = cfp;
@@ -461,11 +467,6 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
     // This should not happen for ddtrace (it can only happen when a thread is still being created), but I've imported
     // it from https://github.com/ruby/ruby/pull/7116 in a "just in case" kind of mindset.
     if (cfp == NULL) return 0;
-
-    // As of this writing, we don't support profiling with MN enabled, and this only happens in that mode, but as we
-    // probably want to experiment with it in the future, I've decided to import https://github.com/ruby/ruby/pull/9310
-    // here.
-    if (ec == NULL) return 0;
 
     // Fix: Skip dummy frame that shows up in main thread.
     //

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   # We have separate specs that assert on these behaviors.
   def samples_from_pprof_without_gc_and_overhead(encoded_profile)
     samples_from_pprof(encoded_profile)
-      .reject { |it| it.locations.first.path == "Garbage Collection" }
+      .reject { |it| it.locations&.first&.path == "Garbage Collection" }
       .reject { |it| it.labels.include?(:"profiler overhead") }
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR tries to import the fix added in https://github.com/ruby/ruby/pull/13643 / https://bugs.ruby-lang.org/issues/21441 by applying it on the "reader" side: e.g. assuming we may see `ec != NULL` but `vm_stack == NULL` or `vm_stack_size == 0` during sampling.

**Motivation:**

I am not sure if this could happen in practice for the profiler, but given the extra check is cheap and means that our version of the fix applies to all Rubies without any need for the upstream fix, this seems worth to have.

**Change log entry**

Yes. Profiling: Add workaround for Ruby VM bug

**Additional Notes:**

I've included two other small fixes in this PR; I recommend reviewing commit-by-commit.

**How to test the change?**

Unfortunately I don't have a lot of ideas for how to test this :/

(Other than spending some amount of time to create a throwaway modified Ruby that would trigger profiling on the exact situation and see if breaks or not... Given that's quite an investment and the change seems quite simple, I'm not sure it's worth the time.)
