### PR TITLE
Update bundler in lockfiles

### DIFF
--- a/gemfiles/ruby_2.6_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_activesupport.gemfile.lock
@@ -236,4 +236,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_aws.gemfile.lock
+++ b/gemfiles/ruby_2.6_aws.gemfile.lock
@@ -1542,4 +1542,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_contrib_old.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.6_core_old.gemfile.lock
@@ -113,4 +113,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_2.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_dalli_latest.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_latest.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_devise_min.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_7.gemfile.lock
@@ -133,4 +133,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_elasticsearch_latest.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_excon_latest.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_latest.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_faraday_min.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_1.13.gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.6_graphql_2.0.gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_hanami_1.gemfile.lock
@@ -214,4 +214,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_http.gemfile.lock
+++ b/gemfiles/ruby_2.6_http.gemfile.lock
@@ -141,4 +141,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_karafka_min.gemfile.lock
@@ -139,4 +139,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_latest.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_mongo_min.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_2.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_opensearch_latest.gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry.gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.6_opentelemetry_otlp.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_1.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_2.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rack_latest.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_mysql2.gemfile.lock
@@ -243,4 +243,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres.gemfile.lock
@@ -243,4 +243,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis.gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_redis_activesupport.gemfile.lock
@@ -263,4 +263,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_postgres_sidekiq.gemfile.lock
@@ -251,4 +251,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails5_semantic_logger.gemfile.lock
@@ -242,4 +242,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_mysql2.gemfile.lock
@@ -262,4 +262,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres.gemfile.lock
@@ -262,4 +262,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_redis.gemfile.lock
@@ -264,4 +264,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_postgres_sidekiq.gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails61_semantic_logger.gemfile.lock
@@ -261,4 +261,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_mysql2.gemfile.lock
@@ -259,4 +259,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres.gemfile.lock
@@ -259,4 +259,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis.gemfile.lock
@@ -261,4 +261,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_redis_activesupport.gemfile.lock
@@ -279,4 +279,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_postgres_sidekiq.gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails6_semantic_logger.gemfile.lock
@@ -258,4 +258,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.6_rails_old_redis.gemfile.lock
@@ -270,4 +270,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_3.gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_4.gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_redis_latest.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.6_relational_db.gemfile.lock
@@ -152,4 +152,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis3.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.6_resque2_redis4.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_rest_client_latest.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_2.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.6_sinatra_3.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_10.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_11.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_12.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_7.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_8.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_9.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_latest.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.6_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.6_stripe_min.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport.gemfile.lock
@@ -232,4 +232,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_aws.gemfile.lock
+++ b/gemfiles/ruby_2.7_aws.gemfile.lock
@@ -1542,4 +1542,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_contrib.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib.gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_contrib_old.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_core_old.gemfile.lock
+++ b/gemfiles/ruby_2.7_core_old.gemfile.lock
@@ -113,4 +113,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_2.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_dalli_latest.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_latest.gemfile.lock
@@ -222,4 +222,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_devise_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_devise_min.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_7.gemfile.lock
@@ -133,4 +133,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_elasticsearch_latest.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_excon_latest.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_latest.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_faraday_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_faraday_min.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_1.13.gemfile.lock
@@ -268,4 +268,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.0.gemfile.lock
@@ -268,4 +268,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.1.gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.2.gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_2.7_graphql_2.3.gemfile.lock
@@ -270,4 +270,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_hanami_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_hanami_1.gemfile.lock
@@ -216,4 +216,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_http.gemfile.lock
+++ b/gemfiles/ruby_2.7_http.gemfile.lock
@@ -141,4 +141,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_karafka_min.gemfile.lock
@@ -139,4 +139,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_latest.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_mongo_min.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_2.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_opensearch_latest.gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry.gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_2.7_opentelemetry_otlp.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rack_1.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_1.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rack_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_2.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rack_latest.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_mysql2.gemfile.lock
@@ -243,4 +243,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres.gemfile.lock
@@ -243,4 +243,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis.gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_redis_activesupport.gemfile.lock
@@ -263,4 +263,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_postgres_sidekiq.gemfile.lock
@@ -251,4 +251,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails5_semantic_logger.gemfile.lock
@@ -242,4 +242,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_mysql2.gemfile.lock
@@ -262,4 +262,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres.gemfile.lock
@@ -262,4 +262,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_redis.gemfile.lock
@@ -264,4 +264,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_postgres_sidekiq.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails61_semantic_logger.gemfile.lock
@@ -261,4 +261,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_mysql2.gemfile.lock
@@ -260,4 +260,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres.gemfile.lock
@@ -259,4 +259,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis.gemfile.lock
@@ -261,4 +261,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_redis_activesupport.gemfile.lock
@@ -279,4 +279,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_postgres_sidekiq.gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails6_semantic_logger.gemfile.lock
@@ -258,4 +258,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_old_redis.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_redis_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_3.gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_redis_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_4.gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_redis_latest.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_relational_db.gemfile.lock
+++ b/gemfiles/ruby_2.7_relational_db.gemfile.lock
@@ -151,4 +151,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis3.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_2.7_resque2_redis4.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_rest_client_latest.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_2.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_sinatra_3.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_10.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_11.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_12.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_7.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_8.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_9.gemfile.lock
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_latest.gemfile.lock
@@ -116,4 +116,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_2.7_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_2.7_stripe_min.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock (>= 3.10.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.22

--- a/gemfiles/ruby_3.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport.gemfile.lock
@@ -234,4 +234,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_aws.gemfile.lock
+++ b/gemfiles/ruby_3.0_aws.gemfile.lock
@@ -1544,4 +1544,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib.gemfile.lock
@@ -190,4 +190,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_contrib_old.gemfile.lock
@@ -125,4 +125,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.0_core_old.gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_2.gemfile.lock
@@ -151,4 +151,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_dalli_latest.gemfile.lock
@@ -151,4 +151,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_latest.gemfile.lock
@@ -263,4 +263,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_devise_min.gemfile.lock
@@ -222,4 +222,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_7.gemfile.lock
@@ -139,4 +139,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_elasticsearch_latest.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_excon_latest.gemfile.lock
@@ -152,4 +152,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_faraday_latest.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_1.13.gemfile.lock
@@ -270,4 +270,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.0.gemfile.lock
@@ -270,4 +270,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.1.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.2.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.0_graphql_2.3.gemfile.lock
@@ -273,4 +273,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_http.gemfile.lock
+++ b/gemfiles/ruby_3.0_http.gemfile.lock
@@ -143,4 +143,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_latest.gemfile.lock
@@ -173,4 +173,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_karafka_min.gemfile.lock
@@ -165,4 +165,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_latest.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_mongo_min.gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_2.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_opensearch_latest.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry.gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.0_opentelemetry_otlp.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_1.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_2.gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rack_latest.gemfile.lock
@@ -125,4 +125,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_mysql2.gemfile.lock
@@ -265,4 +265,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres.gemfile.lock
@@ -265,4 +265,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_redis.gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_postgres_sidekiq.gemfile.lock
@@ -281,4 +281,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_semantic_logger.gemfile.lock
@@ -264,4 +264,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails61_trilogy.gemfile.lock
@@ -273,4 +273,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails7.gemfile.lock
@@ -258,4 +258,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails71.gemfile.lock
@@ -288,4 +288,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_old_redis.gemfile.lock
@@ -312,4 +312,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_3.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_4.gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_redis_latest.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.0_relational_db.gemfile.lock
@@ -154,4 +154,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis3.gemfile.lock
@@ -139,4 +139,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.0_resque2_redis4.gemfile.lock
@@ -143,4 +143,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_rest_client_latest.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_2.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_3.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_sinatra_4.gemfile.lock
@@ -151,4 +151,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_10.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_11.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_12.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_7.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_8.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_9.gemfile.lock
@@ -121,4 +121,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_latest.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.0_stripe_min.gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.5.23

--- a/gemfiles/ruby_3.1_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport.gemfile.lock
@@ -255,4 +255,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_aws.gemfile.lock
+++ b/gemfiles/ruby_3.1_aws.gemfile.lock
@@ -1565,4 +1565,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib.gemfile.lock
@@ -211,4 +211,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_contrib_old.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.1_core_old.gemfile.lock
@@ -136,4 +136,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_2.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_dalli_latest.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_latest.gemfile.lock
@@ -264,4 +264,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_devise_min.gemfile.lock
@@ -240,4 +240,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_7.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_elasticsearch_latest.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_excon_latest.gemfile.lock
@@ -173,4 +173,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_faraday_latest.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_1.13.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.0.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.1.gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.2.gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.1_graphql_2.3.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_http.gemfile.lock
+++ b/gemfiles/ruby_3.1_http.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_latest.gemfile.lock
@@ -207,4 +207,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_karafka_min.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_mongo_min.gemfile.lock
@@ -174,4 +174,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_2.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_opensearch_latest.gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp.gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_opentelemetry_otlp_1_5.gemfile.lock
@@ -194,4 +194,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_1.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_2.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rack_latest.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_mysql2.gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres.gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_redis.gemfile.lock
@@ -287,4 +287,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_postgres_sidekiq.gemfile.lock
@@ -301,4 +301,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_semantic_logger.gemfile.lock
@@ -284,4 +284,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails61_trilogy.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails7.gemfile.lock
@@ -278,4 +278,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails71.gemfile.lock
@@ -292,4 +292,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_old_redis.gemfile.lock
@@ -329,4 +329,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_3.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_4.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_redis_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.1_relational_db.gemfile.lock
@@ -175,4 +175,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis3.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.1_resque2_redis4.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_rest_client_latest.gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_2.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_3.gemfile.lock
@@ -169,4 +169,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_sinatra_4.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_10.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_11.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_12.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_7.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_8.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_9.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_latest.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.1_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.1_stripe_min.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.6.9

--- a/gemfiles/ruby_3.2_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport.gemfile.lock
@@ -255,4 +255,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_aws.gemfile.lock
+++ b/gemfiles/ruby_3.2_aws.gemfile.lock
@@ -1565,4 +1565,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib.gemfile.lock
@@ -211,4 +211,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_contrib_old.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.2_core_old.gemfile.lock
@@ -136,4 +136,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_2.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_dalli_latest.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_latest.gemfile.lock
@@ -265,4 +265,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_devise_min.gemfile.lock
@@ -240,4 +240,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_7.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_elasticsearch_latest.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_excon_latest.gemfile.lock
@@ -173,4 +173,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_faraday_latest.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_1.13.gemfile.lock
@@ -288,4 +288,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.0.gemfile.lock
@@ -288,4 +288,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.1.gemfile.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.2.gemfile.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.2_graphql_2.3.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_http.gemfile.lock
+++ b/gemfiles/ruby_3.2_http.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_latest.gemfile.lock
@@ -207,4 +207,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_karafka_min.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_mongo_min.gemfile.lock
@@ -174,4 +174,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_2.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_opensearch_latest.gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry.gemfile.lock
@@ -149,4 +149,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp.gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_opentelemetry_otlp_1_5.gemfile.lock
@@ -194,4 +194,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rack_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_1.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_2.gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rack_latest.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_mysql2.gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres.gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_redis.gemfile.lock
@@ -287,4 +287,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_postgres_sidekiq.gemfile.lock
@@ -301,4 +301,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_semantic_logger.gemfile.lock
@@ -284,4 +284,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails61_trilogy.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails7.gemfile.lock
@@ -278,4 +278,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails71.gemfile.lock
@@ -292,4 +292,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8.gemfile.lock
@@ -334,4 +334,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_mysql2.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_redis.gemfile.lock
@@ -345,4 +345,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_postgres_sidekiq.gemfile.lock
@@ -359,4 +359,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_semantic_logger.gemfile.lock
@@ -342,4 +342,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails8_trilogy.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_old_redis.gemfile.lock
@@ -329,4 +329,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_3.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_4.gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_redis_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.2_relational_db.gemfile.lock
@@ -175,4 +175,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis3.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.2_resque2_redis4.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_rest_client_latest.gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_2.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_3.gemfile.lock
@@ -169,4 +169,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_sinatra_4.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_10.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_11.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_12.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_7.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_8.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_9.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_latest.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.2_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.2_stripe_min.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport.gemfile.lock
@@ -254,4 +254,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_aws.gemfile.lock
+++ b/gemfiles/ruby_3.3_aws.gemfile.lock
@@ -1564,4 +1564,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib.gemfile.lock
@@ -212,4 +212,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_contrib_old.gemfile.lock
@@ -145,4 +145,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.3_core_old.gemfile.lock
@@ -135,4 +135,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_2.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_dalli_latest.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_latest.gemfile.lock
@@ -265,4 +265,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_devise_min.gemfile.lock
@@ -240,4 +240,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_7.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_elasticsearch_latest.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_excon_latest.gemfile.lock
@@ -173,4 +173,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_faraday_latest.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_1.13.gemfile.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.0.gemfile.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.1.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.2.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.3_graphql_2.3.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_http.gemfile.lock
+++ b/gemfiles/ruby_3.3_http.gemfile.lock
@@ -163,4 +163,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_latest.gemfile.lock
@@ -207,4 +207,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_karafka_min.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_mongo_min.gemfile.lock
@@ -174,4 +174,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_2.gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_opensearch_latest.gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp.gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_opentelemetry_otlp_1_5.gemfile.lock
@@ -194,4 +194,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_2.gemfile.lock
@@ -143,4 +143,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rack_latest.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_mysql2.gemfile.lock
@@ -293,4 +293,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres.gemfile.lock
@@ -286,4 +286,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_redis.gemfile.lock
@@ -288,4 +288,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_postgres_sidekiq.gemfile.lock
@@ -302,4 +302,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_semantic_logger.gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails61_trilogy.gemfile.lock
@@ -292,4 +292,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails7.gemfile.lock
@@ -278,4 +278,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails71.gemfile.lock
@@ -292,4 +292,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8.gemfile.lock
@@ -334,4 +334,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_mysql2.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_redis.gemfile.lock
@@ -345,4 +345,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_postgres_sidekiq.gemfile.lock
@@ -359,4 +359,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_semantic_logger.gemfile.lock
@@ -342,4 +342,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails8_trilogy.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails_app.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_app.gemfile.lock
@@ -354,4 +354,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_old_redis.gemfile.lock
@@ -329,4 +329,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_3.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_4.gemfile.lock
@@ -137,4 +137,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_redis_latest.gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.3_relational_db.gemfile.lock
@@ -175,4 +175,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis3.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.3_resque2_redis4.gemfile.lock
@@ -163,4 +163,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_rest_client_latest.gemfile.lock
@@ -154,4 +154,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_2.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_3.gemfile.lock
@@ -169,4 +169,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_sinatra_4.gemfile.lock
@@ -172,4 +172,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_10.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_11.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_12.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_7.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_8.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_9.gemfile.lock
@@ -142,4 +142,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_latest.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.3_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.3_stripe_min.gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_activesupport.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport.gemfile.lock
@@ -272,4 +272,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_aws.gemfile.lock
+++ b/gemfiles/ruby_3.4_aws.gemfile.lock
@@ -1702,4 +1702,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_contrib.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib.gemfile.lock
@@ -222,4 +222,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_contrib_old.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_core_old.gemfile.lock
+++ b/gemfiles/ruby_3.4_core_old.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_2.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_dalli_latest.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_latest.gemfile.lock
@@ -234,4 +234,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_devise_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_devise_min.gemfile.lock
@@ -221,4 +221,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_7.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_elasticsearch_latest.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_excon_latest.gemfile.lock
@@ -147,4 +147,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_faraday_latest.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_1.13.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.0.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.1.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.2.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_3.4_graphql_2.3.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_http.gemfile.lock
+++ b/gemfiles/ruby_3.4_http.gemfile.lock
@@ -171,4 +171,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_latest.gemfile.lock
@@ -179,4 +179,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_karafka_min.gemfile.lock
@@ -169,4 +169,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_latest.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_mongo_min.gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_2.gemfile.lock
@@ -166,4 +166,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_opensearch_latest.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp.gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_opentelemetry_otlp_1_5.gemfile.lock
@@ -177,4 +177,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rack_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_2.gemfile.lock
@@ -154,4 +154,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rack_latest.gemfile.lock
@@ -152,4 +152,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_mysql2.gemfile.lock
@@ -302,4 +302,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres.gemfile.lock
@@ -297,4 +297,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_redis.gemfile.lock
@@ -299,4 +299,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_postgres_sidekiq.gemfile.lock
@@ -313,4 +313,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_semantic_logger.gemfile.lock
@@ -296,4 +296,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails61_trilogy.gemfile.lock
@@ -301,4 +301,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails7.gemfile.lock
@@ -283,4 +283,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails71.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails71.gemfile.lock
@@ -295,4 +295,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8.gemfile.lock
@@ -314,4 +314,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_mysql2.gemfile.lock
@@ -323,4 +323,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres.gemfile.lock
@@ -323,4 +323,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_redis.gemfile.lock
@@ -325,4 +325,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_postgres_sidekiq.gemfile.lock
@@ -340,4 +340,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_semantic_logger.gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails8_trilogy.gemfile.lock
@@ -325,4 +325,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_old_redis.gemfile.lock
@@ -308,4 +308,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_redis_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_3.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_redis_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_4.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_redis_latest.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_relational_db.gemfile.lock
+++ b/gemfiles/ruby_3.4_relational_db.gemfile.lock
@@ -183,4 +183,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis3.gemfile.lock
@@ -174,4 +174,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_3.4_resque2_redis4.gemfile.lock
@@ -178,4 +178,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_rest_client_latest.gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_2.gemfile.lock
@@ -173,4 +173,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_3.gemfile.lock
@@ -174,4 +174,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_sinatra_4.gemfile.lock
@@ -177,4 +177,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_10.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_11.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_12.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_7.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_8.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_9.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_latest.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2

--- a/gemfiles/ruby_3.4_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_3.4_stripe_min.gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   webrick (>= 1.8.2)
 
 BUNDLED WITH
-   2.5.21
+   2.7.2


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Update Bundler in lockfiles.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

`bundler` 2.5 emits warnings on `rubygems` 3.7:

```
     RuntimeError:
       Test script produced unexpected output: /usr/local/bundle/gems/bundler-2.5.21/lib/bundler/rubygems_ext.rb:292: warning: already initialized constant Gem::Platform::JAVA
       /usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:259: warning: previous definition of JAVA was here
       /usr/local/bundle/gems/bundler-2.5.21/lib/bundler/rubygems_ext.rb:293: warning: already initialized constant Gem::Platform::MSWIN
       /usr/local/lib/ruby/site_ruby/3.3.0/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
       ---8<---
       (and so on)
```

Impacts ruby 3.2, 3.3, and 3.4 which are those that got updated to rubygems 3.7 (thus bundler 2.7 alongside) and it looks like bundler 2.5 doesn't quite like it but 2.5 is the one that gets used because of the lockfiles.

Quite likely this change which does account for running bundler on < 3.7 rubygems while this one doesn't account for bundler < 2.7 on rubygems 3.7

I think it's a simple matter of making the 3.2, 3.3, and 3.4 lockfiles use bundler 2.7.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Also updates others to match the ones in the images; not necessary but saves a bit of time and gives us some use of various bundler versions.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI

<!-- Unsure? Have a question? Request a review! -->
