### PR TITLE
Add DSM Integration to the Waterdrop instrumentation

### DIFF
--- a/lib/datadog/tracing/contrib/waterdrop/middleware.rb
+++ b/lib/datadog/tracing/contrib/waterdrop/middleware.rb
@@ -19,6 +19,17 @@ module Datadog
                 WaterDrop.inject(trace_op.to_digest, message[:headers] ||= {})
               end
 
+              if Datadog::DataStreams.enabled?
+                Datadog::DataStreams.set_produce_checkpoint(
+                  type: 'kafka',
+                  destination: message[:topic],
+                  auto_instrumentation: true
+                ) do |key, value|
+                  message[:headers] ||= {}
+                  message[:headers][key] = value
+                end
+              end
+
               message
             end
 

--- a/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/monitor_spec.rb
@@ -2,10 +2,7 @@
 
 require 'datadog/tracing/contrib/support/spec_helper'
 
-# FFI::Function background native thread
-ThreadHelpers.with_leaky_thread_creation(:rdkafka) do
-  require 'karafka'
-end
+require 'karafka'
 require 'datadog'
 
 RSpec.describe 'Karafka monitor' do

--- a/spec/datadog/tracing/contrib/waterdrop/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/distributed/propagation_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/tracing/contrib/support/spec_helper'
-
-# FFI::Function background native thread
-ThreadHelpers.with_leaky_thread_creation(:rdkafka) do
-  require 'waterdrop'
-end
+require 'waterdrop'
 require 'datadog'
 
 RSpec.describe Datadog::Tracing::Contrib::WaterDrop::Distributed::Propagation do

--- a/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/tracing/contrib/support/spec_helper'
-
-# FFI::Function background native thread
-ThreadHelpers.with_leaky_thread_creation(:rdkafka) do
-  require 'waterdrop'
-end
+require 'waterdrop'
 require 'datadog'
 
 RSpec.describe 'WaterDrop middleware' do
@@ -58,6 +54,66 @@ RSpec.describe 'WaterDrop middleware' do
           'x-datadog-trace-id' => low_order_trace_id(span.trace_id).to_s,
           'x-datadog-parent-id' => span.id.to_s
         )
+      end
+    end
+
+    context 'when DataStreams is enabled' do
+      before do
+        allow(Datadog::DataStreams).to receive(:enabled?).and_return(true)
+        allow(Datadog::DataStreams).to receive(:set_produce_checkpoint) do |**_kwargs, &block|
+          block.call('data_streams_key', 'data_streams_value')
+        end
+      end
+
+      it 'calls set_produce_checkpoint and injects headers' do
+        message = {topic: 'some_topic', payload: 'hello'}
+
+        middleware.call(message)
+
+        expect(Datadog::DataStreams).to have_received(:set_produce_checkpoint).with(
+          type: 'kafka',
+          destination: 'some_topic',
+          auto_instrumentation: true
+        )
+        expect(message[:headers]).to include('data_streams_key' => 'data_streams_value')
+      end
+
+      it 'initializes headers if not present' do
+        message = {topic: 'some_topic', payload: 'hello'}
+
+        middleware.call(message)
+
+        expect(Datadog::DataStreams).to have_received(:set_produce_checkpoint).with(
+          type: 'kafka',
+          destination: 'some_topic',
+          auto_instrumentation: true
+        )
+      end
+
+      it 'preserves existing headers' do
+        message = {topic: 'some_topic', payload: 'hello', headers: {'existing' => 'header'}}
+
+        middleware.call(message)
+
+        expect(message[:headers]).to include(
+          'data_streams_key' => 'data_streams_value',
+          'existing' => 'header'
+        )
+      end
+    end
+
+    context 'when DataStreams is disabled' do
+      before do
+        allow(Datadog::DataStreams).to receive(:enabled?).and_return(false)
+        allow(Datadog::DataStreams).to receive(:set_produce_checkpoint)
+      end
+
+      it 'does not call set_produce_checkpoint' do
+        message = {topic: 'some_topic', payload: 'hello'}
+
+        middleware.call(message)
+
+        expect(Datadog::DataStreams).not_to have_received(:set_produce_checkpoint)
       end
     end
   end

--- a/spec/datadog/tracing/contrib/waterdrop/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/patcher_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/tracing/contrib/support/spec_helper'
-
-# FFI::Function background native thread
-ThreadHelpers.with_leaky_thread_creation(:rdkafka) do
-  require 'waterdrop'
-end
+require 'waterdrop'
 require 'datadog'
 
 RSpec.describe 'Waterdrop patcher' do
@@ -70,6 +66,20 @@ RSpec.describe 'Waterdrop patcher' do
             Datadog::Tracing::Contrib::WaterDrop::Middleware
           ]
         )
+      end
+    end
+
+    context 'when DataStreams is enabled' do
+      before do
+        allow(Datadog::DataStreams).to receive(:enabled?).and_return(true)
+      end
+
+      it 'patches without errors' do
+        expect do
+          WaterDrop::Producer.new do |config|
+            config.client_class = WaterDrop::Clients::Buffered
+          end
+        end.not_to raise_error
       end
     end
   end

--- a/spec/datadog/tracing/contrib/waterdrop/producer_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/producer_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 require 'datadog/tracing/contrib/support/spec_helper'
-
-# FFI::Function background native thread
-ThreadHelpers.with_leaky_thread_creation(:rdkafka) do
-  require 'waterdrop'
-end
+require 'waterdrop'
 require 'datadog'
 
 RSpec.describe 'Waterdrop monitor' do


### PR DESCRIPTION
This is one commit on top of the Waterdrop PR (here: https://github.com/DataDog/dd-trace-rb/pull/4874) to add DSM to the Waterdrop instrumentation

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
This PR adds DSM instrumentation to Waterdrop ensuring that if DSM is enabled and they use the Karafka ecosystem, a customer can have DSM through their architecture

<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Adding DSM to Ruby and all design partners use Waterdrop
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

Yes. Waterdrop producers are compatible with Data Streams Monitoring (DSM)

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
