### PR TITLE
Repair loading of DI code when DI is enabled via environment variable

### DIFF
--- a/lib/datadog.rb
+++ b/lib/datadog.rb
@@ -8,5 +8,12 @@ require_relative 'datadog/tracing/contrib'
 require_relative 'datadog/profiling'
 require_relative 'datadog/appsec'
 require_relative 'datadog/di'
+
+# Line probes will not work on Ruby < 2.6 because of lack of :script_compiled
+# trace point. Activate DI automatically on supported Ruby versions but
+# always load its settings so that, for example, turning DI off when
+# we are on Ruby 2.5 does not produce exceptions.
+require_relative 'datadog/di/boot' if RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby'
+
 require_relative 'datadog/error_tracking'
 require_relative 'datadog/kit'

--- a/lib/datadog/di.rb
+++ b/lib/datadog/di.rb
@@ -35,9 +35,3 @@ module Datadog
     end
   end
 end
-
-# Line probes will not work on Ruby < 2.6 because of lack of :script_compiled
-# trace point. Activate DI automatically on supported Ruby versions but
-# always load its settings so that, for example, turning DI off when
-# we are on Ruby 2.5 does not produce exceptions.
-require_relative 'di/boot' if RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby'

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -7,13 +7,13 @@ REQUIRES = [
   { require: 'datadog/core', check: 'Datadog::Core' },
   { require: 'datadog/error_tracking', check: 'Datadog::ErrorTracking' },
   { require: 'datadog/di', check: 'Datadog::DI',
-    env: { 'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'false' },
+    env: { DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'false' },
     condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },
   # DI initializes itsef when it's loaded and the environment variable
   # instructs DI to be enabled, therefore needs separate tests with the
   # environment variable being enabled and disabled.
   { require: 'datadog/di', check: 'Datadog::DI',
-    env: { 'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'true' },
+    env: { DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true' },
     condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },
   { require: 'datadog/di/preload', check: 'Datadog::DI::CodeTracker',
     condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -2,24 +2,24 @@ require 'shellwords'
 require 'open3'
 
 REQUIRES = [
-  {require: 'datadog', check: 'Datadog::Core'},
-  {require: 'datadog/appsec', check: 'Datadog::AppSec'},
-  {require: 'datadog/core', check: 'Datadog::Core'},
-  {require: 'datadog/error_tracking', check: 'Datadog::ErrorTracking'},
-  {require: 'datadog/di', check: 'Datadog::DI',
-    env: {'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'false'},
-    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
+  { require: 'datadog', check: 'Datadog::Core' },
+  { require: 'datadog/appsec', check: 'Datadog::AppSec' },
+  { require: 'datadog/core', check: 'Datadog::Core' },
+  { require: 'datadog/error_tracking', check: 'Datadog::ErrorTracking' },
+  { require: 'datadog/di', check: 'Datadog::DI',
+    env: { 'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'false' },
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },
   # DI initializes itsef when it's loaded and the environment variable
   # instructs DI to be enabled, therefore needs separate tests with the
   # environment variable being enabled and disabled.
-  {require: 'datadog/di', check: 'Datadog::DI',
-    env: {'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'true'},
-    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
-  {require: 'datadog/di/preload', check: 'Datadog::DI::CodeTracker',
-    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
-  {require: 'datadog/kit', check: 'Datadog::Kit'},
-  {require: 'datadog/profiling', check: 'Datadog::Profiling'},
-  {require: 'datadog/tracing', check: 'Datadog::Tracing'},
+  { require: 'datadog/di', check: 'Datadog::DI',
+    env: { 'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'true' },
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },
+  { require: 'datadog/di/preload', check: 'Datadog::DI::CodeTracker',
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' } },
+  { require: 'datadog/kit', check: 'Datadog::Kit' },
+  { require: 'datadog/profiling', check: 'Datadog::Profiling' },
+  { require: 'datadog/tracing', check: 'Datadog::Tracing' },
 ].freeze
 
 RSpec.describe 'loading of products' do
@@ -27,18 +27,11 @@ RSpec.describe 'loading of products' do
     req = spec.fetch(:require)
 
     context req do
-      if env = spec[:env]
-        with_env **env
+      if (env = spec[:env])
+        with_env(**env)
       end
 
       let(:const) { spec.fetch(:check) }
-
-      if condition = spec[:condition]
-        before do
-          skip 'condition is false' unless condition.call
-        end
-      end
-
       let(:code) do
         <<-E
           if defined?(Datadog)
@@ -55,6 +48,12 @@ RSpec.describe 'loading of products' do
 
           exit 0
         E
+      end
+
+      if (condition = spec[:condition])
+        before do
+          skip 'condition is false' unless condition.call
+        end
       end
 
       it 'loads successfully by itself' do

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -7,6 +7,13 @@ REQUIRES = [
   {require: 'datadog/core', check: 'Datadog::Core'},
   {require: 'datadog/error_tracking', check: 'Datadog::ErrorTracking'},
   {require: 'datadog/di', check: 'Datadog::DI',
+    env: {'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'false'},
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
+  # DI initializes itsef when it's loaded and the environment variable
+  # instructs DI to be enabled, therefore needs separate tests with the
+  # environment variable being enabled and disabled.
+  {require: 'datadog/di', check: 'Datadog::DI',
+    env: {'DD_DYNAMIC_INSTRUMENTATION_ENABLED' => 'true'},
     condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
   {require: 'datadog/di/preload', check: 'Datadog::DI::CodeTracker',
     condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
@@ -20,6 +27,10 @@ RSpec.describe 'loading of products' do
     req = spec.fetch(:require)
 
     context req do
+      if env = spec[:env]
+        with_env **env
+      end
+
       let(:const) { spec.fetch(:check) }
 
       if condition = spec[:condition]

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -2,23 +2,27 @@ require 'shellwords'
 require 'open3'
 
 REQUIRES = [
-  ['datadog', 'Datadog::Core'],
-  ['datadog/appsec', 'Datadog::AppSec'],
-  ['datadog/core', 'Datadog::Core'],
-  ['datadog/error_tracking', 'Datadog::ErrorTracking'],
-  ['datadog/di', 'Datadog::DI',
-   -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
-  ['datadog/di/preload', 'Datadog::DI::CodeTracker',
-   -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }],
-  ['datadog/kit', 'Datadog::Kit'],
-  ['datadog/profiling', 'Datadog::Profiling'],
-  ['datadog/tracing', 'Datadog::Tracing'],
+  {require: 'datadog', check: 'Datadog::Core'},
+  {require: 'datadog/appsec', check: 'Datadog::AppSec'},
+  {require: 'datadog/core', check: 'Datadog::Core'},
+  {require: 'datadog/error_tracking', check: 'Datadog::ErrorTracking'},
+  {require: 'datadog/di', check: 'Datadog::DI',
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
+  {require: 'datadog/di/preload', check: 'Datadog::DI::CodeTracker',
+    condition: -> { RUBY_VERSION >= '2.6' && RUBY_ENGINE != 'jruby' }},
+  {require: 'datadog/kit', check: 'Datadog::Kit'},
+  {require: 'datadog/profiling', check: 'Datadog::Profiling'},
+  {require: 'datadog/tracing', check: 'Datadog::Tracing'},
 ].freeze
 
 RSpec.describe 'loading of products' do
-  REQUIRES.each do |(req, const, condition)|
+  REQUIRES.each do |spec|
+    req = spec.fetch(:require)
+
     context req do
-      if condition
+      let(:const) { spec.fetch(:check) }
+
+      if condition = spec[:condition]
         before do
           skip 'condition is false' unless condition.call
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Rearranges DI code so that the trigger for DI initialization is in `datadog` require rather than `datadog/di`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
If `DD_DYNAMIC_INSTRUMENTATION_ENABLED` is set to true and we require `datadog/di`, there was an error:

```
  1) loading of products datadog/di produces no output
     Failure/Error: raise("Test script failed with exit status #{status.exitstatus}:\n#{out}") unless status.success?
     
     RuntimeError:
       Test script failed with exit status 1:
       /home/w/apps/dd-trace-rb/lib/datadog/di/boot.rb:28:in `<top (required)>': undefined method `logger' for module Datadog (NoMethodError)
     
         Datadog.logger.debug("di: activating code tracking")
                ^^^^^^^
       	from /home/w/apps/dd-trace-rb/lib/datadog/di.rb:43:in `require_relative'
       	from /home/w/apps/dd-trace-rb/lib/datadog/di.rb:43:in `<top (required)>'
       	from /home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
       	from /home/w/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
       	from -:7:in `<main>'
     # ./spec/loading_spec.rb:64:in `block (4 levels) in <top (required)>'
     # ./spec/support/core_helpers.rb:89:in `block (2 levels) in with_env'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:24:in `block in modify'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:15:in `synchronize'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:15:in `modify'
     # ./spec/support/core_helpers.rb:88:in `block in with_env'
     # ./spec/spec_helper.rb:272:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:154:in `block (2 levels) in <top (required)>'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

  2) loading of products datadog/di loads successfully by itself
     Failure/Error: expect(rv).to be true
     
       expected true
            got false
     # ./spec/loading_spec.rb:59:in `block (4 levels) in <top (required)>'
     # ./spec/support/core_helpers.rb:89:in `block (2 levels) in with_env'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:24:in `block in modify'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:15:in `synchronize'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/climate_control-1.2.0/lib/climate_control.rb:15:in `modify'
     # ./spec/support/core_helpers.rb:88:in `block in with_env'
     # ./spec/spec_helper.rb:272:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:154:in `block (2 levels) in <top (required)>'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /home/w/.cache/vendor/bundle/ruby/3.3.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

```

This is because DI tried to initialize itself if the environment variable requested it, triggered from `datadog/di.rb`.

However, DI doesn't work without a bunch of core bits that aren't initialized by `datadog/di.rb`, such as `Datadog.logger`. In practice, requiring `datadog` first requires `datadog/tracing` which initializes all of that, and then `datadog/di` is required.

This PR moves the DI initialization trigger from `datadog/di.rb` to `datadog.rb`, such that loading `datadog/di.rb` would load all DI code but would not initialize DI.


**Change log entry**
None: Requiring `datadog/di` directly was not and is not a supported operation for customers, thus this PR does not change customer-visible behavior.
	

<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Unit test added
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
