### PR TITLE
Skip Telemetry spec on Ruby 2.5

### DIFF
--- a/spec/datadog/core/telemetry/worker_forking_spec.rb
+++ b/spec/datadog/core/telemetry/worker_forking_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe Datadog::Core::Telemetry::Component do
       end
 
       it 'restarts worker after fork' do
+        skip 'flaky on Ruby 2.5 (APMLP-931)' if RUBY_VERSION.start_with?('2.5.')
+
         expect(component.enabled?).to be true
         expect(component.worker).to be_a(Datadog::Core::Telemetry::Worker)
         expect(component.worker.enabled?).to be true


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Skip Telemetry spec on Ruby 2.5

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Super flaky on 2.5 only. Couldn't figure out why, might even be a 2.5-specific bug regarding `expect_in_fork`.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

No

**Additional Notes:**
<!-- Anything else we should know when reviewing? -->

JIRA:
- [APMLP-931](https://datadoghq.atlassian.net/browse/APMLP-931)

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Time!

<!-- Unsure? Have a question? Request a review! -->


[APMLP-931]: https://datadoghq.atlassian.net/browse/APMLP-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ