### PR TITLE
[PROF-13115] Disable heap profiling on Ruby 4 preview due to incompatibility

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -220,6 +220,12 @@ module Datadog
             "Please upgrade to Ruby >= 3.1 in order to use this feature. Heap profiling has been disabled."
           )
           return false
+        elsif RUBY_VERSION.start_with?("4.")
+          logger.warn(
+            "Heap profiling is not supported in current Ruby version (#{RUBY_VERSION}) due to https://bugs.ruby-lang.org/issues/21710. " \
+            "Heap profiling has been disabled."
+          )
+          return false
         end
 
         unless allocation_profiling_enabled

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -868,6 +868,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
       before do
         skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
+        skip "Heap profiling is disabled on Ruby 4 until https://bugs.ruby-lang.org/issues/21710 is fixed" if RUBY_VERSION.start_with?("4.")
         allow(Datadog.logger).to receive(:warn)
         expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
       end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -334,6 +334,20 @@ RSpec.describe Datadog::Profiling::Component do
             end
           end
 
+          context "on Ruby 4.0 or newer" do
+            let(:testing_version) { "4.0.0" }
+
+            it "initializes StackRecorder without heap sampling support and warns" do
+              expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
+                .and_call_original
+
+              expect(logger).to receive(:warn).with(/Heap profiling is not supported.*21710/)
+
+              build_profiler_component
+            end
+          end
+
           context "and allocation profiling disabled" do
             before do
               settings.profiling.allocation_enabled = false


### PR DESCRIPTION
**What does this PR do?**

This PR disables the heap profiling feature when running on Ruby 4 as right now it can trigger the crash reported in
https://bugs.ruby-lang.org/issues/21710 .

**Motivation:**

Until either https://bugs.ruby-lang.org/issues/21710 gets fixed or we change the heap profiler to use the new
[`rb_gc_mark_weak` API](https://bugs.ruby-lang.org/issues/19783) it's not safe to enable the heap profiling feature on Ruby 4.

**Change log entry**

None. (This is undone by a later PR.)

~~Not anymore. Disable heap profiling on Ruby 4 preview due to incompatibility~~

**Additional Notes:**

I'm preparing a PR with other, smaller fixes for the profiler Ruby 4 support, but I decided to split this one by itself so we could have a separate, clear, changelog entry about this change, as well as a single PR to discuss this subject.

**How to test the change?**

We don't yet have Ruby 4 in CI, so this can only be tested locally or by mocking the `RUBY_VERSION`.