### PR TITLE
Unignore files causing Steep `FATAL`

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -563,12 +563,6 @@ target :datadog do
   # References `RubyVM::YJIT`, which does not have type information.
   ignore 'lib/datadog/core/environment/yjit.rb'
 
-  # These blow up with `FATAL`:
-  ignore 'lib/datadog/open_feature/resolution_details.rb'
-  ignore 'lib/datadog/kit/appsec/events/v2.rb'
-  ignore 'lib/datadog/core/logger.rb'
-  ignore 'lib/datadog/tracing/contrib/rack/route_inference.rb'
-
   library 'bundler'
   library 'pathname'
   library 'cgi'


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Revert "Ignore some files with `FATAL` errors in Steep"

**Motivation:**
<!-- What inspired you to submit this pull request? -->

Splitting away https://github.com/DataDog/dd-trace-rb/pull/5319 from https://github.com/DataDog/dd-trace-rb/pull/5294 caused the latter to add ignored files while the former fixed the cause.

Merging both concurrently led to files still being ignored in spite of fixes.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

Nope

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
