### PR TITLE
Use images-rb base images for integrations

### DIFF
--- a/integration/images/ruby/2.1/Dockerfile
+++ b/integration/images/ruby/2.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.1-gnu-gcc
 
 # Add Jessie repos
 # Fixes https://www.lucas-nussbaum.net/blog/?p=947

--- a/integration/images/ruby/2.2/Dockerfile
+++ b/integration/images/ruby/2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.2-gnu-gcc
 
 # Add Jessie repos
 # Fixes https://www.lucas-nussbaum.net/blog/?p=947

--- a/integration/images/ruby/2.3/Dockerfile
+++ b/integration/images/ruby/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.3-gnu-gcc
 
 # Add stretch repos
 RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list

--- a/integration/images/ruby/2.4/Dockerfile
+++ b/integration/images/ruby/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.4-gnu-gcc
 
 # Add stretch repos
 RUN sed -i 's/jessie/stretch/g' /etc/apt/sources.list

--- a/integration/images/ruby/2.5/Dockerfile
+++ b/integration/images/ruby/2.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.5-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/2.6/Dockerfile
+++ b/integration/images/ruby/2.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.6-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/2.7/Dockerfile
+++ b/integration/images/ruby/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ghcr.io/datadog/images-rb/engines/ruby:2.7-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/3.0/Dockerfile
+++ b/integration/images/ruby/3.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.0-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/3.1/Dockerfile
+++ b/integration/images/ruby/3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.1-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/3.2/Dockerfile
+++ b/integration/images/ruby/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.2-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/3.3/Dockerfile
+++ b/integration/images/ruby/3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.3-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/images/ruby/3.4/Dockerfile
+++ b/integration/images/ruby/3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4
+FROM ghcr.io/datadog/images-rb/engines/ruby:3.4-gnu-gcc
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Change the base images of integrations to use our https://github.com/DataDog/images-rb images.

**Motivation:**
Propagating @lloeki 's suggestion in #4924!

**Change log entry**
No

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Green CI.

<!-- Unsure? Have a question? Request a review! -->
