### PR TITLE
Fix JRuby 9.4 RSpec termination race-condition

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -141,7 +141,11 @@ module Datadog
 
             @condition.broadcast
           ensure
-            @mutex.unlock
+            # NOTE: The `locked?` check is not preventing a context switching, hence
+            #       it is not preventing a race condition. But in some rare cases
+            #       in RSpec of JRuby 9.4 the test case will not let locking happen.
+            #       That will cause specs to fail.
+            @mutex.unlock if @mutex.locked?
           end
         end
 


### PR DESCRIPTION
**What does this PR do?**

Fix intermittent bug in RSpec test case for JRuby 9.4 (**TESTS ONLY**)

**Motivation:**

The test is suboptimal and will hammer the lifting method which will cause the remote worker thread to continue lifting when RSpec is already finished the test case.

That will lead to exception that Mutex is not locked. And boiled down as Deadlocks and Havoc 

**Change log entry**

None.

**Additional Notes:**

The test should be improved because the worker thread consider itself unhealthy.

**How to test the change?**

CI