### PR TITLE
Add typing for Socket.hostname

### DIFF
--- a/sig/datadog/core/environment/socket.rbs
+++ b/sig/datadog/core/environment/socket.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Environment
       module Socket
-        def self?.hostname: () -> String
+        def self?.hostname: () -> ::String
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
Type `Datadog::Core::Environment::Socket.hostname` return value as `String` instead of `untyped`.

**Motivation:**
Incremental RBS precision improvement. `hostname` always returns a frozen `String` from `::Socket.gethostname`.

**Change log entry**
None.

**Additional Notes:**
Signature-only change (no runtime code modified).

**How to test the change?**
`bundle exec steep check lib/datadog/core/environment/socket.rb` passes at both normal and information severity.