### PR TITLE
add note about RC

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2082,7 +2082,10 @@ client.query("SELECT * FROM users WHERE group='x'")
 To change the default behavior of `datadog`, you can use, in order of priority, with 1 being the highest:
 
 1. [Remote Configuration](https://docs.datadoghq.com/agent/remote_config).
-2. Options set inside a `Datadog.configure` block, e.g.:
+
+   **Note**: By default, Remote Configuration is enabled. To disable it, set `DD_REMOTE_CONFIGURATION_ENABLED=false` or use `Datadog.configure { |c| c.remote.enabled = false }`. 
+
+1. Options set inside a `Datadog.configure` block, e.g.:
 
    ```ruby
    Datadog.configure do |c|
@@ -2093,7 +2096,7 @@ To change the default behavior of `datadog`, you can use, in order of priority, 
    end
    ```
 
-3. Environment variables.
+1. Environment variables.
 
 **If a higher priority value is set for an option, setting that option with a lower priority value will not change its effective value.**
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
https://datadoghq.atlassian.net/browse/DOCS-7320

Someone noted that we have this documented in the release note in ruby tracer v1.11.0, and request it be added to public docs:
> To opt out of Remote Configuration, it can be done via either the environment variable DD_REMOTE_CONFIGURATION_ENABLED=false or Datadog.configure { |c| c.remote.enabled = false }.


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
