### PR TITLE
Add support of Forwarded header for remote IP detection

### DIFF
--- a/sig/datadog/core/utils/network.rbs
+++ b/sig/datadog/core/utils/network.rbs
@@ -10,7 +10,7 @@ module Datadog
         private
 
         def self.ip_header: (Datadog::Core::HeaderCollection headers, ::Array[::String] ip_headers_to_check) -> untyped?
-        def self.extract_ips_from_forwarded_header: (::String header_value) -> ::Array[::String]
+        def self.process_forwarded_header_values: (::Array[::String] values) -> ::Array[::String]
         def self.strip_zone_specifier: (::String ipv6) -> ::String
         def self.strip_ipv6_port: (::String ip) -> ::String
         def self.strip_ipv4_port: (::String ip) -> ::String

--- a/spec/datadog/core/utils/network_spec.rb
+++ b/spec/datadog/core/utils/network_spec.rb
@@ -43,10 +43,12 @@ RSpec.describe Datadog::Core::Utils::Network do
         end
 
         it 'correctly parses multiple for IPs' do
-          headers = Datadog::Core::HeaderCollection.from_hash({'Forwarded' => 'for=10.42.42.42; for=43.43.43.43'})
+          headers = Datadog::Core::HeaderCollection.from_hash(
+            {'Forwarded' => 'for=127.0.0.1;host="example.host";by=2.2.2.2;proto=http,for="1.1.1.1:6543"'}
+          )
 
           result = described_class.stripped_ip_from_request_headers(headers)
-          expect(result).to eq('43.43.43.43')
+          expect(result).to eq('1.1.1.1')
         end
 
         it 'correctly parses IPv6' do


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for `Forwarded` header for remote IP detection.

**Motivation:**
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Forwarded

**Change log entry**
Yes. Tracing: Add `Forwarded` header to the list of headers used for remote IP detection.

**Additional Notes:**
None.

**How to test the change?**
CI