### PR TITLE
[PROF-12841] Fix profiler not identifying executables with gems they belong to

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -224,6 +224,7 @@ target :datadog do
   # References `RubyVM::YJIT`, which does not have type information.
   ignore 'lib/datadog/core/environment/yjit.rb'
 
+  library 'bundler'
   library 'pathname'
   library 'cgi'
   library 'logger', 'monitor'

--- a/lib/datadog/profiling/collectors/code_provenance.rb
+++ b/lib/datadog/profiling/collectors/code_provenance.rb
@@ -22,6 +22,7 @@ module Datadog
           @libraries_by_path = {}
           @seen_files = Set.new
           @seen_libraries = Set.new
+          @executable_paths = [Gem.bindir, (Bundler.bin_path.to_s if defined?(Bundler))].uniq.compact.freeze
 
           record_library(
             Library.new(
@@ -51,7 +52,8 @@ module Datadog
           :libraries_by_name,
           :libraries_by_path,
           :seen_files,
-          :seen_libraries
+          :seen_libraries,
+          :executable_paths
 
         def record_library(library)
           libraries_by_name[library.name] = library
@@ -79,13 +81,20 @@ module Datadog
           loaded_specs.each do |spec|
             next if libraries_by_name.key?(spec.name)
 
+            extra_paths = [(spec.extension_dir if spec.extensions.any?)]
+            spec.executables&.each do |executable|
+              executable_paths.each do |path|
+                extra_paths << File.join(path, executable)
+              end
+            end
+
             record_library(
               Library.new(
                 kind: "library",
                 name: spec.name,
                 version: spec.version,
                 path: spec.gem_dir,
-                extra_paths: [(spec.extension_dir if spec.extensions.any?)],
+                extra_paths: extra_paths,
               )
             )
             recorded_library = true
@@ -119,7 +128,7 @@ module Datadog
           attr_reader :kind, :name, :version
 
           def initialize(kind:, name:, version:, path:, extra_paths:)
-            extra_paths = Array(extra_paths).reject { |p| p.nil? || p.empty? }.map { |p| p.dup.freeze }
+            extra_paths = Array(extra_paths).compact.reject(&:empty?).map { |p| p.dup.freeze }
             @kind = kind.freeze
             @name = name.dup.freeze
             @version = version.to_s.dup.freeze

--- a/sig/datadog/profiling/collectors/code_provenance.rbs
+++ b/sig/datadog/profiling/collectors/code_provenance.rbs
@@ -12,6 +12,7 @@ module Datadog
         attr_reader libraries_by_path: Hash[String, Library]
         attr_reader seen_files: Set[String]
         attr_reader seen_libraries: Set[Library]
+        attr_reader executable_paths: Array[String]
 
         def record_library: (Library) -> void
         def sort_libraries_by_longest_path_first: () -> void

--- a/spec/datadog/profiling/collectors/code_provenance_spec.rb
+++ b/spec/datadog/profiling/collectors/code_provenance_spec.rb
@@ -32,11 +32,16 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
           kind: "library",
           name: "datadog",
           version: Datadog::VERSION::STRING,
-          paths: contain_exactly(start_with("/"), include("extensions").and(include(RUBY_PLATFORM))),
+          paths: contain_exactly(
+            start_with("/"),
+            include("extensions").and(include(RUBY_PLATFORM)),
+            "#{Gem.bindir}/ddprofrb",
+            "#{Bundler.bin_path}/ddprofrb",
+          ),
         },
         {
           kind: "library",
-          name: "rspec-core",
+          name: "rspec",
           version: start_with("3."), # This will one day need to be bumped for RSpec 4
           paths: contain_exactly(start_with("/")),
         },
@@ -59,6 +64,20 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
       )
     end
 
+    it "includes the executables for gems with executables" do
+      refresh
+
+      expect(generate_result.find { |it| it[:name] == "rspec-core" }.fetch(:paths)).to contain_exactly(
+        Gem.loaded_specs.fetch("rspec-core").gem_dir,
+        "#{Gem.bindir}/rspec",
+        "#{Bundler.bin_path}/rspec",
+      )
+
+      # Sanity checks
+      expect(Gem.bindir).to start_with("/")
+      expect(Bundler.bin_path.to_s).to start_with("/")
+    end
+
     it "records the correct path for datadog" do
       refresh
 
@@ -78,6 +97,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
             version: "not_loaded_version",
             gem_dir: "/not_loaded/",
             extensions: [],
+            executables: [],
           ),
           instance_double(
             Gem::Specification,
@@ -85,6 +105,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
             version: "is_loaded_version",
             gem_dir: "/is_loaded/",
             extensions: [],
+            executables: [],
           )
         ],
       )
@@ -131,6 +152,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
               version: "1.2.3",
               gem_dir: "/dd-trace-rb",
               extensions: [],
+              executables: [],
             ),
             instance_double(
               Gem::Specification,
@@ -138,6 +160,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
               version: "4.5.6",
               gem_dir: "/dd-trace-rb/vendor/bundle/ruby/2.7.0/gems/byebug-11.1.3",
               extensions: [],
+              executables: [],
             )
           ],
         )

--- a/vendor/rbs/bundler/0/bundler.rbs
+++ b/vendor/rbs/bundler/0/bundler.rbs
@@ -1,0 +1,3 @@
+module Bundler
+  def self.bin_path: () -> Pathname
+end

--- a/vendor/rbs/gem/0/gem.rbs
+++ b/vendor/rbs/gem/0/gem.rbs
@@ -16,4 +16,5 @@ class Gem::BasicSpecification
   def gem_dir: () -> String
   def extension_dir: () -> String
   def extensions: () -> Array[String]
+  def executables: () -> Array[String]?
 end


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the profiler's "code provenance" metadata to include the paths to gem executables (if any).

This ensures that, when e.g. starting `puma` via `bin/puma` or `bundle exec puma`, we still identify the puma executable as belonging to the `puma` gem.

**Motivation:**

The "code provenance" is used to power the "Only My Code" feature that shows up in multiple places in the profiler UX, and so we want it to be as accurate as possible.

**Change log entry**

Yes. Fix profiler not identifying executables with gems they belong to

**Additional Notes:**

N/A

**How to test the change?**

This change includes test coverage. It can also be tested easily by running

```bash
DD_PROFILING_ENABLED=true DD_SERVICE=test-provenance bundle exec ddprofrb exec pry -e "sleep 1; exit"
```

and checking that `bin/pry` is correctly categorized as belonging to the `pry` gem in the Datadog UX.

Here's how this looked before:

> <img width="770" height="282" alt="image" src="https://github.com/user-attachments/assets/7c23c43c-065a-4b59-8864-ed641333d035" />
> <img width="786" height="271" alt="image" src="https://github.com/user-attachments/assets/8c6a6da6-03ac-4556-9847-20afc65e1f9a" />

and now:

> <img width="769" height="289" alt="image" src="https://github.com/user-attachments/assets/ef022f7d-bbe4-44ac-87b1-5921246011eb" />
