### PR TITLE
Add top-level type `any` as semantic version of `untyped`

### DIFF
--- a/sig/datadog.rbs
+++ b/sig/datadog.rbs
@@ -1,4 +1,26 @@
 module Datadog
+  # This type is a semantic version of `untyped` when the accepted or returned
+  # value is literally anything. And `untyped` should be used as a signal that
+  # the typing is not finished yet.
+  #
+  # WARNING: This type should be used sparingly and only when there are no distinct
+  #          types that can be used to represent the value.
+  #
+  # Examples:
+  #
+  #   when Hash values are impossible to narrow down to a specific type
+  #
+  #   ```rbs
+  #   def my_function: (::Hash[::String, any] payload) -> void
+  #   ```
+  #
+  #   or when an arbitrary Array with uncontrolled values is needed
+  #
+  #   ```rbs
+  #   def my_function: (::Array[any] payload) -> void
+  #   ```
+  type any = untyped
+
   extend Core::Extensions
   extend Core::Configuration
 


### PR DESCRIPTION
**What does this PR do?**

Add a Datadog top-level semantic type `any`.

**Motivation:**

The type `any` is going to represent a scenario when the narrowing is impossible to do or when it doesn't make sense to do. And type `untyped` should represent an actual untyped type (no time, not done, etc)

**Change log entry**

No.

**Additional Notes:**

We can get more value out of `untyped` checks once we start moving to `any` in case when it's really any type.

**How to test the change?**

CI