### PR TITLE
[NO-TICKET] Add `@DataDog/ruby-guild` as fallback codeowner on rbs folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,12 +17,12 @@ lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
 ext/ @DataDog/profiling-rb @DataDog/ruby-guild
 
 # RBS signatures
-sig/datadog/appsec/ @DataDog/asm-ruby
-sig/datadog/appsec.rbs @DataDog/asm-ruby
-sig/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
-sig/datadog/tracing.rbs @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby
-sig/datadog/opentelemetry/ @DataDog/apm-sdk-capabilities-ruby
-sig/datadog/opentelemetry.rbs @DataDog/apm-sdk-capabilities-ruby
+sig/datadog/appsec/ @DataDog/asm-ruby @DataDog/ruby-guild
+sig/datadog/appsec.rbs @DataDog/asm-ruby @DataDog/ruby-guild
+sig/datadog/tracing/ @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby @DataDog/ruby-guild
+sig/datadog/tracing.rbs @DataDog/apm-idm-ruby @DataDog/apm-sdk-capabilities-ruby @DataDog/ruby-guild
+sig/datadog/opentelemetry/ @DataDog/apm-sdk-capabilities-ruby @DataDog/ruby-guild
+sig/datadog/opentelemetry.rbs @DataDog/apm-sdk-capabilities-ruby @DataDog/ruby-guild
 sig/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 sig/datadog/profiling.rbs @DataDog/profiling-rb @DataDog/ruby-guild
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds `@DataDog/ruby-guild` as an additional codeowner on rbs folders.

**Motivation:**

While looking at @vpellan's PR
https://github.com/DataDog/dd-trace-rb/pull/5014 it seems overkill to need reviews from across n teams for type signature changes.

I think at this point we want to encourage all rbs contributions and lower their overhead, not make it really annoying to get them into the project, so the more reviewers the better.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

CODEOWNERS changes are always annoying to test; on the other hand, if anything is wrong, it's easy to revert.
