### PR TITLE
[NO-TICKET] Replace `tracing-ruby` team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,33 +7,31 @@ docs/GettingStarted.md @DataDog/documentation
 # Library
 lib/datadog/appsec/ @DataDog/asm-ruby
 lib/datadog/appsec.rb @DataDog/asm-ruby
-lib/datadog/tracing/ @DataDog/tracing-ruby
-lib/datadog/tracing/contrib/ @DataDog/tracing-ruby
-lib/datadog/tracing.rb @DataDog/tracing-ruby
-lib/datadog/opentelemetry/ @DataDog/tracing-ruby
-lib/datadog/opentelemetry.rb @DataDog/tracing-ruby
-lib-injection/ @DataDog/tracing-ruby
+lib/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+lib/datadog/tracing.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+lib/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
+lib/datadog/opentelemetry.rb @DataDog/apm-sdk-api-ruby
+lib-injection/ @DataDog/lang-platform-ruby
 lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
 ext/ @DataDog/profiling-rb @DataDog/ruby-guild
+ext/libdatadog_api/ @DataDog/profiling-rb @DataDog/apm-sdk-api-ruby
 
 # RBS signatures
 sig/datadog/appsec/ @DataDog/asm-ruby
 sig/datadog/appsec.rbs @DataDog/asm-ruby
-sig/datadog/tracing/ @DataDog/tracing-ruby
-sig/datadog/tracing/contrib/ @DataDog/tracing-ruby
-sig/datadog/tracing.rbs @DataDog/tracing-ruby
-sig/datadog/opentelemetry/ @DataDog/tracing-ruby
-sig/datadog/opentelemetry.rbs @DataDog/tracing-ruby
+sig/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+sig/datadog/tracing.rbs @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+sig/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
+sig/datadog/opentelemetry.rbs @DataDog/apm-sdk-api-ruby
 sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 
 # Specs
 spec/datadog/appsec/ @DataDog/asm-ruby
-spec/datadog/tracing/ @DataDog/tracing-ruby
-spec/datadog/tracing/contrib/ @DataDog/tracing-ruby
-spec/datadog/tracing_spec.rb @DataDog/tracing-ruby
-spec/datadog/opentelemetry/ @DataDog/tracing-ruby
-spec/datadog/opentelemetry_spec.rb @DataDog/tracing-ruby
+spec/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+spec/datadog/tracing_spec.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
+spec/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
+spec/datadog/opentelemetry_spec.rb @DataDog/apm-sdk-api-ruby
 spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR change `tracing-ruby` team in `CODEOWNERS` to `apm-sdk-api-ruby`, `apm-idm-ruby`, and `lang-platform-ruby` for their corresponding folders.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
`tracing-ruby` team does not exists anymore and has been split into 3 teams. These teams have specific scopes that allows more fine-grained code ownership.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None.

<!-- Unsure? Have a question? Request a review! -->
