### PR TITLE
Remove ruby version check on http request spec

### DIFF
--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -348,19 +348,7 @@ RSpec.describe 'net/http requests' do
         let(:span) { spans.last }
 
         it 'adds distributed tracing headers' do
-          # The block syntax only works with Ruby < 2.3 and the hash syntax
-          # only works with Ruby >= 2.3, so we need to support both.
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-            expect(WebMock).to(
-              have_requested(:get, "#{uri}#{path}").with { |req|
-                distributed_tracing_headers.all? do |(header, value)|
-                  req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
-                end
-              }
-            )
-          else
-            expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
-          end
+          expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
         end
       end
 
@@ -394,19 +382,7 @@ RSpec.describe 'net/http requests' do
         let(:span) { spans.last }
 
         it 'adds distributed tracing headers' do
-          # The block syntax only works with Ruby < 2.3 and the hash syntax
-          # only works with Ruby >= 2.3, so we need to support both.
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-            expect(WebMock).to(
-              have_requested(:get, "#{uri}#{path}").with { |req|
-                distributed_tracing_headers.all? do |(header, value)|
-                  req.headers[header.split('-').map(&:capitalize).join('-')] == value.to_s
-                end
-              }
-            )
-          else
-            expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
-          end
+          expect(WebMock).to have_requested(:get, "#{uri}#{path}").with(headers: distributed_tracing_headers)
         end
       end
 


### PR DESCRIPTION
Cleaning up http_request_spec ruby version checks since CI runs against 2.5+.
Nothing else changed with the PR, all tests should continue to pass. There is still one other place or two that still do these checks that I'd like to cleanup in another PR