### PR TITLE
[PROF-12141] Upgrade to libdatadog 19.1

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
 
   # When updating the version here, please also update the version in `libdatadog_extconf_helpers.rb`
   # (and yes we have a test for it)
-  spec.add_dependency 'libdatadog', '~> 18.1.0.1.0'
+  spec.add_dependency 'libdatadog', '~> 19.1.0.1.0'
 
   # Will no longer be a default gem on Ruby 3.5, see
   # https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c and

--- a/ext/libdatadog_extconf_helpers.rb
+++ b/ext/libdatadog_extconf_helpers.rb
@@ -8,7 +8,7 @@ module Datadog
   module LibdatadogExtconfHelpers
     # Used to make sure the correct gem version gets loaded, as extconf.rb does not get run with "bundle exec" and thus
     # may see multiple libdatadog versions. See https://github.com/DataDog/dd-trace-rb/pull/2531 for the horror story.
-    LIBDATADOG_VERSION = '~> 18.1.0.1.0'
+    LIBDATADOG_VERSION = '~> 19.1.0.1.0'
 
     # Used as an workaround for a limitation with how dynamic linking works in environments where the datadog gem and
     # libdatadog are moved after the extension gets compiled.

--- a/gemfiles/jruby_9.2_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -89,7 +89,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_aws.gemfile.lock
+++ b/gemfiles/jruby_9.2_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1450,7 +1450,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.2_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.6.6)

--- a/gemfiles/jruby_9.2_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,7 +62,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -54,7 +54,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_faraday_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_faraday_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.2_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,7 +99,7 @@ GEM
     io-wait (0.3.1-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_http.gemfile.lock
+++ b/gemfiles/jruby_9.2_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,7 +46,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,7 +52,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -54,7 +54,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,7 +83,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,7 +85,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -86,7 +86,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,7 +85,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -86,7 +86,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,7 +85,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,7 +100,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,7 +103,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,7 +96,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,7 +99,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails6_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.2_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -106,7 +106,7 @@ GEM
     jdbc-postgres (42.6.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.2_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,7 +62,7 @@ GEM
     jdbc-sqlite3 (3.28.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.2_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -29,7 +29,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,7 +36,7 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.2_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.2_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.2_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -90,7 +90,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_aws.gemfile.lock
+++ b/gemfiles/jruby_9.3_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1450,7 +1450,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.3_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -44,7 +44,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,7 +45,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,7 +37,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_faraday_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_faraday_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.3_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_http.gemfile.lock
+++ b/gemfiles/jruby_9.3_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,7 +46,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_karafka_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -43,7 +43,7 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,7 +35,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,7 +37,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,7 +84,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,7 +84,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,7 +84,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,7 +84,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,7 +85,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,7 +84,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,7 +97,7 @@ GEM
     jdbc-mysql (8.0.27)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,7 +97,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,7 +97,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,7 +97,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails6_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,7 +97,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.3_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -105,7 +105,7 @@ GEM
     jdbc-postgres (42.6.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.3_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -58,7 +58,7 @@ GEM
     jdbc-sqlite3 (3.42.0.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.3_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,7 +36,7 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.3_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.3_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.3_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_activesupport.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,7 +85,7 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_aws.gemfile.lock
+++ b/gemfiles/jruby_9.4_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1450,7 +1450,7 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_contrib.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_contrib_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_core_old.gemfile.lock
+++ b/gemfiles/jruby_9.4_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_dalli_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_dalli_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,7 +46,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,7 +46,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_excon_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_faraday_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,7 +38,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,7 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,7 +99,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/jruby_9.4_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_http.gemfile.lock
+++ b/gemfiles/jruby_9.4_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,7 +46,7 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_karafka_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,7 +45,7 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_karafka_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,7 +41,7 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_mongo_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,7 +33,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_mongo_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,7 +36,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,7 +38,7 @@ GEM
     json (2.12.2-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rack_1.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rack_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rack_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -105,7 +105,7 @@ GEM
     jdbc-mysql (8.0.30)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,7 +102,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,7 +101,7 @@ GEM
     jdbc-postgres (42.2.25)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rails_old_redis.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -105,7 +105,7 @@ GEM
     jdbc-postgres (42.6.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_redis_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_redis_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_redis_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_relational_db.gemfile.lock
+++ b/gemfiles/jruby_9.4_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,7 +60,7 @@ GEM
     jdbc-sqlite3 (3.42.0.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -28,7 +28,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/jruby_9.4_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -29,7 +29,7 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_rest_client_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,7 +35,7 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_11.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_12.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/jruby_9.4_stripe_min.gemfile.lock
+++ b/gemfiles/jruby_9.4_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -31,7 +31,7 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
+    libdatadog (19.1.0.1.0)
     libddwaf (1.24.1.0.0-java)
       ffi (~> 1.0)
     logger (1.7.0)

--- a/gemfiles/ruby_2.5_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -94,8 +94,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_aws.gemfile.lock
+++ b/gemfiles/ruby_2.5_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1455,8 +1455,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.5_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -67,8 +67,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,8 +68,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -67,8 +67,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -67,8 +67,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,8 +59,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_faraday_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.5_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -109,8 +109,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_http.gemfile.lock
+++ b/gemfiles/ruby_2.5_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -57,8 +57,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,8 +59,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_mysql2.gemfile.lock
@@ -59,7 +59,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres.gemfile.lock
@@ -59,7 +59,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_redis.gemfile.lock
@@ -59,7 +59,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_postgres_sidekiq.gemfile.lock
@@ -56,7 +56,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails4_semantic_logger.gemfile.lock
@@ -59,7 +59,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -82,8 +82,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,8 +84,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,8 +85,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,8 +84,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -85,8 +85,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,8 +84,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,8 +99,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,8 +102,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -102,8 +102,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -95,8 +95,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,8 +97,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,8 +98,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,8 +97,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,8 +98,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails6_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,8 +97,8 @@ GEM
     io-wait (0.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.5_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -105,8 +105,8 @@ GEM
     io-wait (0.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.5_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -53,8 +53,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.5_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -34,8 +34,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.5_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.5_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.5_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -95,8 +95,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1455,8 +1455,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -67,8 +67,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,8 +68,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,8 +50,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -48,8 +48,8 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,8 +84,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,8 +97,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -91,8 +91,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1455,8 +1455,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -87,8 +87,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,8 +68,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -105,8 +105,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -109,8 +109,8 @@ GEM
     inflecto (0.0.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -48,8 +48,8 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -40,8 +40,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -84,8 +84,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -83,8 +83,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -97,8 +97,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -96,8 +96,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -40,8 +40,8 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -35,8 +35,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -90,8 +90,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1455,8 +1455,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,9 +50,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,9 +50,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,9 +99,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -80,9 +80,9 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,8 +51,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,8 +51,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,9 +51,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -56,9 +56,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -103,8 +103,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -106,8 +106,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     httpclient (2.8.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,9 +62,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,9 +51,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,9 +50,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -43,8 +43,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -38,8 +38,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -101,8 +101,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -100,8 +100,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -104,8 +104,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -109,8 +109,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -125,8 +125,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -116,9 +116,9 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,9 +50,9 @@ GEM
     hashdiff (1.1.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,8 +51,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -33,8 +33,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -34,8 +34,8 @@ GEM
     hashdiff (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -53,9 +53,9 @@ GEM
       domain_name (~> 0.5)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -37,8 +37,8 @@ GEM
     hashdiff (1.1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -36,8 +36,8 @@ GEM
     hashdiff (1.1.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,8 +99,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1464,8 +1464,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -55,8 +55,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,9 +99,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -86,9 +86,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -65,9 +65,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,8 +112,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,8 +112,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -114,8 +114,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -58,8 +58,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -72,9 +72,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,9 +68,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,8 +50,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -44,9 +44,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-darwin)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -47,8 +47,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -109,8 +109,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,8 +112,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -117,8 +117,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,8 +128,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -121,9 +121,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -43,8 +43,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,9 +62,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,8 +99,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1464,8 +1464,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -55,8 +55,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,9 +99,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -86,9 +86,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -65,9 +65,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -110,8 +110,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -110,8 +110,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -114,8 +114,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -58,8 +58,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -72,9 +72,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,9 +68,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,8 +50,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -47,8 +47,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -109,8 +109,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,8 +112,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -117,8 +117,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,8 +128,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -135,9 +135,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -121,9 +121,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -43,8 +43,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,9 +62,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -98,8 +98,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1463,8 +1463,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -55,8 +55,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -99,9 +99,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -86,9 +86,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,8 +59,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -65,9 +65,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -110,8 +110,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -110,8 +110,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -114,8 +114,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -57,8 +57,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -72,9 +72,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -68,9 +68,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -47,8 +47,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,9 +60,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,9 +108,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -107,8 +107,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -107,8 +107,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -108,8 +108,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -107,8 +107,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -117,8 +117,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,8 +128,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -135,9 +135,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -136,9 +136,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_rails_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_app.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -148,8 +148,8 @@ GEM
     json (2.10.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -121,9 +121,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,9 +59,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -59,8 +59,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -41,8 +41,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -42,8 +42,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -110,8 +110,8 @@ GEM
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     king_konf (1.0.1)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -1594,8 +1594,8 @@ GEM
     jmespath (1.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -51,8 +51,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,8 +49,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,9 +49,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,9 +49,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -89,8 +89,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -79,9 +79,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -61,8 +61,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -60,8 +60,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_excon_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -47,8 +47,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -55,9 +55,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,8 +113,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,8 +113,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,8 +113,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,8 +113,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,8 +113,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -61,8 +61,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -61,9 +61,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -58,9 +58,9 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,9 +49,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,9 +49,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,8 +52,8 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -47,8 +47,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -50,9 +50,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,9 +112,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -112,8 +112,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -111,8 +111,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -114,8 +114,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -117,8 +117,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -127,8 +127,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -127,9 +127,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,9 +128,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,9 +128,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,9 +128,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -129,9 +129,9 @@ GEM
     json (2.12.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,9 +128,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -128,9 +128,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -113,9 +113,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -49,9 +49,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -62,8 +62,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -46,8 +46,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -52,9 +52,9 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-aarch64-linux)

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     datadog (2.19.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
+      libdatadog (~> 19.1.0.1.0)
       libddwaf (~> 1.24.1.0.0)
       logger
       msgpack
@@ -45,8 +45,8 @@ GEM
       reline (>= 0.4.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
-    libdatadog (18.1.0.1.0-aarch64-linux)
-    libdatadog (18.1.0.1.0-x86_64-linux)
+    libdatadog (19.1.0.1.0-aarch64-linux)
+    libdatadog (19.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.24.1.0.0-x86_64-linux)


### PR DESCRIPTION
**What does this PR do?**

This PR bumps the libdatadog version to 19.1 --
https://github.com/DataDog/libdatadog/pull/1146 .

**Motivation:**

Make sure we're up-to-date with the latest libdatadog goodies. In particular, this version brings faster crashtracking reporting (which is nice because otherwise it could time out and not report data, or only report partial data).

**Change log entry**

Yes. Upgrade libdatadog dependency to 19.1.

**Additional Notes:**

N/A

**How to test the change?**

We have test coverage for features that depend on libdatadog, so green CI is good!
