### PR TITLE
Add `appsec.api_security.missing_route` telemetry

### DIFF
--- a/lib/datadog/appsec/context.rb
+++ b/lib/datadog/appsec/context.rb
@@ -121,10 +121,8 @@ module Datadog
       def export_request_telemetry
         return if @trace.nil?
 
-        @state[:missing_route] = @span&.get_tag(Tracing::Metadata::Ext::HTTP::TAG_ROUTE).nil?
-
         Metrics::TelemetryExporter.export_waf_request_metrics(@metrics.waf, self)
-        Metrics::TelemetryExporter.export_api_security_metrics(@state)
+        Metrics::TelemetryExporter.export_api_security_metrics(self)
       end
 
       def finalize!

--- a/lib/datadog/appsec/metrics/telemetry_exporter.rb
+++ b/lib/datadog/appsec/metrics/telemetry_exporter.rb
@@ -24,18 +24,18 @@ module Datadog
           )
         end
 
-        def export_api_security_metrics(context_state)
-          web_framework = context_state[:web_framework]
+        def export_api_security_metrics(context)
+          web_framework = context.state[:web_framework]
           return unless web_framework
 
-          if context_state[:missing_route]
+          if context.span&.get_tag(Tracing::Metadata::Ext::HTTP::TAG_ROUTE).nil?
             AppSec.telemetry.inc(
               AppSec::Ext::TELEMETRY_METRICS_NAMESPACE, 'api_security.missing_route', 1,
               tags: {framework: web_framework}
             )
           end
 
-          metric_name = context_state[:schema_extracted] ? 'schema' : 'no_schema'
+          metric_name = context.state[:schema_extracted] ? 'schema' : 'no_schema'
           AppSec.telemetry.inc(
             AppSec::Ext::TELEMETRY_METRICS_NAMESPACE, "api_security.request.#{metric_name}", 1,
             tags: {framework: web_framework}

--- a/sig/datadog/appsec/metrics/telemetry_exporter.rbs
+++ b/sig/datadog/appsec/metrics/telemetry_exporter.rbs
@@ -4,7 +4,7 @@ module Datadog
       module TelemetryExporter
         def self?.export_waf_request_metrics: (Metrics::Collector::Store metrics, AppSec::Context context) -> void
 
-        def self?.export_api_security_metrics: (::Hash[::Symbol, any] state) -> void
+        def self?.export_api_security_metrics: (AppSec::Context context) -> void
       end
     end
   end

--- a/spec/datadog/appsec/context_spec.rb
+++ b/spec/datadog/appsec/context_spec.rb
@@ -270,47 +270,5 @@ RSpec.describe Datadog::AppSec::Context do
         context.export_request_telemetry
       end
     end
-
-    context 'when span has http.route tag' do
-      before do
-        span.set_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_ROUTE, '/users/:id')
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_waf_request_metrics)
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_api_security_metrics)
-      end
-
-      it 'sets missing_route state to false' do
-        context.export_request_telemetry
-
-        expect(context.state[:missing_route]).to be false
-      end
-    end
-
-    context 'when span does not have http.route tag' do
-      before do
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_waf_request_metrics)
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_api_security_metrics)
-      end
-
-      it 'sets missing_route state to true' do
-        context.export_request_telemetry
-
-        expect(context.state[:missing_route]).to be true
-      end
-    end
-
-    context 'when span is nil' do
-      let(:context) { described_class.new(trace, nil, waf_runner) }
-
-      before do
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_waf_request_metrics)
-        allow(Datadog::AppSec::Metrics::TelemetryExporter).to receive(:export_api_security_metrics)
-      end
-
-      it 'sets missing_route state to true' do
-        context.export_request_telemetry
-
-        expect(context.state[:missing_route]).to be true
-      end
-    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
It adds `appsec.api_security.route_missing` telemetry when the request had no route tag set.

**Motivation:**
We want to track more metrics via telemetry to identify problems sooner.

**Change log entry**
None. This change is internal.

**Additional Notes:**
APPSEC-60123

**How to test the change?**
CI
