### PR TITLE
[NO-TICKET] Minor: Add more details to libdatadog build error message

### DIFF
--- a/ext/libdatadog_api/extconf.rb
+++ b/ext/libdatadog_api/extconf.rb
@@ -26,7 +26,9 @@ if ENV['DD_NO_EXTENSION'].to_s.strip.downcase == 'true'
 end
 skip_building_extension!('current Ruby VM is not supported') if RUBY_ENGINE != 'ruby'
 skip_building_extension!('Microsoft Windows is not supported') if Gem.win_platform?
-skip_building_extension!('issue setting up `libdatadog` gem') if Datadog::LibdatadogExtconfHelpers.libdatadog_issue?
+
+libdatadog_issue = Datadog::LibdatadogExtconfHelpers.libdatadog_issue?
+skip_building_extension!("issue setting up `libdatadog` gem: #{libdatadog_issue}") if libdatadog_issue
 
 require 'mkmf'
 

--- a/ext/libdatadog_extconf_helpers.rb
+++ b/ext/libdatadog_extconf_helpers.rb
@@ -5,6 +5,8 @@ require 'pathname'
 
 module Datadog
   # Contains a bunch of shared helpers that get used during building of extensions that link to libdatadog
+  #
+  # Note: Specs for this file currently live in `spec/datadog/profiling/native_extension_helpers_spec.rb`.
   module LibdatadogExtconfHelpers
     # Used to make sure the correct gem version gets loaded, as extconf.rb does not get run with "bundle exec" and thus
     # may see multiple libdatadog versions. See https://github.com/DataDog/dd-trace-rb/pull/2531 for the horror story.
@@ -123,8 +125,15 @@ module Datadog
     end
 
     def self.libdatadog_issue?
-      try_loading_libdatadog { |_exception| return true }
-      Libdatadog.pkgconfig_folder.nil?
+      try_loading_libdatadog do |exception|
+        return "There was an error loading `libdatadog`: #{exception.class} #{exception.message}"
+      end
+
+      unless Libdatadog.pkgconfig_folder
+        "The `libdatadog` gem installed on your system is missing binaries for your platform variant. " \
+          "Your platform: " \
+          "`#{Libdatadog.current_platform}`; available binaries: `#{Libdatadog.available_binaries.join("`, `")}`"
+      end
     end
   end
 end

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -284,6 +284,14 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !LibdatadogHelpers
       context 'when forked' do
         # This tests that the callback registered with `Utils::AtForkMonkeyPatch.at_fork`
         # does not contain a stale instance of the crashtracker component.
+
+        around do |example|
+          # Avoid triggering warnings from the agent settings resolver when these are set in the testing environment
+          ClimateControl.modify('DD_AGENT_HOST' => nil, 'DD_TRACE_AGENT_PORT' => nil) do
+            example.run
+          end
+        end
+
         it 'ensures the latest configuration applied' do
           allow(described_class).to receive(:_native_start_or_update_on_fork)
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds more details to the warning message that's printed when something is wrong with libdatadog.

Here's two examples of how they'll show up with this change:

> WARN: Skipping build of libdatadog_api (issue setting up `libdatadog` gem: There was an error loading libdatadog: RuntimeError hello!). Some functionality will not be available.

or

> WARN: Skipping build of libdatadog_api (issue setting up `libdatadog` gem: The `libdatadog` gem installed on your system is missing binaries for your platform variant. Your platform: `x86_64-linux`; available binaries: `lib`, `LICENSE`, `NOTICE`, `include`, `LICENSE-3rdparty.yml`, `bin`, `cmake`). Some functionality will not be available.

**Motivation:**

In practice, Ruby hides these messages by default so I find these are more useful for new team members: I've seen two different people running into them when running `bundle exec rake clean compile` recently.

**Change log entry**

Yes. Add more details to libdatadog build error message

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage. You can also trigger the issue manualy, by, e.g. misconfiguring `LIBDATADOG_VENDOR_OVERRIDE` env variable to point at a wrong or non-existing folder.