### PR TITLE
Add version 5.x handling for dalli contrib

### DIFF
--- a/lib/datadog/tracing/contrib/dalli/integration.rb
+++ b/lib/datadog/tracing/contrib/dalli/integration.rb
@@ -14,6 +14,7 @@ module Datadog
 
           MINIMUM_VERSION = Gem::Version.new('2.0.0')
           DALLI_PROTOCOL_BINARY_VERSION = Gem::Version.new('3.0.0')
+          DALLI_PROTOCOL_META_VERSION = Gem::Version.new('5.0.0')
 
           # @public_api Changing the integration name or integration options can cause breaking changes
           register_as :dalli, auto_patch: true
@@ -31,7 +32,9 @@ module Datadog
           end
 
           def self.dalli_class
-            if version >= DALLI_PROTOCOL_BINARY_VERSION
+            if version >= DALLI_PROTOCOL_META_VERSION
+              ::Dalli::Protocol::Meta
+            elsif version >= DALLI_PROTOCOL_BINARY_VERSION
               ::Dalli::Protocol::Binary
             else
               ::Dalli::Server

--- a/spec/datadog/tracing/contrib/dalli/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/dalli/integration_spec.rb
@@ -70,13 +70,23 @@ RSpec.describe Datadog::Tracing::Contrib::Dalli::Integration do
         end
       end
 
-      context 'that meets the dalli protocol version' do
+      context 'that meets the dalli protocol binary version' do
         it 'Loads the Dalli::Protocol::Binary class' do
-          if Gem.loaded_specs['dalli'].version < described_class::DALLI_PROTOCOL_BINARY_VERSION
-            skip 'running on dalli below min'
-          end
+          version = Gem.loaded_specs['dalli'].version
+          binary_range = described_class::DALLI_PROTOCOL_BINARY_VERSION...described_class::DALLI_PROTOCOL_META_VERSION
+          skip 'not running on dalli 3.x/4.x' unless binary_range.cover?(version)
 
           expect(dalli_class).to eq ::Dalli::Protocol::Binary
+        end
+      end
+
+      context 'that meets the dalli protocol meta version' do
+        it 'Loads the Dalli::Protocol::Meta class' do
+          if Gem.loaded_specs['dalli'].version < described_class::DALLI_PROTOCOL_META_VERSION
+            skip 'running on dalli below 5.0'
+          end
+
+          expect(dalli_class).to eq ::Dalli::Protocol::Meta
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

Adjust `dalli` contrib to work with breaking changes of version 5.x

**Motivation:**

Resolve #5358

**Change log entry**

Yes. Fix compatibility with `dalli` 5.0+

**Additional Notes:**

dalli 5.0 removed `Dalli::Protocol::Binary` (and SASL auth) entirely — now only `Dalli::Protocol::Meta` exists.

**How to test the change?**

CI