### PR TITLE
[NO-TICKET] Workaround profiling benchmark flakiness on Ruby 2.5

### DIFF
--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
     # to especially affect 2.6 but we have no indication otherwise that we have issues in Ruby 2.6, I decided to skip
     # this for now and rely on this spec running on other Ruby versions to validate the benchmark is ok.
     skip("Skipping on Ruby 2.6 as it's flaky and we couldn't figure out why yet") if RUBY_VERSION.start_with?("2.6")
+
+    # Update: Because no good deed goes unpunished we also saw flakiness on 2.5 and actually that one provided NO
+    # control frame information AND NO C level backtrace information -- so effectively no info.
+    # For similar reasons as 2.6 above, I think this is at "let's keep an eye out on, and try to figure it out" level so
+    # here's one more skip and let's hope that if/when this shows up on a modern Ruby we can get some actual interesting
+    # info to debug.
+    skip("Skipping on Ruby 2.5 as it's flaky and we couldn't figure out why yet") if RUBY_VERSION.start_with?("2.5")
   end
 
   around do |example|


### PR DESCRIPTION
**What does this PR do?**

If this PR sounds familiar, it's because we already did the same for Ruby 2.6 in #5077. It skips the `profling/validate_benchmarks_spec.rb` on Ruby 2.5 to avoid causing flaky CI failures.

This time we got a test timeout failure in
<https://github.com/DataDog/dd-trace-rb/actions/runs/20915747970/job/60088843877> and trying to get more info from Ruby yielded no luck:

```
     RuntimeError:
       Failure or timeout in `expect_in_fork` (Crashing Ruby to get stacktrace as requested by `trigger_stacktrace_on_kill`), STDOUT: `Current pid is 8207
       Calculating -------------------------------------
       profiling - stack collector (ruby frames - native filenames enabled)
                                 4.262k (± 9.1%) i/s  (234.64 μs/i) -     42.000 in   0.010039s
       `, STDERR: `[BUG] Segmentation fault at 0x0000000000001cc9
       ruby 2.5.9p229 (2021-04-05 revision 67939) [x86_64-linux]

       -- Control frame information -----------------------------------------------

       -- Machine register context ------------------------------------------------
        RIP: 0x00007f899464500c RBP: 0x0000000000000000 RSP: 0x00007fff48075170
        RAX: 0xfffffffffffffffc RBX: 0x000056152d208f70 RCX: 0x00007f899464500c
        RDX: 0x0000000000000000 RDI: 0x000056152d208f98 RSI: 0x0000000000000080
         R8: 0x0000000000000000  R9: 0x000056152d208a20 R10: 0x0000000000000000
        R11: 0x0000000000000246 R12: 0x0000000000000b84 R13: 0x000056152d208fd8
        R14: 0x0000000000000000 R15: 0x000056152d208f98 EFL: 0x0000000000000246

       -- Other runtime information -----------------------------------------------

       * Loaded script: /usr/local/bundle/gems/rspec-core-3.13.6/exe/rspec

       * Loaded features:
```

...that is, the two most important things we should get here are the "Control frame information" and the "C level backtrace information" and neither are available.

**Important**: Ignore the crash part! We induce the crash when the timeout happens **as a way of getting Ruby to try to print more debug info** so the important part is the timeout + the attempt to get info out of Ruby, the "segmentation fault" is artificial and caused by us on purpose.

As I stated in the previous PR:

> The objective of this spec is to validate that the benchmarks don't
> bitrot -- nothing else, so for now let's skip running them on Ruby 2.6
> and rely on the fact they do run on other Ruby versions to keep them
> working (and maybe someday get to the bottom of this issue).

The same is true for Ruby 2.5, so let's skip it for now and hope that if/when this shows up on a modern Ruby we can get some actual interesting info to debug.

**Motivation:**

Zero flaky specs!

**Change log entry**

None.

**Additional Notes:**

Afaik the "C level backtrace information" requires some extra dependencies so I assume our Ruby 2.5 might be missing them.

**How to test the change?**

Validate spec still runs on all Rubies other than 2.5 and 2.6.