### PR TITLE
Add `input_truncated` metric to `appsec.waf.requests` telemetry

### DIFF
--- a/lib/datadog/appsec/metrics/collector.rb
+++ b/lib/datadog/appsec/metrics/collector.rb
@@ -5,14 +5,28 @@ module Datadog
     module Metrics
       # A class responsible for collecting WAF and RASP call metrics.
       class Collector
-        Store = Struct.new(:evals, :matches, :errors, :timeouts, :duration_ns, :duration_ext_ns, keyword_init: true)
+        Store = Struct.new(
+          :evals,
+          :matches,
+          :errors,
+          :timeouts,
+          :duration_ns,
+          :duration_ext_ns,
+          :input_truncated_count,
+          keyword_init: true
+        )
 
         attr_reader :waf, :rasp
 
         def initialize
           @mutex = Mutex.new
-          @waf = Store.new(evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0)
-          @rasp = Store.new(evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0)
+
+          @waf = Store.new(
+            evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0, input_truncated_count: 0
+          )
+          @rasp = Store.new(
+            evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0, input_truncated_count: 0
+          )
         end
 
         def record_waf(result)
@@ -23,6 +37,7 @@ module Datadog
             @waf.timeouts += 1 if result.timeout?
             @waf.duration_ns += result.duration_ns
             @waf.duration_ext_ns += result.duration_ext_ns
+            @waf.input_truncated_count += 1 if result.input_truncated?
           end
         end
 
@@ -34,6 +49,7 @@ module Datadog
             @rasp.timeouts += 1 if result.timeout?
             @rasp.duration_ns += result.duration_ns
             @rasp.duration_ext_ns += result.duration_ext_ns
+            @rasp.input_truncated_count += 1 if result.input_truncated?
           end
         end
       end

--- a/lib/datadog/appsec/metrics/telemetry_exporter.rb
+++ b/lib/datadog/appsec/metrics/telemetry_exporter.rb
@@ -18,7 +18,8 @@ module Datadog
               waf_timeout: metrics.timeouts.positive?.to_s,
               request_blocked: context.interrupted?.to_s,
               block_failure: 'false',
-              rate_limited: (!context.trace.sampled?).to_s
+              rate_limited: (!context.trace.sampled?).to_s,
+              input_truncated: metrics.input_truncated_count.positive?.to_s,
             }
           )
         end

--- a/lib/datadog/appsec/security_engine/result.rb
+++ b/lib/datadog/appsec/security_engine/result.rb
@@ -9,7 +9,7 @@ module Datadog
         class Base
           attr_reader :events, :actions, :derivatives, :duration_ns, :duration_ext_ns
 
-          def initialize(events:, actions:, derivatives:, timeout:, duration_ns:, duration_ext_ns:)
+          def initialize(events:, actions:, derivatives:, timeout:, duration_ns:, duration_ext_ns:, input_truncated:)
             @events = events
             @actions = actions
             @derivatives = derivatives
@@ -17,6 +17,7 @@ module Datadog
             @timeout = timeout
             @duration_ns = duration_ns
             @duration_ext_ns = duration_ext_ns
+            @input_truncated = input_truncated
           end
 
           def timeout?
@@ -29,6 +30,10 @@ module Datadog
 
           def error?
             raise NotImplementedError
+          end
+
+          def input_truncated?
+            @input_truncated
           end
         end
 
@@ -58,11 +63,12 @@ module Datadog
         class Error
           attr_reader :events, :actions, :derivatives, :duration_ns, :duration_ext_ns
 
-          def initialize(duration_ext_ns:)
+          def initialize(duration_ext_ns:, input_truncated:)
             @events = []
             @actions = @derivatives = {}
             @duration_ns = 0
             @duration_ext_ns = duration_ext_ns
+            @input_truncated = input_truncated
           end
 
           def timeout?
@@ -75,6 +81,10 @@ module Datadog
 
           def error?
             true
+          end
+
+          def input_truncated?
+            @input_truncated
           end
         end
       end

--- a/lib/datadog/appsec/security_engine/runner.rb
+++ b/lib/datadog/appsec/security_engine/runner.rb
@@ -42,7 +42,7 @@ module Datadog
           report_execution(result)
 
           unless SUCCESSFUL_EXECUTION_CODES.include?(result.status)
-            return Result::Error.new(duration_ext_ns: stop_ns - start_ns)
+            return Result::Error.new(duration_ext_ns: stop_ns - start_ns, input_truncated: result.input_truncated?)
           end
 
           klass = (result.status == :match) ? Result::Match : Result::Ok
@@ -52,7 +52,8 @@ module Datadog
             derivatives: result.derivatives,
             timeout: result.timeout,
             duration_ns: result.total_runtime,
-            duration_ext_ns: (stop_ns - start_ns)
+            duration_ext_ns: (stop_ns - start_ns),
+            input_truncated: result.input_truncated?
           )
         ensure
           @mutex.unlock

--- a/sig/datadog/appsec/metrics/collector.rbs
+++ b/sig/datadog/appsec/metrics/collector.rbs
@@ -15,7 +15,9 @@ module Datadog
 
           attr_accessor duration_ext_ns: ::Integer
 
-          def self.new: (evals: ::Integer, matches: ::Integer, errors: ::Integer, timeouts: ::Integer, duration_ns: ::Integer, duration_ext_ns: ::Integer) -> void
+          attr_accessor input_truncated_count: ::Integer
+
+          def self.new: (evals: ::Integer, matches: ::Integer, errors: ::Integer, timeouts: ::Integer, duration_ns: ::Integer, duration_ext_ns: ::Integer, input_truncated_count: ::Integer) -> void
         end
 
         @mutex: Mutex

--- a/sig/datadog/appsec/security_engine/result.rbs
+++ b/sig/datadog/appsec/security_engine/result.rbs
@@ -21,6 +21,8 @@ module Datadog
 
           @duration_ext_ns: ::Integer
 
+          @input_truncated: bool
+
           attr_reader events: events
 
           attr_reader actions: actions
@@ -31,13 +33,15 @@ module Datadog
 
           attr_reader duration_ext_ns: ::Integer
 
-          def initialize: (events: events, actions: actions, derivatives: derivatives, timeout: bool, duration_ns: ::Integer, duration_ext_ns: ::Integer) -> void
+          def initialize: (events: events, actions: actions, derivatives: derivatives, timeout: bool, duration_ns: ::Integer, duration_ext_ns: ::Integer, input_truncated: bool) -> void
 
           def timeout?: () -> bool
 
           def match?: () -> bool
 
           def error?: () -> bool
+
+          def input_truncated?: () -> bool
         end
 
         # A result that indicates a security rule match
@@ -66,6 +70,8 @@ module Datadog
 
           @duration_ext_ns: ::Integer
 
+          @input_truncated: bool
+
           attr_reader events: events
 
           attr_reader actions: actions
@@ -76,13 +82,15 @@ module Datadog
 
           attr_reader duration_ext_ns: ::Integer
 
-          def initialize: (duration_ext_ns: ::Integer) -> void
+          def initialize: (duration_ext_ns: ::Integer, input_truncated: bool) -> void
 
           def timeout?: () -> false
 
           def match?: () -> false
 
           def error?: () -> true
+
+          def input_truncated?: () -> bool
         end
       end
     end

--- a/spec/datadog/appsec/metrics/collector_spec.rb
+++ b/spec/datadog/appsec/metrics/collector_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.waf.timeouts).to eq(0)
         expect(collector.waf.duration_ns).to eq(0)
         expect(collector.waf.duration_ext_ns).to eq(0)
+        expect(collector.waf.input_truncated_count).to eq(0)
       end
     end
 
@@ -22,7 +23,8 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100, duration_ext_ns: 200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100,
+          duration_ext_ns: 200, input_truncated: false
         )
       end
 
@@ -33,6 +35,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.waf.timeouts).to eq(0)
         expect(collector.waf.duration_ns).to eq(100)
         expect(collector.waf.duration_ext_ns).to eq(200)
+        expect(collector.waf.input_truncated_count).to eq(0)
       end
     end
 
@@ -44,13 +47,15 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result_1) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100, duration_ext_ns: 200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100,
+          duration_ext_ns: 200, input_truncated: false
         )
       end
 
       let(:result_2) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 1000, duration_ext_ns: 1200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 1000,
+          duration_ext_ns: 1200, input_truncated: false
         )
       end
 
@@ -60,6 +65,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.waf.errors).to eq(0)
         expect(collector.waf.duration_ns).to eq(1100)
         expect(collector.waf.duration_ext_ns).to eq(1400)
+        expect(collector.waf.input_truncated_count).to eq(0)
       end
     end
 
@@ -72,17 +78,21 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result_1) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 100, duration_ext_ns: 500
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 100,
+          duration_ext_ns: 500, input_truncated: false
         )
       end
 
       let(:result_2) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
-          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 400, duration_ext_ns: 1200
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 400,
+          duration_ext_ns: 1200, input_truncated: false
         )
       end
 
-      let(:result_3) { Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 300) }
+      let(:result_3) do
+        Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 300, input_truncated: false)
+      end
 
       it 'accumulates timeouts in addition to other metics' do
         expect(collector.waf.evals).to eq(3)
@@ -91,6 +101,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.waf.timeouts).to eq(2)
         expect(collector.waf.duration_ns).to eq(500)
         expect(collector.waf.duration_ext_ns).to eq(2000)
+        expect(collector.waf.input_truncated_count).to eq(0)
       end
     end
   end
@@ -104,6 +115,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.rasp.timeouts).to eq(0)
         expect(collector.rasp.duration_ns).to eq(0)
         expect(collector.rasp.duration_ext_ns).to eq(0)
+        expect(collector.rasp.input_truncated_count).to eq(0)
       end
     end
 
@@ -112,7 +124,8 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100, duration_ext_ns: 200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100,
+          duration_ext_ns: 200, input_truncated: false
         )
       end
 
@@ -123,6 +136,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.rasp.timeouts).to eq(0)
         expect(collector.rasp.duration_ns).to eq(100)
         expect(collector.rasp.duration_ext_ns).to eq(200)
+        expect(collector.rasp.input_truncated_count).to eq(0)
       end
     end
 
@@ -134,13 +148,15 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result_1) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100, duration_ext_ns: 200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 100,
+          duration_ext_ns: 200, input_truncated: false
         )
       end
 
       let(:result_2) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
-          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 1000, duration_ext_ns: 1200
+          events: [], actions: {}, derivatives: {}, timeout: false, duration_ns: 1000,
+          duration_ext_ns: 1200, input_truncated: false
         )
       end
 
@@ -151,6 +167,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.rasp.timeouts).to eq(0)
         expect(collector.rasp.duration_ns).to eq(1100)
         expect(collector.rasp.duration_ext_ns).to eq(1400)
+        expect(collector.rasp.input_truncated_count).to eq(0)
       end
     end
 
@@ -163,17 +180,22 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
 
       let(:result_1) do
         Datadog::AppSec::SecurityEngine::Result::Ok.new(
-          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 100, duration_ext_ns: 500
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 100,
+          duration_ext_ns: 500, input_truncated: false
         )
       end
 
       let(:result_2) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
-          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 400, duration_ext_ns: 1200
+          events: [], actions: {}, derivatives: {}, timeout: true, duration_ns: 400,
+          duration_ext_ns: 1200,
+          input_truncated: false
         )
       end
 
-      let(:result_3) { Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 300) }
+      let(:result_3) do
+        Datadog::AppSec::SecurityEngine::Result::Error.new(duration_ext_ns: 300, input_truncated: false)
+      end
 
       it 'accumulates timeouts in addition to other metics' do
         expect(collector.rasp.evals).to eq(3)
@@ -182,6 +204,7 @@ RSpec.describe Datadog::AppSec::Metrics::Collector do
         expect(collector.rasp.timeouts).to eq(2)
         expect(collector.rasp.duration_ns).to eq(500)
         expect(collector.rasp.duration_ext_ns).to eq(2000)
+        expect(collector.rasp.input_truncated_count).to eq(0)
       end
     end
   end

--- a/spec/datadog/appsec/metrics/telemetry_exporter_spec.rb
+++ b/spec/datadog/appsec/metrics/telemetry_exporter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Datadog::AppSec::Metrics::TelemetryExporter do
 
     let(:waf_metrics) do
       Datadog::AppSec::Metrics::Collector::Store.new(
-        evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0
+        evals: 0, matches: 0, errors: 0, timeouts: 0, duration_ns: 0, duration_ext_ns: 0, input_truncated_count: 0
       )
     end
 
@@ -40,7 +40,8 @@ RSpec.describe Datadog::AppSec::Metrics::TelemetryExporter do
           waf_timeout: 'false',
           request_blocked: 'false',
           block_failure: 'false',
-          rate_limited: 'false'
+          rate_limited: 'false',
+          input_truncated: 'false'
         }
       )
 
@@ -75,6 +76,17 @@ RSpec.describe Datadog::AppSec::Metrics::TelemetryExporter do
       expect(Datadog::AppSec.telemetry).to receive(:inc).with(
         Datadog::AppSec::Ext::TELEMETRY_METRICS_NAMESPACE, 'waf.requests', 1,
         tags: hash_including(waf_timeout: 'true')
+      )
+
+      described_class.export_waf_request_metrics(waf_metrics, context)
+    end
+
+    it 'sets input_truncated as "true" when metrics has non-zero count of input truncations' do
+      waf_metrics.input_truncated_count = 1
+
+      expect(Datadog::AppSec.telemetry).to receive(:inc).with(
+        Datadog::AppSec::Ext::TELEMETRY_METRICS_NAMESPACE, 'waf.requests', 1,
+        tags: hash_including(input_truncated: 'true')
       )
 
       described_class.export_waf_request_metrics(waf_metrics, context)

--- a/vendor/rbs/libddwaf-stub/0/datadog/appsec/waf.rbs
+++ b/vendor/rbs/libddwaf-stub/0/datadog/appsec/waf.rbs
@@ -94,6 +94,8 @@ module Datadog
 
         @derivatives: untyped
 
+        @input_truncated: bool
+
         attr_reader status: untyped
 
         attr_reader events: untyped
@@ -107,6 +109,10 @@ module Datadog
         attr_reader derivatives: untyped
 
         def initialize: (untyped status, untyped events, untyped total_runtime, untyped timeout, untyped actions, untyped derivatives) -> void
+
+        def mark_as_input_truncated!: () -> bool
+
+        def input_truncated?: () -> bool
       end
 
       class Context


### PR DESCRIPTION
**What does this PR do?**
This PR adds `input_truncated` metric to `appsec.waf.requests` telemetry.

**Motivation:**
This change is extracted to a separate PR from #4839, since it required changes to `libddwaf-rb` gem.

**Change log entry**
None. This change is internal.

**Additional Notes:**
Follow up for https://github.com/DataDog/dd-trace-rb/pull/4839
Related `libddwaf-rb` PR: https://github.com/DataDog/libddwaf-rb/pull/91

This PR is in draft mode until changes to `libddwaf-rb` are merged and released.

**How to test the change?**
CI and manual testing.