### PR TITLE
[NO-TICKET] Fix flaky profiler spec when trying to sample "Process::Waiter" thread

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1102,7 +1102,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         all_samples = try_wait_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples_for_thread(samples, process_waiter_thread).any?
+          samples if samples_for_thread(samples, process_waiter_thread)&.first&.locations&.any?
         end
 
         cpu_and_wall_time_worker.stop


### PR DESCRIPTION
**What does this PR do?**

This PR tweaks the `try_wait_until` in one of the profiler's integration-like specs to make sure that the background thread has started and can be sampled before asserting on its backtrace.

The objective is to avoid a flaky situation we saw in CI where the sample had empty locations.

**Motivation:**

Looking at `ddtrace_rb_profile_frames` in `private_vm_api_access.c` it's possible (although highly unlikely) that we see the thread half-way through being initialized and thus `return 0`, causing empty locations, instead of
`return PLACEHOLDER_STACK_IN_NATIVE_CODE` which triggers the `In native code` placeholder that the test is trying to assert on.

(I'm not sure which one of the "return 0" conditions we hit here, and I'm somewhat curious, but I could not reproduce this issue locally, as depressingly usual with such racy-like situations.)

The objective of this test is _not_ to test this behavior, but to check that this thread can be sampled correctly, so if we observe an empty locations it makes sense to keep trying to see if we can get a better sample. If we don't the test will still fail.

**Change log entry**

None.

**Additional Notes:**

Failure in CI from Ruby 3.0
<https://github.com/DataDog/dd-trace-rb/actions/runs/20245761677/job/58125329813#step:5:2829>:

```
Failures:

  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start Process::Waiter crash regression tests can sample an instance of Process::Waiter without crashing
     Failure/Error: expect(sample.locations.first.path).to eq "In native code"

     NoMethodError:
       undefined method `path' for nil:NilClass
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:1111:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:274:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:154:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 23.65 seconds (files took 1.03 seconds to load)
777 examples, 1 failure, 54 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:1096 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start Process::Waiter crash regression tests can sample an instance of Process::Waiter without crashing

Randomized with seed 11713

Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.13.6/lib:/usr/local/bundle/gems/rspec-support-3.13.6/lib /usr/local/bundle/gems/rspec-core-3.13.6/exe/rspec --pattern spec/datadog/profiling/\*\*/\*_spec.rb,spec/datadog/profiling_spec.rb --seed 11713 -t ~ractors failed
```

**How to test the change?**

Validate that the test still passes :)
