### PR TITLE
Fix vaccine image race condition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,8 +166,9 @@ vaccine:
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:v68058725-73f34e7-2025.06-1
   tags: ["arch:amd64"]
   stage: vaccine
-  needs: [create-multiarch-lib-injection-image]
-
+  needs:
+    - create-multiarch-lib-injection-image
+    - kubernetes-injection-test-ecr-publish
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts


### PR DESCRIPTION
**What does this PR do?**

I have found plenty of vaccine jobs are failing because the images that it depends on are NOT available. It turned out the wrong job dependency can be causing this a race condition.

Failed example: https://github.com/DataDog/vaccine/actions/runs/16465895286


**Change log entry**
Nope