### PR TITLE
[NO-TICKET] Minor: Fix profiler code provenance spec failing on some Ruby builds

### DIFF
--- a/spec/datadog/profiling/collectors/code_provenance_spec.rb
+++ b/spec/datadog/profiling/collectors/code_provenance_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Datadog::Profiling::Collectors::CodeProvenance do
   end
 
   let(:expected_platform_fragment) do
-    platform_fragment = RUBY_PLATFORM
+    platform_fragment = Gem::Platform.local.to_s
     platform_fragment.sub(/darwin(\d+)/, 'darwin-\1')
   end
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the profiler code provenance spec failing on Ubuntu builds of Ruby (e.g. `apt install ruby`) due to `RUBY_PLATFORM` being slightly different from what the spec expected there. 

**Motivation:**

Make sure we have a green test suite on Ubuntu builds of Ruby.

**Change log entry**

None. (Only affects specs)

**Additional Notes:**

The spec was using RUBY_PLATFORM to match extension directory paths, but RubyGems normalizes the platform string when creating extension directories. For example, on Ubuntu's default Ruby build, RUBY_PLATFORM is x86_64-linux-gnu but the extension directory uses x86_64-linux.

Using Gem::Platform.local.to_s instead matches what RubyGems actually uses, making the spec pass across different Ruby builds.

**How to test the change?**

Check spec still passes in CI, and passes on e.g. a Datadog workspace (where I installed the Ubuntu Ruby build).
