### PR TITLE
[DOCS-13353] Add Ruby 4.0 to compatibility documentation

### DIFF
--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -10,7 +10,8 @@ The Ruby Datadog Trace library is open source. See the [dd-trace-rb][1] GitHub r
 <!-- Ensure that all "# TODO: Ruby 3.5 - " comments are addressed before including 3.5 in our public support docs -->
 | Type  | Documentation              | Version   | Support type              | Gem version support |
 |-------|----------------------------|-----------|---------------------------|---------------------|
-| MRI   | https://www.ruby-lang.org/ | 3.4       | [latest](#support-latest) | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 4.0       | [latest](#support-latest) | Latest              |
+|       |                            | 3.4       | [latest](#support-latest) | Latest              |
 |       |                            | 3.3       | [latest](#support-latest) | Latest              |
 |       |                            | 3.2       | [latest](#support-latest) | Latest              |
 |       |                            | 3.1       | [latest](#support-latest) | Latest              |


### PR DESCRIPTION
### What does this PR do?

Fixes DOCS-13353

This PR adds Ruby 4.0 to the supported Ruby interpreters table in the compatibility documentation. Initial support for Ruby 4.0 was added in dd-trace-rb v2.24.0.

Per the v2.24.0 release notes:
> We've also introduced initial support for Ruby 4.0. While comprehensive validation is ongoing, we welcome any feedback if you encounter issues using this Ruby version.

### Motivation

Ruby v4 was released in late December 2025: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/

Support was added in v2.24.0: https://github.com/DataDog/dd-trace-rb/releases/tag/v2.24.0

The compatibility documentation needs to be updated to reflect this support.

### Additional Notes

This change will automatically propagate to the Datadog documentation site via the pull_config.yaml configuration.