### PR TITLE
run CI at least once a day, including weekends

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
       - master
   workflow_dispatch: {}
   schedule:
-    - cron: "00 04 * * 2-6"
+    - cron: "00 04 * * 0-6"
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on: # yamllint disable-line rule:truthy
       - master
   schedule:
     - cron: 0 */4 * * 1-5
+    - cron: 0 3 * * 0,6
 
 # Default permissions for all jobs
 permissions: {}


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Run CI once a day during weekends

**Motivation:**

> Datadog monitors are not able to skip saturday/sunday. Without those runs  it'll trigger false positives for weekends, and could also lead to missed errors. 

And also

> there was even the case of an update to some dependency (doesn't matter which) that happened on a Saturday
and that broke 2.5 CI because reasons (doesn't matter)
> but since schedule runs only on Friday late evening + Sunday late evening this was only pinpointed to a "something changed during these 48h" instead of a more direct "THAT DAY EXACTLY".

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
