### PR TITLE
Add new gemfiles to lock-dependency commit

### DIFF
--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -99,6 +99,8 @@ jobs:
           path: gemfiles
           pattern: lock-dependency-${{ github.run_id }}-*
           merge-multiple: true
+      - name: Stage changes # Since ghcommit-action does not pick up unstaged files
+        run: git add gemfiles
       - run: git diff --color=always
       - name: Commit changes
         uses: planetscale/ghcommit-action@f24050e41f8694750427d111b52f4ef9ca81a32d # v0.2.18


### PR DESCRIPTION
This issue was noticed recently (https://github.com/DataDog/dd-trace-rb/pull/4924#discussion_r2414455430) and it caused by a known limitation of [planetscale/ghcommit-action](https://github.com/planetscale/ghcommit-action/issues/43).

Here you can see where our job failed to pick up the newly added gemfile.lock: https://github.com/DataDog/dd-trace-rb/actions/runs/18348438937/job/52262026349#step:7:298

**Change log entry**
No
