### PR TITLE
Use better type definitions for OT baggage module

### DIFF
--- a/lib/datadog/opentelemetry/api/baggage.rb
+++ b/lib/datadog/opentelemetry/api/baggage.rb
@@ -26,7 +26,7 @@ module Datadog
         # to ::OpenTelemetry::Context.current
         # @return [Context]
         def clear(context: ::OpenTelemetry::Context.current)
-          context.ensure_trace.baggage.clear
+          context.ensure_trace&.baggage&.clear
           context
         end
 

--- a/sig/datadog/opentelemetry/api/baggage.rbs
+++ b/sig/datadog/opentelemetry/api/baggage.rbs
@@ -6,15 +6,15 @@ module Datadog
       module Baggage
         def initialize: (?trace: Datadog::Tracing::TraceOperation?) -> void
 
-        def clear: (?context: untyped) -> untyped
+        def clear: (?context: OpenTelemetry::Context) -> OpenTelemetry::Context
 
-        def value: (String key, ?context: untyped) -> String?
+        def value: (String key, ?context: OpenTelemetry::Context) -> String?
 
-        def values: (?context: untyped) -> Hash[String, String]
+        def values: (?context: OpenTelemetry::Context) -> Hash[String, String]
 
-        def set_value: (String key, String value, ?metadata: String?, ?context: untyped) -> untyped
+        def set_value: (String key, String value, ?metadata: String?, ?context: OpenTelemetry::Context) -> OpenTelemetry::Context
 
-        def remove_value: (String key, ?context: untyped) -> untyped
+        def remove_value: (String key, ?context: OpenTelemetry::Context) -> OpenTelemetry::Context
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
This PR adds better type definitions for `OpenTelemetry::Baggage` from the file that was deleted in https://github.com/DataDog/dd-trace-rb/pull/5145.

**Motivation:**
This is a separate PR, since there was a small problem that was detected by steep and had to be fixed.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
CI.
