### PR TITLE
[APPSEC-59592] Add Trace Tagging remote capability to AppSec

### DIFF
--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -25,6 +25,11 @@ module Datadog
         CAP_ASM_TRUSTED_IPS = 1 << 10
         CAP_ASM_RASP_SSRF = 1 << 23
         CAP_ASM_RASP_SQLI = 1 << 21
+        CAP_ASM_AUTO_USER_INSTRUM_MODE = 1 << 31
+        CAP_ASM_ENDPOINT_FINGERPRINT = 1 << 32
+        CAP_ASM_SESSION_FINGERPRINT = 1 << 33
+        CAP_ASM_NETWORK_FINGERPRINT = 1 << 34
+        CAP_ASM_HEADER_FINGERPRINT = 1 << 35
         CAP_ASM_TRACE_TAGGING_RULES = 1 << 43
 
         # TODO: we need to dynamically add CAP_ASM_ACTIVATION once we support it
@@ -40,6 +45,11 @@ module Datadog
           CAP_ASM_TRUSTED_IPS,
           CAP_ASM_RASP_SSRF,
           CAP_ASM_RASP_SQLI,
+          CAP_ASM_AUTO_USER_INSTRUM_MODE,
+          CAP_ASM_ENDPOINT_FINGERPRINT,
+          CAP_ASM_SESSION_FINGERPRINT,
+          CAP_ASM_NETWORK_FINGERPRINT,
+          CAP_ASM_HEADER_FINGERPRINT,
           CAP_ASM_TRACE_TAGGING_RULES,
         ].freeze
 

--- a/sig/datadog/appsec/remote.rbs
+++ b/sig/datadog/appsec/remote.rbs
@@ -7,47 +7,57 @@ module Datadog
       class NoRulesError < StandardError
       end
 
-      CAP_ASM_RESERVED_1: Integer
+      CAP_ASM_RESERVED_1: ::Integer
 
-      CAP_ASM_ACTIVATION: Integer
+      CAP_ASM_ACTIVATION: ::Integer
 
-      CAP_ASM_IP_BLOCKING: Integer
+      CAP_ASM_IP_BLOCKING: ::Integer
 
-      CAP_ASM_DD_RULES: Integer
+      CAP_ASM_DD_RULES: ::Integer
 
-      CAP_ASM_EXCLUSIONS: Integer
+      CAP_ASM_EXCLUSIONS: ::Integer
 
-      CAP_ASM_REQUEST_BLOCKING: Integer
+      CAP_ASM_REQUEST_BLOCKING: ::Integer
 
-      CAP_ASM_RESPONSE_BLOCKING: Integer
+      CAP_ASM_RESPONSE_BLOCKING: ::Integer
 
-      CAP_ASM_USER_BLOCKING: Integer
+      CAP_ASM_USER_BLOCKING: ::Integer
 
-      CAP_ASM_CUSTOM_RULES: Integer
+      CAP_ASM_CUSTOM_RULES: ::Integer
 
-      CAP_ASM_CUSTOM_BLOCKING_RESPONSE: Integer
+      CAP_ASM_CUSTOM_BLOCKING_RESPONSE: ::Integer
 
-      CAP_ASM_TRUSTED_IPS: Integer
+      CAP_ASM_TRUSTED_IPS: ::Integer
 
-      CAP_ASM_RASP_SSRF: Integer
+      CAP_ASM_RASP_SSRF: ::Integer
 
-      CAP_ASM_RASP_SQLI: Integer
+      CAP_ASM_RASP_SQLI: ::Integer
 
-      CAP_ASM_TRACE_TAGGING_RULES: Integer
+      CAP_ASM_AUTO_USER_INSTRUM_MODE: ::Integer
 
-      ASM_CAPABILITIES: Array[Integer]
+      CAP_ASM_ENDPOINT_FINGERPRINT: ::Integer
 
-      ASM_PRODUCTS: ::Array[String]
+      CAP_ASM_SESSION_FINGERPRINT: ::Integer
 
-      def self.capabilities: () -> ::Array[Integer]
+      CAP_ASM_NETWORK_FINGERPRINT: ::Integer
 
-      def self.products: () -> ::Array[String]
+      CAP_ASM_HEADER_FINGERPRINT: ::Integer
+
+      CAP_ASM_TRACE_TAGGING_RULES: ::Integer
+
+      ASM_CAPABILITIES: Array[::Integer]
+
+      ASM_PRODUCTS: ::Array[::String]
+
+      def self.capabilities: () -> ::Array[::Integer]
+
+      def self.products: () -> ::Array[::String]
 
       def self.receivers: (Datadog::Core::Telemetry::Component telemetry) -> ::Array[Core::Remote::Dispatcher::Receiver]
 
       def self.remote_features_enabled?: () -> bool
 
-      def self.parse_content: (Datadog::Core::Remote::Configuration::Content content) -> Hash[String, untyped]
+      def self.parse_content: (Datadog::Core::Remote::Configuration::Content content) -> ::Hash[::String, untyped]
     end
   end
 end

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -20,9 +20,10 @@ RSpec.describe Datadog::AppSec::Remote do
       end
 
       it 'returns capabilities' do
-        expect(described_class.capabilities).to eq(
-          [4, 128, 16, 32, 64, 8, 256, 512, 1024, 8_388_608, 2_097_152, 8_796_093_022_208]
-        )
+        expect(described_class.capabilities).to eq([
+          4, 128, 16, 32, 64, 8, 256, 512, 1024, 8_388_608, 2_097_152, 2_147_483_648,
+          4_294_967_296, 8_589_934_592, 17_179_869_184, 34_359_738_368, 8_796_093_022_208
+        ])
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Add definition for trace tagging remote capability

**Motivation:**

Last bit for the JWT and Trace Tagging RFC

**Change log entry**

None.

**Additional Notes:**

I've remove comments because the copy the constants names. I've pushed a bit more of missing remote config capabilities

**How to test the change?**

CI + [ST](https://github.com/DataDog/system-tests/pull/5457)