### PR TITLE
[PROF-14030] Add integration tests for libdatadog OTel process context

### DIFF
--- a/spec/datadog/core/process_discovery_spec.rb
+++ b/spec/datadog/core/process_discovery_spec.rb
@@ -217,8 +217,10 @@ RSpec.describe Datadog::Core::ProcessDiscovery do
     end
   end
 
-  describe 'OTel process context support', skip: !LibdatadogHelpers.supported? do
+  describe 'OTel process context support', if: !PlatformHelpers.mac? do
     before do
+      skip_if_libdatadog_not_supported
+
       allow(Datadog::Core::Environment::Container).to receive(:container_id).and_return('test-container-id')
 
       Datadog.configure do |c|


### PR DESCRIPTION
**What does this PR do?**

This PR adds integration tests for the [libdatadog](https://github.com/DataDog/libdatadog/pull/1658) support for [OTel process context](https://github.com/open-telemetry/opentelemetry-specification/pull/4719).

**Motivation:**

Starting in libdatadog v29, the process context is automatically published together with the process discovery feature, so we don't need to do anything from the Ruby side to turn it on.

Yet, we want to make sure this is in good shape as this is a WIP effort so having a few Ruby-level integration tests seems nice.

**Change log entry**

None. (Only changes tests)

**Additional Notes:**

For Datadog folks -- more details on this work can be found on
 #ebpf-context-propagation on our slack.

The process context is stored as a protobuf message in a very special memory location, hence the new test using protobuf + the weird code to parse memory.

**How to test the change?**

Validate that new spec is passing!
