### PR TITLE
add id-token write permission to system tests

### DIFF
--- a/.github/workflows/system-tests-official.yml
+++ b/.github/workflows/system-tests-official.yml
@@ -122,6 +122,7 @@ jobs:
     secrets: inherit  # zizmor: ignore[secrets-inherit]
     permissions:
       contents: read
+      id-token: write
       packages: write
     with:
       library: ruby


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Adds the id-token permission to system tests.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

This will allow requesting an OIDC token which is needed to get the current ref from a separate repository.

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
