### PR TITLE
Run each AppSec integration test in a separate process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -331,10 +331,12 @@ namespace :spec do
     end
 
     # Datadog AppSec integration specs (syntetic rails application)
+    # Every file runs in a separate process to avoid leakage of Rails state.
     desc '' # "Explicitly hiding from `rake -T`"
-    RSpec::Core::RakeTask.new(:integration) do |t, args|
-      t.pattern = 'spec/datadog/appsec/integration/**/*_spec.rb'
-      t.rspec_opts = args.to_a.join(' ')
+    task :integration do
+      Dir['spec/datadog/appsec/integration/**/*_spec.rb'].shuffle.each do |file|
+        sh "bundle exec rspec #{file}"
+      end
     end
 
     # Datadog AppSec integrations

--- a/spec/datadog/appsec/integration/contrib/rack/request_headers_collection_for_identity_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/rack/request_headers_collection_for_identity_spec.rb
@@ -6,6 +6,7 @@ require 'rack/test'
 
 require 'datadog/tracing'
 require 'datadog/appsec'
+require 'datadog/kit/appsec/events'
 
 RSpec.describe 'Rack-request headers collection for identity.set_user' do
   include Rack::Test::Methods


### PR DESCRIPTION
**What does this PR do?**
This PR changes `rake test:appsec:integration` so that the task runs each test file as a separate process.

**Motivation:**
Rails has a lot of global state, which is quite hard to reset between tests that create different minimal Rails applications.

**Change log entry**
None. This change is internal.

**Additional Notes:**
None.

**How to test the change?**
CI

<!-- Unsure? Have a question? Request a review! -->
