### PR TITLE
Disable comment amending for claude unless requested

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 
 ## Never
 
-- Use `git commit --amend` (always create new commits)
+- Use `git commit --amend` unless the user explicitly and clearly requests it (always create new commits by default)
 - Commit secrets, tokens, or credentials
 - Edit files under `gemfiles/` (auto-generated; use `bundle exec rake dependency:generate`)
 - Change versioning (`lib/datadog/version.rb`, `CHANGELOG.md`)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Adds additional claude rules:

/ Never `commit --amend`. It tried to do that today.

**Motivation:**
Agent safety
<!-- What inspired you to submit this pull request? -->

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
This PR description was hand-written!
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
