### PR TITLE
DI: add exception serialization tests

### DIFF
--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -105,20 +105,26 @@ RSpec.describe Datadog::DI::Serializer do
       # the lack of serialization of their messages (because we cannot do
       # so safely - guaranteeing not to invoke customer code).
       {name: 'Exception instance', input: IOError.new('test error'),
-      expected: {type: 'IOError', fields: {}}},
+       expected: {type: 'IOError', fields: {}}},
       {name: 'Exception instance with a field', input: DISerializerExceptionWithFieldsTestClass.new('test error'),
-      expected: {type: 'DISerializerExceptionWithFieldsTestClass', fields: {
-        '@test_field': {
-          value: 'bar', type: 'String'}}}},
+       expected: {type: 'DISerializerExceptionWithFieldsTestClass', fields: {
+         "@test_field": {
+           value: 'bar', type: 'String'
+         }
+       }}},
       {name: 'Exception instance with @message field', input: DISerializerExceptionWithMessageFieldTestClass.new('test error'),
-      expected: {type: 'DISerializerExceptionWithMessageFieldTestClass', fields: {
-        '@message': {
-          value: 'bar', type: 'String'}}}},
+       expected: {type: 'DISerializerExceptionWithMessageFieldTestClass', fields: {
+         "@message": {
+           value: 'bar', type: 'String'
+         }
+       }}},
       {name: 'Custom exception instance which raises in #message', input: DISerializerExceptionWithMessageRaiseTestClass.new('test error'),
-      expected: {type: 'DISerializerExceptionWithMessageRaiseTestClass', fields: {
-        # Fields are still serialized.
-        '@message': {
-          value: 'bar', type: 'String'}}}},
+       expected: {type: 'DISerializerExceptionWithMessageRaiseTestClass', fields: {
+         # Fields are still serialized.
+         "@message": {
+           value: 'bar', type: 'String'
+         }
+       }}},
     ]
 
     define_serialize_value_cases(cases)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Datadog::DI::Serializer do
       {name: 'DateTime value', input: DateTime.new(2020, 1, 2, 3, 4, 5),
        expected: {type: 'DateTime', value: '2020-01-02T03:04:05+00:00'}},
 
-      # Exception classes do not have a dedicated serialier, but document
+      # Exception classes do not have a dedicated serializer, but document
       # the lack of serialization of their messages (because we cannot do
       # so safely - guaranteeing not to invoke customer code).
       {name: 'Exception instance', input: IOError.new('test error'),

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -30,7 +30,32 @@ end
 # Should have no instance variables
 class DISerializerSpecTestClass; end
 
-class DISerializerCustomExceptionTestClass; end
+class DISerializerCustomExceptionTestClass < StandardError; end
+
+class DISerializerExceptionWithFieldsTestClass < StandardError
+  def initialize(message)
+    super
+    @test_field = 'bar'
+  end
+end
+
+class DISerializerExceptionWithMessageFieldTestClass < StandardError
+  def initialize(message)
+    super
+    @message = 'bar'
+  end
+end
+
+class DISerializerExceptionWithMessageRaiseTestClass < StandardError
+  def initialize(message)
+    super
+    @message = 'bar'
+  end
+
+  def message
+    raise 'uh oh'
+  end
+end
 
 RSpec.describe Datadog::DI::Serializer do
   di_test
@@ -75,6 +100,25 @@ RSpec.describe Datadog::DI::Serializer do
        expected: {type: 'Date', value: '2020-01-02'}},
       {name: 'DateTime value', input: DateTime.new(2020, 1, 2, 3, 4, 5),
        expected: {type: 'DateTime', value: '2020-01-02T03:04:05+00:00'}},
+
+      # Exception classes do not have a dedicated serialier, but document
+      # the lack of serialization of their messages (because we cannot do
+      # so safely - guaranteeing not to invoke customer code).
+      {name: 'Exception instance', input: IOError.new('test error'),
+      expected: {type: 'IOError', fields: {}}},
+      {name: 'Exception instance with a field', input: DISerializerExceptionWithFieldsTestClass.new('test error'),
+      expected: {type: 'DISerializerExceptionWithFieldsTestClass', fields: {
+        '@test_field': {
+          value: 'bar', type: 'String'}}}},
+      {name: 'Exception instance with @message field', input: DISerializerExceptionWithMessageFieldTestClass.new('test error'),
+      expected: {type: 'DISerializerExceptionWithMessageFieldTestClass', fields: {
+        '@message': {
+          value: 'bar', type: 'String'}}}},
+      {name: 'Custom exception instance which raises in #message', input: DISerializerExceptionWithMessageRaiseTestClass.new('test error'),
+      expected: {type: 'DISerializerExceptionWithMessageRaiseTestClass', fields: {
+        # Fields are still serialized.
+        '@message': {
+          value: 'bar', type: 'String'}}}},
     ]
 
     define_serialize_value_cases(cases)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds unit tests for serializing exception classes.

**Motivation:**
Exception capture would include the exceptions into dynamic instrumentation payloads, yet there was no existing test coverage for how they would be serialized.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
For safety reasons we do NOT serialize exception messages - I don't see how to do so while guaranteeing that we do not call customer code. It is expected that custom exceptions may have their `message` method overwritten.

Unfortunately this means only the exception class would be available in dynamic instrumentation along with any instance variables set by the custom exception classes.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
