### PR TITLE
Add #blocking_enabled? for no-op AI Guard result

### DIFF
--- a/lib/datadog/ai_guard/evaluation/no_op_result.rb
+++ b/lib/datadog/ai_guard/evaluation/no_op_result.rb
@@ -24,6 +24,10 @@ module Datadog
         def abort?
           false
         end
+
+        def blocking_enabled?
+          false
+        end
       end
     end
   end

--- a/sig/datadog/ai_guard/evaluation/no_op_result.rbs
+++ b/sig/datadog/ai_guard/evaluation/no_op_result.rbs
@@ -13,6 +13,8 @@ module Datadog
         def deny?: () -> bool
 
         def abort?: () -> bool
+
+        def blocking_enabled?: () -> bool
       end
     end
   end

--- a/spec/datadog/ai_guard_spec.rb
+++ b/spec/datadog/ai_guard_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe Datadog::AIGuard do
           expect(result).to be_allow
           expect(result).not_to be_deny
           expect(result).not_to be_abort
+          expect(result).not_to be_blocking_enabled
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
It fixes AI Guard evaluation when AI Guard is disabled by adding a missing method to no-op result.
Follow-up for #5144.

**Motivation:**
One system test was failing for the case when AI Guard is disabled.

**Change log entry**
None. AI Guard was not released yet.

**Additional Notes:**
None.

**How to test the change?**
CI and system-tests.

[APPSEC-59937](https://datadoghq.atlassian.net/browse/APPSEC-59937)

[APPSEC-59937]: https://datadoghq.atlassian.net/browse/APPSEC-59937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ