### PR TITLE
Update ffi to 1.17.3 on ruby 4

### DIFF
--- a/gemfiles/ruby_4.0_activesupport.gemfile.lock
+++ b/gemfiles/ruby_4.0_activesupport.gemfile.lock
@@ -96,7 +96,9 @@ GEM
       zeitwerk (~> 2.6)
     erb (5.0.2)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     grape (2.2.0)
@@ -139,7 +141,8 @@ GEM
     memory_profiler (0.9.14)
     method_source (1.1.0)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
@@ -154,6 +157,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -304,4 +308,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_aws.gemfile.lock
+++ b/gemfiles/ruby_4.0_aws.gemfile.lock
@@ -1692,7 +1692,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -1800,4 +1802,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_contrib.gemfile.lock
+++ b/gemfiles/ruby_4.0_contrib.gemfile.lock
@@ -37,7 +37,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -211,4 +213,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_contrib_old.gemfile.lock
+++ b/gemfiles/ruby_4.0_contrib_old.gemfile.lock
@@ -36,7 +36,9 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -142,4 +144,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_core_old.gemfile.lock
+++ b/gemfiles/ruby_4.0_core_old.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (4.8.3)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -132,4 +134,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_dalli_2.gemfile.lock
+++ b/gemfiles/ruby_4.0_dalli_2.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_dalli_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_dalli_latest.gemfile.lock
@@ -34,8 +34,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
-    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     google-protobuf (3.25.8-arm64-darwin)
@@ -137,4 +138,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_devise_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_devise_latest.gemfile.lock
@@ -75,7 +75,9 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -104,7 +106,8 @@ GEM
     memory_profiler (0.9.14)
     method_source (1.1.0)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     nokogiri (1.18.10)
@@ -116,6 +119,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -242,4 +246,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_devise_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_devise_min.gemfile.lock
@@ -62,7 +62,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubis (2.7.0)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -86,7 +88,7 @@ GEM
     memory_profiler (0.9.14)
     method_source (1.1.0)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     nokogiri (1.18.10)
@@ -198,4 +200,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_elasticsearch_7.gemfile.lock
+++ b/gemfiles/ruby_4.0_elasticsearch_7.gemfile.lock
@@ -47,7 +47,9 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -153,4 +155,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_elasticsearch_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_elasticsearch_latest.gemfile.lock
@@ -46,7 +46,9 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -152,4 +154,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_environment.gemfile.lock
+++ b/gemfiles/ruby_4.0_environment.gemfile.lock
@@ -58,7 +58,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -176,4 +178,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_excon_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_excon_latest.gemfile.lock
@@ -34,7 +34,9 @@ GEM
     dogstatsd-ruby (5.7.1)
     excon (1.3.2)
       logger
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -135,4 +137,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_faraday_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_faraday_latest.gemfile.lock
@@ -38,7 +38,9 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -143,4 +145,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_graphql_1.13.gemfile.lock
+++ b/gemfiles/ruby_4.0_graphql_1.13.gemfile.lock
@@ -95,7 +95,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -135,7 +137,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -153,6 +156,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -286,4 +290,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_graphql_2.0.gemfile.lock
+++ b/gemfiles/ruby_4.0_graphql_2.0.gemfile.lock
@@ -95,7 +95,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -135,7 +137,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -153,6 +156,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -286,4 +290,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_graphql_2.1.gemfile.lock
+++ b/gemfiles/ruby_4.0_graphql_2.1.gemfile.lock
@@ -95,7 +95,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -135,7 +137,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -153,6 +156,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -286,4 +290,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_graphql_2.2.gemfile.lock
+++ b/gemfiles/ruby_4.0_graphql_2.2.gemfile.lock
@@ -95,7 +95,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -135,7 +137,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -153,6 +156,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -286,4 +290,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_graphql_2.3.gemfile.lock
+++ b/gemfiles/ruby_4.0_graphql_2.3.gemfile.lock
@@ -95,7 +95,14 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
     fiber-storage (1.0.1)
     fiddle (1.1.8)
     globalid (1.3.0)
@@ -141,7 +148,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -159,6 +167,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -299,4 +308,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_http.gemfile.lock
+++ b/gemfiles/ruby_4.0_http.gemfile.lock
@@ -35,7 +35,9 @@ GEM
     domain_name (0.6.20240107)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -157,4 +159,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_karafka_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_karafka_latest.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -166,4 +168,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_karafka_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_karafka_min.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -148,4 +150,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_mongo_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_mongo_latest.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -137,4 +139,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_mongo_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_mongo_min.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -136,4 +138,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_openfeature_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_openfeature_latest.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_openfeature_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_openfeature_min.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_opensearch_2.gemfile.lock
+++ b/gemfiles/ruby_4.0_opensearch_2.gemfile.lock
@@ -38,7 +38,9 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -152,4 +154,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_opensearch_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_opensearch_latest.gemfile.lock
@@ -38,7 +38,9 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -147,4 +149,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_opentelemetry.gemfile.lock
+++ b/gemfiles/ruby_4.0_opentelemetry.gemfile.lock
@@ -32,17 +32,17 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux-gnu)
-    ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
-    ffi (1.17.2-arm-linux-musl)
-    ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
-    ffi (1.17.2-x86-linux-musl)
-    ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
-    ffi (1.17.2-x86_64-linux-musl)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     google-protobuf (3.25.8-aarch64-linux)
@@ -195,4 +195,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_opentelemetry_otlp.gemfile.lock
+++ b/gemfiles/ruby_4.0_opentelemetry_otlp.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     googleapis-common-protos-types (1.20.0)
@@ -156,4 +158,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_opentelemetry_otlp_1_5.gemfile.lock
+++ b/gemfiles/ruby_4.0_opentelemetry_otlp_1_5.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     googleapis-common-protos-types (1.20.0)
@@ -156,4 +158,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rack_2.gemfile.lock
+++ b/gemfiles/ruby_4.0_rack_2.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -140,4 +142,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rack_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_rack_latest.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -140,4 +142,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rails7.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails7.gemfile.lock
@@ -101,7 +101,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -134,7 +136,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -152,6 +155,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.3)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -272,4 +276,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rails71.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails71.gemfile.lock
@@ -116,7 +116,9 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -154,7 +156,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -175,6 +178,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -311,4 +315,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rails8.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails8.gemfile.lock
@@ -152,7 +152,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     net-imap (0.5.10)
       date
@@ -174,6 +175,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -309,4 +311,4 @@ DEPENDENCIES
   webrick (>= 1.7.0)
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rails8_trilogy.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails8_trilogy.gemfile.lock
@@ -110,7 +110,9 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
@@ -153,7 +155,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -174,6 +177,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    prism (1.8.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -322,4 +326,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_redis_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_redis_3.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_redis_4.gemfile.lock
+++ b/gemfiles/ruby_4.0_redis_4.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_redis_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_redis_latest.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -138,4 +140,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_resque2_redis3.gemfile.lock
+++ b/gemfiles/ruby_4.0_resque2_redis3.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -163,4 +165,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_resque2_redis4.gemfile.lock
+++ b/gemfiles/ruby_4.0_resque2_redis4.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -167,4 +169,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_rest_client_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_rest_client_latest.gemfile.lock
@@ -33,7 +33,9 @@ GEM
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
     domain_name (0.6.20240107)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -147,4 +149,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_sinatra_2.gemfile.lock
+++ b/gemfiles/ruby_4.0_sinatra_2.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -159,4 +161,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_sinatra_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_sinatra_3.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -160,4 +162,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_sinatra_4.gemfile.lock
+++ b/gemfiles/ruby_4.0_sinatra_4.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -166,4 +168,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_10.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_10.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_11.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_11.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_12.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_12.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_7.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_7.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_8.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_8.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_9.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_9.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_latest.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_stripe_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_stripe_min.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -134,4 +136,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_waterdrop_latest.gemfile.lock
+++ b/gemfiles/ruby_4.0_waterdrop_latest.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -161,4 +163,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/gemfiles/ruby_4.0_waterdrop_min.gemfile.lock
+++ b/gemfiles/ruby_4.0_waterdrop_min.gemfile.lock
@@ -32,7 +32,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-gnu)
     fiddle (1.1.8)
     google-protobuf (3.25.8)
     hashdiff (1.2.1)
@@ -161,4 +163,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.3


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Updates ffi version in gemfile locks for ruby 4

**Motivation:**
<!-- What inspired you to submit this pull request? -->
In https://github.com/DataDog/dd-trace-rb/pull/5200 the version restriction on ffi was removed, but since all of the dependencies are locked, this didn't increase any of the ffi versions in the lock files.

This PR updates ffi in all of the ruby 4 gemfiles/lock files.

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
Existing CI