### PR TITLE
Update SYSTEM_TESTS_SCENARIOS_GROUPS for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,7 @@ requirements_json_test:
 configure_system_tests:
   variables:
     SYSTEM_TESTS_REF: 107798bd55a6d4ca247b88d01a1316549b8bafe9 # Automated: This reference is automatically updated.
-    SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,lib-injection,docker_ssi"
+    SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 
 save_versions:


### PR DESCRIPTION
This PR enables the SIMPLE_AUTO_INJECTION_APPSEC system test scenario to verify that AppSec is working in CI for lib-injection/SSI deployments.

System test PR: https://github.com/DataDog/system-tests/pull/6205

**Change log entry**

No. (Updated by @strech)