### PR TITLE
[APPSEC-58115] Add Business Logic Events SDK v2

### DIFF
--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -13,7 +13,7 @@ module Datadog
         class User < Argument
           attr_reader :id, :login, :session_id
 
-          def initialize(id, login = nil, session_id = nil)
+          def initialize(id = nil, login = nil, session_id = nil)
             super()
 
             @id = id

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -55,8 +55,8 @@ module Datadog
 
               user_attributes = build_user_attributes(user_or_id, login)
 
-              export_tags(span, metadata, namespace: LOGIN_SUCCESS_EVENT)
-              export_tags(span, user_attributes, namespace: "#{LOGIN_SUCCESS_EVENT}.usr")
+              set_span_tags(span, metadata, namespace: LOGIN_SUCCESS_EVENT)
+              set_span_tags(span, user_attributes, namespace: "#{LOGIN_SUCCESS_EVENT}.usr")
               span.set_tag('appsec.events.users.login.success.track', 'true')
               span.set_tag('_dd.appsec.events.users.login.success.sdk', 'true')
 
@@ -110,7 +110,7 @@ module Datadog
                 raise TypeError, '`user_exists` argument must be a boolean'
               end
 
-              export_tags(span, metadata, namespace: LOGIN_FAILURE_EVENT)
+              set_span_tags(span, metadata, namespace: LOGIN_FAILURE_EVENT)
               span.set_tag('appsec.events.users.login.failure.track', 'true')
               span.set_tag('_dd.appsec.events.users.login.failure.sdk', 'true')
               span.set_tag('appsec.events.users.login.failure.usr.login', login)
@@ -161,12 +161,11 @@ module Datadog
               end
             end
 
-            def export_tags(span, source, namespace:)
-              namespace = "appsec.events.#{namespace}"
-              source.each do |key, value|
+            def set_span_tags(span, tags, namespace:)
+              tags.each do |name, value|
                 next if value.nil?
 
-                span.set_tag("#{namespace}.#{key}", value)
+                span.set_tag("appsec.events.#{namespace}.#{name}", value)
               end
             end
 

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require_relative '../../identity'
+
+module Datadog
+  module Kit
+    module AppSec
+      module Events
+        # The second version of Business Logic Events SDK
+        module V2
+          LOGIN_SUCCESS_EVENT = 'users.login.success'
+          LOGIN_FAILURE_EVENT = 'users.login.failure'
+          TELEMETRY_METRICS_NAMESPACE = 'appsec'
+          TELEMETRY_METRICS_SDK_EVENT = 'sdk.event'
+          TELEMETRY_METRICS_SDK_VERSION = 'v2'
+          TELEMETRY_METRICS_EVENTS_INTO_TYPES = {
+            LOGIN_SUCCESS_EVENT => 'login_success',
+            LOGIN_FAILURE_EVENT => 'login_failure'
+          }.freeze
+
+          class << self
+            # TODO: Write doc
+            def track_user_login_success(login, user_or_id = nil, **metadata)
+              trace = service_entry_trace
+              span = service_entry_span
+
+              if trace.nil? || span.nil?
+                return Datadog.logger.warn(
+                  'Kit::AppSec: Tracing is not enabled. Please enable tracing if you want to track events'
+                )
+              end
+
+              user_attributes = build_user_attributes(user_or_id, login)
+
+              export_tags(span, metadata, namespace: LOGIN_SUCCESS_EVENT)
+              export_tags(span, user_attributes, namespace: "#{LOGIN_SUCCESS_EVENT}.usr")
+              span.set_tag('appsec.events.users.login.success.track', 'true')
+              span.set_tag('_dd.appsec.events.users.login.success.sdk', 'true')
+
+              trace.keep!
+
+              record_event_telemetry_metric(LOGIN_SUCCESS_EVENT)
+              ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_SUCCESS_EVENT)
+
+              return Kit::Identity.set_user(trace, span, **user_attributes) if user_attributes.key?(:id)
+
+              # NOTE: This is a fallback for the case when we don't have an ID,
+              #       but need to trigger WAF.
+              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(nil, login)
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+            end
+
+            def track_user_login_failure(login, user_exists = false, **metadata)
+              trace = service_entry_trace
+              span = service_entry_span
+
+              if trace.nil? || span.nil?
+                return Datadog.logger.warn(
+                  'Kit::AppSec: Tracing is not enabled. Please enable tracing if you want to track events'
+                )
+              end
+
+              unless user_exists.is_a?(TrueClass) || user_exists.is_a?(FalseClass)
+                raise TypeError, 'user existence flag must be a boolean'
+              end
+
+              export_tags(span, metadata, namespace: LOGIN_FAILURE_EVENT)
+              span.set_tag('appsec.events.users.login.failure.track', 'true')
+              span.set_tag('_dd.appsec.events.users.login.failure.sdk', 'true')
+              span.set_tag('appsec.events.users.login.failure.usr.login', login)
+              span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists.to_s)
+
+              trace.keep!
+
+              record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
+              ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)
+
+              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(nil, login)
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+            end
+
+            private
+
+            # NOTE: Current tracer implementation does not provide a way to
+            #       get the service entry span. This is a shortcut we take now.
+            def service_entry_trace
+              return Datadog::Tracing.active_trace unless Datadog::AppSec.active_context
+
+              Datadog::AppSec.active_context&.trace
+            end
+
+            # NOTE: Current tracer implementation does not provide a way to
+            #       get the service entry span. This is a shortcut we take now.
+            def service_entry_span
+              return Datadog::Tracing.active_span unless Datadog::AppSec.active_context
+
+              Datadog::AppSec.active_context&.span
+            end
+
+            def build_user_attributes(user_or_id, login)
+              raise TypeError, 'login argument must be a String' unless login.is_a?(String)
+
+              return { login: login } unless user_or_id
+              return { login: login, id: user_or_id } unless user_or_id.is_a?(Hash)
+
+              raise ArgumentError, 'missing required key `:id`' unless user_or_id.key?(:id)
+              raise TypeError, 'key `:id` must be a String' unless user_or_id[:id].is_a?(String)
+
+              user_or_id.merge(login: login)
+            end
+
+            def export_tags(span, source, namespace:)
+              namespace = "appsec.events.#{namespace}"
+              source.each do |key, value|
+                next if value.nil?
+
+                span.set_tag("#{namespace}.#{key}", value)
+              end
+            end
+
+            # TODO: In case if we need to introduce telemetry metrics to the SDK v1
+            #       or highly increase the number of metrics, this method should be
+            #       extracted into a proper module.
+            def record_event_telemetry_metric(event)
+              telemetry = ::Datadog.send(:components)&.telemetry
+
+              if telemetry.nil?
+                return Datadog.logger.debug(
+                  'Kit::AppSec: Telemetry component is unavailabl. Skip recording SDK metrics'
+                )
+              end
+
+              tags = {
+                event_type: TELEMETRY_METRICS_EVENTS_INTO_TYPES[event],
+                sdk_version: TELEMETRY_METRICS_SDK_VERSION
+              }
+              telemetry.inc(TELEMETRY_METRICS_NAMESPACE, TELEMETRY_METRICS_SDK_EVENT, 1, tags: tags)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -42,7 +42,8 @@ module Datadog
               record_event_telemetry_metric(LOGIN_SUCCESS_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_SUCCESS_EVENT)
 
-              return Kit::Identity.set_user(trace, span, **user_attributes) if user_attributes.key?(:id)
+              # NOTE: Guard-clause will not work with Steep typechecking
+              return Kit::Identity.set_user(trace, span, **user_attributes) if user_attributes.key?(:id) # steep:ignore
 
               # NOTE: This is a fallback for the case when we don't have an ID,
               #       but need to trigger WAF.

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -173,7 +173,7 @@ module Datadog
             #       or highly increase the number of metrics, this method should be
             #       extracted into a proper module.
             def record_event_telemetry_metric(event)
-              telemetry = ::Datadog.send(:components)&.telemetry
+              telemetry = ::Datadog.send(:components, allow_initialization: false)&.telemetry
 
               if telemetry.nil?
                 return Datadog.logger.debug(

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -19,7 +19,27 @@ module Datadog
           }.freeze
 
           class << self
-            # TODO: Write doc
+            # Attach user login success information to the service entry span
+            # and trigger AppSec event processing.
+            #
+            # @param login [String] The user login (e.g., username or email).
+            # @param user_or_id [String, Hash<Symbol, String>] (optional) If a
+            #   String, considered as a user ID, if a Hash, considered as a user
+            #   attributes. The Hash must include `:id` as a key.
+            # @param metadata [Hash<Symbol, String>] Additional flat free-form
+            #   metadata to attach to the event.
+            #
+            # @example Login only
+            #   Datadog::Kit::AppSec::Events::V2.track_user_login_success('alice@example.com')
+            #
+            # @example Login and user attributes
+            #   Datadog::Kit::AppSec::Events::V2.track_user_login_success(
+            #     'alice@example.com',
+            #     { id: 'user-123', email: 'alice@example.com', name: 'Alice' },
+            #     ip: '192.168.1.1', device: 'mobile', 'usr.country': 'US'
+            #   )
+            #
+            # @return [void]
             def track_user_login_success(login, user_or_id = nil, **metadata)
               trace = service_entry_trace
               span = service_entry_span
@@ -51,6 +71,25 @@ module Datadog
               ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
             end
 
+            # Attach user login failure information to the service entry span
+            # and trigger AppSec event processing.
+            #
+            # @param login [String] The user login (e.g., username or email).
+            # @param user_exists [Boolean] Whether the user exists in the system.
+            # @param metadata [Hash<Symbol, String>] Additional flat free-form
+            #   metadata to attach to the event.
+            #
+            # @example Login only
+            #   Datadog::Kit::AppSec::Events::V2.track_user_login_failure('alice@example.com')
+            #
+            # @example With user existence and metadata
+            #   Datadog::Kit::AppSec::Events::V2.track_user_login_failure(
+            #     'alice@example.com',
+            #     true,
+            #     ip: '192.168.1.1', device: 'mobile', 'usr.country': 'US'
+            #   )
+            #
+            # @return [void]
             def track_user_login_failure(login, user_exists = false, **metadata)
               trace = service_entry_trace
               span = service_entry_span

--- a/sig/datadog/appsec/instrumentation/gateway.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway.rbs
@@ -6,6 +6,7 @@ module Datadog
         type final_call_result = untyped
         type final_call = ^() -> final_call_result
         type stack = ::Proc
+        type argument = Gateway::Argument | ::String
 
         type stack_result = ::Array[nil | middleware_result | final_call_result]
 
@@ -13,9 +14,9 @@ module Datadog
 
         def initialize: () -> void
 
-        def push: (::String name, Gateway::Argument env) ?{ () -> final_call_result } -> stack_result
+        def push: (::String name, argument env) ?{ () -> final_call_result } -> stack_result
 
-        def watch: (::String name, ::Symbol key) { (stack next, Gateway::Argument env) -> stack_result } -> void
+        def watch: (::String name, ::Symbol key) { (stack next, argument env) -> stack_result } -> void
 
         def pushed?: (::String name) -> bool
       end

--- a/sig/datadog/appsec/instrumentation/gateway/argument.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway/argument.rbs
@@ -6,20 +6,21 @@ module Datadog
           def initialize: (*untyped) -> void
         end
 
+        # FIXME: This sig will be rewritten
         class User < Argument
-          @id: String
+          @id: ::String?
 
-          @login: String?
+          @login: ::String?
 
-          @session_id: String?
+          @session_id: ::String?
 
-          attr_reader id: String
+          attr_reader id: ::String?
 
-          attr_reader login: String?
+          attr_reader login: ::String?
 
-          attr_reader session_id: String?
+          attr_reader session_id: ::String?
 
-          def initialize: (String id, String? login, String? session_id) -> void
+          def initialize: (?::String? id, ?::String? login, ?::String? session_id) -> void
         end
       end
     end

--- a/sig/datadog/kit/appsec/events/v2.rbs
+++ b/sig/datadog/kit/appsec/events/v2.rbs
@@ -31,7 +31,7 @@ module Datadog
 
           def self.build_user_attributes: (user_or_id? user_or_id, ::String login) -> attributes
 
-          def self.export_tags: (Tracing::SpanOperation span, ::Hash[::Symbol, untyped] source, namespace: ::String) -> void
+          def self.set_span_tags: (Tracing::SpanOperation span, ::Hash[::Symbol, untyped] tags, namespace: ::String) -> void
 
           def self.record_event_telemetry_metric: (::String event) -> void
         end

--- a/sig/datadog/kit/appsec/events/v2.rbs
+++ b/sig/datadog/kit/appsec/events/v2.rbs
@@ -19,9 +19,9 @@ module Datadog
 
           TELEMETRY_METRICS_EVENTS_INTO_TYPES: Hash[::String, ::String]
 
-          def self.track_user_login_success: (::String login, ?user_or_id user_or_id, **attributes metadata) -> void
+          def self.track_user_login_success: (::String login, ?user_or_id user_or_id, attributes metadata) -> void
 
-          def self.track_user_login_failure: (::String login, ?bool user_exists, **attributes metadata) -> void
+          def self.track_user_login_failure: (::String login, ?bool user_exists, attributes metadata) -> void
 
           private
 

--- a/sig/datadog/kit/appsec/events/v2.rbs
+++ b/sig/datadog/kit/appsec/events/v2.rbs
@@ -1,0 +1,41 @@
+module Datadog
+  module Kit
+    module AppSec
+      module Events
+        module V2
+          type attributes = ::Hash[::Symbol, ::String | nil]
+
+          type user_or_id = nil | ::String | attributes
+
+          LOGIN_SUCCESS_EVENT: ::String
+
+          LOGIN_FAILURE_EVENT: ::String
+
+          TELEMETRY_METRICS_NAMESPACE: ::String
+
+          TELEMETRY_METRICS_SDK_EVENT: ::String
+
+          TELEMETRY_METRICS_SDK_VERSION: ::String
+
+          TELEMETRY_METRICS_EVENTS_INTO_TYPES: Hash[::String, ::String]
+
+          def self.track_user_login_success: (::String login, ?user_or_id user_or_id, **attributes metadata) -> void
+
+          def self.track_user_login_failure: (::String login, ?bool user_exists, **attributes metadata) -> void
+
+          private
+
+          def self.service_entry_trace: () -> (Tracing::TraceSegment | Tracing::TraceOperation)?
+
+          def self.service_entry_span: () -> Tracing::SpanOperation?
+
+          def self.build_user_attributes: (user_or_id? user_or_id, ::String login) -> attributes
+
+          def self.export_tags: (Tracing::SpanOperation span, ::Hash[::Symbol, untyped] source, namespace: ::String) -> void
+
+          def self.record_event_telemetry_metric: (::String event) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/kit/identity.rbs
+++ b/sig/datadog/kit/identity.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Identity
       type trace = Tracing::TraceSegment | Tracing::TraceOperation
 
-      def self.set_user: (trace trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::Symbol, ::String | nil] others) -> void
+      def self.set_user: (?trace trace, ?Tracing::SpanOperation span, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::Symbol, ::String | nil] others) -> void
     end
   end
 end

--- a/sig/datadog/kit/identity.rbs
+++ b/sig/datadog/kit/identity.rbs
@@ -1,7 +1,9 @@
 module Datadog
   module Kit
     module Identity
-      def self.set_user: (Datadog::Tracing::TraceOperation trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::Symbol, ::String | nil] others) -> void
+      type trace = Tracing::TraceSegment | Tracing::TraceOperation
+
+      def self.set_user: (trace trace, id: ::String, ?email: ::String?, ?name: ::String?, ?session_id: ::String?, ?role: ::String?, ?scope: ::String?, **::Hash[::Symbol, ::String | nil] others) -> void
     end
   end
 end

--- a/spec/datadog/kit/appsec/events/v2_spec.rb
+++ b/spec/datadog/kit/appsec/events/v2_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'datadog/tracing/trace_operation'
+require 'datadog/kit/appsec/events/v2'
+
+RSpec.describe Datadog::Kit::AppSec::Events::V2 do
+  let(:sdk) { described_class }
+  let(:trace_op) { Datadog::Tracing::TraceOperation.new }
+
+  describe '#track_user_login_success' do
+    context 'when AppSec context is active' do
+      let(:context) { instance_double(Datadog::AppSec::Context, trace: trace, span: span) }
+      let(:trace) { Datadog::Tracing::TraceOperation.new }
+      let(:span) { trace.build_span('root') }
+
+      before { allow(Datadog::AppSec).to receive(:active_context).and_return(context) }
+
+      it 'raises exception when user key :id is missing' do
+        expect { sdk.track_user_login_success('john.snow', {}) }
+          .to raise_error(ArgumentError, 'missing required key `:id`')
+      end
+
+      it 'raises exception when user key :id is nil' do
+        expect { sdk.track_user_login_success('john.snow', {id: nil}) }
+          .to raise_error(TypeError, 'key `:id` must be a String')
+      end
+
+      it 'sets required tags on service entry span' do
+        expect { sdk.track_user_login_success('john.snow') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.success.usr.login' => 'john.snow',
+            'appsec.events.users.login.success.track' => 'true',
+            '_dd.appsec.events.users.login.success.sdk' => 'true',
+          )
+
+        expect(span.tags).not_to have_key('usr.login')
+      end
+
+      it 'sets additional user data as tags on service entry span' do
+        expect { sdk.track_user_login_success('john.snow', '13') }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.login.success.usr.id' => '13',
+            'appsec.events.users.login.success.usr.login' => 'john.snow',
+            'appsec.events.users.login.success.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.login.success.sdk' => 'true',
+          )
+      end
+
+      it 'sets metadata as tags on service entry span' do
+        expect { sdk.track_user_login_success('john.snow', '13', hello: 'world') }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.login.success.usr.id' => '13',
+            'appsec.events.users.login.success.usr.login' => 'john.snow',
+            'appsec.events.users.login.success.hello' => 'world',
+            'appsec.events.users.login.success.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.login.success.sdk' => 'true',
+          )
+      end
+
+      it 'sets user login from argument and overrides it in user object' do
+        expect { sdk.track_user_login_success('john.snow', {id: '13'}, login: 'john.wick') }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.login.success.usr.id' => '13',
+            'appsec.events.users.login.success.usr.login' => 'john.snow',
+            'appsec.events.users.login.success.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.login.success.sdk' => 'true',
+          )
+      end
+
+      it 'sets user id from argument and ignores it in metadata' do
+        expect { sdk.track_user_login_success('john.snow', '42', 'usr.id': '13') }
+          .to change { span.tags }.to include(
+            'usr.id' => '42',
+            'appsec.events.users.login.success.usr.id' => '42'
+          )
+      end
+
+      it 'sets user login from argument and ignores it in metadata' do
+        expect { sdk.track_user_login_success('john.snow', '42', 'usr.login': 'john.doe') }
+          .to change { span.tags }.to include(
+            'usr.login' => 'john.snow',
+            'appsec.events.users.login.success.usr.login' => 'john.snow'
+          )
+      end
+
+      it 'sets track to true even if metadata track key is false' do
+        expect { sdk.track_user_login_success('john.snow', '42', track: 'false') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.success.track' => 'true',
+          )
+      end
+
+      it 'record telemetry metrics' do
+        expect_any_instance_of(Datadog::Core::Telemetry::Component).to receive(:inc)
+          .with('appsec', 'sdk.event', 1, tags: { event_type: 'login_success', sdk_version: 'v2' })
+
+        sdk.track_user_login_success('john.snow')
+      end
+    end
+  end
+
+  describe '#track_user_login_failure' do
+    context 'when AppSec context is active' do
+      let(:context) { instance_double(Datadog::AppSec::Context, trace: trace, span: span) }
+      let(:trace) { Datadog::Tracing::TraceOperation.new }
+      let(:span) { trace.build_span('root') }
+
+      before { allow(Datadog::AppSec).to receive(:active_context).and_return(context) }
+
+      it 'sets user existance to false when it is not provided' do
+        expect { sdk.track_user_login_failure('john.snow') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.failure.usr.login' => 'john.snow',
+            'appsec.events.users.login.failure.usr.exists' => 'false',
+            'appsec.events.users.login.failure.track' => 'true',
+            '_dd.appsec.events.users.login.failure.sdk' => 'true',
+          )
+      end
+
+      it 'sets metadata as tags on service entry span' do
+        expect { sdk.track_user_login_failure('john.snow', true, hello: 'world') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.failure.usr.login' => 'john.snow',
+            'appsec.events.users.login.failure.usr.exists' => 'true',
+            'appsec.events.users.login.failure.hello' => 'world',
+            'appsec.events.users.login.failure.track' => 'true',
+            '_dd.appsec.events.users.login.failure.sdk' => 'true',
+          )
+      end
+
+      it 'sets id from argument and ignores it in metadata' do
+        expect { sdk.track_user_login_failure('john.snow', false, 'usr.id': 'john.doe') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.failure.usr.login' => 'john.snow',
+          )
+      end
+
+      it 'sets track to true even if metadata track key is false' do
+        expect { sdk.track_user_login_failure('john.snow', false, track: 'false') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.failure.track' => 'true',
+          )
+      end
+
+      it 'sets exists from argument even if metadata exists key is false' do
+        expect { sdk.track_user_login_failure('john.snow', false, 'usr.exists': 'true') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.login.failure.usr.exists' => 'false',
+          )
+      end
+
+      it 'sets exists from argument only if it is a boolean' do
+        expect { sdk.track_user_login_failure('john.snow', 'true') }
+          .to raise_error(TypeError, 'user existence flag must be a boolean')
+
+        expect { sdk.track_user_login_failure('john.snow', 1) }
+          .to raise_error(TypeError, 'user existence flag must be a boolean')
+      end
+
+      it 'record telemetry metrics' do
+        expect_any_instance_of(Datadog::Core::Telemetry::Component).to receive(:inc)
+          .with('appsec', 'sdk.event', 1, tags: { event_type: 'login_failure', sdk_version: 'v2' })
+
+        sdk.track_user_login_failure('john.snow')
+      end
+    end
+  end
+end

--- a/spec/datadog/kit/appsec/events/v2_spec.rb
+++ b/spec/datadog/kit/appsec/events/v2_spec.rb
@@ -131,13 +131,17 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
       end
 
       context 'when telemetry is not available' do
-        before { allow(Datadog).to receive(:logger).and_return(logger) }
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(nil)
+          allow(components).to receive(:logger).and_return(logger)
+        end
 
         let(:logger) { instance_double(Logger) }
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
 
         it 'does not record telemetry metrics' do
           expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
-          expect_any_instance_of(Datadog::Core::Telemetry::Component).not_to receive(:inc)
 
           sdk.track_user_login_success('john.snow')
         end
@@ -231,13 +235,17 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
       end
 
       context 'when telemetry is not available' do
-        before { allow(Datadog).to receive(:logger).and_return(logger) }
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(nil)
+          allow(components).to receive(:logger).and_return(logger)
+        end
 
         let(:logger) { instance_double(Logger) }
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
 
         it 'does not record telemetry metrics' do
           expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
-          expect_any_instance_of(Datadog::Core::Telemetry::Component).not_to receive(:inc)
 
           sdk.track_user_login_failure('john.snow')
         end

--- a/spec/datadog/kit/appsec/events/v2_spec.rb
+++ b/spec/datadog/kit/appsec/events/v2_spec.rb
@@ -113,11 +113,34 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
           )
       end
 
-      it 'record telemetry metrics' do
-        expect_any_instance_of(Datadog::Core::Telemetry::Component).to receive(:inc)
-          .with('appsec', 'sdk.event', 1, tags: {event_type: 'login_success', sdk_version: 'v2'})
+      context 'when telemetry is available' do
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(telemetry)
+        end
 
-        sdk.track_user_login_success('john.snow')
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
+        let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+
+        it 'record telemetry metrics' do
+          expect(telemetry).to receive(:inc)
+            .with('appsec', 'sdk.event', 1, tags: {event_type: 'login_success', sdk_version: 'v2'})
+
+          sdk.track_user_login_success('john.snow')
+        end
+      end
+
+      context 'when telemetry is not available' do
+        before { allow(Datadog).to receive(:logger).and_return(logger) }
+
+        let(:logger) { instance_double(Logger) }
+
+        it 'does not record telemetry metrics' do
+          expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
+          expect_any_instance_of(Datadog::Core::Telemetry::Component).not_to receive(:inc)
+
+          sdk.track_user_login_success('john.snow')
+        end
       end
     end
   end
@@ -190,11 +213,34 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
           )
       end
 
-      it 'record telemetry metrics' do
-        expect_any_instance_of(Datadog::Core::Telemetry::Component).to receive(:inc)
-          .with('appsec', 'sdk.event', 1, tags: {event_type: 'login_failure', sdk_version: 'v2'})
+      context 'when telemetry is available' do
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(telemetry)
+        end
 
-        sdk.track_user_login_failure('john.snow')
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
+        let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+
+        it 'record telemetry metrics' do
+          expect(telemetry).to receive(:inc)
+            .with('appsec', 'sdk.event', 1, tags: {event_type: 'login_failure', sdk_version: 'v2'})
+
+          sdk.track_user_login_failure('john.snow')
+        end
+      end
+
+      context 'when telemetry is not available' do
+        before { allow(Datadog).to receive(:logger).and_return(logger) }
+
+        let(:logger) { instance_double(Logger) }
+
+        it 'does not record telemetry metrics' do
+          expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
+          expect_any_instance_of(Datadog::Core::Telemetry::Component).not_to receive(:inc)
+
+          sdk.track_user_login_failure('john.snow')
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Introduces second version of the Business Logic Events SDK.

**Motivation:**

We are pushing better SDK API that will suite to the actual data most of the time available at hand when emitting business logic events.

**Change log entry**

Yes. AppSec: Added Business Logic Events SDK v2.

**Additional Notes:**

There is a shortcut we take in order to compute service entry trace/span. In V2 you can control it, but in V2 there is no such functionality. Unfortunately, tracer doesn't support such information, even tho there is a functionality we would like to have, but it's hidden on different layer of the stack.

**How to test the change?**

CI + ST should cover 99% 😬 