### PR TITLE
[NO-TICKET] Tag profiles with sequence number

### DIFF
--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -157,6 +157,7 @@ module Datadog
       require_relative 'profiling/native_extension'
       require_relative 'profiling/tag_builder'
       require_relative 'profiling/http_transport'
+      require_relative 'profiling/sequence_tracker'
 
       replace_noop_allocation_count
 

--- a/lib/datadog/profiling/sequence_tracker.rb
+++ b/lib/datadog/profiling/sequence_tracker.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../core/utils/forking'
+
+module Datadog
+  module Profiling
+    # Used to generate the `profile_seq` tag, which effectively counts how many profiles we've attempted to report
+    # from a given runtime-id.
+    #
+    # Note that the above implies a few things:
+    # 1. The sequence number only gets incremented when we decide to report a profile and create a `Flush` for it
+    # 2. The `SequenceTracker` must live across profiler reconfigurations and resets, since no matter how many
+    #    profiler instances get created due to reconfiguration, the runtime-id is still the same, so the sequence number
+    #    should be kept and not restarted from 0
+    # 3. The `SequenceTracker` must be reset after a fork, since the runtime-id will change, and we want to start
+    #    counting from 0 again
+    #
+    # This is why this module is implemented as a singleton that we reuse, not as an instance that we recreate.
+    module SequenceTracker
+      class << self
+        include Core::Utils::Forking
+
+        def get_next
+          reset! unless defined?(@sequence_number)
+          after_fork! { reset! }
+
+          next_seq = @sequence_number
+          @sequence_number += 1
+          next_seq
+        end
+
+        private
+
+        def reset!
+          @sequence_number = 0
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/profiling/sequence_tracker.rb
+++ b/lib/datadog/profiling/sequence_tracker.rb
@@ -16,6 +16,10 @@ module Datadog
     #    counting from 0 again
     #
     # This is why this module is implemented as a singleton that we reuse, not as an instance that we recreate.
+    #
+    # Note that this module is not thread-safe, so it's up to the callers to make sure
+    # it's only used by a single thread at a time (which is what the `Profiling::Exporter`)
+    # is doing.
     module SequenceTracker
       class << self
         include Core::Utils::Forking

--- a/lib/datadog/profiling/tag_builder.rb
+++ b/lib/datadog/profiling/tag_builder.rb
@@ -12,10 +12,12 @@ module Datadog
       def self.call(
         settings:,
         # Other metadata
+        profile_seq:,
         profiler_version: Core::Environment::Identity.gem_datadog_version
       )
         hash = Core::TagBuilder.tags(settings).merge(
           FORM_FIELD_TAG_PROFILER_VERSION => profiler_version,
+          'profile_seq' => profile_seq.to_s,
         )
         Core::Utils.encode_tags(hash)
       end

--- a/sig/datadog/profiling/exporter.rbs
+++ b/sig/datadog/profiling/exporter.rbs
@@ -8,11 +8,12 @@ module Datadog
       attr_reader pprof_recorder: Datadog::Profiling::StackRecorder
       attr_reader code_provenance_collector: Datadog::Profiling::Collectors::CodeProvenance?
       attr_reader minimum_duration_seconds: ::Integer
-      attr_reader time_provider: untyped
+      attr_reader time_provider: singleton(::Time)
       attr_reader last_flush_finish_at: ::Time?
       attr_reader created_at: ::Time
       attr_reader internal_metadata: ::Hash[::Symbol, untyped]
       attr_reader info_json: ::String
+      attr_reader sequence_tracker: singleton(Datadog::Profiling::SequenceTracker)
 
       public
 
@@ -23,7 +24,8 @@ module Datadog
         code_provenance_collector: Datadog::Profiling::Collectors::CodeProvenance?,
         internal_metadata: ::Hash[::Symbol, untyped],
         ?minimum_duration_seconds: ::Integer,
-        ?time_provider: untyped
+        ?time_provider: singleton(::Time),
+        ?sequence_tracker: singleton(Datadog::Profiling::SequenceTracker)
       ) -> void
 
       def flush: () -> Datadog::Profiling::Flush?

--- a/sig/datadog/profiling/sequence_tracker.rbs
+++ b/sig/datadog/profiling/sequence_tracker.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module Profiling
+    module SequenceTracker
+      @sequence_number: Integer
+
+      extend Core::Utils::Forking
+
+      def self.get_next: () -> Integer
+      def self.reset!: () -> void
+    end
+  end
+end

--- a/sig/datadog/profiling/tag_builder.rbs
+++ b/sig/datadog/profiling/tag_builder.rbs
@@ -1,7 +1,11 @@
 module Datadog
   module Profiling
     module TagBuilder
-      def self.call: (settings: untyped) -> untyped
+      def self.call: (
+        settings: untyped,
+        ?profiler_version: ::String,
+        profile_seq: ::Integer
+      ) -> ::Hash[::String, ::String]
     end
   end
 end

--- a/spec/datadog/profiling/sequence_tracker_spec.rb
+++ b/spec/datadog/profiling/sequence_tracker_spec.rb
@@ -1,0 +1,52 @@
+require "datadog/profiling/spec_helper"
+require "datadog/profiling/sequence_tracker"
+
+RSpec.describe Datadog::Profiling::SequenceTracker do
+  describe ".get_next" do
+    subject(:get_next) { described_class.get_next }
+
+    before do
+      # Reset the sequence number before each test to ensure clean state
+      described_class.send(:reset!)
+    end
+
+    it "increments the sequence on every call" do
+      expect(described_class.get_next).to eq(0)
+      expect(described_class.get_next).to eq(1)
+      expect(described_class.get_next).to eq(2)
+    end
+
+    context "when called after a fork" do
+      before { skip("Spec requires Ruby VM supporting fork") unless PlatformHelpers.supports_fork? }
+
+      it "resets the sequence number to 0 in the forked process" do
+        expect(described_class.get_next).to eq(0)
+        expect(described_class.get_next).to eq(1)
+
+        expect_in_fork do
+          expect(described_class.get_next).to eq(0)
+          expect(described_class.get_next).to eq(1)
+        end
+      end
+
+      it "continues incrementing in the parent process after fork" do
+        expect(described_class.get_next).to eq(0)
+        expect(described_class.get_next).to eq(1)
+
+        expect_in_fork do
+          expect(described_class.get_next).to eq(0)
+          expect(described_class.get_next).to eq(1)
+        end
+
+        expect(described_class.get_next).to eq(2)
+        expect(described_class.get_next).to eq(3)
+      end
+    end
+  end
+
+  describe ".reset!" do
+    it "is private" do
+      expect(described_class.private_methods).to include(:reset!)
+    end
+  end
+end

--- a/spec/datadog/profiling/tag_builder_spec.rb
+++ b/spec/datadog/profiling/tag_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
   describe ".call" do
     let(:settings) { Datadog::Core::Configuration::Settings.new }
 
-    subject(:call) { described_class.call(settings: settings) }
+    subject(:call) { described_class.call(settings: settings, profile_seq: 123) }
 
     it "returns a hash with the tags to be attached to a profile" do
       expect(call).to include(
@@ -16,6 +16,7 @@ RSpec.describe Datadog::Profiling::TagBuilder do
         "runtime_engine" => RUBY_ENGINE,
         "runtime-id" => Datadog::Core::Environment::Identity.id,
         "runtime_version" => RUBY_VERSION,
+        "profile_seq" => "123",
       )
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new tag to reported profiles: `profile_seq`. This tag provides a sequence number for reported profiles for a given runtime-id.

**Motivation:**

This tag has already been adopted by the Go and .NET profilers, and is useful for use-cases such as:

* Focus on, or exclude application boot time (which usually has quite different profiles)
* Clearly identify when profiles are missing (because e.g. they failed to be reported and there's gaps in the sequence)

**Change log entry**

Yes. Profiling: Tag profiles with sequence number

**Additional Notes:**

This feature is quite straightforward, the only weird part is that we carry state across profiler reconfigurations (e.g. state is a singleton), and we also need to reset it after the app forks, because runtime-id changes.

**How to test the change?**

This change includes test coverage.