### PR TITLE
DI: rename test exception method to exception_method

### DIFF
--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -54,7 +54,7 @@ class HookTestClass
     [arg, options]
   end
 
-  def exception
+  def exception_method
     raise TestException, 'Test exception'
   end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -709,7 +709,7 @@ RSpec.describe Datadog::DI::Instrumenter do
 
     context 'when target method raises an exception' do
       let(:probe_args) do
-        {type_name: 'HookTestClass', method_name: 'exception'}
+        {type_name: 'HookTestClass', method_name: 'exception_method'}
       end
 
       it 'invokes callback' do
@@ -718,7 +718,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         expect do
-          HookTestClass.new.exception
+          HookTestClass.new.exception_method
         end.to raise_error(HookTestClass::TestException)
 
         expect(observed_calls.length).to eq 1


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Renames a method called `exception` in the test suite to `exception_method`.

**Motivation:**
The previous name was confusing when it was mentioned in e.g. trace point inspection.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
