### PR TITLE
[PROF-11898] Switch profiler stack truncation strategy and improve sampling performance

### DIFF
--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -109,7 +109,7 @@ class ProfilerSampleLoopBenchmark
         end
       end
 
-      x.save! "#{File.basename(__FILE__)}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.save! "#{File.basename(__FILE__)}-#{mode}-results.json" unless VALIDATE_BENCHMARK_MODE
       x.compare!
     end
 
@@ -132,7 +132,7 @@ class ProfilerSampleLoopBenchmark
         add_extra_frame_and_sample(collector) # This makes the stack change
       end
 
-      x.save! "#{File.basename(__FILE__)}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.save! "#{File.basename(__FILE__)}-varying-depth-results.json" unless VALIDATE_BENCHMARK_MODE
       x.compare!
     end
 

--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -43,16 +43,47 @@ class ProfilerSampleLoopBenchmark
     Thread.new { deep_stack.call }.tap { |t| t.name = "Deep stack #{depth}" }
   end
 
+  def go_to_depth_and_run(depth: 2900, &block)
+    current_depth = caller.size
+    return yield if current_depth > depth
+
+    # rubocop:disable Lint/DuplicateBranch
+    # Simulate "some" complexity in the method bytecode
+    case current_depth % 10
+    when 0
+      go_to_depth_and_run(depth: depth, &block)
+    when 1
+      go_to_depth_and_run(depth: depth, &block)
+    when 2
+      go_to_depth_and_run(depth: depth, &block)
+    when 3
+      go_to_depth_and_run(depth: depth, &block)
+    when 4
+      go_to_depth_and_run(depth: depth, &block)
+    when 5
+      go_to_depth_and_run(depth: depth, &block)
+    when 6
+      go_to_depth_and_run(depth: depth, &block)
+    when 7
+      go_to_depth_and_run(depth: depth, &block)
+    when 8
+      go_to_depth_and_run(depth: depth, &block)
+    when 9
+      go_to_depth_and_run(depth: depth, &block)
+    end
+    # rubocop:enable Lint/DuplicateBranch
+  end
+
   def run_benchmark(mode: :ruby)
     threads = Array.new(4) { mode == :ruby ? thread_with_very_deep_stack : thread_with_very_deep_stack_and_native_frames }
     collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder)
 
     if mode == :native
-      if !Datadog::Profiling::Collectors::Stack._native_filenames_available?
+      unless Datadog::Profiling::Collectors::Stack._native_filenames_available?
         if OS.linux?
           raise 'Native filenames are not available. This is not expected on Linux!'
         else
-          puts "Skipping benchmarking native_frames, not supported outside of Linux"
+          puts 'Skipping benchmarking native_frames, not supported outside of Linux'
           return
         end
       end
@@ -70,21 +101,11 @@ class ProfilerSampleLoopBenchmark
         **benchmark_time,
       )
 
-      x.report("stack collector (#{mode} frames - native filenames enabled) #{ENV['CONFIG']}") do
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(
-          collector,
-          PROFILER_OVERHEAD_STACK_THREAD,
-          false
-        )
-      end
+      x.report("stack collector (#{mode} frames - native filenames enabled) #{ENV['CONFIG']}") { sample(collector) }
 
       if mode == :native
         x.report("stack collector (#{mode} frames - native filenames disabled) #{ENV['CONFIG']}") do
-          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(
-            collector_without_native_filenames,
-            PROFILER_OVERHEAD_STACK_THREAD,
-            false
-          )
+          sample(collector_without_native_filenames)
         end
       end
 
@@ -95,6 +116,40 @@ class ProfilerSampleLoopBenchmark
     threads.map(&:kill).each(&:join)
     @recorder.serialize!
   end
+
+  def run_varying_depth_benchmark
+    collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder, max_frames: 3000)
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? { time: 0.01, warmup: 0 } : { time: 10, warmup: 2 }
+      x.config(
+        **benchmark_time,
+      )
+
+      # This benchmark checks the performance of samples when the stack keeps changing
+      x.report("stack collector (varying depth) #{ENV['CONFIG']}") do
+        sample(collector)
+        add_extra_frame_and_sample(collector) # This makes the stack change
+      end
+
+      x.save! "#{File.basename(__FILE__)}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    File.write('test.out', @recorder.serialize!._native_bytes)
+  end
+
+  def sample(collector)
+    Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(
+      collector,
+      PROFILER_OVERHEAD_STACK_THREAD,
+      false
+    )
+  end
+
+  def add_extra_frame_and_sample(collector)
+    sample(collector)
+  end
 end
 
 puts "Current pid is #{Process.pid}"
@@ -103,4 +158,5 @@ ProfilerSampleLoopBenchmark.new.instance_exec do
   create_profiler
   run_benchmark(mode: :ruby)
   run_benchmark(mode: :native)
+  go_to_depth_and_run { run_varying_depth_benchmark }
 end

--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -136,7 +136,7 @@ class ProfilerSampleLoopBenchmark
       x.compare!
     end
 
-    File.write('test.out', @recorder.serialize!._native_bytes)
+    @recorder.serialize!
   end
 
   def sample(collector)

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -526,7 +526,7 @@ static void add_truncated_frames_placeholder(sampling_buffer* buffer) {
   // this to non-static strings, don't forget to check that lifetimes are properly respected.
   buffer->locations[0] = (ddog_prof_Location) {
     .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C(""), .build_id_id = {}},
-    .function = (ddog_prof_Function) {.name = DDOG_CHARSLICE_C("Truncated Frames"), .filename = DDOG_CHARSLICE_C("")},
+    .function = {.name = DDOG_CHARSLICE_C("Truncated Frames"), .filename = DDOG_CHARSLICE_C(""), .filename_id = {}},
     .line = 0,
   };
 }

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -524,7 +524,7 @@ static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_Char
 static void add_truncated_frames_placeholder(sampling_buffer* buffer) {
   // Important note: The strings below are static so we don't need to worry about their lifetime. If we ever want to change
   // this to non-static strings, don't forget to check that lifetimes are properly respected.
-  buffer->locations[buffer->max_frames - 1] = (ddog_prof_Location) {
+  buffer->locations[0] = (ddog_prof_Location) {
     .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C(""), .build_id_id = {}},
     .function = (ddog_prof_Function) {.name = DDOG_CHARSLICE_C("Truncated Frames"), .filename = DDOG_CHARSLICE_C("")},
     .line = 0,

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -417,6 +417,7 @@ calc_lineno(const rb_iseq_t *iseq, const VALUE *pc)
 // * Imported fix from https://github.com/ruby/ruby/pull/8280 to keep us closer to upstream
 // * Added potential fix for https://github.com/ruby/ruby/pull/13643 (this one is a just-in-case, unclear if it happens
 //   for ddtrace)
+// * Reversed order of iteration to better enable caching
 //
 // What is rb_profile_frames?
 // `rb_profile_frames` is a Ruby VM debug API added for use by profilers for sampling the stack trace of a Ruby thread.
@@ -495,7 +496,20 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
     // See comment on `record_placeholder_stack_in_native_code` for a full explanation of what this means (and why we don't just return 0)
     if (end_cfp <= cfp) return PLACEHOLDER_STACK_IN_NATIVE_CODE;
 
-    for (i=0; i<limit && cfp != end_cfp; cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp)) {
+    // This is the position just after the top of the stack -- e.g. where a new frame pushed on the stack would end up.
+    const rb_control_frame_t *top_sentinel = RUBY_VM_NEXT_CONTROL_FRAME(cfp);
+
+    // We iterate the stack from bottom (beginning of thread) to the top (currently-active frame). This is different
+    // from upstream rb_profile_frames, but actually matches what `backtrace_each` does (yes, different Ruby VM APIs
+    // iterate in different directions).
+    // We do this to better take advantage of the `same_frame` caching mechanism: By starting from the bottom of the
+    // stack towards the top, we can usually keep most of the stack intact when the code is only going up and down
+    // a few methods at the top. Before this change, the cache was really only useful if between samples the app had
+    // not moved from the current stack, as adding or removing one frame would invalidate the existing cache (because
+    // every position would shift).
+    cfp = RUBY_VM_NEXT_CONTROL_FRAME(end_cfp);
+
+    for (i=0; i<limit && cfp != top_sentinel; cfp = RUBY_VM_NEXT_CONTROL_FRAME(cfp)) {
         if (cfp->iseq && !cfp->pc) {
           // Fix: Do nothing -- this frame should not be used
           //

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -212,21 +212,6 @@ uint64_t native_thread_id_for(VALUE thread) {
   #endif
 }
 
-// Returns the stack depth by using the same approach as rb_profile_frames and backtrace_each: get the positions
-// of the end and current frame pointers and subtracting them.
-ptrdiff_t stack_depth_for(VALUE thread) {
-  const rb_execution_context_t *ec = thread_struct_from_object(thread)->ec;
-  const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
-
-  if (end_cfp == NULL) return 0;
-
-  // Skip dummy frame, as seen in `backtrace_each` (`vm_backtrace.c`) and our custom rb_profile_frames
-  // ( https://github.com/ruby/ruby/blob/4bd38e8120f2fdfdd47a34211720e048502377f1/vm_backtrace.c#L890-L914 )
-  end_cfp = RUBY_VM_NEXT_CONTROL_FRAME(end_cfp);
-
-  return end_cfp <= cfp ? 0 : end_cfp - cfp - 1;
-}
-
 // This was renamed in Ruby 3.2
 #if !defined(ccan_list_for_each) && defined(list_for_each)
   #define ccan_list_for_each list_for_each

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.h
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.h
@@ -41,7 +41,6 @@ rb_nativethread_id_t pthread_id_for(VALUE thread);
 bool is_current_thread_holding_the_gvl(void);
 current_gvl_owner gvl_owner(void);
 uint64_t native_thread_id_for(VALUE thread);
-ptrdiff_t stack_depth_for(VALUE thread);
 void ddtrace_thread_list(VALUE result_array);
 bool is_thread_alive(VALUE thread);
 VALUE thread_name_for(VALUE thread);

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -672,16 +672,18 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       expect(gathered_stack.size).to be max_frames
     end
 
-    it "matches the Ruby backtrace API up to max_frames - 1" do
-      expect(gathered_stack[0...(max_frames - 1)]).to eq reference_stack[0...(max_frames - 1)]
+    it "matches the Ruby backtrace API when comparing from the root of the thread" do
+      expect(gathered_stack[0...(max_frames - 1)]).to eq reference_stack[-max_frames...-1]
     end
 
-    it "includes a placeholder 'Truncated Frames' frame" do
-      placeholder = 1
-      omitted_frames = target_stack_depth - max_frames + placeholder
-
-      expect(omitted_frames).to be 96
-      expect(gathered_stack.last).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
+    it "gathers frames from the root of the thread and replaces the root with a placeholder" do
+      expect(gathered_stack).to contain_exactly(
+        have_attributes(base_label: "deep_stack_5"),
+        have_attributes(base_label: "deep_stack_4"),
+        have_attributes(base_label: "deep_stack_3"),
+        have_attributes(base_label: "deep_stack_2"),
+        have_attributes(base_label: "Truncated Frames", path: "", lineno: 0),
+      )
     end
 
     context "when stack is exactly 1 item deeper than the configured max_frames" do

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -862,7 +862,7 @@ class DeepStackSimulator
     first_method =
       (defined?(DatadogThreadDebugger) && Thread.include?(DatadogThreadDebugger)) ? :deep_stack_3 : :deep_stack_2
 
-      thread = Thread.new { DeepStackSimulator.new(target_depth: depth, ready_queue: ready_queue).send(first_method) }
+    thread = Thread.new { DeepStackSimulator.new(target_depth: depth, ready_queue: ready_queue).send(first_method) }
     thread.name = "Deep stack #{depth}" if thread.respond_to?(:name=)
     ready_queue.pop
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -681,21 +681,21 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         have_attributes(base_label: "deep_stack_5"),
         have_attributes(base_label: "deep_stack_4"),
         have_attributes(base_label: "deep_stack_3"),
-        have_attributes(base_label: "deep_stack_2"),
+        have_attributes(base_label: "thread_with_stack_depth"),
         have_attributes(base_label: "Truncated Frames", path: "", lineno: 0),
       )
     end
 
-    context "when stack is exactly 1 item deeper than the configured max_frames" do
-      let(:target_stack_depth) { 6 }
+    context "when stack is the same depth as the configured max_frames" do
+      let(:target_stack_depth) { max_frames }
 
       it "includes a placeholder frame" do
         expect(gathered_stack.last).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
       end
     end
 
-    context "when stack is exactly as deep as the configured max_frames" do
-      let(:target_stack_depth) { 5 }
+    context "when stack is exactly 1 item less deep than the configured max_frames" do
+      let(:target_stack_depth) { max_frames - 1 }
 
       it "matches the Ruby backtrace API" do
         expect(gathered_stack).to eq reference_stack
@@ -860,9 +860,9 @@ class DeepStackSimulator
     # Since in this helper we want to have precise control over how many frames are on the stack of a given thread,
     # we need to take into account that the DatadogThreadDebugger adds one more frame to the stack.
     first_method =
-      (defined?(DatadogThreadDebugger) && Thread.include?(DatadogThreadDebugger)) ? :deep_stack_2 : :deep_stack_1
+      (defined?(DatadogThreadDebugger) && Thread.include?(DatadogThreadDebugger)) ? :deep_stack_3 : :deep_stack_2
 
-    thread = Thread.new(&DeepStackSimulator.new(target_depth: depth, ready_queue: ready_queue).method(first_method))
+      thread = Thread.new { DeepStackSimulator.new(target_depth: depth, ready_queue: ready_queue).send(first_method) }
     thread.name = "Deep stack #{depth}" if thread.respond_to?(:name=)
     ready_queue.pop
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -672,25 +672,25 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       expect(gathered_stack.size).to be max_frames
     end
 
-    it "matches the Ruby backtrace API when comparing from the root of the thread" do
-      expect(gathered_stack[0...(max_frames - 1)]).to eq reference_stack[-max_frames...-1]
+    it "matches the last (max_frames - 1) frames from the Ruby backtrace API" do
+      expect(gathered_stack[1..(max_frames - 1)]).to eq reference_stack[-(max_frames - 1)..-1]
     end
 
-    it "gathers frames from the root of the thread and replaces the root with a placeholder" do
+    it "gathers max_frames frames from the root of the thread and replaces the topmost frame with a placeholder" do
       expect(gathered_stack).to contain_exactly(
-        have_attributes(base_label: "deep_stack_5"),
+        have_attributes(base_label: "Truncated Frames", path: "", lineno: 0),
         have_attributes(base_label: "deep_stack_4"),
         have_attributes(base_label: "deep_stack_3"),
         have_attributes(base_label: "thread_with_stack_depth"),
-        have_attributes(base_label: "Truncated Frames", path: "", lineno: 0),
+        have_attributes(base_label: "initialize"),
       )
     end
 
     context "when stack is the same depth as the configured max_frames" do
       let(:target_stack_depth) { max_frames }
 
-      it "includes a placeholder frame" do
-        expect(gathered_stack.last).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
+      it "includes a placeholder frame as the topmost frame of the stack" do
+        expect(gathered_stack.first).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
       end
     end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -676,21 +676,19 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       expect(gathered_stack[0...(max_frames - 1)]).to eq reference_stack[0...(max_frames - 1)]
     end
 
-    it "includes a placeholder frame including the number of skipped frames" do
+    it "includes a placeholder 'Truncated Frames' frame" do
       placeholder = 1
       omitted_frames = target_stack_depth - max_frames + placeholder
 
       expect(omitted_frames).to be 96
-      expect(gathered_stack.last).to have_attributes(base_label: "", path: "96 frames omitted", lineno: 0)
+      expect(gathered_stack.last).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
     end
 
     context "when stack is exactly 1 item deeper than the configured max_frames" do
       let(:target_stack_depth) { 6 }
 
-      it "includes a placeholder frame stating that 2 frames were omitted" do
-        # Why 2 frames omitted and not 1? That's because the placeholder takes over 1 space in the buffer, so
-        # if there were 6 frames on the stack and the limit is 5, then 4 of those frames will be present in the output
-        expect(gathered_stack.last).to have_attributes(base_label: "", path: "2 frames omitted", lineno: 0)
+      it "includes a placeholder frame" do
+        expect(gathered_stack.last).to have_attributes(base_label: "Truncated Frames", path: "", lineno: 0)
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR changes how we do stack sampling and truncation in the profiler by:

1. Removing the count of frames truncated from the reported stack. This allows us to get rid of the `stack_depth_for` which actually had an off-by-one bug (at least -- there may have been other bugs hiding in there because it calculated the number of frames differently from `rb_profile_frames`)
2. Moving the truncated frames marker to the leaf frame, mirroring the behavior in the Python profiler
3. Reverse the direction of stack sampling to improve cache hit performance

**Motivation:**

I started this PR to fix the off-by-one in the "frames omitted frame" and to align the Ruby stack truncation behavior with Python, and realized that the new truncation logic could also be taken advantage of to improve sampling performance.

The amount of work we save when we can reuse a cached frame is still somewhat small, but I expect that, when we move to the new interning APIs in libdatadog, we'll benefit even more since e.g. we'll be able to reuse ids or entire stacks.

**Change log entry**

Yes. Switch profiler stack truncation strategy and improve sampling performance

**Additional Notes:**

Up until now, truncated stacks looked like this:

> <img width="948" height="479" alt="image-20250717-144640" src="https://github.com/user-attachments/assets/76574f44-19eb-4224-ad23-a252fe642387" />

This behavior has been unchanged for years, and it could cause some confusion as it prevents stacks from merging (e.g. by having a different "N frames omitted" value).

In fact, Ruby was alone among the our profilers in having this behavior.

After this PR, truncation looks like this (when caused by the library):

> <img width="771" height="660" alt="image" src="https://github.com/user-attachments/assets/0232dc4e-26fa-425d-9230-60d5ff297237" />

Truncating the leaf and not the root allows us to sample in a way that keeps our buffer stable and reusable across calls. I've added a new benchmark to show this, and on my test machine I see a speed-up of around 8%:

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]
Warming up --------------------------------------
tmp - stack collector (varying depth) master-2
                       131.000 i/100ms
Calculating -------------------------------------
tmp - stack collector (varying depth) master-2
                          1.324k (± 1.4%) i/s  (755.22 μs/i) -     13.362k in  10.093502s

Comparison:
tmp - stack collector (varying depth) reverse-stack-2:     1431.4 i/s
tmp - stack collector (varying depth) reverse-stack-1:     1407.3 i/s - same-ish: difference falls within error
tmp - stack collector (varying depth) master-2:     1324.1 i/s - 1.08x  slower
tmp - stack collector (varying depth) master-1:     1319.6 i/s - 1.08x  slower
```

**How to test the change?**

I've updated our test coverage to validate the new behavior. Here's also a tiny Ruby script I used when I wanted to see this in the UX:

```ruby
def thread_with_very_deep_stack(depth: 500)
  deep_stack = proc do |n|
    if n > 0
      deep_stack.call(n - 1)
    else
      sleep
    end
  end

  Thread.new { deep_stack.call(depth) }.tap { |t| t.name = "Deep stack #{depth}" }
end

thread = thread_with_very_deep_stack()
sleep 1
```
