### PR TITLE
Disable Ruby 3.5 preview1 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,6 @@ concurrency:
 
 jobs:
   # ADD NEW RUBIES HERE
-  ruby-35:
-    name: "Ruby 3.5"
-    uses: ./.github/workflows/_unit_test.yml
-    with:
-      engine: ruby
-      version: "3.5"
-      alias: ruby-35
-
   ruby-34:
     name: "Ruby 3.4"
     uses: ./.github/workflows/_unit_test.yml
@@ -145,7 +137,6 @@ jobs:
         DD_GIT_REPOSITORY_URL: "${{ github.repositoryUrl }}"
     needs:
       # ADD NEW RUBIES HERE
-      - ruby-35
       - ruby-34
       - ruby-33
       - ruby-32
@@ -192,7 +183,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       # ADD NEW RUBIES HERE
-      - ruby-35
       - ruby-34
       - ruby-33
       - ruby-32
@@ -232,7 +222,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       # ADD NEW RUBIES HERE
-      - ruby-35
       - ruby-34
       - ruby-33
       - ruby-32


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Disable Ruby 3.5 preview1 testing

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Crashes with simplecov are simply too frequent.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Testing will be attempted to be reintroduced at 4.0 preview2 level.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

CI should not have 3.5

<!-- Unsure? Have a question? Request a review! -->
