### PR TITLE
chore(ci): add final_status property on junit XML [APMSP-2610]

### DIFF
--- a/.github/add_final_status.xsl
+++ b/.github/add_final_status.xsl
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+We're using not-that-ideal XSLT here as this change, because it must be done over 17+ repos.
+It's a workaround until this gets integrated into a better place, such as datadog-ci or the backend.
+* ticket: https://datadoghq.atlassian.net/browse/APMSP-2610
+* RFC: https://docs.google.com/document/d/1OaX_h09fCXWmK_1ADrwvilt8Yt5h4WjC7UUAdS3Y3uw/edit?pli=1&tab=t.0#heading=h.tfy5viz7rz2
+-->
+
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <!-- Identity transform: copy everything as-is by default -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,11 @@ jobs:
           DD_GIT_COMMIT_SHA: ${{ github.sha }}
         run: echo "DD_GIT_COMMIT_SHA=$DD_GIT_COMMIT_SHA" >> "$GITHUB_ENV"
       - run: echo "$DD_GIT_COMMIT_SHA"
+      # We're using not-that-ideal XSLT here as this change, because it must be done over 17+ repos.
+      # It's a workaround until this gets integrated into a better place, such as datadog-ci or the backend.
+      #
+      # * ticket: https://datadoghq.atlassian.net/browse/APMSP-2610
+      # * RFC: https://docs.google.com/document/d/1OaX_h09fCXWmK_1ADrwvilt8Yt5h4WjC7UUAdS3Y3uw/edit?pli=1&tab=t.0#heading=h.tfy5viz7rz2
       - name: Add final_status property
         run: |
           apk add libxslt


### PR DESCRIPTION
### What does this PR do?

Add a `<property name="dd_tags[test.final_status]" value="pass" />` on every test case reported through junit

### Motivation

Some repositories intentionally use mechanisms that ignore test failures (there are valid reasons to still execute those tests behind the scenes).

In these cases, the reported test status cannot be relied upon by Test Optimization to monitor repository health or trigger team notifications.

To ensure a consistent and unified approach, we will instead use final_status — the property specifically designed and used by the Test Optimization integration for this purpose.


**Additional Notes:**

I'm using the not-that-ideal XSLT here as this change, because it must be done over [17+ repos](https://datadoghq.atlassian.net/browse/APMSP-2610), and it's a workaround until this gets integrated into a better place, such as datadog-ci or the backend. 

We're trying to work with the team on this, please have a look on this [RFC](https://docs.google.com/document/d/1OaX_h09fCXWmK_1ADrwvilt8Yt5h4WjC7UUAdS3Y3uw/edit?pli=1&tab=t.0#heading=h.tfy5viz7rz2) for more context.

**How to test the change?**

No `N/A` in this [query](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id_v2%3A%2A%2Fdd-trace-rb%20%40git.branch%3Acbeauchesne%2Ffinal_status&agg_m=%40test.full_name&agg_m_source=base&agg_q=%40test.final_status&agg_q_source=base&agg_t=cardinality&currentTab=overview&eventStack=&fromUser=false&index=citest&sort_m=count&sort_m_source=base&sort_t=count&top_n=10&top_o=top&viz=timeseries&x_missing=false&start=1772465922956&end=1773070722956&paused=false)