### PR TITLE
Fix an error in AppSec route extractor for not-found routes in Rails 8

### DIFF
--- a/sig/datadog/appsec/api_security/route_extractor.rbs
+++ b/sig/datadog/appsec/api_security/route_extractor.rbs
@@ -12,6 +12,8 @@ module Datadog
 
         RAILS_ROUTES_KEY: String
 
+        RAILS_PATH_PARAMS_KEY: String
+
         RAILS_FORMAT_SUFFIX: String
 
         def self.route_pattern: (APISecurity::_Request request) -> String

--- a/spec/datadog/appsec/api_security/route_extractor_spec.rb
+++ b/spec/datadog/appsec/api_security/route_extractor_spec.rb
@@ -92,6 +92,21 @@ RSpec.describe Datadog::AppSec::APISecurity::RouteExtractor do
         it { expect(described_class.route_pattern(request)).to eq('/api/v1/users/:id/posts/:post_id') }
       end
 
+      context 'when route_uri_pattern is not set, but request path parameters are present' do
+        before do
+          allow(request).to receive(:env).and_return({
+            'action_dispatch.routes' => route_set,
+            'action_dispatch.request.path_parameters' => {}
+          })
+        end
+
+        let(:router) { double('ActionDispatch::Routing::RouteSet::Router') }
+        let(:route_set) { double('ActionDispatch::Routing::RouteSet', router: router) }
+        let(:request) { double('Rack::Request', env: {}, script_name: '', path: '/users/1') }
+
+        it { expect(described_class.route_pattern(request)).to eq('/users/1') }
+      end
+
       context 'when Rails router cannot recognize request' do
         before do
           allow(request).to receive(:env).and_return({'action_dispatch.routes' => route_set})


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an exception in AppSec RouteExtractor that happens in Rails 8.0 and above for not-found routes. The error only happens if the application has any routes with constraints, such as the subdomain.

**Motivation:**
Issue #4784 

**Change log entry**
Yes. AppSec: Fix an error in RouteExtractor for not-found routes.

**Additional Notes:**
None.

**How to test the change?**
Manual testing with app generator and CI.
