### PR TITLE
[APPSEC-57330] Rework trace keeping for AppSec

### DIFF
--- a/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
@@ -3,6 +3,7 @@
 require_relative '../ext'
 require_relative '../configuration'
 require_relative '../data_extractor'
+require_relative '../../../trace_keeper'
 
 module Datadog
   module AppSec
@@ -25,7 +26,7 @@ module Datadog
                 return result
               end
 
-              context.trace.keep!
+              TraceKeeper.keep!(context.trace)
 
               if result
                 record_successful_signin(context, resource)

--- a/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
@@ -3,6 +3,7 @@
 require_relative '../ext'
 require_relative '../configuration'
 require_relative '../data_extractor'
+require_relative '../../../trace_keeper'
 
 module Datadog
   module AppSec
@@ -26,7 +27,7 @@ module Datadog
 
                 next yield(resource) if resource.new_record? && block_given?
 
-                context.trace.keep!
+                TraceKeeper.keep!(context.trace)
                 record_successful_signup(context, resource)
                 Instrumentation.gateway.push('appsec.events.user_lifecycle', Ext::EVENT_SIGNUP)
 

--- a/lib/datadog/appsec/event.rb
+++ b/lib/datadog/appsec/event.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require_relative 'rate_limiter'
+require_relative 'trace_keeper'
 require_relative 'compressed_json'
 
 module Datadog
@@ -40,8 +41,7 @@ module Datadog
 
       class << self
         def tag_and_keep!(context, waf_result)
-          # We want to keep the trace in case of security event
-          context.trace&.keep!
+          TraceKeeper.keep!(context.trace)
 
           if context.span
             if waf_result.actions.key?('block_request') || waf_result.actions.key?('redirect_request')
@@ -50,8 +50,6 @@ module Datadog
 
             context.span.set_tag('appsec.event', 'true')
           end
-
-          add_distributed_tags(context.trace)
         end
 
         def record(context, request: nil, response: nil)
@@ -66,8 +64,7 @@ module Datadog
               end
 
               if event_group.any? { |event| event.attack? || event.schema? }
-                trace.keep!
-                trace[Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER] = Tracing::Sampling::Ext::Decision::ASM
+                TraceKeeper.keep!(trace)
 
                 context.span['_dd.origin'] = 'appsec'
                 context.span.set_tags(request_tags(request)) if request
@@ -124,7 +121,7 @@ module Datadog
             end
           end
 
-          tags['_dd.appsec.json'] = json_parse({triggers: triggers}) unless triggers.empty?
+          tags['_dd.appsec.json'] = json_parse({ triggers: triggers }) unless triggers.empty?
           tags
         end
 
@@ -137,18 +134,6 @@ module Datadog
           AppSec.telemetry.report(e, description: 'AppSec: Failed to convert value into JSON')
 
           nil
-        end
-
-        # Propagate to downstream services the information that the current distributed trace is
-        # containing at least one ASM security event.
-        def add_distributed_tags(trace)
-          return unless trace
-
-          trace.set_tag(
-            Datadog::Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
-            Datadog::Tracing::Sampling::Ext::Decision::ASM
-          )
-          trace.set_distributed_source(Datadog::AppSec::Ext::PRODUCT_BIT)
         end
       end
     end

--- a/lib/datadog/appsec/trace_keeper.rb
+++ b/lib/datadog/appsec/trace_keeper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    # This class is used to mark trace as manual keep and tag it as ASM product.
+    module TraceKeeper
+      def self.keep!(trace)
+        return unless trace
+
+        # NOTE: This action will not set correct decision maker value, so the
+        #       trace keeping must be done with additional steps below
+        trace.keep!
+
+        # Propagate to downstream services the information that
+        # the current distributed trace is containing at least one ASM event.
+        trace.set_tag(
+          Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
+          Tracing::Sampling::Ext::Decision::ASM
+        )
+        trace.set_distributed_source(Ext::PRODUCT_BIT)
+      end
+    end
+  end
+end

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../identity'
+require_relative '../../appsec/trace_keeper'
 
 module Datadog
   module Kit
@@ -126,7 +127,7 @@ module Datadog
                 span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
               end
 
-              trace.keep!
+              ::Datadog::AppSec::TraceKeeper.keep!(trace)
             else
               set_trace_and_span_context('track', trace, span) do |active_trace, active_span|
                 active_span.set_tag("appsec.events.#{event}.track", 'true')
@@ -138,7 +139,7 @@ module Datadog
                   active_span.set_tag("appsec.events.#{event}.#{k}", v) unless v.nil?
                 end
 
-                active_trace.keep!
+                ::Datadog::AppSec::TraceKeeper.keep!(active_trace)
               end
             end
 

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../identity'
+require_relative '../../../appsec/trace_keeper'
 
 module Datadog
   module Kit
@@ -60,7 +61,7 @@ module Datadog
               span.set_tag('appsec.events.users.login.success.track', 'true')
               span.set_tag('_dd.appsec.events.users.login.success.sdk', 'true')
 
-              trace.keep!
+              ::Datadog::AppSec::TraceKeeper.keep!(trace)
 
               record_event_telemetry_metric(LOGIN_SUCCESS_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_SUCCESS_EVENT)
@@ -116,7 +117,7 @@ module Datadog
               span.set_tag('appsec.events.users.login.failure.usr.login', login)
               span.set_tag('appsec.events.users.login.failure.usr.exists', user_exists.to_s)
 
-              trace.keep!
+              ::Datadog::AppSec::TraceKeeper.keep!(trace)
 
               record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)

--- a/sig/datadog/appsec/event.rbs
+++ b/sig/datadog/appsec/event.rbs
@@ -35,8 +35,6 @@ module Datadog
       def self.response_tags: (_ResponseInterface response) -> tags
 
       def self.json_parse: (untyped value) -> ::String?
-
-      def self.add_distributed_tags: (::Datadog::Tracing::TraceOperation? trace) -> void
     end
   end
 end

--- a/spec/datadog/appsec/trace_keeper_spec.rb
+++ b/spec/datadog/appsec/trace_keeper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/trace_keeper'
+
+RSpec.describe Datadog::AppSec::TraceKeeper do
+  describe '.keep!' do
+    context 'when trace is given' do
+      let(:trace) { Datadog::Tracing::TraceOperation.new }
+
+      it 'sets trace source tag' do
+        expect { described_class.keep!(trace) }
+          .to change { trace.get_tag('_dd.p.ts') }.from(nil).to('02')
+      end
+
+      it 'sets trace decision maker tag' do
+        expect { described_class.keep!(trace) }
+          .to change { trace.get_tag('_dd.p.dm') }.from(nil).to('-5')
+      end
+    end
+
+    context 'when trace is not given' do
+      it { expect { described_class.keep!(nil) }.to_not raise_error }
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Unify trace keeping in AppSec and extract it into a separate module. In addition replace how do we keep traces in `Kit::AppSec` and for generated User Events.

**Motivation:**

New RFC requirement to track SDK and User Events as ASM events that are subject of trace keeping.

**Change log entry**

Yes. AppSec: Update security trace tags for Business Logic Events and User Events SDK v1/v2.

**Additional Notes:**

None.

**How to test the change?**

CI + ST