### PR TITLE
Update AppSec blocking HTML template

### DIFF
--- a/lib/datadog/appsec/assets/blocked.html
+++ b/lib/datadog/appsec/assets/blocked.html
@@ -100,7 +100,8 @@
     <footer>
         <p>Security provided by <a
                 href="https://www.datadoghq.com/product/security-platform/application-security-monitoring/"
-                target="_blank">Datadog</a></p>
+                target="_blank"
+                rel="noopener noreferrer">Datadog</a></p>
     </footer>
 </body>
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds `rel="noopener noreferrer"` to the Datadog link in the blocking HTML template.

**Motivation:**
A customer is reporting that their vulnerability scanner is flagging the default ASM WAF blocking page for a security issue.

**Change log entry**
Yes. Make AppSec blocking page more friendly to vulnerability scanners.

**Additional Notes:**
None.

**How to test the change?**
CI