### PR TITLE
DI: document custom serialization API and remove defaulting of depth …

### DIFF
--- a/lib/datadog/di/contrib/active_record.rb
+++ b/lib/datadog/di/contrib/active_record.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# steep thinks all of the arguments are nil here and does not know what ActiveRecord is.
+# steep:ignore:start
+
 Datadog::DI::Serializer.register(
   # This serializer uses a dynamic condition to determine its applicability
   # to a particular value. A simpler case could have been a serializer for
@@ -10,7 +13,7 @@ Datadog::DI::Serializer.register(
   # logic for "instances of classes derived from X", but a condition Proc
   # is more universal.
   condition: lambda { |value| ActiveRecord::Base === value }
-) do |serializer, value, name:, depth:| # steep:ignore
+) do |serializer, value, name:, depth:|
   # +serializer+ is an instance of DI::Serializer.
   # Use it to perform the serialization to primitive values.
   #
@@ -25,13 +28,11 @@ Datadog::DI::Serializer.register(
   # It should always be an integer.
   # Reduce it by 1 when invoking +serialize_value+ on the contents of +value+.
   # This serializer could also potentially do its own depth limiting.
-  #
-  # steep thinks all of the arguments are nil here
-  # steep:ignore:start
   value_to_serialize = {
     attributes: value.attributes,
     new_record: value.new_record?,
   }
   serializer.serialize_value(value_to_serialize, depth: depth - 1, type: value.class)
-  # steep:ignore:end
 end
+
+# steep:ignore:end


### PR DESCRIPTION
…to nil

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Removes defaulting of `depth` to `nil` in the one custom serializer in DI.

Also, adds documentation for the parameters in custom serializers.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
@vpellan was adding types and identified a possible issue with `depth` being nil: the rest of DI code assumes `depth` is an integer, for example https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/di/serializer.rb#L229.

The code in custom serializer was written defensively and performs the depth check for its own benefit. It should never receive a `depth` of `nil` from DI to begin with.

The existing serializer code may be interpreted to mean that `serialize_value` can be invoked with `depth` of `nil` which is not the case.

This PR also adds documentation for parameters used in the custom serializer to make understanding the code easier.

**Change log entry**
None (the issue is theoretical).
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Existing CI. There isn't realistically a way to have the custom serializer be invoked with nil depth therefore this PR does not add any test cases.

<!-- Unsure? Have a question? Request a review! -->
