### PR TITLE
Use Mutex#synchronize to solve JRuby mutex not locked error

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -135,13 +135,11 @@ module Datadog
 
           # Release all current waiters
           def lift
-            @mutex.lock
+            @mutex.synchronize do
+              @once ||= true
 
-            @once ||= true
-
-            @condition.broadcast
-          ensure
-            @mutex.unlock
+              @condition.broadcast
+            end
           end
         end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Uses Mutex#synchronize instead of manual  lock & unlock calls to (hopefully) properly unlock the mutex in remote config worker.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Flaky tests on JRuby: https://github.com/DataDog/ruby-guild/issues/256, https://datadoghq.atlassian.net/browse/LANGPLAT-871
<!-- What inspired you to submit this pull request? -->

The issue is that sometimes mutex is attempted to be unlocked when it is not locked.

**Change log entry**
Yes: core/fix: improve locking code for remote configuration worker
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

I also attempted this alternate diff which also fixed the issue:
```
diff --git a/lib/datadog/core/remote/component.rb b/lib/datadog/core/remote/component.rb
index 18e33bea25..f73d9742b6 100644
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -137,11 +137,13 @@ module Datadog
           def lift
             @mutex.lock
 
-            @once ||= true
+            begin
+              @once ||= true
 
-            @condition.broadcast
-          ensure
-            @mutex.unlock
+              @condition.broadcast
+            ensure
+              @mutex.unlock
+            end
           end
         end
 
```


**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->

Following @Strech 's investigation in https://datadoghq.atlassian.net/browse/LANGPLAT-871, I reproduced the failure locally (both in and not in docker) using the following:

```
export BUNDLE_GEMFILE=gemfiles/ruby_3.4_mongo_min.gemfile

while true; do if ! TEST_DATADOG_INTEGRATION=1 BUNDLE_GEMFILE=./gemfiles/jruby_9.4_contrib.gemfile bundle exec rspec --pattern spec/datadog/tracing/contrib/suite/\*\*/\*_spec.rb --format=doc; then break; fi; done
```

After a couple of iterations, this would fail with the above error. The seeds specified in the ticket did not reproduce the failure for me - running the tests without explicitly specifying the seeds was needed.

With the change in this PR, I ran the above command for ~5 minutes without errors.

I have not further investigated the interaction between remote config worker and test polling intervals.