### PR TITLE
[SINT-3864] Sign CI images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ default:
       --file .gitlab/Dockerfile-$RUBY_VERSION
       .
     - docker push --all-tags $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE
-    - ddsign sign $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE --digest-from-docker
+    - ddsign sign $RUBY_CUSTOM_IMAGE_BASE/$RUBY_VERSION-$ARCHITECTURE:$CI_PIPELINE_ID --digest-from-docker
 
 build-image-amd64:
   extends: .build-image-base


### PR DESCRIPTION
**What does this PR do?**
Use ddsign to sign CI images built in the CI.

**Motivation:**
This quarter, SDLC Security aims to enforce all images running in our gitlab CI to be signed.

**Change log entry**
None.

**Additional Notes:**
n/a

**How to test the change?**
Check the successful build CI jobs at https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/jobs/1064322576 for instance
