### PR TITLE
[NO-TICKET] Skip profiling + ractor specs on Ruby 4.0.0-preview2

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1164,6 +1164,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       # ...same thing for the tracepoint for allocation counting/profiling :(
       let(:allocation_profiling_enabled) { false }
 
+      before do
+        # We also saw weird segfaults inside regular Ruby code **after** this spec ran in 4.0.0preview2. For now
+        # let's skip for this Ruby, and we can re-examine it if the issue shows up on a later 4.0.0 release.
+        #
+        # If you see this skip being around after the stable Ruby 4.0 was released and added to CI, do get rid of it ;)
+        skip "Ruby 4.0.0-preview2 Ractors are too buggy to run this spec" if RUBY_DESCRIPTION.include?("4.0.0preview2")
+      end
+
       describe "handle_sampling_signal" do
         include_examples "does not trigger a sample",
           (

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -83,16 +83,24 @@ RSpec.describe Datadog::Profiling::NativeExtension do
       end
 
       context "on a background Ractor", ractors: true do
-        # @ivoanjo: When we initially added this test, our test suite kept deadlocking in CI in a later test (not on
-        # this one).
-        #
-        # It turns out that Ruby 3.0 Ractors seem to have some bug that even running `Ractor.new { 'hello' }.take` will
-        # cause a later spec to fail, usually with a (native C) stack with `gc_finalize_deferred`.
-        #
-        # I was able to see this even on both Linux with 3.0.3 and macOS with 3.0.4. Thus, I decided to skip this
-        # spec on Ruby 3.0. We can always run it manually if we change something around this helper; and we have
-        # coverage on 3.1+ anyway.
-        before { skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.") }
+        before do
+          # @ivoanjo: When we initially added this test, our test suite kept deadlocking in CI in a later test (not on
+          # this one).
+          #
+          # It turns out that Ruby 3.0 Ractors seem to have some bug that even running `Ractor.new { 'hello' }.take` will
+          # cause a later spec to fail, usually with a (native C) stack with `gc_finalize_deferred`.
+          #
+          # I was able to see this even on both Linux with 3.0.3 and macOS with 3.0.4. Thus, I decided to skip this
+          # spec on Ruby 3.0. We can always run it manually if we change something around this helper; and we have
+          # coverage on 3.1+ anyway.
+          skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.")
+
+          # We also saw weird segfaults inside regular Ruby code **after** this spec ran in 4.0.0preview2. For now
+          # let's skip for this Ruby, and we can re-examine it if the issue shows up on a later 4.0.0 release.
+          #
+          # If you see this skip being around after the stable Ruby 4.0 was released and added to CI, do get rid of it ;)
+          skip "Ruby 4.0.0-preview2 Ractors are too buggy to run this spec" if RUBY_DESCRIPTION.include?("4.0.0preview2")
+        end
 
         subject(:ddtrace_rb_ractor_main_p) do
           Ractor.new do


### PR DESCRIPTION
**What does this PR do?**

This PR adds a skip for the profiling + ractor tests on Ruby 4.0.0-preview2 as we've seen them crashing in VM inside Ruby code in a way that doesn't at all look related to profiling.

I claim it's OK to skip this for now as:

1. The profiler actually doesn't support background ractors, so this testing is mostly there to check that we're correctly skipping them

2. The logic for skipping background ractors is not Ruby-version-specific, so there's nothing to indicate that we'd be "surprised" by a 4.0.0-preview2 behavior

3. The skip is specific to the preview release. This means that either we'll never see this happen again (if upstream fixed the issue since) or if we do, we'll know it needs looking into more detail.

**Motivation:**

Let's avoid this flaky behavior in CI.

**Change log entry**

None.

**Additional Notes:**

Here's one example of such a crash from
<https://github.com/DataDog/dd-trace-rb/actions/runs/20256245891/job/58158928432>:

```
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.13.6/lib:/usr/local/bundle/gems/rspec-support-3.13.6/lib /usr/local/bundle/gems/rspec-core-3.13.6/exe/rspec --pattern spec/datadog/profiling/\*\*/\*_spec.rb --seed 19124 -t ractors
Run options: include {focus: true, ractors: true}

Randomized with seed 19124

Datadog::Profiling::Collectors::CpuAndWallTimeWorker
  Ractor safety
    when called from a background ractor
      handle_sampling_signal
/__w/dd-trace-rb/dd-trace-rb/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:1170: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
        does not trigger a sample
      sample_from_postponed_job
        does not trigger a sample

Datadog::Profiling::NativeExtension
  ddtrace_rb_ractor_main_p
    when Ruby has support for Ractors
      on a background Ractor
        is expected to equal false
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615: [BUG] Segmentation fault at 0x0000558c776ad008
ruby 4.0.0preview2 (2025-11-17 master 4fa6e9938c) +PRISM [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0018 p:0006 s:0092 e:000089 l:n b:---- BLOCK  /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615 [FINISH]
c:0017 p:---- s:0086 e:000085 l:y b:---- CFUNC  :map
c:0016 p:0076 s:0082 e:000081 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615
c:0015 p:0006 s:0073 e:000072 l:n b:---- BLOCK  /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615 [FINISH]
c:0014 p:---- s:0069 e:000068 l:y b:---- CFUNC  :map
c:0013 p:0076 s:0065 e:000064 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615
c:0012 p:0007 s:0056 e:000055 l:n b:---- BLOCK  /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121 [FINISH]
c:0011 p:---- s:0052 e:000051 l:y b:---- CFUNC  :map
c:0010 p:0030 s:0048 e:000047 l:n b:---- BLOCK  /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121
c:0009 p:0026 s:0045 e:000044 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/configuration.rb:2097
c:0008 p:0006 s:0041 e:000040 l:n b:---- BLOCK  /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:116
c:0007 p:0009 s:0037 e:000036 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/reporter.rb:74
c:0006 p:0019 s:0032 e:000031 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:115
c:0005 p:0035 s:0025 e:000024 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:89
c:0004 p:0080 s:0019 e:000018 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:71
c:0003 p:0013 s:0011 e:000010 l:y b:0001 METHOD /usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:45
c:0002 p:0010 s:0006 e:000005 l:n b:---- EVAL   /usr/local/bundle/gems/rspec-core-3.13.6/exe/rspec:4 [FINISH]
c:0001 p:0000 s:0003 E:000580 l:y b:---- DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
/usr/local/bundle/gems/rspec-core-3.13.6/exe/rspec:4:in '<main>'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:45:in 'invoke'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:71:in 'run'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:89:in 'run'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:115:in 'run_specs'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/reporter.rb:74:in 'report'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:116:in 'block in run_specs'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/configuration.rb:2097:in 'with_suite_hooks'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'block (2 levels) in run_specs'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'map'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/runner.rb:121:in 'block (3 levels) in run_specs'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'run'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'map'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'block in run'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'run'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'map'
/usr/local/bundle/gems/rspec-core-3.13.6/lib/rspec/core/example_group.rb:615:in 'block in run'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 3

-- Machine register context ------------------------------------------------
 RIP: 0x00007fb7d65b13bd RBP: 0x0000558c77696700 RSP: 0x00007ffc86036de0
 RAX: 0x00000000000168f0 RBX: 0x0000000000001690 RCX: 0x0000000000000001
 RDX: 0x0000558c72e3ac30 RDI: 0x00007fb7b716cc10 RSI: 0x0000000000000000
  R8: 0x000000000000001f  R9: 0x0000000000000000 R10: 0x0000000000000000
 R11: 0x0000000000000293 R12: 0x00007fb7b716cc10 R13: 0x0000000000005a91
 R14: 0x0000558c77695b30 R15: 0x0000000000005a91 EFL: 0x0000000000010216

-- C level backtrace information -------------------------------------------
/usr/local/lib/libruby.so.4.0(rb_print_backtrace+0x14) [0x7fb7d65eeb00] /usr/src/ruby/vm_dump.c:1105
/usr/local/lib/libruby.so.4.0(rb_vm_bugreport) /usr/src/ruby/vm_dump.c:1450
/usr/local/lib/libruby.so.4.0(rb_bug_for_fatal_signal+0x106) [0x7fb7d63b9c56] /usr/src/ruby/error.c:1130
/usr/local/lib/libruby.so.4.0(sigsegv+0x42) [0x7fb7d6524062] /usr/src/ruby/signal.c:948
/lib/x86_64-linux-gnu/libc.so.6(0x7fb7d5ef3df0) [0x7fb7d5ef3df0]
/usr/local/lib/libruby.so.4.0(rb_obj_written+0x0) [0x7fb7d65b13bd] /usr/src/ruby/vm_method.c:164
/usr/local/lib/libruby.so.4.0(vm_cc_table_dup_i) /usr/src/ruby/vm_method.c:164
/usr/local/lib/libruby.so.4.0(rb_id_table_foreach+0x94) [0x7fb7d6569644] /usr/src/ruby/id_table.c:285
/usr/local/lib/libruby.so.4.0(rb_vm_cc_table_dup+0x32) [0x7fb7d65bdba2] /usr/src/ruby/vm_method.c:173
/usr/local/lib/libruby.so.4.0(vm_populate_cc+0x29) [0x7fb7d65c1851] /usr/src/ruby/vm_insnhelper.c:2165
/usr/local/lib/libruby.so.4.0(vm_search_cc) /usr/src/ruby/vm_insnhelper.c:2278
/usr/local/lib/libruby.so.4.0(vm_search_method_slowpath0+0x5) [0x7fb7d65cfb1e] /usr/src/ruby/vm_insnhelper.c:2292
/usr/local/lib/libruby.so.4.0(vm_search_method_fastpath) /usr/src/ruby/vm_insnhelper.c:2372
/usr/local/lib/libruby.so.4.0(vm_sendish) /usr/src/ruby/vm_insnhelper.c:6133
/usr/local/lib/libruby.so.4.0(vm_exec_core) /usr/src/ruby/insns.def:902
/usr/local/lib/libruby.so.4.0(vm_exec_loop+0xa) [0x7fb7d65d5b58] /usr/src/ruby/vm.c:2811
/usr/local/lib/libruby.so.4.0(rb_vm_exec) /usr/src/ruby/vm.c:2787
/usr/local/lib/libruby.so.4.0(vm_yield_with_cref+0x8c) [0x7fb7d65daa10] /usr/src/ruby/vm.c:1865
/usr/local/lib/libruby.so.4.0(vm_yield) /usr/src/ruby/vm.c:1873
/usr/local/lib/libruby.so.4.0(rb_yield_0) /usr/src/ruby/vm_eval.c:1362
/usr/local/lib/libruby.so.4.0(rb_yield) /usr/src/ruby/vm_eval.c:1378
/usr/local/lib/libruby.so.4.0(rb_ary_collect+0x5c) [0x7fb7d62eda8c] /usr/src/ruby/array.c:3673
/usr/local/lib/libruby.so.4.0(vm_call_cfunc_with_frame_+0x101) [0x7fb7d65b91a1] /usr/src/ruby/vm_insnhelper.c:3915
/usr/local/lib/libruby.so.4.0(vm_sendish+0xce) [0x7fb7d65c26be] /usr/src/ruby/vm_insnhelper.c:6134
/usr/local/lib/libruby.so.4.0(vm_exec_core+0xd27) [0x7fb7d65d06d7] /usr/src/ruby/insns.def:854
/usr/local/lib/libruby.so.4.0(vm_exec_loop+0xa) [0x7fb7d65d5b58] /usr/src/ruby/vm.c:2811
/usr/local/lib/libruby.so.4.0(rb_vm_exec) /usr/src/ruby/vm.c:2787
/usr/local/lib/libruby.so.4.0(vm_yield_with_cref+0x8c) [0x7fb7d65daa10] /usr/src/ruby/vm.c:1865
/usr/local/lib/libruby.so.4.0(vm_yield) /usr/src/ruby/vm.c:1873
/usr/local/lib/libruby.so.4.0(rb_yield_0) /usr/src/ruby/vm_eval.c:1362
/usr/local/lib/libruby.so.4.0(rb_yield) /usr/src/ruby/vm_eval.c:1378
/usr/local/lib/libruby.so.4.0(rb_ary_collect+0x5c) [0x7fb7d62eda8c] /usr/src/ruby/array.c:3673
/usr/local/lib/libruby.so.4.0(vm_call_cfunc_with_frame_+0x101) [0x7fb7d65b91a1] /usr/src/ruby/vm_insnhelper.c:3915
/usr/local/lib/libruby.so.4.0(vm_sendish+0xce) [0x7fb7d65c26be] /usr/src/ruby/vm_insnhelper.c:6134
/usr/local/lib/libruby.so.4.0(vm_exec_core+0xd27) [0x7fb7d65d06d7] /usr/src/ruby/insns.def:854
/usr/local/lib/libruby.so.4.0(vm_exec_loop+0xa) [0x7fb7d65d5b58] /usr/src/ruby/vm.c:2811
/usr/local/lib/libruby.so.4.0(rb_vm_exec) /usr/src/ruby/vm.c:2787
/usr/local/lib/libruby.so.4.0(vm_yield_with_cref+0x8c) [0x7fb7d65daa10] /usr/src/ruby/vm.c:1865
/usr/local/lib/libruby.so.4.0(vm_yield) /usr/src/ruby/vm.c:1873
/usr/local/lib/libruby.so.4.0(rb_yield_0) /usr/src/ruby/vm_eval.c:1362
/usr/local/lib/libruby.so.4.0(rb_yield) /usr/src/ruby/vm_eval.c:1378
/usr/local/lib/libruby.so.4.0(rb_ary_collect+0x5c) [0x7fb7d62eda8c] /usr/src/ruby/array.c:3673
/usr/local/lib/libruby.so.4.0(vm_call_cfunc_with_frame_+0x101) [0x7fb7d65b91a1] /usr/src/ruby/vm_insnhelper.c:3915
/usr/local/lib/libruby.so.4.0(vm_sendish+0xce) [0x7fb7d65c26be] /usr/src/ruby/vm_insnhelper.c:6134
/usr/local/lib/libruby.so.4.0(vm_exec_core+0xd27) [0x7fb7d65d06d7] /usr/src/ruby/insns.def:854
/usr/local/lib/libruby.so.4.0(vm_exec_loop+0xa) [0x7fb7d65d5e6a] /usr/src/ruby/vm.c:2811
/usr/local/lib/libruby.so.4.0(rb_vm_exec) /usr/src/ruby/vm.c:2790
/usr/local/lib/libruby.so.4.0(rb_ec_exec_node+0x9b) [0x7fb7d63c100b] /usr/src/ruby/eval.c:283
/usr/local/lib/libruby.so.4.0(ruby_run_node+0x83) [0x7fb7d63c77c3] /usr/src/ruby/eval.c:321
/usr/local/bin/ruby(rb_main+0x21) [0x558c43376110] ./main.c:42
/usr/local/bin/ruby(main) ./main.c:62
/lib/x86_64-linux-gnu/libc.so.6(0x7fb7d5eddca8) [0x7fb7d5eddca8]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7fb7d5eddd65]
[0x558c43376151]
```

**How to test the change?**

Try to run the specs on Ruby 4.0.0-preview2 and validate that they no longer run:

```
$ bundle exec rspec spec/datadog/profiling/ --seed 19124 -t ractors --format=documentation
Run options: include {focus: true, ractors: true}

Randomized with seed 19124

Datadog::Profiling::Collectors::CpuAndWallTimeWorker
  Ractor safety
    when called from a background ractor
      handle_sampling_signal
        does not trigger a sample (PENDING: Ruby 4.0.0-preview2 Ractors are too buggy to run this spec)
      sample_from_postponed_job
        does not trigger a sample (PENDING: Ruby 4.0.0-preview2 Ractors are too buggy to run this spec)

Datadog::Profiling::NativeExtension
  ddtrace_rb_ractor_main_p
    when Ruby has support for Ractors
      on a background Ractor
        example at ./spec/datadog/profiling/native_extension_spec.rb:111 (PENDING: Ruby 4.0.0-preview2 Ractors are too buggy to run this spec)

Finished in 0.02313 seconds (files took 1.14 seconds to load)
3 examples, 0 failures, 3 pending

Randomized with seed 19124
```
