### PR TITLE
[PROF-13115] Bootstrap installing dependencies on Ruby 4.0.0-preview2

### DIFF
--- a/ruby-4.0.gemfile
+++ b/ruby-4.0.gemfile
@@ -1,0 +1,70 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'base64'
+gem 'benchmark' # Required for Ruby 3.5+ where benchmark is no longer a default gem
+gem 'benchmark-ips', '~> 2.8'
+gem 'benchmark-memory', '< 0.2' # V0.2 only works with 2.5+
+gem 'bigdecimal'
+gem 'climate_control', '~> 1.2.0'
+gem 'concurrent-ruby'
+gem 'fiddle' # Required for Ruby 3.5+ where fiddle is no longer a default gem
+
+# Optional extensions
+# TODO: Move this to Appraisals?
+# dogstatsd v5, but lower than 5.2, has possible memory leak with datadog.
+# @see https://github.com/DataDog/dogstatsd-ruby/issues/182
+gem 'dogstatsd-ruby', '>= 3.3.0', '!= 5.0.0', '!= 5.0.1', '!= 5.1.0'
+
+gem 'zstd-ruby'
+
+# Profiler testing dependencies
+# NOTE: We're excluding versions 3.7.0 and 3.7.1 for the reasons documented in #1424.
+#       Since most of our customers won't have BUNDLE_FORCE_RUBY_PLATFORM=true, it's not something we want to add
+#       to our CI, so we just shortcut and exclude specific versions that were affecting our CI.
+gem 'google-protobuf', ['~> 3.0', '!= 3.7.0', '!= 3.7.1']
+
+gem 'json-schema', '< 3' # V3 only works with 2.5+
+gem 'memory_profiler', '~> 0.9'
+gem 'mutex_m'
+gem 'os', '~> 1.1'
+gem 'ostruct'
+# debug permits evaluating more expressions than byebug, however
+# debug does not show context on stack navigation.
+gem 'byebug'
+gem 'pry'
+gem 'rake', '>= 10.5'
+gem 'rake-compiler', '~> 1.1', '>= 1.1.1' # To compile native extensions
+gem 'rspec', '~> 3.13'
+gem 'rspec-collection_matchers', '~> 1.1'
+gem 'rspec_junit_formatter', '>= 0.5.1'
+gem 'rspec-wait', '~> 0'
+
+gem 'simplecov', '~> 0.22.0'
+
+gem 'warning', '~> 1' # NOTE: Used in spec_helper.rb
+gem 'webmock', '>= 3.10.0'
+gem 'webrick', '>= 1.8.2'
+
+group :check do
+  gem 'rbs', '~> 3.7', require: false
+  gem 'steep', '~> 1.10', require: false
+  gem 'ruby_memcheck', '>= 3'
+  gem 'standard', require: false
+
+  # Rubocop version must be pinned to major.minor because its demanded
+  # style changes between minor versions.
+  # Most recent standard as of this writing (1.45) depends on rubocop 1.71.
+  # There is rubocop 1.73 but that downgrades standard to 1.35.
+  gem 'rubocop', '~> 1.71.0', require: false
+  gem 'rubocop-packaging', '~> 0.5.2', require: false
+  gem 'rubocop-performance', '~> 1.20', require: false
+  gem 'rubocop-rspec', '~> 2.31', require: false
+end
+
+group :dev do
+  gem 'appraisal', '~> 2.4.0', require: false
+  gem 'pimpmychangelog', '~> 0.1.3', require: false
+  gem 'ruby-lsp', require: false
+end


### PR DESCRIPTION
**What does this PR do?**

This PR adds the `ruby-4.0.gemfile` file that's needed for running `bundle install` on Ruby 4.0.0-preview2.

The contents of this file being added are copy/pasted from `ruby-3.5.gemfile` with no changes.

I did not add or change anything on purpose: This is a very minimal part of the Ruby 4 CI support being prepared in
https://github.com/DataDog/dd-trace-rb/pull/5084 but unlocks local development with Ruby 4.0. I suggest we keep adjustments/cleanups/etc for that later PR where we officially add Ruby 4.0 to our CI.

**Motivation:**

Without this file it's impossible to do local development on Ruby 4.0.0-preview2.

It also came up in
<https://github.com/DataDog/datadog-ruby_core_source/pull/19>: we want to check if the profiler extension compiles on Ruby 4.0 and we're not able without this file.

With this PR we can run `bundle install` and start running tests and tackling what's missing.

**Change log entry**

None.

(This doesn't get a changelog entry since it affects only development -- the `Gemfile` nor the version-specific variants are not shipped as part of the released gem)

**Additional Notes:**

N/A

**How to test the change?**

Validate that it's possible to run `bundle install` on Ruby 4.0.
