### PR TITLE
Report actual exception when reporting ThreadErrors

### DIFF
--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -238,7 +238,7 @@ module Datadog
           yield write_components
         rescue ThreadError => e
           logger_without_components.error(
-            'Detected deadlock during datadog initialization. ' \
+            "Detected deadlock during datadog initialization: #{e.class}: #{e}. " \
             'Please report this at https://github.com/datadog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
             "\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
           )


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Reports actual exception when reporting "deadlock" during configuration processing.

**Motivation:**
In the investigation that led to the fix in https://github.com/DataDog/dd-trace-rb/pull/4957, we discovered that the error was mutex not locked and not a deadlock. This could have been surfaced by the message directly, potentially leading to the issue being fixed sooner and saving us some aggravation due to flaky CI.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing tests