### PR TITLE
[NO-TICKET] Datadog::Core::Remote::Negotiation must have default value for logger keyword param in the initializer to avoid breaking datadog-ci gem

### DIFF
--- a/lib/datadog/core/remote/negotiation.rb
+++ b/lib/datadog/core/remote/negotiation.rb
@@ -9,7 +9,7 @@ module Datadog
       class Negotiation
         attr_reader :logger
 
-        def initialize(_settings, agent_settings, logger:, suppress_logging: {})
+        def initialize(_settings, agent_settings, logger: Datadog.logger, suppress_logging: {})
           @logger = logger
           @transport_root = Datadog::Core::Remote::Transport::HTTP.root(agent_settings: agent_settings, logger: logger)
           @logged = suppress_logging

--- a/sig/datadog/core/remote/negotiation.rbs
+++ b/sig/datadog/core/remote/negotiation.rbs
@@ -7,7 +7,7 @@ module Datadog
 
 	attr_reader logger: Core::Logger
 
-        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettings agent_settings, logger: Core::Logger, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
+        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettings agent_settings, ?logger: Core::Logger, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
 
         def endpoint?: (::String path) -> bool
 

--- a/spec/datadog/core/remote/negotiation_spec.rb
+++ b/spec/datadog/core/remote/negotiation_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
   let(:logger) { logger_allowing_debug }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
 
+  describe '#initialize' do
+    context 'when instantiated without logger parameter like datadog-ci gem does' do
+      it 'uses Datadog.logger as logger' do
+        negotiation = described_class.new(settings, agent_settings, suppress_logging: {no_config_endpoint: true})
+        expect(negotiation.logger).to be Datadog.logger
+      end
+    end
+  end
+
   describe '#endpoint?' do
     include_context 'HTTP connection stub'
 


### PR DESCRIPTION
**What does this PR do?**
Restores default value for logger keyword param in the internal `Datadog::Core::Remote::Negotiation` class to avoid breaking `datadog-ci`

**Motivation:**
datadog-ci gem is broken with the following error:
```
/root/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/dd-trace-rb-c6dc7b8ee3e3/lib/datadog/core/remote/negotiation.rb:12:in `initialize': missing keyword: :logger (ArgumentError)
	from /root/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/datadog-ci-rb-5119bf51a06c/lib/datadog/ci/transport/api/builder.rb:44:in `new'
```

**Change log entry**
None

**How to test the change?**
The unit test is added that shows how this class is used