### PR TITLE
[NO-TICKET] Add seed to CI unit tests

### DIFF
--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -26,7 +26,6 @@ on: # yamllint disable-line rule:truthy
 
   workflow_dispatch:
     inputs:
-      # TODO: Provides concurrency control for each ruby version
       engine:
         description: "`ruby` or `jruby`"
         required: true
@@ -43,6 +42,8 @@ on: # yamllint disable-line rule:truthy
         description: "The seed to reproduce a CI run"
         required: false
         type: number
+
+permissions: {}
 
 jobs:
   batch:
@@ -78,9 +79,7 @@ jobs:
         batches_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["batches"].to_json')
         misc_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["misc"].to_json')
 
-        echo "seed=$seed_data" >> "$GITHUB_OUTPUT"
-        echo "batches=$batches_data" >> "$GITHUB_OUTPUT"
-        echo "misc=$misc_data" >> "$GITHUB_OUTPUT"
+        { echo "seed=$seed_data"; echo "batches=$batches_data"; echo "misc=$misc_data"; } >> "$GITHUB_OUTPUT"
     - name: Generate batch summary
       env:
         batches_json: "${{ steps.set-batches.outputs.batches }}"

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -1,4 +1,4 @@
-name: Unit Test Template
+name: Unit Tests (Ruby version specific)
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
@@ -23,6 +23,26 @@ on: # yamllint disable-line rule:truthy
       cache-key:
         description: "The cache key for bundle"
         value: ${{ jobs.batch.outputs.cache-key }}
+
+  workflow_dispatch:
+    inputs:
+      # TODO: Provides concurrency control for each ruby version
+      engine:
+        description: "`ruby` or `jruby`"
+        required: true
+        type: string
+      version:
+        description: "The version of the engine (2.x or 3.x for Ruby, 9.x or 10.x for JRuby)"
+        required: true
+        type: string
+      alias:
+        description: "The alias of the engine (e.g. `ruby-34` for Ruby 3.4)"
+        required: true
+        type: string
+      seed:
+        description: "The seed to reproduce a CI run"
+        required: false
+        type: number
 
 jobs:
   batch:

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -13,6 +13,9 @@ on: # yamllint disable-line rule:truthy
       alias:
         required: true
         type: string
+      seed:
+        required: false
+        type: number
     outputs:
       lockfile:
         description: "The lockfile artifact"
@@ -26,6 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: batch
     outputs:
+      seed: "${{ steps.set-batches.outputs.seed }}"
       batches: "${{ steps.set-batches.outputs.batches }}"
       misc: "${{ steps.set-batches.outputs.misc }}"
       cache-key: "${{ steps.bundle-cache.outputs.cache-key }}"
@@ -43,20 +47,25 @@ jobs:
 
     - id: set-batches
       name: Distribute tasks into batches
+      env:
+        CI_TEST_SEED: "${{ inputs.seed || '' }}"
       run: |
         data=$(bundle exec rake github:generate_batches)
         echo "$data" | ruby -rjson -e 'puts JSON.pretty_generate(JSON.parse(STDIN.read))'
 
         # Extract each key and set it as a separate output
+        seed_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["seed"]')
         batches_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["batches"].to_json')
         misc_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["misc"].to_json')
 
+        echo "seed=$seed_data" >> "$GITHUB_OUTPUT"
         echo "batches=$batches_data" >> "$GITHUB_OUTPUT"
         echo "misc=$misc_data" >> "$GITHUB_OUTPUT"
     - name: Generate batch summary
-      run: bundle exec rake github:generate_batch_summary
       env:
         batches_json: "${{ steps.set-batches.outputs.batches }}"
+        CI_TEST_SEED: "${{ steps.set-batches.outputs.seed }}"
+      run: bundle exec rake github:generate_batch_summary
 
   # `Initialize containers` step becomes quite heavily when many services are used.
   #
@@ -88,6 +97,7 @@ jobs:
     timeout-minutes: 30
     env:
       BATCHED_TASKS: "${{ toJSON(matrix.tasks) }}"
+      CI_TEST_SEED: "${{ needs.batch.outputs.seed }}"
     strategy:
       fail-fast: false
       matrix:
@@ -152,6 +162,7 @@ jobs:
     timeout-minutes: 30
     env:
       BATCHED_TASKS: "${{ toJSON(matrix.tasks) }}"
+      CI_TEST_SEED: "${{ needs.batch.outputs.seed }}"
     strategy:
       fail-fast: false
       matrix:

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -79,13 +79,13 @@ namespace :github do
     summary = ENV['GITHUB_STEP_SUMMARY']
 
     File.open(summary, 'a') do |f|
+      f.puts "*__Seed__: #{ENV['CI_TEST_SEED']}*"
       data['include'].each do |batch|
         rows = batch['tasks'].map do |t|
           "* #{t["task"]} (#{t["group"]})"
         end
 
         f.puts <<~SUMMARY
-          *__Seed__: #{ENV['CI_TEST_SEED']}*
           <details>
           <summary>Batch #{batch["batch"]} (#{batch["tasks"].length} tasks)</summary>
 

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -47,7 +47,7 @@ namespace :github do
     end
 
     # Seed
-    rng = ENV['CI_TEST_SEED'] && ENV['CI_TEST_SEED'] != '' ? Random.new(ENV['CI_TEST_SEED'].to_i) : Random.new
+    rng = (ENV['CI_TEST_SEED'] && ENV['CI_TEST_SEED'] != '') ? Random.new(ENV['CI_TEST_SEED'].to_i) : Random.new
     matching_tasks.shuffle!(random: rng)
 
     batch_count = 7
@@ -79,7 +79,7 @@ namespace :github do
     summary = ENV['GITHUB_STEP_SUMMARY']
 
     File.open(summary, 'a') do |f|
-      f.puts "*__Seed__: #{ENV['CI_TEST_SEED']}*"
+      f.puts "*__Seed__: #{ENV["CI_TEST_SEED"]}*"
       data['include'].each do |batch|
         rows = batch['tasks'].map do |t|
           "* #{t["task"]} (#{t["group"]})"
@@ -121,7 +121,7 @@ namespace :github do
   task :run_batch_tests do
     tasks = JSON.parse(ENV['BATCHED_TASKS'] || {})
 
-    rng = ENV['CI_TEST_SEED'] && ENV['CI_TEST_SEED'] != '' ? Random.new(ENV['CI_TEST_SEED'].to_i) : Random.new
+    rng = Random.new(ENV['CI_TEST_SEED'].to_i)
 
     tasks.each do |task|
       env = {'BUNDLE_GEMFILE' => task['gemfile']}


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR adds a seed input to the CI Unit tests workflow, which should give the same batches output, and same RSpec seeds.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
It should be easier to reproduce flaky tests

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Once merged, workflow_dispatch

<!-- Unsure? Have a question? Request a review! -->
