### PR TITLE
[PROF-12846] Fix profiler not categorizing its own sleep/waiting in timeline

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -354,6 +354,10 @@ void sample_thread(
           state_label->str  = DDOG_CHARSLICE_C("blocked");
         } else if (CHARSLICE_EQUALS("wait_readable", name_slice)) { // Expected to be IO#wait_readable
           state_label->str  = DDOG_CHARSLICE_C("network");
+        } else if (CHARSLICE_EQUALS("_native_idle_sampling_loop", name_slice)) { // Expected to be Datadog::Profiler::Collectors::IdleSamplingHelper#_native_idle_sampling_loop
+          state_label->str  = DDOG_CHARSLICE_C("waiting");
+        } else if (CHARSLICE_EQUALS("_native_sampling_loop", name_slice)) { // Expected to be Datadog::Profiler::Collectors::CpuAndWallTimeWorker#_native_sampling_loop
+          state_label->str  = DDOG_CHARSLICE_C("sleeping");
         }
         #ifdef NO_PRIMITIVE_POP // Ruby < 3.2
           else if (CHARSLICE_EQUALS("pop", name_slice)) { // Expected to be Queue/SizedQueue#pop


### PR DESCRIPTION
**What does this PR do?**

This PR extends the timeline thread state categorization code to recognize two frames from the profiler.

**Motivation:**

These two frames quite commonly show up on application profiles, and so its useful for them to be correctly categorized.

**Change log entry**

Yes. Fix profiler not categorizing its own sleep/waiting in timeline

**Additional Notes:**

Getting a thread inside the `_native_sampling_loop` for testing in this case is quite awkward so I only added test coverage for the `_native_idle_sampling_loop` which is quite easy to trigger.

**How to test the change?**

This tiny test script produced samples from both of these frames that were uncategorized:

```
DD_PROFILING_ENABLED=true DD_SERVICE=ivoanjo-testing-categ-fix bundle exec ddprofrb exec ruby -e "end_at = Time.now + 3; while Time.now < end_at; end"
```

Here's how it looked before:

> <img width="899" height="265" alt="image" src="https://github.com/user-attachments/assets/e54ead3d-953b-419f-9039-d624edd431c2" />
> <img width="913" height="278" alt="image" src="https://github.com/user-attachments/assets/e05dc565-70a3-49f3-aea3-3bff0125fcd5" />

and how it looks now:

> <img width="1052" height="278" alt="image" src="https://github.com/user-attachments/assets/dcf81f35-e551-4b8c-b571-94c50baab586" />
> <img width="894" height="259" alt="image" src="https://github.com/user-attachments/assets/1c30dcfd-6501-4b2f-866e-a3e641357de7" />



