### PR TITLE
[NO-TICKET] Simplify CODEOWNERS for `ext` folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,6 @@ lib-injection/ @DataDog/lang-platform-ruby
 lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
 ext/ @DataDog/profiling-rb @DataDog/ruby-guild
-ext/libdatadog_api/ @DataDog/profiling-rb @DataDog/apm-sdk-api-ruby
 
 # RBS signatures
 sig/datadog/appsec/ @DataDog/asm-ruby


### PR DESCRIPTION
**What does this PR do?**

This PR simplifies the CODEOWNERS for the `ext/` folder by removing the more specific restriction on `ext/libdatadog_api/`.

**Motivation:**

Since both @Datadog/profiling-rb @Datadog/apm-sdk-api-ruby are quite small groups, we end up with situations like in
https://github.com/DataDog/dd-trace-rb/pull/4831 where two team-members already reviewed the PR but I need to get a third one that matches the really small groups.

Instead, like for most other things in the repo, let's rely on Ruby guild members being able to approve changes. We can always re-adjust later if needed.

**Change log entry**
None.

**Additional Notes:**

N/A

**How to test the change?**

Validate that when opening PRs touching `ext/libdatadog_api/`, the required reviews are from
@Datadog/profiling-rb @Datadog/ruby-guild.