### PR TITLE
Assert on empty standard error in execution spec.

### DIFF
--- a/spec/datadog/core/environment/execution_spec.rb
+++ b/spec/datadog/core/environment/execution_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
 
     context 'when given WebMock', skip: Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2') do
       it do
-        out, _err, status = Bundler.with_unbundled_env do
+        out, err, status = Bundler.with_unbundled_env do
           Open3.capture3('ruby', stdin_data: <<-RUBY
             require 'bundler/inline'
 
@@ -278,6 +278,7 @@ RSpec.describe Datadog::Core::Environment::Execution do
           )
         end
 
+        expect(err).to be_empty
         expect(out).to end_with('ACTUAL:true')
         expect(status.exitstatus).to eq(0)
       end


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds an extra assertion to execution spec.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
The idea here is that if the test fails, there usually would be some error output on standard error and standard output may be empty. Thus having an assertion on standard output containing expected text fails the test, but does not help with troubleshooting.

The extra assertion on standard error being empty is meant to reveal the actual issue.

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
Existing CI
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
