### PR TITLE
feat: add process tags to crash tracking

### DIFF
--- a/lib/datadog/core/crashtracking/tag_builder.rb
+++ b/lib/datadog/core/crashtracking/tag_builder.rb
@@ -2,6 +2,7 @@
 
 require_relative '../tag_builder'
 require_relative '../utils'
+require_relative '../environment/process'
 
 module Datadog
   module Core
@@ -12,6 +13,11 @@ module Datadog
           hash = Core::TagBuilder.tags(settings).merge(
             'is_crash' => 'true',
           )
+
+          if settings.experimental_propagate_process_tags_enabled
+            process_tags = Environment::Process.serialized
+            hash['process_tags'] = process_tags unless process_tags.empty?
+          end
 
           Utils.encode_tags(hash)
         end

--- a/lib/datadog/core/tag_builder.rb
+++ b/lib/datadog/core/tag_builder.rb
@@ -3,7 +3,6 @@
 require_relative 'environment/socket'
 require_relative 'environment/identity'
 require_relative 'environment/git'
-require_relative 'environment/process'
 
 module Datadog
   module Core
@@ -28,7 +27,7 @@ module Datadog
         # Note that user tags get overwritten by our tags, and also
         # that user tags do not get compacted (nil values are sent as
         # empty strings).
-        constructed_tags = settings.tags.merge(fixed_environment_tags).merge({
+        settings.tags.merge(fixed_environment_tags).merge({
           # Hostname can possibly change during application runtime.
           'host' => Environment::Socket.hostname,
           # Runtime ID changes upon a fork.
@@ -40,13 +39,6 @@ module Datadog
           'service' => settings.service,
           'version' => settings.version,
         }.compact)
-
-        if settings.experimental_propagate_process_tags_enabled
-          process_tags = Environment::Process.serialized
-          constructed_tags['process_tags'] = process_tags unless process_tags.empty?
-        end
-
-        constructed_tags
       end
 
       def self.serialize_tags(tags)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Adds process tags to Crash Tracking.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

AIDM-260

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.



If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None.

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

Follows the Python implementation: https://github.com/DataDog/dd-trace-py/pull/15223

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Two ways:
1. I tested with `BUNDLE_GEMFILE=gemfiles/ruby_3.3_core_old.gemfile bundle exec rspec spec/datadog/core/crashtracking/tag_builder_spec.rb`
2. I also had a local Ruby script crash and I validated the tags show up when enabled, see AIDM-260


<!-- Unsure? Have a question? Request a review! -->
