### PR TITLE
Karafka & Waterdrop: support different configurations per topic

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1161,6 +1161,10 @@ require 'datadog'
 
 Datadog.configure do |c|
   c.tracing.instrument :karafka, **options
+
+  # different options for different kafka topics
+  c.tracing.instrument :karafka, describes: "some-topic", distributed_tracing: false
+  c.tracing.instrument :karafka, describes: /^topic-regex-.*/, enabled: false
 end
 
 ```
@@ -1183,6 +1187,10 @@ require 'datadog'
 
 Datadog.configure do |c|
   c.tracing.instrument :waterdrop, **options
+
+  # different options for different kafka topics
+  c.tracing.instrument :waterdrop, describes: "some-topic", distributed_tracing: false
+  c.tracing.instrument :waterdrop, describes: /^topic-regex-.*/, enabled: false
 end
 
 ```

--- a/lib/datadog/tracing/contrib/karafka/framework.rb
+++ b/lib/datadog/tracing/contrib/karafka/framework.rb
@@ -9,18 +9,28 @@ module Datadog
         # - instrument parts of the framework when needed
         module Framework
           def self.setup
+            karafka_configurations = Datadog.configuration.tracing.fetch_integration(:karafka).configurations
+            waterdrop_configurations = Datadog.configuration.tracing.fetch_integration(:waterdrop).configurations
+
             Datadog.configure do |datadog_config|
-              karafka_config = datadog_config.tracing[:karafka]
-              activate_waterdrop!(datadog_config, karafka_config)
+              karafka_configurations.each do |config_name, karafka_config|
+                # Do +not+ overwrite custom WaterDrop configurations
+                # (e.g. user-created with `describes`)
+                next if config_name != :default && waterdrop_configurations.key?(config_name)
+
+                activate_waterdrop!(datadog_config, config_name, karafka_config)
+              end
             end
           end
 
           # Apply relevant configuration from Karafka to WaterDrop
-          def self.activate_waterdrop!(datadog_config, karafka_config)
+          def self.activate_waterdrop!(datadog_config, config_name, karafka_config)
             datadog_config.tracing.instrument(
               :waterdrop,
+              enabled: karafka_config[:enabled],
               service_name: karafka_config[:service_name],
               distributed_tracing: karafka_config[:distributed_tracing],
+              describes: config_name,
             )
           end
         end

--- a/lib/datadog/tracing/contrib/karafka/integration.rb
+++ b/lib/datadog/tracing/contrib/karafka/integration.rb
@@ -38,6 +38,10 @@ module Datadog
           def patcher
             Patcher
           end
+
+          def resolver
+            @resolver ||= Contrib::Configuration::Resolvers::PatternResolver.new
+          end
         end
       end
     end

--- a/lib/datadog/tracing/contrib/waterdrop/integration.rb
+++ b/lib/datadog/tracing/contrib/waterdrop/integration.rb
@@ -36,6 +36,10 @@ module Datadog
           def patcher
             Patcher
           end
+
+          def resolver
+            @resolver ||= Contrib::Configuration::Resolvers::PatternResolver.new
+          end
         end
       end
     end

--- a/lib/datadog/tracing/contrib/waterdrop/middleware.rb
+++ b/lib/datadog/tracing/contrib/waterdrop/middleware.rb
@@ -13,7 +13,7 @@ module Datadog
               trace_op = Datadog::Tracing.active_trace
 
               if trace_op && Datadog::Tracing::Distributed::PropagationPolicy.enabled?(
-                global_config: configuration,
+                global_config: datadog_configuration(message[:topic]),
                 trace: trace_op
               )
                 WaterDrop.inject(trace_op.to_digest, message[:headers] ||= {})
@@ -35,8 +35,8 @@ module Datadog
 
             private
 
-            def configuration
-              Datadog.configuration.tracing[:waterdrop]
+            def datadog_configuration(topic)
+              Datadog.configuration.tracing[:waterdrop, topic]
             end
           end
         end

--- a/sig/datadog/tracing/contrib/waterdrop/integration.rbs
+++ b/sig/datadog/tracing/contrib/waterdrop/integration.rbs
@@ -5,6 +5,8 @@ module Datadog
         class Integration
           include Contrib::Integration
 
+          @resolver: Contrib::Configuration::Resolvers::PatternResolver
+
           MINIMUM_VERSION: ::Gem::Version
 
           def self.register_as: (untyped name, ?registry: untyped, ?auto_patch: bool, **untyped options) -> untyped
@@ -18,6 +20,8 @@ module Datadog
           def new_configuration: () -> Configuration::Settings
 
           def patcher: () -> untyped
+
+          def resolver: () -> Contrib::Configuration::Resolvers::PatternResolver
         end
       end
     end

--- a/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
@@ -8,16 +8,19 @@ end
 require 'datadog'
 
 RSpec.describe 'Karafka patcher' do
-  let(:configuration_options) { {distributed_tracing: true} }
   let(:client_id) { SecureRandom.uuid }
   let(:span) do
     spans.find { |s| s.name == span_name }
   end
+  let(:config_block) do
+    ->(c) {
+      c.tracing.instrument :karafka, distributed_tracing: true
+      c.tracing.instrument :karafka, describes: /special_/, distributed_tracing: false
+    }
+  end
 
   before do
-    Datadog.configure do |c|
-      c.tracing.instrument :karafka, configuration_options
-    end
+    Datadog.configure(&config_block)
   end
 
   around do |example|
@@ -31,16 +34,12 @@ RSpec.describe 'Karafka patcher' do
     let(:span_name) { Datadog::Tracing::Contrib::Karafka::Ext::SPAN_MESSAGE_CONSUME }
 
     it 'is expected to send a span' do
-      metadata = ::Karafka::Messages::Metadata.new
-      metadata['offset'] = 412
+      metadata = ::Karafka::Messages::Metadata.new(offset: 412, timestamp: Time.now, topic: 'topic_a')
       raw_payload = rand.to_s
 
       message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-      allow(message).to receive(:timestamp).and_return(Time.now)
-      allow(message).to receive(:topic).and_return('topic_a')
 
-      topic = ::Karafka::Routing::Topic.new('topic_a', double(id: 0))
-
+      topic = ::Karafka::Routing::Topic.new(message.topic, double(id: 0))
       messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
 
       expect(messages).to all(be_a(::Karafka::Messages::Message))
@@ -55,20 +54,21 @@ RSpec.describe 'Karafka patcher' do
     end
 
     context 'when the message has tracing headers' do
+      let(:topic_name) { 'topic_a' }
       let(:message) do
         headers = {}
         Datadog::Tracing.trace('producer') do |span, trace|
           Datadog::Tracing::Contrib::Karafka.inject(trace.to_digest, headers)
         end
-        metadata = ::Karafka::Messages::Metadata.new
-        metadata['offset'] = 412
-        metadata[headers_accessor] = headers
+        metadata = ::Karafka::Messages::Metadata.new(
+          :offset => 412,
+          headers_accessor => headers,
+          :topic => topic_name,
+          :timestamp => Time.now
+        )
         raw_payload = rand.to_s
 
-        message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-        allow(message).to receive(:timestamp).and_return(Time.now)
-        allow(message).to receive(:topic).and_return('topic_a')
-        message
+        ::Karafka::Messages::Message.new(raw_payload, metadata)
       end
       let(:headers_accessor) do
         ::Karafka::Messages::Metadata.members.include?(:raw_headers) ? 'raw_headers' : 'headers'
@@ -85,7 +85,7 @@ RSpec.describe 'Karafka patcher' do
             consumer_span = Datadog::Tracing.active_span
             consumer_trace = Datadog::Tracing.active_trace
 
-            topic = ::Karafka::Routing::Topic.new('topic_a', double(id: 0))
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
             messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
             # NOTE: The following will iterate through the messages and create a new span representing
             #       the individual message processing (and `span` will refer to that particular span)
@@ -108,8 +108,16 @@ RSpec.describe 'Karafka patcher' do
         end
       end
 
-      context 'when distributed tracing is not enabled' do
-        let(:configuration_options) { {distributed_tracing: false} }
+      context 'when distributed tracing is disabled for the topic in particular' do
+        let(:topic_name) { 'special_topic' }
+
+        it 'correctly sets the configuration' do
+          expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be true
+
+          expect(Datadog.configuration.tracing[:karafka, 'special_topic'][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka, 'special_topic'][:distributed_tracing]).to be false
+        end
 
         it 'does not continue the span that produced the message' do
           consumer_span = nil
@@ -119,7 +127,38 @@ RSpec.describe 'Karafka patcher' do
             consumer_span = Datadog::Tracing.active_span
             consumer_trace = Datadog::Tracing.active_trace
 
-            topic = ::Karafka::Routing::Topic.new('topic_a', double(id: 0))
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
+            messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
+            expect(messages).to all(be_a(::Karafka::Messages::Message))
+
+            # assert that the current trace re-set to the original trace after iterating the messages
+            expect(Datadog::Tracing.active_trace).to eq(consumer_trace)
+            expect(Datadog::Tracing.active_span).to eq(consumer_span)
+          end
+
+          expect(spans).to have(3).items
+
+          # assert that the message span is not continuation of the producer span
+          expect(span.parent_id).to eq(consumer_span.id)
+          expect(span.trace_id).to eq(consumer_trace.id)
+        end
+      end
+
+      context 'when distributed tracing is not enabled' do
+        let(:config_block) do
+          ->(c) { c.tracing.instrument :karafka, distributed_tracing: false }
+        end
+
+        it 'does not continue the span that produced the message' do
+          consumer_span = nil
+          consumer_trace = nil
+
+          Datadog::Tracing.trace('consumer') do
+            consumer_span = Datadog::Tracing.active_span
+            consumer_trace = Datadog::Tracing.active_trace
+
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
+
             messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
             # NOTE: The following will iterate through the messages and create a new span representing
             #       the individual message processing (and `span` will refer to that particular span)
@@ -148,12 +187,11 @@ RSpec.describe 'Karafka patcher' do
     let(:span_name) { Datadog::Tracing::Contrib::Karafka::Ext::SPAN_WORKER_PROCESS }
 
     it 'is expected to send a span' do
-      metadata = ::Karafka::Messages::Metadata.new
-      metadata['offset'] = 412
+      metadata = ::Karafka::Messages::Metadata.new(offset: 412, topic: 'topic_a')
       raw_payload = rand.to_s
 
       message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-      job = double(executor: double(topic: double(name: 'topic_a', consumer: 'ABC'), partition: 0), messages: [message])
+      job = double(executor: double(topic: double(name: message.topic, consumer: 'ABC'), partition: 0), messages: [message])
 
       Karafka.monitor.instrument('worker.processed', {job: job}) do
         # Noop
@@ -195,15 +233,15 @@ RSpec.describe 'Karafka patcher' do
       end
 
       it 'automatically enables WaterDrop instrumentation' do
-        Karafka::App.setup do |c|
-          c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
-        end
-
-        expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
-        expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be true
+         Karafka::App.setup do |c|
+           c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
+         end
 
         expect(Datadog.configuration.tracing[:waterdrop][:enabled]).to be true
         expect(Datadog.configuration.tracing[:waterdrop][:distributed_tracing]).to be true
+
+        expect(Datadog.configuration.tracing[:waterdrop, 'special_topic'][:enabled]).to be true
+        expect(Datadog.configuration.tracing[:waterdrop, 'special_topic'][:distributed_tracing]).to be false
       end
 
       context 'when user does not supply a custom producer' do
@@ -238,10 +276,31 @@ RSpec.describe 'Karafka patcher' do
       end
 
       context 'when the waterdrop integration is manually configured' do
-        it 'appends the datadog middleware to Karafka.producer only once' do
-          Datadog.configure do |c|
-            c.tracing.instrument :waterdrop, configuration_options
+        let(:config_block) do
+          ->(c) {
+            c.tracing.instrument :karafka, distributed_tracing: true
+            c.tracing.instrument :karafka, describes: /special_/, distributed_tracing: false
+            c.tracing.instrument :waterdrop, describes: /special_/, distributed_tracing: true
+          }
+        end
+
+        it 'does not overwrite custom WaterDrop configurations' do
+          Karafka::App.setup do |c|
+            c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
           end
+
+          expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be(true)
+          expect(Datadog.configuration.tracing[:karafka, 'special_topic'][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka, 'special_topic'][:distributed_tracing]).to be(false)
+
+          expect(Datadog.configuration.tracing[:waterdrop][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:waterdrop][:distributed_tracing]).to be(true)
+          expect(Datadog.configuration.tracing[:waterdrop, 'special_topic'][:enabled]).to be(true)
+          expect(Datadog.configuration.tracing[:waterdrop, 'special_topic'][:distributed_tracing]).to be(true)
+        end
+
+        it 'appends the datadog middleware to Karafka.producer only once' do
           Karafka::App.setup do |c|
             c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
           end

--- a/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe 'Karafka patcher' do
       end
 
       it 'automatically enables WaterDrop instrumentation' do
-         Karafka::App.setup do |c|
-           c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
-         end
+        Karafka::App.setup do |c|
+          c.kafka = {"bootstrap.servers": '127.0.0.1:9092'}
+        end
 
         expect(Datadog.configuration.tracing[:waterdrop][:enabled]).to be true
         expect(Datadog.configuration.tracing[:waterdrop][:distributed_tracing]).to be true

--- a/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
@@ -212,8 +212,10 @@ RSpec.describe 'Karafka patcher' do
     around do |example|
       # Reset before and after each example; don't allow global state to linger.
       Datadog.registry[:waterdrop].reset_configuration!
+      reset_activate_framework_once!
       example.run
       Datadog.registry[:waterdrop].reset_configuration!
+      reset_activate_framework_once!
 
       # reset Karafka internal state as well
       Karafka::App.config.internal.status.reset!
@@ -222,6 +224,10 @@ RSpec.describe 'Karafka patcher' do
     end
 
     let(:producer_middlewares) { Karafka.producer.middleware.instance_variable_get(:@steps) }
+
+    def reset_activate_framework_once!
+      Datadog::Tracing::Contrib::Karafka::Patcher::ACTIVATE_FRAMEWORK_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
+    end
 
     def waterdrop_compatible?
       Datadog::Tracing::Contrib::WaterDrop::Integration.compatible?

--- a/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
@@ -8,16 +8,19 @@ end
 require "datadog"
 
 RSpec.describe "Karafka patcher" do
-  let(:configuration_options) { {distributed_tracing: true} }
   let(:client_id) { SecureRandom.uuid }
   let(:span) do
     spans.find { |s| s.name == span_name }
   end
+  let(:config_block) do
+    ->(c) {
+      c.tracing.instrument :karafka, distributed_tracing: true
+      c.tracing.instrument :karafka, describes: /special_/, distributed_tracing: false
+    }
+  end
 
   before do
-    Datadog.configure do |c|
-      c.tracing.instrument :karafka, configuration_options
-    end
+    Datadog.configure(&config_block)
   end
 
   around do |example|
@@ -31,16 +34,12 @@ RSpec.describe "Karafka patcher" do
     let(:span_name) { Datadog::Tracing::Contrib::Karafka::Ext::SPAN_MESSAGE_CONSUME }
 
     it "is expected to send a span" do
-      metadata = ::Karafka::Messages::Metadata.new
-      metadata["offset"] = 412
+      metadata = ::Karafka::Messages::Metadata.new(offset: 412, timestamp: Time.now, topic: "topic_a")
       raw_payload = rand.to_s
 
       message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-      allow(message).to receive(:timestamp).and_return(Time.now)
-      allow(message).to receive(:topic).and_return("topic_a")
 
-      topic = ::Karafka::Routing::Topic.new("topic_a", double(id: 0))
-
+      topic = ::Karafka::Routing::Topic.new(message.topic, double(id: 0))
       messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
 
       expect(messages).to all(be_a(::Karafka::Messages::Message))
@@ -55,20 +54,21 @@ RSpec.describe "Karafka patcher" do
     end
 
     context "when the message has tracing headers" do
+      let(:topic_name) { "topic_a" }
       let(:message) do
         headers = {}
         Datadog::Tracing.trace("producer") do |span, trace|
           Datadog::Tracing::Contrib::Karafka.inject(trace.to_digest, headers)
         end
-        metadata = ::Karafka::Messages::Metadata.new
-        metadata["offset"] = 412
-        metadata[headers_accessor] = headers
+        metadata = ::Karafka::Messages::Metadata.new(
+          :offset => 412,
+          headers_accessor => headers,
+          :topic => topic_name,
+          :timestamp => Time.now
+        )
         raw_payload = rand.to_s
 
-        message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-        allow(message).to receive(:timestamp).and_return(Time.now)
-        allow(message).to receive(:topic).and_return("topic_a")
-        message
+        ::Karafka::Messages::Message.new(raw_payload, metadata)
       end
       let(:headers_accessor) do
         ::Karafka::Messages::Metadata.members.include?(:raw_headers) ? "raw_headers" : "headers"
@@ -85,7 +85,7 @@ RSpec.describe "Karafka patcher" do
             consumer_span = Datadog::Tracing.active_span
             consumer_trace = Datadog::Tracing.active_trace
 
-            topic = ::Karafka::Routing::Topic.new("topic_a", double(id: 0))
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
             messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
             # NOTE: The following will iterate through the messages and create a new span representing
             #       the individual message processing (and `span` will refer to that particular span)
@@ -108,8 +108,16 @@ RSpec.describe "Karafka patcher" do
         end
       end
 
-      context "when distributed tracing is not enabled" do
-        let(:configuration_options) { {distributed_tracing: false} }
+      context "when distributed tracing is disabled for the topic in particular" do
+        let(:topic_name) { "special_topic" }
+
+        it "correctly sets the configuration" do
+          expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be true
+
+          expect(Datadog.configuration.tracing[:karafka, "special_topic"][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka, "special_topic"][:distributed_tracing]).to be false
+        end
 
         it "does not continue the span that produced the message" do
           consumer_span = nil
@@ -119,7 +127,38 @@ RSpec.describe "Karafka patcher" do
             consumer_span = Datadog::Tracing.active_span
             consumer_trace = Datadog::Tracing.active_trace
 
-            topic = ::Karafka::Routing::Topic.new("topic_a", double(id: 0))
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
+            messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
+            expect(messages).to all(be_a(::Karafka::Messages::Message))
+
+            # assert that the current trace re-set to the original trace after iterating the messages
+            expect(Datadog::Tracing.active_trace).to eq(consumer_trace)
+            expect(Datadog::Tracing.active_span).to eq(consumer_span)
+          end
+
+          expect(spans).to have(3).items
+
+          # assert that the message span is not continuation of the producer span
+          expect(span.parent_id).to eq(consumer_span.id)
+          expect(span.trace_id).to eq(consumer_trace.id)
+        end
+      end
+
+      context "when distributed tracing is not enabled" do
+        let(:config_block) do
+          ->(c) { c.tracing.instrument :karafka, distributed_tracing: false }
+        end
+
+        it "does not continue the span that produced the message" do
+          consumer_span = nil
+          consumer_trace = nil
+
+          Datadog::Tracing.trace("consumer") do
+            consumer_span = Datadog::Tracing.active_span
+            consumer_trace = Datadog::Tracing.active_trace
+
+            topic = ::Karafka::Routing::Topic.new(topic_name, double(id: 0))
+
             messages = ::Karafka::Messages::Builders::Messages.call([message], topic, 0, Time.now)
             # NOTE: The following will iterate through the messages and create a new span representing
             #       the individual message processing (and `span` will refer to that particular span)
@@ -148,12 +187,11 @@ RSpec.describe "Karafka patcher" do
     let(:span_name) { Datadog::Tracing::Contrib::Karafka::Ext::SPAN_WORKER_PROCESS }
 
     it "is expected to send a span" do
-      metadata = ::Karafka::Messages::Metadata.new
-      metadata["offset"] = 412
+      metadata = ::Karafka::Messages::Metadata.new(offset: 412, topic: "topic_a")
       raw_payload = rand.to_s
 
       message = ::Karafka::Messages::Message.new(raw_payload, metadata)
-      job = double(executor: double(topic: double(name: "topic_a", consumer: "ABC"), partition: 0), messages: [message])
+      job = double(executor: double(topic: double(name: message.topic, consumer: "ABC"), partition: 0), messages: [message])
 
       Karafka.monitor.instrument("worker.processed", {job: job}) do
         # Noop
@@ -199,11 +237,11 @@ RSpec.describe "Karafka patcher" do
           c.kafka = {"bootstrap.servers": "127.0.0.1:9092"}
         end
 
-        expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
-        expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be true
-
         expect(Datadog.configuration.tracing[:waterdrop][:enabled]).to be true
         expect(Datadog.configuration.tracing[:waterdrop][:distributed_tracing]).to be true
+
+        expect(Datadog.configuration.tracing[:waterdrop, "special_topic"][:enabled]).to be true
+        expect(Datadog.configuration.tracing[:waterdrop, "special_topic"][:distributed_tracing]).to be false
       end
 
       context "when user does not supply a custom producer" do
@@ -238,10 +276,31 @@ RSpec.describe "Karafka patcher" do
       end
 
       context "when the waterdrop integration is manually configured" do
-        it "appends the datadog middleware to Karafka.producer only once" do
-          Datadog.configure do |c|
-            c.tracing.instrument :waterdrop, configuration_options
+        let(:config_block) do
+          ->(c) {
+            c.tracing.instrument :karafka, distributed_tracing: true
+            c.tracing.instrument :karafka, describes: /special_/, distributed_tracing: false
+            c.tracing.instrument :waterdrop, describes: /special_/, distributed_tracing: true
+          }
+        end
+
+        it "does not overwrite custom WaterDrop configurations" do
+          Karafka::App.setup do |c|
+            c.kafka = {"bootstrap.servers": "127.0.0.1:9092"}
           end
+
+          expect(Datadog.configuration.tracing[:karafka][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka][:distributed_tracing]).to be(true)
+          expect(Datadog.configuration.tracing[:karafka, "special_topic"][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:karafka, "special_topic"][:distributed_tracing]).to be(false)
+
+          expect(Datadog.configuration.tracing[:waterdrop][:enabled]).to be true
+          expect(Datadog.configuration.tracing[:waterdrop][:distributed_tracing]).to be(true)
+          expect(Datadog.configuration.tracing[:waterdrop, "special_topic"][:enabled]).to be(true)
+          expect(Datadog.configuration.tracing[:waterdrop, "special_topic"][:distributed_tracing]).to be(true)
+        end
+
+        it "appends the datadog middleware to Karafka.producer only once" do
           Karafka::App.setup do |c|
             c.kafka = {"bootstrap.servers": "127.0.0.1:9092"}
           end

--- a/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
+++ b/spec/datadog/tracing/contrib/karafka/patcher_spec.rb
@@ -212,8 +212,10 @@ RSpec.describe "Karafka patcher" do
     around do |example|
       # Reset before and after each example; don't allow global state to linger.
       Datadog.registry[:waterdrop].reset_configuration!
+      reset_activate_framework_once!
       example.run
       Datadog.registry[:waterdrop].reset_configuration!
+      reset_activate_framework_once!
 
       # reset Karafka internal state as well
       Karafka::App.config.internal.status.reset!
@@ -222,6 +224,10 @@ RSpec.describe "Karafka patcher" do
     end
 
     let(:producer_middlewares) { Karafka.producer.middleware.instance_variable_get(:@steps) }
+
+    def reset_activate_framework_once!
+      Datadog::Tracing::Contrib::Karafka::Patcher::ACTIVATE_FRAMEWORK_ONLY_ONCE.send(:reset_ran_once_state_for_tests)
+    end
 
     def waterdrop_compatible?
       Datadog::Tracing::Contrib::WaterDrop::Integration.compatible?

--- a/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "WaterDrop middleware" do
   before do
     Datadog.configure do |c|
       c.tracing.instrument :waterdrop, tracing_options
+      c.tracing.instrument :waterdrop, describes: /special_/, distributed_tracing: false
     end
   end
 
@@ -54,6 +55,17 @@ RSpec.describe "WaterDrop middleware" do
           "x-datadog-trace-id" => low_order_trace_id(span.trace_id).to_s,
           "x-datadog-parent-id" => span.id.to_s
         )
+      end
+    end
+
+    context "when distributed tracing is disabled for the topic in particular" do
+      it "does not propagate trace context in message headers" do
+        message_1 = {topic: "special_topic", payload: "foo"}
+        Datadog::Tracing.trace("test.span") do
+          middleware.call(message_1)
+        end
+
+        expect(message_1[:headers]).to be_nil
       end
     end
 


### PR DESCRIPTION
~_NOTE: this pull request is blocked until #4876 and #5120 are merged_~

---

**What does this PR do?**
Supports different karafka/waterdrop configurations _per topic_.

**Motivation:**
Most of our Karafka consumers simply iterate through a kafka batch of messages and process them individually. Some of our consumers however have a some logic to _pre-process_ a batch (e.g.: split in smaller batches based on some logic) to process more efficiently later.
In such cases we want to selectively disable Datadog's Waterdrop/Karafka tracing and handle tracing manually ourselves.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**

Automated tests provided.
