### PR TITLE
DI: eliminate Ruby warnings in test suite

### DIFF
--- a/spec/datadog/di/hook_line_load.rb
+++ b/spec/datadog/di/hook_line_load.rb
@@ -1,17 +1,37 @@
-# Comment line - not executable
+# This file is loaded repeatedly in the test suite due to the way DI performs
+# code tracking. Remove the constants if they have already been defined
+# to avoid Ruby warnings.
+begin
+  Object.send(:remove_const, :HookLineLoadTestClass)
+  Object.send(:remove_const, :HookLineIvarLoadTestClass)
+rescue NameError
+end
+
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+
+# Comment line - not executable - line 21
 
 class HookLineLoadTestClass
-  def test_method       # Line 4
-    42                  # Line 5
-  end                   # Line 6
+  def test_method       # Line 24
+    42                  # Line 25
+  end                   # Line 26
 
   def test_method_with_local
     local = 42 # standard:disable Style/RedundantAssignment
-    local               # Line 10 # standard:disable Style/RedundantAssignment
+    local               # Line 30 # standard:disable Style/RedundantAssignment
   end
 
   def test_method_with_arg(arg)
-    arg                 # Line 14
+    arg                 # Line 34
   end
 end
 
@@ -24,16 +44,16 @@ class HookLineIvarLoadTestClass
   end
 
   def test_method
-    1337                 # Line 24
+    1337                 # Line 47
   end
 
   def test_exception
     local = 42
-    raise TestException, 'Intentional exception'       # Line 32
-    local               # Line 33 # standard:disable Lint/UnreachableCode
+    raise TestException, 'Intentional exception'       # Line 52
+    local               # Line 53 # standard:disable Lint/UnreachableCode
   end
 end
 
-unless (actual = File.read(__FILE__).count("\n")) == 39
-  raise "Wrong number of lines in hook_line_load.rb: actual #{actual}, expected 39"
+unless (actual = File.read(__FILE__).count("\n")) == 59
+  raise "Wrong number of lines in hook_line_load.rb: actual #{actual}, expected 59"
 end

--- a/spec/datadog/di/hook_line_recursive.rb
+++ b/spec/datadog/di/hook_line_recursive.rb
@@ -1,6 +1,16 @@
+# This file is loaded repeatedly in the test suite due to the way DI performs
+# code tracking. Remove the constants if they have already been defined
+# to avoid Ruby warnings.
+begin
+  Object.send(:remove_const, :HookLineRecursiveTestClass)
+rescue NameError
+end
+
+# padding
+
 class HookLineRecursiveTestClass
   def recursive(depth)
-    if depth > 0        # Line 3
+    if depth > 0        # Line 13
       recursive(depth - 1) + '-'
     else
       '+'
@@ -8,10 +18,10 @@ class HookLineRecursiveTestClass
   end
 
   def infinitely_recursive(depth = 0)
-    infinitely_recursive(depth + 1)     # Line 11
+    infinitely_recursive(depth + 1)     # Line 21
   end
 end
 
-unless (actual = File.read(__FILE__).count("\n")) == 17
+unless (actual = File.read(__FILE__).count("\n")) == 27
   raise "Wrong number of lines in hook_line_recursive.rb: actual #{actual}, expected 17"
 end

--- a/spec/datadog/di/hook_line_targeted.rb
+++ b/spec/datadog/di/hook_line_targeted.rb
@@ -1,9 +1,19 @@
+# This file is loaded repeatedly in the test suite due to the way DI performs
+# code tracking. Remove the constants if they have already been defined
+# to avoid Ruby warnings.
+begin
+  Object.send(:remove_const, :HookLineTargetedTestClass)
+rescue NameError
+end
+
+# padding
+
 class HookLineTargetedTestClass
-  def test_method       # Line 2
-    42                  # Line 3
+  def test_method       # Line 12
+    42                  # Line 13
   end
 end
 
-unless (actual = File.read(__FILE__).count("\n")) == 9
+unless (actual = File.read(__FILE__).count("\n")) == 19
   raise "Wrong number of lines in hook_line_targeted.rb: actual #{actual}, expected 9"
 end

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -1,3 +1,19 @@
+# This file is loaded repeatedly in the test suite due to the way DI performs
+# code tracking. Remove the constants if they have already been defined
+# to avoid Ruby warnings.
+begin
+  Object.send(:remove_const, :HookTestClass)
+rescue NameError
+end
+begin
+  Object.send(:remove_const, :YieldingMethodMissingHookTestClass)
+rescue NameError
+end
+begin
+  Object.send(:remove_const, :HookIvarTestClass)
+rescue NameError
+end
+
 class HookTestClass
   class TestException < StandardError
   end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -1003,7 +1003,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 5,
+          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 25,
             id: 1, type: :log, rate_limit: rate_limit)
         end
 
@@ -1055,7 +1055,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         let(:code_tracker) { nil }
 
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 1,
+          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 21,
             id: 1, type: :log)
         end
 
@@ -1091,7 +1091,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 1,
+          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 21,
             id: 1, type: :log)
         end
 
@@ -1235,7 +1235,7 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
 
       let(:probe) do
-        Datadog::DI::Probe.new(file: 'hook_line_targeted.rb', line_no: 3,
+        Datadog::DI::Probe.new(file: 'hook_line_targeted.rb', line_no: 13,
           id: 1, type: :log)
       end
 
@@ -1244,7 +1244,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         target = code_tracker.send(:registry)[path]
         expect(target).to be_a(RubyVM::InstructionSequence)
 
-        expect_any_instance_of(TracePoint).to receive(:enable).with(target: target, target_line: 3).and_call_original
+        expect_any_instance_of(TracePoint).to receive(:enable).with(target: target, target_line: 13).and_call_original
 
         instrumenter.hook_line(probe) do |payload|
           observed_calls << payload
@@ -1262,7 +1262,7 @@ RSpec.describe Datadog::DI::Instrumenter do
         end
 
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 6,
+          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 26,
             id: 1, type: :log, rate_limit: rate_limit)
         end
 
@@ -1327,7 +1327,7 @@ RSpec.describe Datadog::DI::Instrumenter do
 
       context 'non-enriched probe' do
         let(:probe_args) do
-          {file: 'hook_line_recursive.rb', line_no: 3}
+          {file: 'hook_line_recursive.rb', line_no: 13}
         end
 
         it 'invokes callback for every method invocation' do
@@ -1360,7 +1360,7 @@ RSpec.describe Datadog::DI::Instrumenter do
       include_context 'with code tracking'
 
       before do
-        require_relative 'hook_line_recursive'
+        load File.join(File.dirname(__FILE__), 'hook_line_recursive.rb')
       end
 
       # We need to use a rate limiter, otherwise the stack is exhausted
@@ -1372,7 +1372,7 @@ RSpec.describe Datadog::DI::Instrumenter do
 
       context 'non-enriched probe' do
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_recursive.rb', line_no: 11,
+          Datadog::DI::Probe.new(file: 'hook_line_recursive.rb', line_no: 21,
             id: 1, type: :log, rate_limit: rate_limit)
         end
 
@@ -1403,7 +1403,7 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
 
       let(:probe) do
-        Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 32,
+        Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 52,
           id: 1, type: :log, rate_limit: rate_limit)
       end
 
@@ -1431,7 +1431,7 @@ RSpec.describe Datadog::DI::Instrumenter do
       include_context 'with code tracking'
 
       let(:probe) do
-        Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 10,
+        Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 30,
           id: 1, type: :log, rate_limit: rate_limit, condition: condition)
       end
 
@@ -1482,7 +1482,7 @@ RSpec.describe Datadog::DI::Instrumenter do
 
       context 'when condition is on instance variable' do
         let(:probe) do
-          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 24,
+          Datadog::DI::Probe.new(file: 'hook_line_load.rb', line_no: 47,
             id: 1, type: :log, rate_limit: rate_limit, condition: condition)
         end
 

--- a/spec/datadog/di/integration/everything_from_remote_config_spec.rb
+++ b/spec/datadog/di/integration/everything_from_remote_config_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe 'DI integration from remote config' do
         {
           id: '11', name: 'bar', type: 'LOG_PROBE',
           where: {
-            sourceFile: 'hook_line_load.rb', lines: [14],
+            sourceFile: 'hook_line_load.rb', lines: [34],
           },
           when: {json: {'contains' => [{'ref' => 'bar'}, 'baz']}},
         }

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -11,8 +11,8 @@ class InstrumentationIntegrationTestClass
 
   def test_method
     a = 21
-    password = 'password'
-    redacted = {b: 33, session: 'blah'}
+    $__password = password = 'password'
+    $__redacted = redacted = {b: 33, session: 'blah'}
     # The following condition causes instrumentation trace point callback
     # to be invoked multiple times in CircleCI on Ruby 3.0-3.2 and 3.4
     #if true || password || redacted

--- a/spec/datadog/di/integration/instrumentation_integration_test_class_2.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class_2.rb
@@ -1,8 +1,8 @@
 class InstrumentationIntegrationTestClass2
   def test_method
     a = 21
-    password = 'password'
-    redacted = {b: 33, session: 'blah'}
+    $__password = password = 'password'
+    $__redacted = redacted = {b: 33, session: 'blah'}
     # padding
     # padding
     # padding

--- a/spec/datadog/di/integration/instrumentation_integration_test_class_3.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class_3.rb
@@ -1,8 +1,8 @@
 class InstrumentationIntegrationTestClass3
   def test_method
     a = 21
-    password = 'password'
-    redacted = {b: 33, session: 'blah'}
+    $__password = password = 'password'
+    $__redacted = redacted = {b: 33, session: 'blah'}
     # padding
     # padding
     # padding

--- a/spec/datadog/di/integration/instrumentation_integration_test_class_4.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class_4.rb
@@ -1,8 +1,8 @@
 class InstrumentationIntegrationTestClass4
   def test_method
     a = 21
-    password = 'password'
-    redacted = {b: 33, session: 'blah'}
+    $__password = password = 'password'
+    $__redacted = redacted = {b: 33, session: 'blah'}
     # padding
     # padding
     # padding

--- a/spec/datadog/di/probe_file_loader_spec.rb
+++ b/spec/datadog/di/probe_file_loader_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Datadog::DI::ProbeFileLoader do
     before do
       expect(Datadog::Core::Environment::Execution).to receive(:development?).and_return(false).at_least(:once)
       Datadog.send(:reset!)
+
+      # Stop environment logger from printing configuration to standard output
+      allow(Datadog::Core::Diagnostics::EnvironmentLogger).to receive(:log_configuration!)
     end
 
     after do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Adjusts test suite code to not produce Ruby warnings
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Many Ruby warnings emitted when running DI tests
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing CI