### PR TITLE
DI: add process tags to dynamic instrumentation

### DIFF
--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -134,7 +134,7 @@ module Datadog
           format_caller_locations(caller_locations)
         end
 
-        {
+        payload = {
           service: settings.service,
           debugger: {
             type: 'snapshot',
@@ -189,6 +189,10 @@ module Datadog
           message: message,
           timestamp: timestamp,
         }
+
+        tag_process_tags!(payload, settings)
+
+        payload
       end
 
       def build_status(probe, message:, status:)
@@ -234,6 +238,15 @@ module Datadog
           '[evaluation error]'
         end.join
         [message, evaluation_errors]
+      end
+
+      def tag_process_tags!(payload, settings)
+        return unless settings.experimental_propagate_process_tags_enabled
+
+        process_tags = Core::Environment::Process.serialized
+        return if process_tags.empty?
+
+        payload[:process_tags] = process_tags
       end
 
       def timestamp_now

--- a/sig/datadog/di/probe_notification_builder.rbs
+++ b/sig/datadog/di/probe_notification_builder.rbs
@@ -32,6 +32,8 @@ module Datadog
 
       def evaluate_template: (untyped template, Context context) -> [String, Array[String]]
 
+      def tag_process_tags!: (Hash[Symbol | String, untyped] payload, Core::Configuration::Settings settings) -> void
+
       def timestamp_now: () -> Integer
 
       def get_local_variables: (TracePoint trace_point) -> Hash[Symbol,untyped]


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Adds process tags to the dynamic instrumentation payloads, similar to what the dd-trace-py is doing today with https://github.com/DataDog/dd-trace-py/pull/15225 .




**Motivation:**
<!-- What inspired you to submit this pull request? -->

For https://datadoghq.atlassian.net/browse/AIDM-256

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Note: This PR should not be merged until https://github.com/DataDog/dd-trace-rb/pull/5110 gets merged

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->

```
docker compose run --rm tracer-3.3 /bin/bash
bundle exec rspec spec/datadog/di/probe_notification_builder_spec.rb
```