### PR TITLE
Skip MongoDB client instrumentation tests on JRuby 9.2

### DIFF
--- a/spec/datadog/tracing/contrib/mongodb/client_spec.rb
+++ b/spec/datadog/tracing/contrib/mongodb/client_spec.rb
@@ -9,6 +9,15 @@ require 'datadog'
 require 'mongo'
 
 RSpec.describe 'Mongo::Client instrumentation' do
+  # Skip reason: On JRuby 9.2, tests are failing with the following exception:
+  #   Mongo::Error::NoServerAvailable: No primary_preferred server is available in cluster:
+  #   #<Cluster topology=Unknown[mongodb:27017] servers=[#<Server address=mongodb:27017 UNKNOWN NO-MONITORING>]>
+  #   with timeout=30, LT=0.015. The following servers have dead monitor threads:
+  #   #<Server address=mongodb:27017 UNKNOWN NO-MONITORING>
+  # This is most likely a JRuby bug or issue because JRuby does not implement fork and should therefore
+  # never have dead monitor threads. MongoDB Ruby driver 2.21.0 deprecated JRuby 9.2 support.
+  before { skip if PlatformHelpers.jruby? && !PlatformHelpers.ruby_version_matches?('>= 2.6') }
+
   let(:configuration_options) { {} }
   # Clear data between tests
   let(:drop_database?) { true }


### PR DESCRIPTION
**What does this PR do?**

Skips MongoDB client instrumentation tests on JRuby 9.2 to prevent CI failures caused by dead monitor threads.

**Motivation:**

JRuby 9.2 tests are failing with `Mongo::Error::NoServerAvailable` due to dead monitor threads.
MongoDB Ruby driver 2.21.0 deprecated JRuby 9.2 support.
The error occurs because of JRuby 9.2 threading bugs, not the tracer code itself.
JRuby 9.3+ does not have this issue.

**Change log entry**

None.

**Additional Notes:**

The skip condition uses `PlatformHelpers.jruby? && !PlatformHelpers.ruby_version_matches?('>= 2.6')` to target JRuby 9.2 specifically (which reports Ruby 2.5.8).

Error being skipped:
```
Mongo::Error::NoServerAvailable: No primary_preferred server is available in cluster: #<Cluster topology=Unknown[mongodb:27017] servers=[#<Server address=mongodb:27017 UNKNOWN NO-MONITORING>]> with timeout=30, LT=0.015. The following servers have dead monitor threads: #<Server address=mongodb:27017 UNKNOWN NO-MONITORING>
```

**How to test the change?**

Run MongoDB tests on JRuby 9.2 - they should be skipped instead of failing.
Run MongoDB tests on JRuby 9.3+ - they should continue to run normally.