### PR TITLE
[NO-TICKET] Fix flaky waf_addresses ordering in engine specs

### DIFF
--- a/spec/datadog/appsec/security_engine/engine_spec.rb
+++ b/spec/datadog/appsec/security_engine/engine_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe Datadog::AppSec::SecurityEngine::Engine do
           expect do
             engine.add_or_update_config(invalid_config, path: 'datadog/603646/ASM_DD/latest/config')
             engine.reconfigure!
-          end.not_to change { engine.new_runner.waf_addresses }
+          end.not_to change { engine.new_runner.waf_addresses.sort }
         end
 
         it 'does not change ruleset_version' do
@@ -705,7 +705,7 @@ RSpec.describe Datadog::AppSec::SecurityEngine::Engine do
       end
 
       it 'does not change waf_addresses' do
-        expect { engine.reconfigure! }.not_to(change { engine.new_runner.waf_addresses })
+        expect { engine.reconfigure! }.not_to(change { engine.new_runner.waf_addresses.sort })
       end
 
       it 'reports error through telemetry' do


### PR DESCRIPTION
**What does this PR do?**

Sort `waf_addresses` inside `change` blocks to make assertions order-insensitive.

**Motivation:**

`known_addresses` from libddwaf returns addresses in non-deterministic order across platforms. On aarch64-linux (CI run #22507006380) the order shifted between before/after snapshots causing a false failure.

**Change log entry**

None

**Additional Notes:**

Only two test sites affected (lines 516, 708). Line 627 already uses `match_array` and is not flaky. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

**How to test the change?**

`bundle exec rspec spec/datadog/appsec/security_engine/engine_spec.rb:512 spec/datadog/appsec/security_engine/engine_spec.rb:707`