### PR TITLE
[LANGPLAT-874] Fix connection pool leaking between test cases

### DIFF
--- a/spec/datadog/tracing/contrib/rails/support/base.rb
+++ b/spec/datadog/tracing/contrib/rails/support/base.rb
@@ -14,6 +14,11 @@ RSpec.shared_context 'Rails base application' do
   end
 
   after do
+    # NOTE: We forsibly close connection pool to avoid leaking connection between
+    #       test cases.
+    #       This call is safe to be used on already closed connection pool.
+    application_record.connection.disconnect! if application_record&.connected?
+
     # Reset references stored in the Rails class
     Rails.application = nil
     Rails.logger = nil


### PR DESCRIPTION
**What does this PR do?**

In shared inlined Rails apps we potentially leaking connection pool between different test cases when executing in fork between non-fork executions

For details see: https://datadoghq.atlassian.net/browse/LANGPLAT-874

**Motivation:**

This is a flaky test fix.

**Change log entry**

None.

**Additional Notes:**

None.

**How to test the change?**

CI is good enough.