### PR TITLE
RC mutex unlock fix via ensure

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -137,11 +137,13 @@ module Datadog
           def lift
             @mutex.lock
 
-            @once ||= true
+            begin
+              @once ||= true
 
-            @condition.broadcast
-          ensure
-            @mutex.unlock
+              @condition.broadcast
+            ensure
+              @mutex.unlock
+            end
           end
         end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Alternate implementation of https://github.com/DataDog/dd-trace-rb/pull/4957 that does not use synchronize.

This PR moves the begin-ensure block below the lock call, such that unlocking is only attempted if locking succeeds.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Flaky CI 

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
