### PR TITLE
chore: update baggage telemetry name

### DIFF
--- a/lib/datadog/tracing/distributed/baggage.rb
+++ b/lib/datadog/tracing/distributed/baggage.rb
@@ -42,7 +42,7 @@ module Datadog
               ::Datadog.logger.warn("Baggage item limit (#{DD_TRACE_BAGGAGE_MAX_ITEMS}) exceeded, dropping excess items")
               # Record telemetry for item count truncation
               record_telemetry_metric(
-                'context_header_style.truncated',
+                'context_header.truncated',
                 1,
                 {'header_style' => 'baggage', 'truncation_reason' => 'baggage_item_count_exceeded'}
               )
@@ -59,7 +59,7 @@ module Datadog
                 ::Datadog.logger.warn("Baggage header size (#{DD_TRACE_BAGGAGE_MAX_BYTES}) exceeded, dropping excess items")
                 # Record telemetry for byte count truncation
                 record_telemetry_metric(
-                  'context_header_style.truncated',
+                  'context_header.truncated',
                   1,
                   {'header_style' => 'baggage', 'truncation_reason' => 'baggage_byte_count_exceeded'}
                 )

--- a/spec/datadog/tracing/distributed/baggage_spec.rb
+++ b/spec/datadog/tracing/distributed/baggage_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Datadog::Tracing::Distributed::Baggage do
         it 'records item count truncation telemetry' do
           expect(telemetry).to receive(:inc).with(
             'instrumentation_telemetry_data.tracers',
-            'context_header_style.truncated',
+            'context_header.truncated',
             1,
             tags: { 'header_style' => 'baggage', 'truncation_reason' => 'baggage_item_count_exceeded' }
           )
@@ -334,7 +334,7 @@ RSpec.describe Datadog::Tracing::Distributed::Baggage do
         it 'records byte count truncation telemetry' do
           expect(telemetry).to receive(:inc).with(
             'instrumentation_telemetry_data.tracers',
-            'context_header_style.truncated',
+            'context_header.truncated',
             1,
             tags: { 'header_style' => 'baggage', 'truncation_reason' => 'baggage_byte_count_exceeded' }
           )


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
- update baggage telemetry truncation name to `context_header.truncated` instead of `context_header_style.truncated`
- this follow the existing metric in dd-go


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->
None. 

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
