### PR TITLE
Enable Remote Configuration tests on macOS (arm64)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       SKIP_SIMPLECOV: 1
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
-      DD_REMOTE_CONFIGURATION_ENABLED: true
+      DD_REMOTE_CONFIGURATION_ENABLED: false
 
     steps:
       - name: Check CPU arch

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       SKIP_SIMPLECOV: 1
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
-      DD_REMOTE_CONFIGURATION_ENABLED: false
+      DD_REMOTE_CONFIGURATION_ENABLED: true
 
     steps:
       - name: Check CPU arch

--- a/spec/datadog/core/libdatadog_load_spec.rb
+++ b/spec/datadog/core/libdatadog_load_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe 'libdatadog native extension' do
     end
 
     it 'loads successfully' do
+      puts "[libdatadog smoke test] Platform: #{RUBY_PLATFORM}"
+      puts "[libdatadog smoke test] Ruby version: #{RUBY_VERSION}"
+      puts "[libdatadog smoke test] Libdatadog pkgconfig folder: #{Libdatadog.pkgconfig_folder.inspect}"
+
+      if Datadog::Core::LIBDATADOG_API_FAILURE
+        puts "[libdatadog smoke test] FAILED: #{Datadog::Core::LIBDATADOG_API_FAILURE}"
+      else
+        puts "[libdatadog smoke test] SUCCESS: Native extension loaded"
+      end
+
       expect(Datadog::Core::LIBDATADOG_API_FAILURE).to be_nil,
         "libdatadog failed to load: #{Datadog::Core::LIBDATADOG_API_FAILURE}"
     end

--- a/spec/datadog/core/libdatadog_load_spec.rb
+++ b/spec/datadog/core/libdatadog_load_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'libdatadog native extension' do
+  # Smoke test to verify libdatadog loads on supported platforms.
+  # This catches platform-specific issues that unit tests miss because they stub LIBDATADOG_API_FAILURE.
+  #
+  # Currently supported platforms:
+  #   - Linux (x86_64, aarch64) - glibc and musl
+  #   - macOS arm64 (Apple Silicon)
+  #
+  # Future platform support:
+  #   - macOS x86_64 (Intel): Add `|| (PlatformHelpers.mac? && RUBY_PLATFORM.include?('x86_64'))` when libdatadog publishes x86_64-darwin gem
+  #   - Windows: Add `|| PlatformHelpers.windows?` if/when libdatadog adds Windows support
+
+  context 'on supported platforms' do
+    before do
+      skip 'Not a supported platform for libdatadog' unless supported_platform?
+    end
+
+    def supported_platform?
+      return false unless PlatformHelpers.mri?
+
+      PlatformHelpers.linux? || (PlatformHelpers.mac? && RUBY_PLATFORM.include?('arm64'))
+    end
+
+    it 'loads successfully' do
+      expect(Datadog::Core::LIBDATADOG_API_FAILURE).to be_nil,
+        "libdatadog failed to load: #{Datadog::Core::LIBDATADOG_API_FAILURE}"
+    end
+  end
+end

--- a/spec/support/libdatadog_helpers.rb
+++ b/spec/support/libdatadog_helpers.rb
@@ -3,8 +3,8 @@ require 'support/platform_helpers'
 
 module LibdatadogHelpers
   def self.supported?
-    # Only works with MRI on Linux
-    if PlatformHelpers.mri? && PlatformHelpers.linux?
+    # Only works with MRI on Linux or macOS (arm64 only, no x86_64-darwin build available)
+    if PlatformHelpers.mri? && (PlatformHelpers.linux? || (PlatformHelpers.mac? && RUBY_PLATFORM.include?('arm64')))
       if Datadog::Core::LIBDATADOG_API_FAILURE
         raise "Libdatadog does not seem to be available: #{Datadog::Core::LIBDATADOG_API_FAILURE}. " \
           'Try running `bundle exec rake compile` before running this test.'


### PR DESCRIPTION
## Motivation

 A customer reported this error when using OpenFeature on Apple Silicon Macs:

 ```
 cannot load such file -- libdatadog_api.3.2_arm64-darwin24
 ```

 This issue was **not caught by existing CI** because:

 1. **System tests** run on Linux only (containerized)
 2. **Unit tests** stub `LIBDATADOG_API_FAILURE`, so they never test real native extension loading
 3. **macOS CI (nix.yml)** runs on arm64-darwin, but libdatadog silently fails to load - the fallback gem installs successfully but contains no macOS
 binaries

 The result: CI passes, but customers hit runtime errors.

 ## Changes

 1. **spec/datadog/core/libdatadog_load_spec.rb** - Smoke test that verifies libdatadog native extension actually loads (not stubbed). Outputs diagnostic
 info:
    ```
    [libdatadog smoke test] Platform: arm64-darwin24
    [libdatadog smoke test] Ruby version: 3.2.2
    [libdatadog smoke test] Libdatadog pkgconfig folder: nil
    [libdatadog smoke test] FAILED: cannot load such file -- libdatadog_api.3.2_arm64-darwin24
    ```

 2. **spec/support/libdatadog_helpers.rb** - Updated `LibdatadogHelpers.supported?` to include macOS arm64

 ## Why a smoke test?

 The smoke test checks `Datadog::Core::LIBDATADOG_API_FAILURE` which is set at **require time** when `lib/datadog/core.rb` loads - before any test mocking
  can happen. This is the only way to verify the native extension actually loads on a given platform.

 Without this test, we have no CI coverage for "does libdatadog load on macOS?" - the existing tests all stub the loading behavior.

 ## Merge Conditions

 ⚠️ **This PR will fail on macOS until libdatadog publishes the arm64-darwin gem.**

 Blocked on: https://github.com/DataDog/libdatadog/pull/1463

 Once that PR merges and a new libdatadog version is released to RubyGems, this PR's CI will pass and can be merged.