### PR TITLE
Fix AppSec Excon SSRF detection middleware test

### DIFF
--- a/spec/datadog/appsec/contrib/excon/ssrf_detection_middleware_spec.rb
+++ b/spec/datadog/appsec/contrib/excon/ssrf_detection_middleware_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'AppSec excon SSRF detection middleware' do
       c.appsec.instrument :excon
     end
 
+    WebMock.disable_net_connect!(allow: agent_url)
+
     allow(Datadog::AppSec).to receive(:active_context).and_return(context)
   end
 
@@ -35,7 +37,7 @@ RSpec.describe 'AppSec excon SSRF detection middleware' do
     it 'does not call waf when making a request' do
       expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
 
-      client.get(path: '/success')
+      client.get(path: '/success', query: 'z=1')
     end
   end
 
@@ -45,7 +47,7 @@ RSpec.describe 'AppSec excon SSRF detection middleware' do
     it 'does not call waf when making a request' do
       expect(Datadog::AppSec.active_context).not_to receive(:run_rasp)
 
-      client.get(path: '/success')
+      client.get(path: '/success', query: 'z=1')
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**
This test fixes AppSec Excon SSRF detection middleware test by disabling net connects for URLs that are not mocked using Excon.

The issue was that Excon stubbed the request to `http://example.com`, but not to `http://example.com?z=1`.

This PR also adds `WebMock.disable_net_connect!` so that we get a better error message in the future.

**Motivation:**
Flaky test:
https://github.com/DataDog/dd-trace-rb/actions/runs/21412561826/job/61653017810?pr=5208

**Change log entry**
No.

**Additional Notes:**
APMLP-929

**How to test the change?**
CI