### PR TITLE
[PROF-13389] Remove profiler warning about Ractor issue

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -293,9 +293,6 @@ module Datadog
             #       for Ruby versions 2.x, 3.1.4+, 3.2.3+ and 3.3.0+
             #       (more details in {Datadog::Profiling::Component.enable_gc_profiling?})
             #
-            # @warn Due to a VM bug in the Ractor implementation (https://bugs.ruby-lang.org/issues/19112) this feature
-            #       stops working when Ractors get garbage collected.
-            #
             # @default `DD_PROFILING_GC_ENABLED` environment variable, otherwise `true`
             option :gc_enabled do |o|
               o.type :bool

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -4,9 +4,6 @@ module Datadog
   module Profiling
     # Responsible for wiring up the Profiler for execution
     module Component
-      ALLOCATION_WITH_RACTORS_ONLY_ONCE = Datadog::Core::Utils::OnlyOnce.new
-      private_constant :ALLOCATION_WITH_RACTORS_ONLY_ONCE
-
       # Passing in a `nil` tracer is supported and will disable the following profiling features:
       # * Profiling in the trace viewer, as well as scoping a profile down to a span
       # * Endpoint aggregation in the profiler UX, including normalization (resource per endpoint call)
@@ -145,7 +142,7 @@ module Datadog
           logger.debug(
             "Using Ractors may result in GC profiling unexpectedly " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
-            "application stability or performance. This does not happen if Ractors are not used."
+            "application stability or performance. This issue is fixed on Ruby 4."
           )
         end
 
@@ -195,13 +192,11 @@ module Datadog
         # On all known versions of Ruby 3.x, due to https://bugs.ruby-lang.org/issues/19112, when a ractor gets
         # garbage collected, Ruby will disable all active tracepoints, which this feature internally relies on.
         elsif RUBY_VERSION.start_with?("3.")
-          ALLOCATION_WITH_RACTORS_ONLY_ONCE.run do
-            logger.info(
-              "Using Ractors may result in allocation profiling " \
-              "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
-              "application stability or performance. This does not happen if Ractors are not used."
-            )
-          end
+          logger.debug(
+            "Using Ractors may result in allocation profiling " \
+            "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
+            "application stability or performance. This issue is fixed on Ruby 4."
+          )
         end
 
         logger.debug("Enabled allocation profiling")

--- a/sig/datadog/profiling/component.rbs
+++ b/sig/datadog/profiling/component.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module Profiling
     module Component
-      ALLOCATION_WITH_RACTORS_ONLY_ONCE: Datadog::Core::Utils::OnlyOnce
-
       def self.build_profiler_component: (
         settings: untyped,
         agent_settings: Datadog::Core::Configuration::AgentSettings,

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -211,8 +211,6 @@ RSpec.describe Datadog::Profiling::Component do
             settings.profiling.allocation_enabled = true
             settings.profiling.advanced.gc_enabled = false # Disable this to avoid any additional warnings coming from it
             stub_const("RUBY_VERSION", testing_version)
-
-            described_class.const_get(:ALLOCATION_WITH_RACTORS_ONLY_ONCE).send(:reset_ran_once_state_for_tests)
           end
 
           context "on Ruby 2.x" do
@@ -276,7 +274,7 @@ RSpec.describe Datadog::Profiling::Component do
           ["3.1.4", "3.2.3", "3.3.0"].each do |fixed_ruby|
             context "on a Ruby 3 version where https://bugs.ruby-lang.org/issues/18464 is fixed (#{fixed_ruby})" do
               let(:testing_version) { fixed_ruby }
-              it "initializes CpuAndWallTimeWorker and StackRecorder with allocation sampling support and warns" do
+              it "initializes CpuAndWallTimeWorker and StackRecorder with allocation sampling support and debug logs" do
                 expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new).with hash_including(
                   allocation_profiling_enabled: true,
                 )
@@ -284,7 +282,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(alloc_samples_enabled: true))
                   .and_call_original
 
-                expect(logger).to receive(:info).with(/Ractors.+stopping/)
+                expect(logger).to receive(:debug).with(/Ractors.+stopping/)
                 expect(logger).to receive(:debug).with(/Enabled allocation profiling/)
 
                 build_profiler_component
@@ -367,8 +365,6 @@ RSpec.describe Datadog::Profiling::Component do
           context "and allocation profiling enabled and supported" do
             before do
               settings.profiling.allocation_enabled = true
-
-              described_class.const_get(:ALLOCATION_WITH_RACTORS_ONLY_ONCE).send(:reset_ran_once_state_for_tests)
             end
 
             it "initializes StackRecorder with heap sampling support and warns" do
@@ -376,7 +372,7 @@ RSpec.describe Datadog::Profiling::Component do
                 .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
                 .and_call_original
 
-              expect(logger).to receive(:info).with(/Ractors.+stopping/)
+              expect(logger).to receive(:debug).with(/Ractors.+stopping/)
               expect(logger).to receive(:debug).with(/Enabled allocation profiling/)
               expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 
@@ -393,7 +389,7 @@ RSpec.describe Datadog::Profiling::Component do
                   .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
                   .and_call_original
 
-                expect(logger).to receive(:info).with(/Ractors.+stopping/)
+                expect(logger).to receive(:debug).with(/Ractors.+stopping/)
                 expect(logger).to receive(:debug).with(/Enabled allocation profiling/)
                 expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 


### PR DESCRIPTION
**What does this PR do?**

For a while now, whenever the GC and more importantly the allocation profiling features were enabled, we logged a user-visible message that if Ractors were used, a bug in Ruby could cause the profiler to miss data (due to https://bugs.ruby-lang.org/issues/19112 ).

The upstream issue has been fixed in <https://github.com/ruby/ruby/pull/15468> (some discussion as well in <https://github.com/ruby/ruby/pull/7184> ).

Thus, this PR does a few small things:

* Update the logged messages to mention the bug doesn't happen on Ruby 4

* Moves all messages to be debug-level messages (our logic already made sure they were only printed on Ruby 3, hah turns out we predicted this!)

  In particular the concern in the past for making the message user-visible by default was that customers might use Ractors and run into this issue. As it turns out that in Ruby 3 ractors were always experimental and had a number of bugs/issues, we don't expect anyone to run Ractors in production with Ruby 3. (Maybe this will change with Ruby 4?)

* Removes the `OnlyOnce` that was used to limit verboseness -- this is extra complexity that we don't need to maintain now that the log is debug level

**Motivation:**

Avoid annoying customers with log messages about Ractor support on Ruby 3.

**Change log entry**

Yes. Remove profiler warning about Ractor issue

**Additional Notes:**

N/A

**How to test the change?**

For the warnings themselves, I've updated our tests to match the new setup.

For the upstream issue, I manually used the testcase from https://bugs.ruby-lang.org/issues/19112 and added prints to the profiling GC and NEWOBJ tracepoints, confirming that on Ruby 3.4 they get disabled but on Ruby 4.0 they work fine.

I considered adding an explicit test for this but it seems a bit brittle as it would be a test for something not happening after Ractor GC which is kinda fishy to test for, so I ended up not doing it.
