### PR TITLE
chore: bump version of the testagent used in tests

### DIFF
--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -136,7 +136,7 @@ jobs:
         JRUBY_OPTS: "--dev" # Faster JVM startup: https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.18.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby
@@ -206,7 +206,7 @@ jobs:
       options: --link mongodb:mongodb_secondary
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.18.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,7 +260,7 @@ services:
       - ddagent_var_run:/var/run/datadog
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.12.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
     ports:
       - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
     depends_on:


### PR DESCRIPTION
**What does this PR do?**

Bumps the version of the testagent used to run tests

**Motivation:**

Test agent v1.37.0 introduces new apis for capturing otlp metrics and logs

**Change log entry**

No. This change only impacts testing (changed by @Strech)

**How to test the change?**

n/a
