### PR TITLE
Remote config: Use Mutex#synchronize in RC worker

### DIFF
--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -23,10 +23,6 @@ module Datadog
 
         private
 
-        def acquire_lock: () -> void
-
-        def release_lock: () -> void
-
         def poll: (::Float interval) -> void
 
         def call: () -> void

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Datadog::Core::Remote::Worker do
     end
 
     it 'acquire and release lock' do
-      expect(worker).to receive(:acquire_lock).at_least(:once)
-      expect(worker).to receive(:release_lock).at_least(:once)
+      expect(worker.instance_variable_get('@mutex')).to receive(:synchronize).at_least(:once)
       worker.start
     end
 
@@ -84,8 +83,7 @@ RSpec.describe Datadog::Core::Remote::Worker do
     end
 
     it 'acquire and release lock' do
-      expect(worker).to receive(:acquire_lock)
-      expect(worker).to receive(:release_lock)
+      expect(worker.instance_variable_get('@mutex')).to receive(:synchronize).at_least(:once)
       worker.stop
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Replaces acquire/release calls with Mutex#synchronize call.
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
Reduce the size of our code - the standard library provides the synchronize call which we were reimplementing.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing tests