### PR TITLE
[APMAPI-1616] Use AST traversal for typing stats instead of Regexp

### DIFF
--- a/.github/scripts/typing_stats_compare.rb
+++ b/.github/scripts/typing_stats_compare.rb
@@ -216,6 +216,6 @@ result << steep_ignore_summary if steep_ignore_summary
 result << untyped_methods_summary if untyped_methods_summary
 result << untyped_others_summary if untyped_others_summary
 if untyped_methods_added > 0 || untyped_others_added > 0
-  result << "*If you believe a method or an attribute is rightfully untyped or partially typed, you can add `# untyped:accept` to the end of the line to remove it from the stats.*\n"
+  result << "*If you believe a method or an attribute is rightfully untyped or partially typed, you can add `# untyped:accept` on the line before the definition to remove it from the stats.*\n"
 end
 print result

--- a/.github/scripts/typing_stats_compute.rb
+++ b/.github/scripts/typing_stats_compute.rb
@@ -178,6 +178,11 @@ signature_paths.each do |sig_path|
   filtered_declarations = ast_traversal(declarations)
 
   filtered_declarations[:methods].each do |method|
+    # Skip definitions with last comment line being `untyped:accept`
+    if method.comment&.string&.end_with?("untyped:accept\n")
+      typed_methods_size += 1
+      next
+    end
     # Overloading can be done inline so we cannot point to the specific overloaded method definition.
     # That's why we combine the status of all overloads to get the overall status of the method.
     # method.overload is an array of MethodDefinition::Overload
@@ -194,6 +199,11 @@ signature_paths.each do |sig_path|
   end
 
   filtered_declarations[:others].each do |declaration|
+    # Skip definitions with last comment line being `untyped:accept`
+    if declaration.comment&.string&.end_with?("untyped:accept\n")
+      typed_others_size += 1
+      next
+    end
     result = is_typed?(declaration.type)
     case result
     when :typed, nil


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Replace Regexp in typing stats by AST traversal.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Prevent any false positives/negatives. This actually found 30 false positives and 46 false negatives.
We will then be able to add the Module path of a function and use it for comparing instead of the line, to prevent creating a comment when a line is just moved around.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
