### PR TITLE
[NO-TICKET] Remove unused `MINIMUM_VERSION` in net/http integration

### DIFF
--- a/lib/datadog/tracing/contrib/http/integration.rb
+++ b/lib/datadog/tracing/contrib/http/integration.rb
@@ -18,8 +18,6 @@ module Datadog
         class Integration
           include Contrib::Integration
 
-          MINIMUM_VERSION = Datadog::VERSION::MINIMUM_RUBY_VERSION
-
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :http, auto_patch: true
           def self.gem_name


### PR DESCRIPTION
**What does this PR do?**

Remove unused constant in net/http (that wasn't even correct as per #2184).

**Motivation:**

Simplify things + Fix #2184

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

Existing coverage for this integration should be enough!