### PR TITLE
[NO-TICKET] Bump minimal required libddwaf version

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'datadog-ruby_core_source', '~> 3.4', '>= 3.4.1'
 
   # Used by appsec
-  spec.add_dependency 'libddwaf', '~> 1.24.1.0.0'
+  spec.add_dependency 'libddwaf', '~> 1.24.1.0.2'
 
   # When updating the version here, please also update the version in `libdatadog_extconf_helpers.rb`
   # (and yes we have a test for it)


### PR DESCRIPTION
**What does this PR do?**

Bump minimal required `libddwaf` version to multi-platform version

**Motivation:**

This should fix issues that appears on the last release attempt.

**Change log entry**

No.

**Additional Notes:**

Let's see how SSI behaves

**How to test the change?**

CI and ST is enough