### PR TITLE
[NO-TICKET] Migrate from codecov to Datadog Code Coverage product

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        informational: true  # Makes status non-blocking
-    patch:
-      default:
-        informational: true # Makes status non-blocking

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
         run: datadog-ci junit upload --verbose tmp/rspec/
 
   coverage:
-    name: codecov/upload
+    name: dd/coverage
     runs-on: ubuntu-24.04
     needs:
       - ruby-34
@@ -183,36 +183,26 @@ jobs:
       - jruby-93
       - jruby-92
     container:
-      image: ghcr.io/datadog/images-rb/engines/ruby:3.4
+      image: datadog/ci:v3.20.0
+      credentials:
+        username: "${{ secrets.DOCKERHUB_USERNAME }}"
+        password: "${{ secrets.DOCKERHUB_TOKEN }}"
+      env:
+        DD_API_KEY: "${{ secrets.DD_API_KEY }}"
+        DD_ENV: ci
+        DATADOG_SITE: datadoghq.com
+        DD_SERVICE: dd-trace-rb
+        DD_GIT_REPOSITORY_URL: "${{ github.repositoryUrl }}"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - name: Download lockfile
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: ${{ needs.ruby-34.outputs.lockfile }}
-      - name: Restore cache
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        id: restore-cache
-        with:
-          key: ${{ needs.ruby-34.outputs.cache-key }}
-          path: "/usr/local/bundle"
-      - run: bundle check || bundle install
+      - run: mkdir -p tmp/coverage && datadog-ci version
       - name: Download all coverage data
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: coverage
+          path: tmp/coverage
           pattern: coverage-*
           merge-multiple: true
-      - name: Generate coverage report
-        run: bundle exec rake coverage:report
-      - name: Upload coverage report
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
-        with:
-          files: coverage/report/coverage.xml
-          # Uncomment the following line to enable verbose output for debugging
-          # verbose: true
+      - name: Upload coverage reports to Datadog
+        run: datadog-ci coverage upload --verbose tmp/coverage/
 
   complete:
     name: Unit Tests (complete)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Datadog Trace Client
 
 [![Gem](https://img.shields.io/gem/v/datadog)](https://rubygems.org/gems/datadog/)
-[![codecov](https://codecov.io/gh/DataDog/dd-trace-rb/branch/master/graph/badge.svg)](https://app.codecov.io/gh/DataDog/dd-trace-rb/branch/master)
 [![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)][api docs]
 
 ``datadog`` is Datadog's client library for Ruby. It includes a suite of tools which provide visibility into the performance and security of Ruby applications, to enable Ruby developers to identify bottlenecks and other issues.

--- a/Rakefile
+++ b/Rakefile
@@ -441,15 +441,7 @@ namespace :coverage do
 
     SimpleCov.collate resultset_files do
       coverage_dir "#{ENV.fetch('COVERAGE_DIR', 'coverage')}/report"
-      if ENV['CI'] == 'true'
-        require 'simplecov-cobertura'
-        formatter SimpleCov::Formatter::MultiFormatter.new(
-          [SimpleCov::Formatter::HTMLFormatter,
-           SimpleCov::Formatter::CoberturaFormatter] # Used by codecov
-        )
-      else
-        formatter SimpleCov::Formatter::HTMLFormatter
-      end
+      formatter SimpleCov::Formatter::HTMLFormatter
     end
   end
 

--- a/jruby-9.2.gemfile
+++ b/jruby-9.2.gemfile
@@ -27,7 +27,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/jruby-9.3.gemfile
+++ b/jruby-9.3.gemfile
@@ -27,7 +27,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/jruby-9.4.gemfile
+++ b/jruby-9.4.gemfile
@@ -27,7 +27,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-2.5.gemfile
+++ b/ruby-2.5.gemfile
@@ -35,7 +35,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-2.6.gemfile
+++ b/ruby-2.6.gemfile
@@ -35,7 +35,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-2.7.gemfile
+++ b/ruby-2.7.gemfile
@@ -35,7 +35,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-3.0.gemfile
+++ b/ruby-3.0.gemfile
@@ -34,7 +34,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-3.1.gemfile
+++ b/ruby-3.1.gemfile
@@ -38,7 +38,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-3.2.gemfile
+++ b/ruby-3.2.gemfile
@@ -37,7 +37,6 @@ gem 'rspec-collection_matchers', '~> 1.1'
 gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-3.3.gemfile
+++ b/ruby-3.3.gemfile
@@ -37,7 +37,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/ruby-3.4.gemfile
+++ b/ruby-3.4.gemfile
@@ -41,7 +41,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'
 gem 'webrick', '>= 1.8.2'

--- a/ruby-3.5.gemfile
+++ b/ruby-3.5.gemfile
@@ -41,7 +41,6 @@ gem 'rspec-wait', '~> 0'
 gem 'rspec_junit_formatter', '>= 0.5.1'
 
 gem 'simplecov', '~> 0.22.0'
-gem 'simplecov-cobertura', '~> 2.1.0' # Used by codecov
 
 gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
 gem 'webmock', '>= 3.10.0'

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'gem release process' do
            |\.rubocop_todo.yml
            |\.semgrepignore
            |\.simplecov
-           |\.codecov.yml
            |\.yardopts
            |\.yamllint.yml
            |ext/\.gitignore


### PR DESCRIPTION
**What does this PR do?**
Migrates to Datadog Code Coverage from Codecov:
- removes codecov action
- uploads simplecov coverage reports to Datadog with `datadog-ci` command line tool
- removes simplecov-cobertura gem (it was used only for codecov)

**Motivation:**
Better code coverage product for better developer experience

**Change log entry**
N/A

**How to test the change?**
We shall see the coverage in Datadog