### PR TITLE
move DD log correlation patch for Active Job to wrap full execution

### DIFF
--- a/lib/datadog/tracing/contrib/active_job/log_injection.rb
+++ b/lib/datadog/tracing/contrib/active_job/log_injection.rb
@@ -6,15 +6,11 @@ module Datadog
       module ActiveJob
         # Active Job log injection wrapped around job execution
         module LogInjection
-          def self.included(base)
-            base.class_eval do
-              around_perform do |_, block|
-                if Datadog.configuration.tracing.log_injection && logger.respond_to?(:tagged)
-                  logger.tagged(Tracing.log_correlation, &block)
-                else
-                  block.call
-                end
-              end
+          def perform_now
+            if Datadog.configuration.tracing.log_injection && logger.respond_to?(:tagged)
+              logger.tagged(Tracing.log_correlation) { super }
+            else
+              super
             end
           end
         end


### PR DESCRIPTION
**What does this PR do?**
Instead of using `around_perform`, we now do the same thing that [Active Job itself](https://github.com/rails/rails/blob/v8.0.3/activejob/lib/active_job/logging.rb#L31-L33) does to tag logs with `[ActiveJob]`, the job class name, and job ID, which is wrapping `perform_now`.

**Motivation:**
The current Active Job integration injects a log correlation tag into the logger via `around_perform`, which is too late to pick up the following logs:

```
[ActiveJob] [FooJob] [540c4718-6668-4f3c-9411-ca52a4cffd15] Performing FooJob (Job ID: 540c4718-6668-4f3c-9411-ca52a4cffd15) from Sidekiq(default) enqueued at 2025-09-26T02:17:44.160363327Z with arguments: #<GlobalID:0x00007f0fae88cb50 @uri=#<URI::GID gid://foo-rails/Foo/019983cf-8422-72d5-85b7-f3dc09a4887e>>
[ActiveJob] [FooJob] [540c4718-6668-4f3c-9411-ca52a4cffd15] Performed FooJob (Job ID: 540c4718-6668-4f3c-9411-ca52a4cffd15) from Sidekiq(default) in 990.29ms
```

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
I looked for an existing test to exercise this, but was unable to find one, and didn't see any tests specifically related to Active Job itself.