### PR TITLE
Add documentation for manually starting RC worker in DI

### DIFF
--- a/docs/DynamicInstrumentationDevelopment.md
+++ b/docs/DynamicInstrumentationDevelopment.md
@@ -9,9 +9,10 @@ Add this to your Rails initializer after `Datadog.configure`:
 
 Datadog.configure do |c|
   c.dynamic_instrumentation.enabled = true
-  # In development environments also set:
-  c.remote.enabled = true
+  # This internal setting should only be used when developing the datadog gem itself and
+  # **should not** ever be used outside of that.
   c.dynamic_instrumentation.internal.development = true
+  c.remote.enabled = true
   # ... other configuration
 end
 


### PR DESCRIPTION
**What does this PR do?**
Adds documentation for manually starting the Remote Configuration worker in Dynamic Instrumentation.

**Motivation:**
The implementation in https://github.com/DataDog/debugger-demos/pull/230 which employed a curl command to hit the application to start RC via the rack middleware was rejected. Instead the request was to have the application start RC via the dd-trace-rb internal APIs, from a rails initializer.

Since this setup is needed in multiple places, here is a PR documenting it for ease of access with claude.

**Change log entry**
None

**Additional Notes:**
Documentation-only change.

**How to test the change?**
Review the documentation for clarity and accuracy.