### PR TITLE
DI: Fix line instrumentation when target line raises an exception

### DIFF
--- a/lib/datadog/di/probe.rb
+++ b/lib/datadog/di/probe.rb
@@ -190,6 +190,15 @@ module Datadog
       def emitting_notified?
         !!@emitting_notified
       end
+
+      def executed_on_line?
+        !!@executed_on_line
+      end
+
+      def executed_on_line!
+        # TODO lock?
+        @executed_on_line = true
+      end
     end
   end
 end

--- a/sig/datadog/di/probe.rbs
+++ b/sig/datadog/di/probe.rbs
@@ -20,6 +20,8 @@ module Datadog
       @capture_snapshot: bool
 
       @rate_limiter: Datadog::Core::RateLimiter
+      
+      @executed_on_line: bool?
 
       def initialize: (id: String, type: Symbol, ?file: String?, ?line_no: Integer?, ?type_name: String?, ?method_name: String?, ?template: String?, ?capture_snapshot: bool,
 	?max_capture_depth: Integer, ?max_capture_attribute_count: Integer?, ?rate_limit: Integer) -> void
@@ -51,6 +53,9 @@ module Datadog
       def line_no!: () -> Integer
       def location: () -> ::String
       def file_matches?: (String path) -> bool
+      
+      def executed_on_line!: -> void
+      def executed_on_line?: -> bool
       
       attr_accessor instrumentation_module: Module?
       attr_accessor instrumentation_trace_point: TracePoint?

--- a/spec/datadog/di/hook_line_load.rb
+++ b/spec/datadog/di/hook_line_load.rb
@@ -30,7 +30,7 @@ class HookLineIvarLoadTestClass
   def test_exception
     local = 42
     raise TestException, 'Intentional exception'       # Line 32
-    local               # Line 33
+    local               # Line 33 # standard:ignore Lint/UnreachableCode
   end
 end
 

--- a/spec/datadog/di/hook_line_load.rb
+++ b/spec/datadog/di/hook_line_load.rb
@@ -30,7 +30,7 @@ class HookLineIvarLoadTestClass
   def test_exception
     local = 42
     raise TestException, 'Intentional exception'       # Line 32
-    local               # Line 33 # standard:ignore Lint/UnreachableCode
+    local               # Line 33 # standard:disable Lint/UnreachableCode
   end
 end
 

--- a/spec/datadog/di/hook_line_load.rb
+++ b/spec/datadog/di/hook_line_load.rb
@@ -1,9 +1,9 @@
 # Comment line - not executable
 
 class HookLineLoadTestClass
-  def test_method       # Line 2
-    42                  # Line 3
-  end
+  def test_method       # Line 4
+    42                  # Line 5
+  end                   # Line 6
 
   def test_method_with_local
     local = 42 # standard:disable Style/RedundantAssignment
@@ -16,6 +16,9 @@ class HookLineLoadTestClass
 end
 
 class HookLineIvarLoadTestClass
+  class TestException < StandardError
+  end
+
   def initialize
     @ivar = 42
   end
@@ -23,8 +26,14 @@ class HookLineIvarLoadTestClass
   def test_method
     1337                 # Line 24
   end
+
+  def test_exception
+    local = 42
+    raise TestException, 'Intentional exception'       # Line 32
+    local               # Line 33
+  end
 end
 
-unless (actual = File.read(__FILE__).count("\n")) == 30
-  raise "Wrong number of lines in hook_line_load.rb: actual #{actual}, expected 30"
+unless (actual = File.read(__FILE__).count("\n")) == 39
+  raise "Wrong number of lines in hook_line_load.rb: actual #{actual}, expected 39"
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Makes it so that when an exception is raised on a line which is instrumented via  a line probe, line execution is only reported once.


**Motivation:**
<!-- What inspired you to submit this pull request? -->

To permit instrumenting `end` lines of methods, DI installs trace points for `line` and `end` events. I learned that when a line raises an exception, this causes the trace point to be invoked twice: one time before the line executes with the `line` event, and again after the exception is raised with the `end` event (since technically the method exits - prematurely - due to the exception).

This PR adds a flag to probe to track whether a line trace point has already been invoked with a `line` event. If this happened, we would ignore a subsequent invocation with a different event type (such as `end`).

**Change log entry**
Yes: correctly produce a single log event when line probe is instrumenting a line that raises an exception
<!-- If this is a customer-visible change, a brief summary to be placed
into the change log.
If you are not a Datadog employee, you can skip this section
and it will be filled or deleted during PR review. -->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Tests are added
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
