### PR TITLE
[skip ci] update process-discovery native FFI

### DIFF
--- a/lib/datadog/core/process_discovery.rb
+++ b/lib/datadog/core/process_discovery.rb
@@ -37,7 +37,6 @@ module Datadog
         # In the C method exposed by ddcommon, memfd_create replaces empty strings by None for these fields.
         def get_metadata(settings)
           {
-            schema_version: 1,
             runtime_id: Core::Environment::Identity.id,
             tracer_language: Core::Environment::Identity.lang,
             tracer_version: Core::Environment::Identity.gem_datadog_version_semver2,

--- a/sig/datadog/core/process_discovery.rbs
+++ b/sig/datadog/core/process_discovery.rbs
@@ -7,7 +7,6 @@ module Datadog
 
       def self._native_store_tracer_metadata: (
         Datadog::Core::Logger logger,
-        schema_version: Integer,
         runtime_id: String,
         tracer_language: String,
         tracer_version: String,
@@ -26,7 +25,6 @@ module Datadog
       def self.shutdown!: () -> void
 
       def self.get_metadata: (Datadog::Core::Configuration::Settings settings) -> {
-        schema_version: Integer,
         runtime_id: String,
         tracer_language: String,
         tracer_version: String,

--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
 
           expect(content).to eq(
             {
-              'schema_version' => 1,
               'runtime_id' => Datadog::Core::Environment::Identity.id,
               'tracer_language' => Datadog::Core::Environment::Identity.lang,
               'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
@@ -79,7 +78,6 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
           # Thus not appearing in the content.
           expect(content).to eq(
             {
-              'schema_version' => 1,
               'runtime_id' => Datadog::Core::Environment::Identity.id,
               'tracer_language' => Datadog::Core::Environment::Identity.lang,
               'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
@@ -107,7 +105,6 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
         expect(described_class).to have_received(:publish)
         expect(content).to eq(
           {
-            'schema_version' => 1,
             'runtime_id' => Datadog::Core::Environment::Identity.id,
             'tracer_language' => Datadog::Core::Environment::Identity.lang,
             'tracer_version' => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,


### PR DESCRIPTION
libdatadog 22.0.0 introduced a breaking change in the process discovery FFI. This commit uses the new API.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
