### PR TITLE
Doc: Updated GraphQL settings that only work through env var

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -888,12 +888,6 @@ To activate your integration, use the `Datadog.configure` method:
 
 ```ruby
 # Inside Rails initializer or equivalent
-# For graphql >= v2.2
-Datadog.configure do |c|
-  c.tracing.instrument :graphql, with_unified_tracer: true, **options
-end
-
-# For graphql < v2.2
 Datadog.configure do |c|
    c.tracing.instrument :graphql, **options
 end
@@ -908,8 +902,8 @@ The `instrument :graphql` method accepts the following parameters. Additional op
 | ------------------------ | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | `enabled`                | `DD_TRACE_GRAPHQL_ENABLED` | `Bool`   | Whether the integration should create spans.                                                                                                                                                                    | `true`           |
 | `schemas`                |                            | `Array`  | Array of `GraphQL::Schema` objects (that support class-based schema only) to trace. If you do not provide any, then tracing will applied to all the schemas.                                                    | `[]`             |
-| `with_unified_tracer`    | `DD_TRACE_GRAPHQL_WITH_UNIFIED_TRACER` | `Bool`   | (Recommended) Enable to instrument with `UnifiedTrace` tracer for `graphql` >= v2.2, **enabling support for Endpoints list** in the Service Catalog. `with_deprecated_tracer` has priority over this. Default is `false`, using `GraphQL::Tracing::DataDogTrace` instead. This option is disabled by default to maintain backwards compatibility, but **will become the default in `datadog` 3.0.0**. | `false` |
-| `with_deprecated_tracer` |                            | `Bool`   | (Not recommended) Enable to instrument with deprecated `GraphQL::Tracing::DataDogTracing`. This has priority over `with_unified_tracer`. Default is `false`, using `GraphQL::Tracing::DataDogTrace` instead | `false` |
+| <!---`with_unified_tracer`--> | `DD_TRACE_GRAPHQL_WITH_UNIFIED_TRACER` | `Bool`   | (Recommended) Enable to instrument with `UnifiedTrace` tracer for `graphql` >= v2.2, **enabling support for Endpoints list** in the Service Catalog. `with_deprecated_tracer` has priority over this. Default is `false`, using `GraphQL::Tracing::DataDogTrace` instead. This option is disabled by default to maintain backwards compatibility, but **will become the default in `datadog` 3.0.0**. | `false` |
+| <!---`with_deprecated_tracer`--> |                            | `Bool`   | (Not recommended) Enable to instrument with deprecated `GraphQL::Tracing::DataDogTracing`. This has priority over `with_unified_tracer`. Default is `false`, using `GraphQL::Tracing::DataDogTrace` instead | `false` |
 | `service_name`           |                            | `String` | Service name used for graphql instrumentation                                                                                                                                                                   | `'ruby-graphql'` |
 | `error_extensions` | `DD_TRACE_GRAPHQL_ERROR_EXTENSIONS` | `Array` | List of extension keys to include in the span event reported for GraphQL queries with errors. | `[]` |
 


### PR DESCRIPTION
**What does this PR do?**

Related issue comment: https://github.com/DataDog/dd-trace-rb/issues/4170#issuecomment-3074067411

This PR updates the documentation on how to configure the GraphQL tracing mechanism, since it cannot be changed once first configuration today (the patching is irreversible).

Because auto-instrumentation always patches GraphQL if available at application startup, trying to change the mechanism in the `Datadog.configure` block does not work.

This PR leaves only the environment variable configuration options publicly documented, since they are the only ones that always work reliably.

The ultimate fix for this patching issues is unfortunately a breaking change, thus needs to wait until the next major release.

**Change log entry**
No.
