### PR TITLE
[INCIDENT-46145] Stub sampling in integration tests

### DIFF
--- a/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/integration_test_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'Rack integration tests' do
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
   let(:api_security_enabled) { false }
-  let(:api_security_sample) { 0.0 }
 
   let(:crs_942_100) do
     {
@@ -265,11 +264,14 @@ RSpec.describe 'Rack integration tests' do
         c.appsec.user_id_denylist = appsec_user_id_denylist
         c.appsec.ruleset = appsec_ruleset
         c.appsec.api_security.enabled = api_security_enabled
-        c.appsec.api_security.sample_delay = api_security_sample.to_i
+        c.appsec.api_security.sample_delay = 0.0
 
         c.remote.enabled = remote_enabled
       end
     end
+
+    allow(Datadog::AppSec::APISecurity).to receive(:sample_trace?).and_return(true)
+    allow(Datadog::AppSec::APISecurity).to receive(:sample?).and_return(true)
 
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
     allow_any_instance_of(Datadog::Tracing::Transport::Traces::Transport).to receive(:native_events_supported?)
@@ -344,7 +346,7 @@ RSpec.describe 'Rack integration tests' do
             c.appsec.enabled = appsec_enabled
             c.appsec.waf_timeout = 10_000_000 # in us
             c.appsec.api_security.enabled = api_security_enabled
-            c.appsec.api_security.sample_delay = api_security_sample.to_i
+            c.appsec.api_security.sample_delay = 0.0
             c.appsec.instrument :rack
           end
         end

--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'Rails integration tests', execute_in_fork: Rails.version.to_i >=
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
   let(:api_security_enabled) { false }
-  let(:api_security_sample) { 0 }
 
   let(:crs_942_100) do
     {
@@ -157,8 +156,11 @@ RSpec.describe 'Rails integration tests', execute_in_fork: Rails.version.to_i >=
       c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
       c.appsec.api_security.enabled = api_security_enabled
-      c.appsec.api_security.sample_delay = api_security_sample.to_i
+      c.appsec.api_security.sample_delay = 0.0
     end
+
+    allow(Datadog::AppSec::APISecurity).to receive(:sample_trace?).and_return(true)
+    allow(Datadog::AppSec::APISecurity).to receive(:sample?).and_return(true)
 
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
     allow_any_instance_of(Datadog::Tracing::Transport::Traces::Transport).to receive(:native_events_supported?)

--- a/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/integration_test_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe 'Sinatra integration tests', skip: PlatformHelpers.jruby_100? do
   let(:appsec_user_id_denylist) { [] }
   let(:appsec_ruleset) { :recommended }
   let(:api_security_enabled) { false }
-  let(:api_security_sample) { 0.0 }
 
   let(:crs_942_100) do
     {
@@ -164,8 +163,11 @@ RSpec.describe 'Sinatra integration tests', skip: PlatformHelpers.jruby_100? do
       c.appsec.user_id_denylist = appsec_user_id_denylist
       c.appsec.ruleset = appsec_ruleset
       c.appsec.api_security.enabled = api_security_enabled
-      c.appsec.api_security.sample_delay = api_security_sample.to_i
+      c.appsec.api_security.sample_delay = 0.0
     end
+
+    allow(Datadog::AppSec::APISecurity).to receive(:sample_trace?).and_return(true)
+    allow(Datadog::AppSec::APISecurity).to receive(:sample?).and_return(true)
 
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
     allow_any_instance_of(Datadog::Tracing::Transport::Traces::Transport).to receive(:native_events_supported?)

--- a/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
+++ b/spec/datadog/appsec/contrib/support/integration/shared_examples.rb
@@ -127,7 +127,6 @@ end
 RSpec.shared_examples 'a trace with AppSec api security tags' do
   context 'with api security enabled' do
     let(:api_security_enabled) { true }
-    let(:api_security_sample) { 0 }
 
     it do
       api_security_tags = service_span.send(:meta).select { |key, _value| key.include?('_dd.appsec.s') }


### PR DESCRIPTION
**What does this PR do?**

Instead of relying on configuration in integration test we are going to stub the sampling to always sample.

**Motivation:**

This should improve stability of tests

**Change log entry**

No.

**Additional Notes:**

Tests I've touched must be rewritten, this will happen eventually.

**How to test the change?**

CI.