### PR TITLE
chore(crashtracking): check result and drop error if ffi api call goes wrong

### DIFF
--- a/ext/libdatadog_api/crashtracker_report_exception.c
+++ b/ext/libdatadog_api/crashtracker_report_exception.c
@@ -81,30 +81,39 @@ static bool process_crash_frames(VALUE frames_data, ddog_crasht_Handle_StackTrac
 
     ddog_crasht_StackFrame_NewResult frame_result = ddog_crasht_StackFrame_new();
     if (frame_result.tag != DDOG_CRASHT_STACK_FRAME_NEW_RESULT_OK) {
+      ddog_Error_drop(&frame_result.err);
       return false;
     }
 
     ddog_crasht_Handle_StackFrame *frame = &frame_result.ok;
 
-    if (ddog_crasht_StackFrame_with_file(frame, char_slice_from_ruby_string(file_val)).tag != DDOG_VOID_RESULT_OK) {
+    ddog_VoidResult file_result = ddog_crasht_StackFrame_with_file(frame, char_slice_from_ruby_string(file_val));
+    if (file_result.tag != DDOG_VOID_RESULT_OK) {
       ddog_crasht_StackFrame_drop(frame);
+      ddog_Error_drop(&file_result.err);
       return false;
     }
-    if (ddog_crasht_StackFrame_with_function(frame, char_slice_from_ruby_string(func_val)).tag != DDOG_VOID_RESULT_OK) {
+    ddog_VoidResult func_result = ddog_crasht_StackFrame_with_function(frame, char_slice_from_ruby_string(func_val));
+    if (func_result.tag != DDOG_VOID_RESULT_OK) {
       ddog_crasht_StackFrame_drop(frame);
+      ddog_Error_drop(&func_result.err);
       return false;
     }
 
     uint32_t line = (uint32_t)FIX2INT(line_val);
     if (line > 0) {
-      if (ddog_crasht_StackFrame_with_line(frame, line).tag != DDOG_VOID_RESULT_OK) {
+      ddog_VoidResult line_result = ddog_crasht_StackFrame_with_line(frame, line);
+      if (line_result.tag != DDOG_VOID_RESULT_OK) {
         ddog_crasht_StackFrame_drop(frame);
+        ddog_Error_drop(&line_result.err);
         return false;
       }
     }
 
-    if (ddog_crasht_StackTrace_push_frame(stack_trace, frame, true).tag != DDOG_VOID_RESULT_OK) {
+    ddog_VoidResult push_result = ddog_crasht_StackTrace_push_frame(stack_trace, frame, true);
+    if (push_result.tag != DDOG_VOID_RESULT_OK) {
       ddog_crasht_StackFrame_drop(frame);
+      ddog_Error_drop(&push_result.err);
       return false;
     }
   }
@@ -120,41 +129,54 @@ static bool build_and_send_crash_report(ddog_crasht_Metadata metadata,
 
   ddog_crasht_CrashInfoBuilder_NewResult builder_result = ddog_crasht_CrashInfoBuilder_new();
   if (builder_result.tag != DDOG_CRASHT_CRASH_INFO_BUILDER_NEW_RESULT_OK) {
+    ddog_Error_drop(&builder_result.err);
     return false;
   }
 
   ddog_crasht_Handle_CrashInfoBuilder *builder = &builder_result.ok;
 
   // Setup builder metadata and configuration
-  if (ddog_crasht_CrashInfoBuilder_with_metadata(builder, metadata).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult metadata_result = ddog_crasht_CrashInfoBuilder_with_metadata(builder, metadata);
+  if (metadata_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&metadata_result.err);
     return false;
   }
 
-  if (ddog_crasht_CrashInfoBuilder_with_kind(builder, DDOG_CRASHT_ERROR_KIND_UNHANDLED_EXCEPTION).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult kind_result = ddog_crasht_CrashInfoBuilder_with_kind(builder, DDOG_CRASHT_ERROR_KIND_UNHANDLED_EXCEPTION);
+  if (kind_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&kind_result.err);
     return false;
   }
 
   // Send ping first
-  if (ddog_crasht_CrashInfoBuilder_upload_ping_to_endpoint(builder, endpoint).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult ping_result = ddog_crasht_CrashInfoBuilder_upload_ping_to_endpoint(builder, endpoint);
+  if (ping_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&ping_result.err);
     return false;
   }
 
   ddog_crasht_ProcInfo proc_info = { .pid = (uint32_t)getpid() };
-  if (ddog_crasht_CrashInfoBuilder_with_proc_info(builder, proc_info).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult proc_info_result = ddog_crasht_CrashInfoBuilder_with_proc_info(builder, proc_info);
+  if (proc_info_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&proc_info_result.err);
     return false;
   }
 
-  if (ddog_crasht_CrashInfoBuilder_with_os_info_this_machine(builder).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult os_info_result = ddog_crasht_CrashInfoBuilder_with_os_info_this_machine(builder);
+  if (os_info_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&os_info_result.err);
     return false;
   }
 
-  if (ddog_crasht_CrashInfoBuilder_with_message(builder, char_slice_from_ruby_string(message)).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult message_result = ddog_crasht_CrashInfoBuilder_with_message(builder, char_slice_from_ruby_string(message));
+  if (message_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&message_result.err);
     return false;
   }
 
@@ -162,6 +184,7 @@ static bool build_and_send_crash_report(ddog_crasht_Metadata metadata,
   ddog_crasht_StackTrace_NewResult stack_result = ddog_crasht_StackTrace_new();
   if (stack_result.tag != DDOG_CRASHT_STACK_TRACE_NEW_RESULT_OK) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&stack_result.err);
     return false;
   }
 
@@ -171,18 +194,22 @@ static bool build_and_send_crash_report(ddog_crasht_Metadata metadata,
 
   // Only mark as complete if we successfully processed all frames
   if (frames_processed_successfully) {
-    if (ddog_crasht_StackTrace_set_complete(stack_trace).tag != DDOG_VOID_RESULT_OK) {
+    ddog_VoidResult complete_result = ddog_crasht_StackTrace_set_complete(stack_trace);
+    if (complete_result.tag != DDOG_VOID_RESULT_OK) {
       ddog_crasht_StackTrace_drop(stack_trace);
       ddog_crasht_CrashInfoBuilder_drop(builder);
+      ddog_Error_drop(&complete_result.err);
       return false;
     }
   }
   // If frames processing failed, we still include the stack trace (which may be empty or partial)
   // but don't mark it as complete, indicating it's incomplete
 
-  if (ddog_crasht_CrashInfoBuilder_with_stack(builder, stack_trace).tag != DDOG_VOID_RESULT_OK) {
+  ddog_VoidResult with_stack_result = ddog_crasht_CrashInfoBuilder_with_stack(builder, stack_trace);
+  if (with_stack_result.tag != DDOG_VOID_RESULT_OK) {
     ddog_crasht_StackTrace_drop(stack_trace);
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&with_stack_result.err);
     return false;
   }
 
@@ -193,12 +220,16 @@ static bool build_and_send_crash_report(ddog_crasht_Metadata metadata,
   ddog_crasht_CrashInfo_NewResult crash_info_result = ddog_crasht_CrashInfoBuilder_build(builder);
   if (crash_info_result.tag != DDOG_CRASHT_RESULT_HANDLE_CRASH_INFO_OK_HANDLE_CRASH_INFO) {
     ddog_crasht_CrashInfoBuilder_drop(builder);
+    ddog_Error_drop(&crash_info_result.err);
     return false;
   }
 
   ddog_crasht_Handle_CrashInfo *crash_info = &crash_info_result.ok;
   ddog_VoidResult upload_result = ddog_crasht_CrashInfo_upload_to_endpoint(crash_info, endpoint);
   bool success = (upload_result.tag == DDOG_VOID_RESULT_OK);
+  if (!success) {
+    ddog_Error_drop(&upload_result.err);
+  }
 
   ddog_crasht_CrashInfo_drop(crash_info);
   return success;


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
We need to check the result returned by FFI call and drop error if it failed.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
No.
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
