### PR TITLE
[PROF-13115] Fix profiler ractor specs failing on Ruby 4

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1184,7 +1184,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
               Ractor.new do
                 Thread.current.name = "background ractor"
                 Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_handle_sampling_signal
-              end.take
+              end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
             end
           )
       end
@@ -1196,7 +1196,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
               Ractor.new do
                 Thread.current.name = "background ractor"
                 Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_sample_from_postponed_job
-              end.take
+              end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
             end
           )
       end

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe Datadog::Profiling::NativeExtension do
         before { skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.") }
 
         subject(:ddtrace_rb_ractor_main_p) do
-          Ractor.new { Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p }.take
+          Ractor.new do
+            Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p
+          end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
         end
 
         it { is_expected.to be false }


### PR DESCRIPTION
**What does this PR do?**

This PR updates the profiler specs to handle the removal of [Ractor#take in Ruby 4.0](https://github.com/ruby/ruby/commit/57d10c6e806c4572eb75084462ecdf883591f4ea)

To keep the specs working on 3.x Rubies, we still use Ractor#take there.

**Motivation:**

Get a green CI with profiling on Ruby 4.0.0-preview2.

**Change log entry**

None. (This only affects specs -- we don't use Ractor#take in production code)

**Additional Notes:**

Thanks @lloeki for flagging this one -- I had missed it on my previous "support 4.0.0-preview2 PRs" as the ractor specs only run when `-t ractors` gets passed in (and CI does that as well).

**How to test the change?**

Run these specs with `-t ractors` and observe they're green on Ruby 3 and 4.