### PR TITLE
Improve CI Elasticsearch healthchecks

### DIFF
--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -227,7 +227,7 @@ jobs:
           xpack.security.enabled: "false"
           ES_JAVA_OPTS: "-Xms750m -Xmx750m"
         options: >-
-          --health-cmd "curl -sf http://localhost:9200/_cluster/health || exit 1"
+          --health-cmd "curl -sf http://localhost:9200/_cluster/health | grep -qE '\"status\":\"(green|yellow)\"' || exit 1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10


### PR DESCRIPTION
**What does this PR do?**
This PR improves healthcheck for Elasticsearch container for our CI.

**Motivation:**
Elasticsearch also responds with a 200 status code for status `red`.

**Change log entry**
None.

**Additional Notes:**
Used Claude for this.

**How to test the change?**
CI