### PR TITLE
Add endpoint collection for Rails routes

### DIFF
--- a/lib/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer.rb
+++ b/lib/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AppSec
+    module APISecurity
+      module EndpointCollection
+        # This module serializes Rails Journey Router routes.
+        class RailsRoutesSerializer
+          FORMAT_SUFFIX = "(.:format)"
+
+          def initialize(routes)
+            @routes = routes
+          end
+
+          def to_enum
+            Enumerator.new do |yielder|
+              @routes.each do |route|
+                next unless route.dispatcher?
+
+                yielder.yield serialize_route(route)
+              end
+            end
+          end
+
+          private
+
+          def serialize_route(route)
+            method = route.verb.empty? ? "*" : route.verb
+            path = route.path.spec.to_s.delete_suffix(FORMAT_SUFFIX)
+
+            {
+              type: "REST",
+              resource_name: "#{method} #{path}",
+              operation_name: "http.request",
+              method: method,
+              path: path
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/configuration/settings.rb
+++ b/lib/datadog/appsec/configuration/settings.rb
@@ -352,6 +352,15 @@ module Datadog
                   o.default true
                 end
 
+                settings :endpoint_collection do
+                  # Enables reporting of application routes at application start via telemetry
+                  option :enabled do |o|
+                    o.type :bool, nilable: true
+                    o.env 'DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED'
+                    o.default false
+                  end
+                end
+
                 # NOTE: Unfortunately, we have to go with Float due to other libs
                 #       setup, even tho we don't plan to support sub-second delays.
                 #

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -134,6 +134,8 @@ module Datadog
           end
 
           def subscribe_to_routes_loaded
+            return unless Datadog.configuration.appsec.api_security.endpoint_collection.enabled
+
             ::ActiveSupport.on_load(:after_routes_loaded) do |app|
               AppSec.telemetry.app_endpoints_loaded(
                 APISecurity::EndpointCollection::RailsRoutesSerializer.new(app.routes.routes).to_enum

--- a/lib/datadog/core/configuration/supported_configurations.rb
+++ b/lib/datadog/core/configuration/supported_configurations.rb
@@ -10,6 +10,7 @@ module Datadog
         {"DD_AGENT_HOST" => {version: ["A"]},
          "DD_API_KEY" => {version: ["A"]},
          "DD_API_SECURITY_ENABLED" => {version: ["A"]},
+         "DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED" => {version: ["A"]},
          "DD_API_SECURITY_REQUEST_SAMPLE_RATE" => {version: ["A"]},
          "DD_API_SECURITY_SAMPLE_DELAY" => {version: ["A"]},
          "DD_APM_TRACING_ENABLED" => {version: ["A"]},

--- a/lib/datadog/core/telemetry/event/message_batch.rb
+++ b/lib/datadog/core/telemetry/event/message_batch.rb
@@ -19,12 +19,6 @@ module Datadog
 
           def payload
             @events.map do |event|
-              if event.type == 'app-endpoints'
-                puts '*****'
-                pp event.payload
-                puts '*****'
-              end
-
               {
                 request_type: event.type,
                 payload: event.payload,

--- a/lib/datadog/core/telemetry/event/message_batch.rb
+++ b/lib/datadog/core/telemetry/event/message_batch.rb
@@ -19,6 +19,12 @@ module Datadog
 
           def payload
             @events.map do |event|
+              if event.type == 'app-endpoints'
+                puts '*****'
+                pp event.payload
+                puts '*****'
+              end
+
               {
                 request_type: event.type,
                 payload: event.payload,

--- a/sig/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer.rbs
+++ b/sig/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer.rbs
@@ -1,0 +1,33 @@
+module Datadog
+  module AppSec
+    module APISecurity
+      module EndpointCollection
+        interface _Route
+          def dispatcher?: () -> bool
+          def verb: () -> String
+          def path: () -> _RoutePath
+        end
+
+        interface _RoutePath
+          def spec: () -> _RouteSpec
+        end
+
+        interface _RouteSpec
+          def to_s: () -> String
+        end
+
+        class RailsRoutesSerializer
+          FORMAT_SUFFIX: String
+
+          @routes: Array[_Route]
+
+          def initialize: (Array[_Route] routes) -> void
+
+          def to_enum: () -> Enumerator[Core::Telemetry::Event::AppEndpointsLoaded::endpoint]
+
+          def serialize_route: (_Route route) -> Core::Telemetry::Event::AppEndpointsLoaded::endpoint
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer_spec.rb
+++ b/spec/datadog/appsec/api_security/endpoint_collection/rails_routes_serializer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/appsec/api_security/endpoint_collection/rails_routes_serializer'
+
+RSpec.describe Datadog::AppSec::APISecurity::EndpointCollection::RailsRoutesSerializer do
+  describe '#to_enum' do
+    it 'returns an Enumerator' do
+      expect(described_class.new([]).to_enum).to be_a(Enumerator)
+    end
+
+    it 'correctly serializes routes' do
+      routes = described_class.new([
+        build_route_double(method: 'GET', path: '/events')
+      ]).to_enum
+
+      expect(routes.count).to eq(1)
+
+      aggregate_failures 'serialized attributes' do
+        expect(routes.first.fetch(:type)).to eq('REST')
+        expect(routes.first.fetch(:resource_name)).to eq('GET /events')
+        expect(routes.first.fetch(:operation_name)).to eq('http.request')
+        expect(routes.first.fetch(:method)).to eq('GET')
+        expect(routes.first.fetch(:path)).to eq('/events')
+      end
+    end
+
+    it 'removes rails format suffix from the path' do
+      routes = described_class.new([
+        build_route_double(method: 'GET', path: '/events(.:format)')
+      ]).to_enum
+
+      aggregate_failures 'path attributes' do
+        expect(routes.first.fetch(:resource_name)).to eq('GET /events')
+        expect(routes.first.fetch(:path)).to eq('/events')
+      end
+    end
+
+    it 'sets method to * for wildcard routes' do
+      routes = described_class.new([
+        build_route_double(method: '*', path: '/')
+      ]).to_enum
+
+      aggregate_failures 'path attributes' do
+        expect(routes.first.fetch(:resource_name)).to eq('* /')
+        expect(routes.first.fetch(:method)).to eq('*')
+      end
+    end
+
+    it 'skips non-dispatcher routes for now' do
+      routes = described_class.new([
+        build_route_double(method: nil, path: 'admin', is_dispatcher: false)
+      ]).to_enum
+
+      expect(routes.to_a).to be_empty
+    end
+  end
+
+  def build_route_double(method:, path:, is_dispatcher: true)
+    instance_double(
+      'ActionDispatch::Journey::Route',
+      dispatcher?: is_dispatcher,
+      verb: method,
+      path: instance_double(
+        'ActionDispatch::Journey::Path::Pattern',
+        spec: path
+      )
+    )
+  end
+end

--- a/spec/datadog/appsec/configuration/settings_spec.rb
+++ b/spec/datadog/appsec/configuration/settings_spec.rb
@@ -1015,6 +1015,44 @@ RSpec.describe Datadog::AppSec::Configuration::Settings do
           end
         end
       end
+
+      describe 'endpoint_collection' do
+        describe '#enabled' do
+          context 'when DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED is undefined' do
+            around do |example|
+              ClimateControl.modify('DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED' => nil) { example.run }
+            end
+
+            it { expect(settings.appsec.api_security.endpoint_collection.enabled).to eq(false) }
+          end
+
+          context 'when DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED is set to true' do
+            around do |example|
+              ClimateControl.modify('DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED' => 'true') { example.run }
+            end
+
+            it { expect(settings.appsec.api_security.endpoint_collection.enabled).to eq(true) }
+          end
+
+          context 'when DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED is set to false' do
+            around do |example|
+              ClimateControl.modify('DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED' => 'false') { example.run }
+            end
+
+            it { expect(settings.appsec.api_security.endpoint_collection.enabled).to eq(false) }
+          end
+        end
+
+        describe '#enabled=' do
+          [true, false].each do |value|
+            context "when given #{value}" do
+              before { settings.appsec.api_security.endpoint_collection.enabled = value }
+
+              it { expect(settings.appsec.api_security.endpoint_collection.enabled).to eq(value) }
+            end
+          end
+        end
+      end
     end
 
     describe 'sca' do

--- a/spec/datadog/appsec/integration/contrib/rails/endpoint_collection_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/rails/endpoint_collection_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'datadog/tracing/contrib/support/spec_helper'
+require 'datadog/appsec/spec_helper'
+require 'rack/test'
+
+require 'action_controller/railtie'
+require 'datadog/tracing'
+require 'datadog/appsec'
+
+RSpec.describe 'Rails Endpoint Collection' do
+  include Rack::Test::Methods
+
+  before do
+    app = Class.new(Rails::Application) do
+      config.root = __dir__
+      config.secret_key_base = 'test-secret-key-base'
+      config.action_dispatch.show_exceptions = :rescuable
+      config.hosts.clear
+      config.eager_load = false
+      config.consider_all_requests_local = true
+      config.logger = Rails.logger = Logger.new(StringIO.new)
+
+      config.file_watcher = Class.new(ActiveSupport::FileUpdateChecker) do
+        def initialize(files, dirs = {}, &block)
+          dirs = dirs.delete('') if dirs.include?('')
+
+          super
+        end
+      end
+    end
+
+    stub_const('RailsTest::Application', app)
+
+    Datadog.configure do |c|
+      c.tracing.enabled = true
+      c.appsec.enabled = true
+      c.appsec.instrument :rails
+
+      c.remote.enabled = false
+    end
+
+    app.initialize!
+
+    app.routes.draw do
+      resources :products
+
+      match '/search', to: 'search#index', via: :all
+    end
+
+    allow(Rails).to receive(:application).and_return(app)
+
+    allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
+    allow_any_instance_of(Datadog::Tracing::Transport::Traces::Transport).to receive(:native_events_supported?)
+  end
+
+  after do
+    clear_traces!
+
+    Datadog.configuration.reset!
+    Datadog.registry[:rack].reset_configuration!
+
+    Datadog::AppSec::RateLimiter.reset!
+    Datadog::AppSec::APISecurity::Sampler.reset!
+
+    ActiveSupport::Dependencies.clear if Rails.application
+    ActiveSupport::Dependencies.autoload_paths = []
+    ActiveSupport::Dependencies.autoload_once_paths = []
+    ActiveSupport::Dependencies._eager_load_paths = Set.new
+    ActiveSupport::Dependencies._autoloaded_tracked_classes = Set.new
+
+    Rails::Railtie::Configuration.class_variable_set(:@@eager_load_namespaces, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_files, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@watchable_dirs, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_generators, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@to_prepare_blocks, nil)
+    Rails::Railtie::Configuration.class_variable_set(:@@app_middleware, nil)
+
+    Rails.app_class = nil
+    Rails.cache = nil
+  end
+
+  it 'reports routes via telemetry' do
+    expect(Datadog::AppSec.telemetry).to receive(:app_endpoints_loaded).with(array_including([
+      {
+        type: 'REST',
+        resource_name: 'GET /products',
+        operation_name: 'http.request',
+        method: 'GET',
+        path: '/products'
+      },
+      {
+        type: 'REST',
+        resource_name: 'POST /products',
+        operation_name: 'http.request',
+        method: 'POST',
+        path: '/products'
+      },
+      {
+        type: 'REST',
+        resource_name: 'GET /products/:id',
+        operation_name: 'http.request',
+        method: 'GET',
+        path: '/products/:id'
+      },
+      {
+        type: 'REST',
+        resource_name: 'GET /products/:id/edit',
+        operation_name: 'http.request',
+        method: 'GET',
+        path: '/products/:id/edit'
+      },
+      {
+        type: 'REST',
+        resource_name: 'PATCH /products/:id',
+        operation_name: 'http.request',
+        method: 'PATCH',
+        path: '/products/:id'
+      },
+      {
+        type: 'REST',
+        resource_name: 'DELETE /products/:id',
+        operation_name: 'http.request',
+        method: 'DELETE',
+        path: '/products/:id'
+      },
+      {
+        type: 'REST',
+        resource_name: '* /search',
+        operation_name: 'http.request',
+        method: '*',
+        path: '/search'
+      }
+    ]))
+
+    ActiveSupport.run_load_hooks(:after_routes_loaded, Rails.application)
+  end
+end

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -10,6 +10,9 @@
     "DD_API_SECURITY_ENABLED": {
       "version": ["A"]
     },
+    "DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED": {
+      "version": ["A"]
+    },
     "DD_API_SECURITY_REQUEST_SAMPLE_RATE": {
       "version": ["A"]
     },


### PR DESCRIPTION
**What does this PR do?**
This PR adds API Security Endpoint Collection feature for Rails framework. The feature is disabled by default for now.

**Motivation:**
We want to know about all existing routes in an instrumented application, not only routes, which get traffic.

**Change log entry**
Yes. AppSec: Add endpoint collection for Rails application for API Security.

**Additional Notes:**
None.

**How to test the change?**
CI and manual testing with generated apps.
