### PR TITLE
Fix flaky AppSec Rails integration test

### DIFF
--- a/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/integration_test_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe 'Rails integration tests', execute_in_fork: Rails.version.to_i >=
   after do
     Datadog.configuration.reset!
     Datadog.registry[:rails].reset_configuration!
+    Datadog::AppSec::APISecurity::Sampler.reset!
   end
 
   context 'for an application' do


### PR DESCRIPTION
**What does this PR do?**
It attempts to fix a flaky AppSec Rails integration test by adding a call to reset API Security sampler between tests.

**Motivation:**
This test is flaky:
https://github.com/DataDog/dd-trace-rb/actions/runs/21000891023/job/60370404063

**Change log entry**
None.

**Additional Notes:**
APMLP-934

**How to test the change?**
CI.

I was running this test in a loop in several Ruby 2.5 containers and couldn't reproduce the error.
