### PR TITLE
[PROF-12143] Report GC tuning environment variables with profiles

### DIFF
--- a/sig/datadog/profiling/collectors/info.rbs
+++ b/sig/datadog/profiling/collectors/info.rbs
@@ -19,6 +19,7 @@ module Datadog
 
         private
         START_TIME: ::Time
+        RUBY_GC_TUNING_ENV_VARS: ::Array[::String]
 
         @info: info
 
@@ -26,8 +27,8 @@ module Datadog
         def collect_runtime_info: () -> runtime_info
         def collect_application_info: (untyped settings) -> application_info
         def collect_profiler_info: (untyped settings) -> profiler_info
-
         def collect_settings_recursively: (untyped v) -> untyped
+        def collect_gc_tuning_info: () -> ::Hash[::Symbol, ::String]
       end
     end
   end

--- a/spec/datadog/profiling/collectors/info_spec.rb
+++ b/spec/datadog/profiling/collectors/info_spec.rb
@@ -105,6 +105,28 @@ RSpec.describe Datadog::Profiling::Collectors::Info do
         end
       end
     end
+
+    describe "gc tuning reporting" do
+      context "when no gc tuning env vars are set" do
+        it "reports an empty hash" do
+          expect(info.fetch(:runtime).fetch(:gc_tuning)).to eq({})
+        end
+      end
+
+      context "when some gc tuning env vars are set" do
+        around do |example|
+          ClimateControl.modify("RUBY_GC_HEAP_FREE_SLOTS" => "12345") do
+            example.run
+          end
+        end
+
+        it "reports the gc tuning env vars" do
+          expect(info.fetch(:runtime).fetch(:gc_tuning)).to eq({
+            RUBY_GC_HEAP_FREE_SLOTS: "12345"
+          })
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the information that gets attached to every profile to include any GC tuning settings that were present.

This information can be seen in the "System Info" section of the single profile view.

**Motivation:**

As more GC tuning settings get added to Ruby, it's useful for performance reasons to know if a given app is operating with the defaults or something has been tweaked.

See <https://mailchi.mp/railsspeed/stop-tuning-rubys-gc> for an interesting discussion of this.

We want to make it easier to spot these GC tuning settings (maybe even automatically in the future?).

**Change log entry**

Yes. Report GC tuning environment variables with profiles.

**Additional Notes:**

Note that only settings that have been changed from the default are sent, as it doesn't seem relevant to send a bunch of empty settings.

**How to test the change?**

I've added test coverage; here's how it looks in staging:

<img width="1050" height="1621" alt="image" src="https://github.com/user-attachments/assets/ae15fd81-0695-4075-a438-9e045856b839" />
