### PR TITLE
Dynamic Instrumentation: fix gsub usage in evaluate_template

### DIFF
--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -195,7 +195,7 @@ module Datadog
       def evaluate_template(template, **vars)
         message = template.dup
         vars.each do |key, value|
-          message.gsub!("{@#{key}}", value.to_s)
+          message.gsub!("{@#{key}}") { value.to_s }
         end
         message
       end

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -326,4 +326,23 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       end
     end
   end
+
+  describe '#evaluate_template' do
+    context 'when there are variables to be substituted' do
+      let(:template) { "{@hello} {@world}" }
+      let(:vars) do
+        {
+          'hello' => 'test',
+          # We need double backslash to check for proper sub/gsub usage.
+          'world' => "\"'\\\\a\#{value}",
+        }
+      end
+
+      let(:expected) { "test \"'\\\\a\#{value}" }
+
+      it 'substitutes correctly' do
+        expect(builder.send(:evaluate_template, template, **vars)).to eq(expected)
+      end
+    end
+  end
 end

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -332,9 +332,9 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       let(:template) { "{@hello} {@world}" }
       let(:vars) do
         {
-          'hello' => 'test',
+          hello: 'test',
           # We need double backslash to check for proper sub/gsub usage.
-          'world' => "\"'\\\\a\#{value}",
+          world: "\"'\\\\a\#{value}",
         }
       end
 

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
         }
       end
 
-      let(:expected) { "test \"'\\\\a\#{value}" }
+      let(:expected) { %(test "'\\\\a\#{value}) }
 
       it 'substitutes correctly' do
         expect(builder.send(:evaluate_template, template, **vars)).to eq(expected)

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
         {
           hello: 'test',
           # We need double backslash to check for proper sub/gsub usage.
-          world: "\"'\\\\a\#{value}",
+          world: %("'\\\\a\#{value}),
         }
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes `gsub` usage to block form from string second argument, which performs unwanted interpolation.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
`gsub` with string arguments still runs them through the regular expression engine and interpolates backslashes and some special characters in the replacement string. The desired behavior was a simple string replacement.

**Change log entry**
Yes: DI: fix incorrect template expression evaluation in some cases
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->
The existing code did not grant access to anything that shouldn't have been accessible (i.e. the #{} syntax). It would replace double backslashes with single backslashes, escapes like `\n` with the corresponding literals like the newline, and include parts of the string into the string via `\\``. 

Additionally, the UI does not currently permit actually specifying message templates for customers.

**How to test the change?**
Unit tests added
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
