### PR TITLE
RC: Stub agent access in RC component spec

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -11,9 +11,11 @@ module Datadog
   module Core
     module Remote
       # Configures the HTTP transport to communicate with the agent
-      # to fetch and sync the remote configuration
+      # to fetch and sync the remote configuration.
+      #
+      # @api private
       class Component
-        attr_reader :logger, :client, :healthy
+        attr_reader :logger, :client, :healthy, :worker
 
         def initialize(settings, capabilities, agent_settings, logger:)
           @logger = logger

--- a/spec/datadog/core/remote/component_spec.rb
+++ b/spec/datadog/core/remote/component_spec.rb
@@ -176,6 +176,11 @@ RSpec.describe Datadog::Core::Remote::Component, :integration do
     subject(:start) { component.start }
     after { component.shutdown! }
 
+    before do
+      allow_any_instance_of(Datadog::Core::Remote::Negotiation).to receive(:endpoint?).and_return(true)
+      allow(component.worker.instance_variable_get("@block")).to receive(:call)
+    end
+
     it { expect { start }.to change { component.started? }.from(false).to(true) }
 
     it 'does not wait for first sync' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Stubs agent access in a unit test.

**Motivation:**
The test is failing if I have no local agent running.
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
This PR is part of my investigation of skipped tests on JRuby - the remaining ones deal with RC barriers.
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing CI
