### PR TITLE
Add check for CGNAT IP range when checking for private IPs

### DIFF
--- a/lib/datadog/core/utils/network.rb
+++ b/lib/datadog/core/utils/network.rb
@@ -21,6 +21,8 @@ module Datadog
           cf-connecting-ipv6
         ].freeze
 
+        CGNAT_IP_RANGE = IPAddr.new('100.64.0.0/10')
+
         class << self
           # Returns a client IP associated with the request if it was
           #   retrieved successfully.
@@ -131,7 +133,7 @@ module Datadog
           end
 
           def global_ip?(parsed_ip)
-            parsed_ip && !parsed_ip.private? && !parsed_ip.loopback? && !parsed_ip.link_local?
+            parsed_ip && !parsed_ip.private? && !parsed_ip.loopback? && !parsed_ip.link_local? && !CGNAT_IP_RANGE.include?(parsed_ip)
           end
         end
       end

--- a/sig/datadog/core/utils/network.rbs
+++ b/sig/datadog/core/utils/network.rbs
@@ -4,6 +4,8 @@ module Datadog
       module Network
         DEFAULT_IP_HEADERS_NAMES: ::Array[::String]
 
+        CGNAT_IP_RANGE: ::IPAddr
+
         def self.stripped_ip_from_request_headers: (Datadog::Core::HeaderCollection headers, ?::Array[::String] ip_headers_to_check) -> ::String?
         def self.stripped_ip: (::String ip) -> String?
 

--- a/spec/datadog/core/utils/network_spec.rb
+++ b/spec/datadog/core/utils/network_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Datadog::Core::Utils::Network do
           result = described_class.stripped_ip_from_request_headers(headers)
           expect(result).to eq('43.43.43.43')
         end
+
+        it 'does not return IPs from carrier-grade NAT IP range' do
+          headers = Datadog::Core::HeaderCollection.from_hash({'X-Forwarded-For' => '100.64.0.105,43.43.43.43,fe80::1'})
+
+          result = described_class.stripped_ip_from_request_headers(headers)
+          expect(result).to eq('43.43.43.43')
+        end
       end
 
       context 'with Forwaded header' do


### PR DESCRIPTION
**What does this PR do?**
This PR changes private IP detection to also treat IPs from `100.54.0.0/10` range as private.

**Motivation:**
This should improve accuracy of remote IP detection. Nowadays this IP range is used more and more for kubernetes pods.

**Change log entry**
Yes. Tracing: Treat IPs from `100.65.0.0/10` IP range as private.

**Additional Notes:**
APPSEC-58079

**How to test the change?**
CI and system tests.
