### PR TITLE
[NO-TICKET] Allow installing gem on Ruby 4.0.x stable

### DIFF
--- a/lib/datadog/version.rb
+++ b/lib/datadog/version.rb
@@ -21,6 +21,6 @@ module Datadog
     # To allow testing with the next unreleased version of Ruby, the version check is performed
     # as `< #{MAXIMUM_RUBY_VERSION}`, meaning prereleases of MAXIMUM_RUBY_VERSION are allowed
     # but not stable MAXIMUM_RUBY_VERSION releases.
-    MAXIMUM_RUBY_VERSION = '4.0'
+    MAXIMUM_RUBY_VERSION = '4.1'
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR is our annual bump to the `MAXIMUM_RUBY_VERSION`, enabling the gem to start being used in the 4.0.x stable series, similar to #3746, #2497, etc.

As explained in the comment, we have a `< MAXIMUM_RUBY_VERSION` in the gemspec which means that up until now only preview/rc versions of Ruby 4.0.0 were allowed.

**Motivation:**

We're getting close to the expected release of Ruby 4.0.0 on December 25th, so we need to bump this so as to avoid blocking users wanting to start using Ruby 4.0.

Thus, the next dd-trace-rb release version will be the first one that can be installed on stable Ruby 4.0.

**Change log entry**

Yes. Allow installing gem on Ruby 4.0.x stable

**Additional Notes:**

We initially added Ruby 4.0 (at the time it was called 3.5) to CI in #4924 and in the "Additional Notes" we listed a few things we still needed to fix.

Not all of those fixes have made it in yet, but we don't believe this is a reason to block folks from trying dd-trace-rb on Ruby 4.0 and giving us feedback.

**How to test the change?**

Validate CI is still green!