### PR TITLE
LANGPLAT-919 Permit telemetry forking spec to do everything in the initial worker …

### DIFF
--- a/spec/datadog/core/telemetry/worker_forking_spec.rb
+++ b/spec/datadog/core/telemetry/worker_forking_spec.rb
@@ -132,7 +132,10 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       before do
         # Reduce interval between event submissions in worker
         # to make the test run faster.
-        expect(component.worker).to receive(:loop_wait_time).at_least(:once).and_return(1)
+        # Using +expect+ instead of +allow+ here has failed in CI,
+        # presumably because it is possible for all of the payloads
+        # to be sent out "immediately" and not require any waiting.
+        allow(component.worker).to receive(:loop_wait_time).and_return(1)
       end
 
       before do


### PR DESCRIPTION
…iteration

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes `expect` to `allow`, making it optional for the test to obtain the wait interval.

**Motivation:**
Flaky test: https://github.com/DataDog/ruby-guild/issues/284
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
The theory here is that it is possible for all payloads to be sent on the first worker iteration, so that no waiting is required at all.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing CI