### PR TITLE
Add support for Ruby HEAD (version 4.0)

### DIFF
--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -21,6 +21,6 @@ module Datadog
     # To allow testing with the next unreleased version of Ruby, the version check is performed
     # as `< #{MAXIMUM_RUBY_VERSION}`, meaning prereleases of MAXIMUM_RUBY_VERSION are allowed
     # but not stable MAXIMUM_RUBY_VERSION releases.
-    MAXIMUM_RUBY_VERSION = '3.5'
+    MAXIMUM_RUBY_VERSION = '4.0'
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Changes the max Ruby version to 4.0

**Motivation:**

Ruby changed the development branch from 3.5 to 4.0 in https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523 Updating the version here allows folks to continue testing the gem against Ruby HEAD (4.0.0.dev) 

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
