### PR TITLE
Update CODEOWNERS (rename apm-sdk-api to apm-sdk-capabilities)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,10 @@ docs/GettingStarted.md @DataDog/documentation
 # Library
 lib/datadog/appsec/ @DataDog/asm-ruby
 lib/datadog/appsec.rb @DataDog/asm-ruby
-lib/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-lib/datadog/tracing.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-lib/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
-lib/datadog/opentelemetry.rb @DataDog/apm-sdk-api-ruby
+lib/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+lib/datadog/tracing.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+lib/datadog/opentelemetry/ @DataDog/apm-sdk-capabilities-ruby
+lib/datadog/opentelemetry.rb @DataDog/apm-sdk-capabilities-ruby
 lib-injection/ @DataDog/lang-platform-ruby
 lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
@@ -19,18 +19,18 @@ ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 # RBS signatures
 sig/datadog/appsec/ @DataDog/asm-ruby
 sig/datadog/appsec.rbs @DataDog/asm-ruby
-sig/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-sig/datadog/tracing.rbs @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-sig/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
-sig/datadog/opentelemetry.rbs @DataDog/apm-sdk-api-ruby
+sig/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+sig/datadog/tracing.rbs @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+sig/datadog/opentelemetry/ @DataDog/apm-sdk-capabilities-ruby
+sig/datadog/opentelemetry.rbs @DataDog/apm-sdk-capabilities-ruby
 sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 
 # Specs
 spec/datadog/appsec/ @DataDog/asm-ruby
-spec/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-spec/datadog/tracing_spec.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-api-ruby
-spec/datadog/opentelemetry/ @DataDog/apm-sdk-api-ruby
-spec/datadog/opentelemetry_spec.rb @DataDog/apm-sdk-api-ruby
+spec/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+spec/datadog/tracing_spec.rb @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
+spec/datadog/opentelemetry/ @DataDog/apm-sdk-capabilities-ruby
+spec/datadog/opentelemetry_spec.rb @DataDog/apm-sdk-capabilities-ruby
 spec/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 spec/datadog/profiling_spec.rb @DataDog/profiling-rb @DataDog/ruby-guild


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Team name changed from API to Capabilities a while ago - this change is required to reflect this in Github teams

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
