### PR TITLE
DI: relax upper bound for reported long method duration

### DIFF
--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -545,10 +545,17 @@ RSpec.describe 'Instrumentation integration' do
               expect(snapshot.fetch(:message)).to match(/\Ahello (\d+\.\d+) ms\z/)
               snapshot.fetch(:message) =~ /\Ahello (\d+\.\d+) ms\z/
               value = Float($1)
-              # Actual execution time will change but it should be under
-              # a second and it should be positive.
+              # Actual execution time varies greatly in CI.
+              # A method that returns an integer will ordinarily report a
+              # duration on the order of 1 millisecond.
+              # However, one time the duration reported was exactly zero.
+              # After the test method was made longer to definitely take
+              # a non-zero amount of time to execute, on one CI run it took
+              # 1.8 seconds.
+              # Therefore, the current brackets are strictly greater than
+              # zero seconds and under 4 seconds.
               expect(value).to be > 0
-              expect(value).to be < 1
+              expect(value).to be < 4
             end
             expect(InstrumentationSpecTestClass.new.long_test_method).to eq(42)
             component.probe_notifier_worker.flush


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Increases the upper bound that the "long_method" is expected to take from 1 to 4 seconds.

**Motivation:**
CI has a run where the method took 1.8 seconds:
https://github.com/DataDog/dd-trace-rb/actions/runs/19936903071/job/57164209793?pr=5109

<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
