### PR TITLE
[LANGPLAT-872] Add `trigger_stacktrace_on_kill` to `expect_in_fork` test helper

### DIFF
--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
 
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
-      it("runs without raising errors") { expect_in_fork(timeout_seconds: 15) { load "./benchmarks/#{benchmark}.rb" } }
+      it("runs without raising errors") { expect_in_fork(timeout_seconds: 15, trigger_stacktrace_on_kill: true) { load "./benchmarks/#{benchmark}.rb" } }
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR improves the `expect_in_fork` test helper to:

1. Make sure stdout and stderr are correctly captured
2. Add a new `trigger_stacktrace_on_kill` feature that sends a SEGV signal to the child process to cause it to run the Ruby crash handler (and thus print what Ruby was doing).

**Motivation:**

We've been getting once-a-week flaky tests on

```
  1) Profiling benchmarks profiling_sample_loop_v2 runs without raising errors
     Failure/Error: raise "Failure or timeout in `expect_in_fork`, STDOUT: `#{stdout}`, STDERR: `#{stderr}`", cause: e
```

due to timeouts.

Looking at the last 6 flakes, 5 of them were on Ruby 2.6:
* (2.6) https://github.com/DataDog/dd-trace-rb/actions/runs/18187093451/attempts/1
* (2.6) https://github.com/DataDog/dd-trace-rb/actions/runs/18176831104/job/51744659989
* (2.6) https://github.com/DataDog/dd-trace-rb/actions/runs/17976049815/attempts/1
* (2.6) https://github.com/DataDog/dd-trace-rb/actions/runs/17863523136/attempts/1
* (3.0) https://github.com/DataDog/dd-trace-rb/actions/runs/16867958314/attempts/1
* (2.6) https://github.com/DataDog/dd-trace-rb/actions/runs/16819071603/attempts/1

This is actually not the first time this test has been flaking, and in the past we've tried to raise the timeout in https://github.com/DataDog/dd-trace-rb/pull/4836 which anecdotally made the flakiness less common, but it clearly didn't go away.

It's unclear to me at this point why exactly this test is flaking: there's definitely an element of time here (e.g. we're launching the benchmark and giving it 15 seconds to run) but we configure the benchmark to run with such a light load that I can't see how it would not finish in 15 seconds.

Thus I want to take a slightly different route: I've introduced the `trigger_stacktrace_on_kill` so we hopefully get a stacktrace of what was going on inside Ruby next time this test flakes, so we can check if there's some accidental blocking going on that we hadn't considered.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

You can see the new feature working by adding a `sleep` somewhere in one of the profiling benchmarks. Here's how it shows up on my machine (and as expected you can immediately tell there's a `sleep` there):

```
$ bundle exec rspec spec/datadog/profiling/validate_benchmarks_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 54290

Profiling benchmarks
  tests all expected benchmarks in the benchmarks folder
  profiling_memory_sample_serialize
    runs without raising errors
  profiling_sample_loop_v2
Waiting for child process to exit after SEGV signal...  (Crashing Ruby to get stacktrace as requested by `trigger_stacktrace_on_kill`)
    runs without raising errors (FAILED - 1)
  profiling_sample_gvl
    runs without raising errors
  profiling_allocation
    runs without raising errors
  profiling_http_transport
    runs without raising errors
  profiling_hold_resume_interruptions
    runs without raising errors
  profiling_gc
    runs without raising errors
  profiling_sample_serialize
    runs without raising errors
  profiling_string_storage_intern
    runs without raising errors

Failures:

  1) Profiling benchmarks profiling_sample_loop_v2 runs without raising errors
     Failure/Error: raise "Failure or timeout in `expect_in_fork`#{crash_note}, STDOUT: `#{stdout}`, STDERR: `#{stderr}`", cause: e

     RuntimeError:
       Failure or timeout in `expect_in_fork` (Crashing Ruby to get stacktrace as requested by `trigger_stacktrace_on_kill`), STDOUT: `Current pid is 303238
       Calculating -------------------------------------
       profiling - stack collector (ruby frames - native filenames enabled)
                                 4.730k (±10.6%) i/s  (211.41 μs/i) -     46.000 in   0.010049s
       Calculating -------------------------------------
       profiling - stack collector (native frames - native filenames enabled)
                                 4.164k (±10.2%) i/s  (240.14 μs/i) -     41.000 in   0.010116s
       profiling - stack collector (native frames - native filenames disabled)
                                 4.258k (± 8.1%) i/s  (234.84 μs/i) -     43.000 in   0.010182s

       Comparison:
       profiling - stack collector (native frames - native filenames disabled) :     4258.2 i/s
       profiling - stack collector (native frames - native filenames enabled) :     4164.3 i/s - same-ish: difference falls within error

       `, STDERR: `benchmarks/profiling_sample_loop_v2.rb:163: [BUG] Segmentation fault at 0x000003e80004a06f
       ruby 3.2.5 (2024-07-26 revision 31d0f1a2e7) [x86_64-linux]

       -- Control frame information -----------------------------------------------
       c:0080 p:---- s:0417 e:000416 CFUNC  :sleep <-- @ivoanjo: I added this sleep locally for testing
       c:0079 p:0022 s:0412 e:000411 BLOCK  benchmarks/profiling_sample_loop_v2.rb:163 [FINISH]
       c:0078 p:---- s:0409 e:000408 CFUNC  :instance_exec
       c:0077 p:0076 s:0405 e:000404 TOP    benchmarks/profiling_sample_loop_v2.rb:159 [FINISH]

...
```