### PR TITLE
chore(crashtracking): update max frames collected by unhandled exception collector to 512 and clarify comment

### DIFF
--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -85,7 +85,7 @@ module Datadog
 
         def report_unhandled_exception(exception, settings: Datadog.configuration)
           # Maximum number of stack frames to include in exception crash reports
-          # This is the same number used for signal-based crashtracking
+          # This is the same number used for signal-based crashtracking's runtime stack
           max_exception_stack_frames = 512
 
           current_tags = self.class.latest_tags(settings)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
I forgot to push the last commit to https://github.com/DataDog/dd-trace-rb/pull/5321

Signal based crash reports' runtime stacks has a max frame set to 512. We should maintain parity with that. This PR does this, and updates the comment to be correct

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
No.
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
