### PR TITLE
[CIEXE-1373] Migrate off legacy CI runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   REPO_NOTIFICATION_CHANNEL: "#guild-dd-ruby"
 
 default:
-  tags: ["runner:main", "size:large"]
+  tags: ["arch:amd64"]
 
 workflow:
   auto_cancel:
@@ -50,7 +50,7 @@ workflow:
 
 build-image-amd64:
   extends: .build-image-base
-  tags: ["runner:docker"]
+  tags: ["docker-in-docker:amd64"]
   variables:
     ARCHITECTURE: amd64
 
@@ -69,7 +69,7 @@ promote-image:
         - .gitlab-ci.yml         # list of images is here so it is a dependency too
       when: manual               # this one is manual, but it means that install-dependencies may be hitting the wrong <base>:current til this is run
       allow_failure: true
-  tags: ["runner:docker"]
+  tags: ["docker-in-docker:amd64"]
   image: $DOCKER_REGISTRY/docker:20.10.13
   parallel:
     matrix:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Migrates the remaining CI jobs using legacy `runner:main` or `runner:docker` runners to the golden path gitlab runners. 

**Motivation:**
<!-- What inspired you to submit this pull request? -->

`runner:main` and `runner:docker` are deprecated runners and will be decommissioned in the near future. 

**Change log entry**

None.
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

The affected CI jobs should be re-run to validate they succeed on the new runners.

<!-- Unsure? Have a question? Request a review! -->
