### PR TITLE
[NO-TICKET] Add memory leak testing for core_with_libdatadog_api specs

### DIFF
--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -25,7 +25,7 @@ jobs:
           bundler: latest
           cache-version: v2 # bump this to invalidate cache
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
-      - run: bundle exec rake compile spec:profiling:memcheck
+      - run: bundle exec rake compile spec:profiling:memcheck spec:core_with_libdatadog_api_memcheck
   test-asan:
     runs-on: ubuntu-24.04
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -226,21 +226,28 @@ namespace :spec do
     t.rspec_opts = args.to_a.join(' ')
   end
 
-  # rubocop:disable Style/MultilineBlockChain
   RSpec::Core::RakeTask.new(:core_with_libdatadog_api) do |t, args|
     t.pattern = CORE_WITH_LIBDATADOG_API.join(', ')
     t.rspec_opts = args.to_a.join(' ')
-  end.tap do |t|
-    # Core with libdatadog is dependent on profiling because crashtracking runtime stacks logic
-    # lives in the profiling extension (they share same logic accessing Ruby internals)
-    Rake::Task[t.name].enhance(
-      [
-        "compile:libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}",
-        "compile:datadog_profiling_native_extension.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
-      ]
-    )
   end
-  # rubocop:enable Style/MultilineBlockChain
+
+  desc 'Run spec:core_with_libdatadog_api tests with memory leak checking'
+  if Gem.loaded_specs.key?('ruby_memcheck')
+    RubyMemcheck::RSpec::RakeTask.new(:core_with_libdatadog_api_memcheck) do |t, args|
+      t.pattern = CORE_WITH_LIBDATADOG_API.join(', ')
+      t.rspec_opts = [*args.to_a, '-t ~memcheck_valgrind_skip'].join(' ')
+    end
+  else
+    task :core_with_libdatadog_api_memcheck do
+      raise 'Memcheck requires the ruby_memcheck gem to be installed'
+    end
+  end
+
+  # These specs require both libdatadog_api and profiling native extensions:
+  # - libdatadog_api provides crashtracking, DDSketch, and other core features
+  # - profiling extension is needed for crashtracking runtime stack capture
+  Rake::Task['spec:core_with_libdatadog_api'].enhance([:compile])
+  Rake::Task['spec:core_with_libdatadog_api_memcheck'].enhance([:compile]) if Gem.loaded_specs.key?('ruby_memcheck')
 
   desc '' # "Explicitly hiding from `rake -T`"
   RSpec::Core::RakeTask.new(:core_with_rails) do |t, args|

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !LibdatadogHelpers
       end
     end
 
-    describe '#report_unhandled_exception' do
+    describe '#report_unhandled_exception', :memcheck_valgrind_skip do
       include_context 'HTTP server'
 
       let(:agent_base_url) { "http://#{hostname}:#{http_server_port}" }
@@ -242,7 +242,7 @@ RSpec.describe Datadog::Core::Crashtracking::Component, skip: !LibdatadogHelpers
       end
     end
 
-    context 'integration testing' do
+    context 'integration testing', :memcheck_valgrind_skip do
       include_context 'HTTP server'
 
       let(:request) do


### PR DESCRIPTION
**What does this PR do?**

Extends CI memory leak testing to cover core_with_libdatadog_api specs.

**Motivation:**

Since we have some native code for these, let's also check there's no leaks there.

**Change log entry**

None.

**Additional Notes:**

I've skipped a lot of the crashtracking tests since they do weird things and they do need to keep some data for the full life of the process (so there's some amount of leaking on purpose).

Using webrick also seemed to trigger some leaky-looking things from the Ruby VM and it wasn't clear if they were real or not.

**How to test the change?**

CI is green!