### PR TITLE
Appsec user auth telemetry

### DIFF
--- a/lib/datadog/appsec/contrib/devise/ext.rb
+++ b/lib/datadog/appsec/contrib/devise/ext.rb
@@ -6,10 +6,6 @@ module Datadog
       module Devise
         # Devise integration constants
         module Ext
-          EVENT_LOGIN_SUCCESS = 'users.login.success'
-          EVENT_LOGIN_FAILURE = 'users.login.failure'
-          EVENT_SIGNUP = 'users.signup'
-
           TAG_DD_USR_ID = '_dd.appsec.usr.id'
           TAG_DD_USR_LOGIN = '_dd.appsec.usr.login'
           TAG_DD_SIGNUP_MODE = '_dd.appsec.events.users.signup.auto.mode'

--- a/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
@@ -30,13 +30,11 @@ module Datadog
 
               if result
                 record_successful_signin(context, resource)
-                Instrumentation.gateway.push('appsec.events.user_lifecycle', Ext::EVENT_LOGIN_SUCCESS)
 
                 return result
               end
 
               record_failed_signin(context, resource)
-              Instrumentation.gateway.push('appsec.events.user_lifecycle', Ext::EVENT_LOGIN_FAILURE)
 
               result
             end

--- a/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
@@ -63,7 +63,7 @@ module Datadog
               #       and because of that we will trigger an additional event even
               #       if it was already done via the SDK
               AppSec::Instrumentation.gateway.push(
-                'identity.set_user', AppSec::Instrumentation::Gateway::User.new(id, login)
+                'identity.set_user', {id: id, login: login, framework: 'devise', event_type: 'login_success'}
               )
             end
 
@@ -80,6 +80,10 @@ module Datadog
                 context.span[Ext::TAG_LOGIN_FAILURE_USR_LOGIN] ||= login
                 context.span[Ext::TAG_LOGIN_FAILURE_USR_EXISTS] ||= 'false'
 
+                AppSec::Instrumentation.gateway.push(
+                  'identity.login_failure', {login: login, framework: 'devise'}
+                )
+
                 return
               end
 
@@ -94,6 +98,10 @@ module Datadog
               context.span[Ext::TAG_DD_USR_LOGIN] = login
               context.span[Ext::TAG_LOGIN_FAILURE_USR_LOGIN] ||= login
               context.span[Ext::TAG_LOGIN_FAILURE_USR_EXISTS] ||= 'true'
+
+              AppSec::Instrumentation.gateway.push(
+                'identity.login_failure', {id: id, login: login, framework: 'devise'}
+              )
             end
           end
         end

--- a/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
@@ -63,7 +63,7 @@ module Datadog
               #       and because of that we will trigger an additional event even
               #       if it was already done via the SDK
               AppSec::Instrumentation.gateway.push(
-                'identity.set_user', {id: id, login: login, framework: 'devise', event_type: 'login_success'}
+                'identity.devise.login_success', {id: id, login: login}
               )
             end
 
@@ -81,7 +81,7 @@ module Datadog
                 context.span[Ext::TAG_LOGIN_FAILURE_USR_EXISTS] ||= 'false'
 
                 AppSec::Instrumentation.gateway.push(
-                  'identity.login_failure', {login: login, framework: 'devise'}
+                  'identity.devise.login_failure', {login: login}
                 )
 
                 return
@@ -100,7 +100,7 @@ module Datadog
               context.span[Ext::TAG_LOGIN_FAILURE_USR_EXISTS] ||= 'true'
 
               AppSec::Instrumentation.gateway.push(
-                'identity.login_failure', {id: id, login: login, framework: 'devise'}
+                'identity.devise.login_failure', {id: id, login: login}
               )
             end
           end

--- a/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
@@ -59,7 +59,7 @@ module Datadog
               #       and because of that we will trigger an additional event even
               #       if it was already done via the SDK
               AppSec::Instrumentation.gateway.push(
-                'identity.set_user', AppSec::Instrumentation::Gateway::User.new(id, login)
+                'identity.set_user', {id: id, login: login, framework: 'devise', event_type: 'signup'}
               )
             end
           end

--- a/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
@@ -29,7 +29,6 @@ module Datadog
 
                 TraceKeeper.keep!(context.trace)
                 record_successful_signup(context, resource)
-                Instrumentation.gateway.push('appsec.events.user_lifecycle', Ext::EVENT_SIGNUP)
 
                 yield(resource) if block_given?
               end

--- a/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signup_tracking_patch.rb
@@ -59,7 +59,7 @@ module Datadog
               #       and because of that we will trigger an additional event even
               #       if it was already done via the SDK
               AppSec::Instrumentation.gateway.push(
-                'identity.set_user', {id: id, login: login, framework: 'devise', event_type: 'signup'}
+                'identity.devise.signup', {id: id, login: login}
               )
             end
           end

--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -45,8 +45,8 @@ module Datadog
                 user_session_id = context.span[Ext::TAG_SESSION_ID] || session_id
 
                 AppSec::Instrumentation.gateway.push(
-                  'identity.set_user',
-                  {id: user_id, session_id: user_session_id, framework: 'devise', event_type: 'authenticated_request'}
+                  'identity.devise.authenticated_request',
+                  {id: user_id, session_id: user_session_id}
                 )
               end
 

--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -44,12 +44,9 @@ module Datadog
                 user_id = context.span[Ext::TAG_USR_ID] || id
                 user_session_id = context.span[Ext::TAG_SESSION_ID] || session_id
 
-                # FIXME: The current implementation of event arguments is forsing us
-                #        to bloat User class, and pass nil-value instead of skip
-                #        passing them at first place.
-                #        This is a temporary situation until we refactor events model.
                 AppSec::Instrumentation.gateway.push(
-                  'identity.set_user', AppSec::Instrumentation::Gateway::User.new(user_id, nil, user_session_id)
+                  'identity.set_user',
+                  {id: user_id, session_id: user_session_id, framework: 'devise', event_type: 'authenticated_request'}
                 )
               end
 

--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -116,7 +116,7 @@ module Datadog
                 gateway.watch('rack.request.finish') do |stack, gateway_request|
                   context = gateway_request.env[AppSec::Ext::CONTEXT_KEY]
 
-                  if context.span.nil? || !gateway.pushed?('appsec.events.user_lifecycle')
+                  if context.span.nil? || Monitor::Gateway::Watcher::IDENTITY_EVENTS.none? { |e| gateway.pushed?(e) }
                     next stack.call(gateway_request.request)
                   end
 

--- a/lib/datadog/appsec/contrib/rack/patcher.rb
+++ b/lib/datadog/appsec/contrib/rack/patcher.rb
@@ -21,6 +21,7 @@ module Datadog
 
           def patch
             Monitor::Gateway::Watcher.watch
+            Monitor::Gateway::TelemetryWatcher.watch
             Gateway::Watcher.watch
             Patcher.instance_variable_set(:@patched, true)
           end

--- a/lib/datadog/appsec/instrumentation/gateway/argument.rb
+++ b/lib/datadog/appsec/instrumentation/gateway/argument.rb
@@ -7,21 +7,6 @@ module Datadog
         # Base class for Gateway Arguments
         class Argument; end # rubocop:disable Lint/EmptyClass
 
-        # Gateway User argument
-        # NOTE: This class is a subject of elimination and will be removed when
-        #       the event system is refactored.
-        class User < Argument
-          attr_reader :id, :login, :session_id
-
-          def initialize(id = nil, login = nil, session_id = nil)
-            super()
-
-            @id = id
-            @login = login
-            @session_id = session_id
-          end
-        end
-
         # This class is used to pass arbitrary data to the event system with an
         # option to tie it to a context.
         #

--- a/lib/datadog/appsec/monitor.rb
+++ b/lib/datadog/appsec/monitor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'monitor/gateway/watcher'
+require_relative 'monitor/gateway/telemetry_watcher'
 
 module Datadog
   module AppSec

--- a/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
@@ -13,51 +13,48 @@ module Datadog
             def watch
               gateway = Instrumentation.gateway
 
-              watch_set_user(gateway)
-              watch_login_failure(gateway)
+              watch_user_lifecycle(gateway)
+              watch_authenticated_request(gateway)
             end
 
-            def watch_set_user(gateway = Instrumentation.gateway)
-              gateway.watch('identity.set_user') do |stack, user_info|
-                event_type = user_info[:event_type]
-                report_missing_user_telemetry(user_info, event_type) if event_type
+            def watch_user_lifecycle(gateway = Instrumentation.gateway)
+              %w[
+                identity.devise.login_success
+                identity.devise.login_failure
+                identity.devise.signup
+              ].each do |event_name|
+                gateway.watch(event_name) do |stack, user_info|
+                  _, framework, event_type = event_name.split('.')
+                  tags = {framework: framework, event_type: event_type}
+
+                  if user_info[:login].nil?
+                    AppSec.telemetry.inc(
+                      Ext::TELEMETRY_METRICS_NAMESPACE, 'instrum.user_auth.missing_user_login', 1, tags: tags
+                    )
+                  end
+
+                  if user_info[:id].nil? && user_info[:login].nil?
+                    AppSec.telemetry.inc(
+                      Ext::TELEMETRY_METRICS_NAMESPACE, 'instrum.user_auth.missing_user_id', 1, tags: tags
+                    )
+                  end
+
+                  stack.call(user_info)
+                end
+              end
+            end
+
+            def watch_authenticated_request(gateway = Instrumentation.gateway)
+              gateway.watch('identity.devise.authenticated_request') do |stack, user_info|
+                tags = {framework: 'devise', event_type: 'authenticated_request'}
+
+                if user_info[:id].nil?
+                  AppSec.telemetry.inc(
+                    Ext::TELEMETRY_METRICS_NAMESPACE, 'instrum.user_auth.missing_user_id', 1, tags: tags
+                  )
+                end
 
                 stack.call(user_info)
-              end
-            end
-
-            def watch_login_failure(gateway = Instrumentation.gateway)
-              gateway.watch('identity.login_failure') do |stack, user_info|
-                report_missing_user_telemetry(user_info, 'login_failure')
-
-                stack.call(user_info)
-              end
-            end
-
-            private
-
-            def report_missing_user_telemetry(user_info, event_type)
-              tags = {framework: user_info[:framework], event_type: event_type}
-
-              missing_login = user_info[:login].nil?
-              missing_id = user_info[:id].nil?
-
-              if missing_login && event_type != 'authenticated_request'
-                AppSec.telemetry.inc(
-                  Ext::TELEMETRY_METRICS_NAMESPACE,
-                  'instrum.user_auth.missing_user_login',
-                  1,
-                  tags: tags,
-                )
-              end
-
-              if missing_id && (event_type == 'authenticated_request' || missing_login)
-                AppSec.telemetry.inc(
-                  Ext::TELEMETRY_METRICS_NAMESPACE,
-                  'instrum.user_auth.missing_user_id',
-                  1,
-                  tags: tags,
-                )
               end
             end
           end

--- a/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../../ext'
+require_relative '../../instrumentation/gateway'
+
+module Datadog
+  module AppSec
+    module Monitor
+      module Gateway
+        # Telemetry watcher for user auth instrumentation events
+        module TelemetryWatcher
+          class << self
+            def watch
+              gateway = Instrumentation.gateway
+
+              watch_set_user(gateway)
+              watch_login_failure(gateway)
+            end
+
+            def watch_set_user(gateway = Instrumentation.gateway)
+              gateway.watch('identity.set_user') do |stack, user_info|
+                event_type = user_info[:event_type]
+                report_missing_user_telemetry(user_info, event_type) if event_type
+
+                stack.call(user_info)
+              end
+            end
+
+            def watch_login_failure(gateway = Instrumentation.gateway)
+              gateway.watch('identity.login_failure') do |stack, user_info|
+                report_missing_user_telemetry(user_info, 'login_failure')
+
+                stack.call(user_info)
+              end
+            end
+
+            private
+
+            def report_missing_user_telemetry(user_info, event_type)
+              tags = {framework: user_info[:framework], event_type: event_type}
+
+              missing_login = user_info[:login].nil?
+              missing_id = user_info[:id].nil?
+
+              if missing_login && event_type != 'authenticated_request'
+                AppSec.telemetry.inc(
+                  Ext::TELEMETRY_METRICS_NAMESPACE,
+                  'instrum.user_auth.missing_user_login',
+                  1,
+                  tags: tags,
+                )
+              end
+
+              if missing_id && (event_type == 'authenticated_request' || missing_login)
+                AppSec.telemetry.inc(
+                  Ext::TELEMETRY_METRICS_NAMESPACE,
+                  'instrum.user_auth.missing_user_id',
+                  1,
+                  tags: tags,
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/telemetry_watcher.rb
@@ -24,7 +24,7 @@ module Datadog
                 identity.devise.signup
               ].each do |event_name|
                 gateway.watch(event_name) do |stack, user_info|
-                  _, framework, event_type = event_name.split('.')
+                  _, framework, event_type = event_name.split('.') #: [String, String, String]
                   tags = {framework: framework, event_type: event_type}
 
                   if user_info[:login].nil?

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -24,18 +24,18 @@ module Datadog
             end
 
             def watch_user_id(gateway = Instrumentation.gateway)
-              gateway.watch('identity.set_user') do |stack, user|
+              gateway.watch('identity.set_user') do |stack, user_info|
                 context = AppSec.active_context
 
-                if user.id.nil? && user.login.nil? && user.session_id.nil?
+                if user_info[:id].nil? && user_info[:login].nil? && user_info[:session_id].nil?
                   Datadog.logger.debug { 'AppSec: skipping WAF check because no user information was provided' }
-                  next stack.call(user)
+                  next stack.call(user_info)
                 end
 
                 persistent_data = {}
-                persistent_data['usr.id'] = user.id if user.id
-                persistent_data['usr.login'] = user.login if user.login
-                persistent_data['usr.session_id'] = user.session_id if user.session_id
+                persistent_data['usr.id'] = user_info[:id] if user_info[:id]
+                persistent_data['usr.login'] = user_info[:login] if user_info[:login]
+                persistent_data['usr.session_id'] = user_info[:session_id] if user_info[:session_id]
 
                 result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
@@ -50,7 +50,7 @@ module Datadog
                   AppSec::ActionsHandler.handle(result.actions)
                 end
 
-                stack.call(user)
+                stack.call(user_info)
               end
             end
 

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -11,12 +11,10 @@ module Datadog
         # Watcher for Apssec internal events
         module Watcher
           ARBITRARY_VALUE = 'invalid'
-          EVENT_LOGIN_SUCCESS = 'users.login.success'
-          EVENT_LOGIN_FAILURE = 'users.login.failure'
-          WATCHED_LOGIN_EVENTS = [EVENT_LOGIN_SUCCESS, EVENT_LOGIN_FAILURE].freeze
 
           IDENTITY_EVENTS = %w[
             identity.sdk.set_user
+            identity.sdk.login_success
             identity.sdk.login_failure
             identity.devise.login_success
             identity.devise.login_failure
@@ -24,12 +22,19 @@ module Datadog
             identity.devise.authenticated_request
           ].freeze
 
+          LOGIN_EVENTS = {
+            'identity.sdk.login_success' => 'server.business_logic.users.login.success',
+            'identity.sdk.login_failure' => 'server.business_logic.users.login.failure',
+            'identity.devise.login_success' => 'server.business_logic.users.login.success',
+            'identity.devise.login_failure' => 'server.business_logic.users.login.failure',
+          }.freeze
+
           class << self
             def watch
               gateway = Instrumentation.gateway
 
               watch_user_id(gateway)
-              watch_user_login(gateway)
+              watch_user_login_event(gateway)
             end
 
             def watch_user_id(gateway = Instrumentation.gateway)
@@ -65,27 +70,27 @@ module Datadog
               end
             end
 
-            def watch_user_login(gateway = Instrumentation.gateway)
-              gateway.watch('appsec.events.user_lifecycle') do |stack, kind|
-                context = AppSec.active_context
+            def watch_user_login_event(gateway = Instrumentation.gateway)
+              LOGIN_EVENTS.each do |event_name, business_logic_key|
+                gateway.watch(event_name) do |stack, user_info|
+                  context = AppSec.active_context
 
-                next stack.call(kind) unless WATCHED_LOGIN_EVENTS.include?(kind)
+                  persistent_data = {business_logic_key => ARBITRARY_VALUE}
+                  result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
 
-                persistent_data = {"server.business_logic.#{kind}" => ARBITRARY_VALUE}
-                result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
+                  if result.match? || result.attributes.any?
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
+                  end
 
-                if result.match? || result.attributes.any?
-                  context.events.push(
-                    AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
-                  )
+                  if result.match?
+                    AppSec::Event.tag(context, result)
+                    AppSec::ActionsHandler.handle(result.actions)
+                  end
+
+                  stack.call(user_info)
                 end
-
-                if result.match?
-                  AppSec::Event.tag(context, result)
-                  AppSec::ActionsHandler.handle(result.actions)
-                end
-
-                stack.call(kind)
               end
             end
           end

--- a/lib/datadog/appsec/monitor/gateway/watcher.rb
+++ b/lib/datadog/appsec/monitor/gateway/watcher.rb
@@ -15,6 +15,15 @@ module Datadog
           EVENT_LOGIN_FAILURE = 'users.login.failure'
           WATCHED_LOGIN_EVENTS = [EVENT_LOGIN_SUCCESS, EVENT_LOGIN_FAILURE].freeze
 
+          IDENTITY_EVENTS = %w[
+            identity.sdk.set_user
+            identity.sdk.login_failure
+            identity.devise.login_success
+            identity.devise.login_failure
+            identity.devise.signup
+            identity.devise.authenticated_request
+          ].freeze
+
           class << self
             def watch
               gateway = Instrumentation.gateway
@@ -24,33 +33,35 @@ module Datadog
             end
 
             def watch_user_id(gateway = Instrumentation.gateway)
-              gateway.watch('identity.set_user') do |stack, user_info|
-                context = AppSec.active_context
+              IDENTITY_EVENTS.each do |event_name|
+                gateway.watch(event_name) do |stack, user_info|
+                  context = AppSec.active_context
 
-                if user_info[:id].nil? && user_info[:login].nil? && user_info[:session_id].nil?
-                  Datadog.logger.debug { 'AppSec: skipping WAF check because no user information was provided' }
-                  next stack.call(user_info)
+                  if user_info[:id].nil? && user_info[:login].nil? && user_info[:session_id].nil?
+                    Datadog.logger.debug { 'AppSec: skipping WAF check because no user information was provided' }
+                    next stack.call(user_info)
+                  end
+
+                  persistent_data = {}
+                  persistent_data['usr.id'] = user_info[:id] if user_info[:id]
+                  persistent_data['usr.login'] = user_info[:login] if user_info[:login]
+                  persistent_data['usr.session_id'] = user_info[:session_id] if user_info[:session_id]
+
+                  result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
+
+                  if result.match? || result.attributes.any?
+                    context.events.push(
+                      AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
+                    )
+                  end
+
+                  if result.match?
+                    AppSec::Event.tag(context, result)
+                    AppSec::ActionsHandler.handle(result.actions)
+                  end
+
+                  stack.call(user_info)
                 end
-
-                persistent_data = {}
-                persistent_data['usr.id'] = user_info[:id] if user_info[:id]
-                persistent_data['usr.login'] = user_info[:login] if user_info[:login]
-                persistent_data['usr.session_id'] = user_info[:session_id] if user_info[:session_id]
-
-                result = context.run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
-
-                if result.match? || result.attributes.any?
-                  context.events.push(
-                    AppSec::SecurityEvent.new(result, trace: context.trace, span: context.span)
-                  )
-                end
-
-                if result.match?
-                  AppSec::Event.tag(context, result)
-                  AppSec::ActionsHandler.handle(result.actions)
-                end
-
-                stack.call(user_info)
               end
             end
 

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -142,7 +142,6 @@ module Datadog
                 ::Datadog::AppSec::TraceKeeper.keep!(active_trace)
               end
             end
-
           end
 
           private

--- a/lib/datadog/kit/appsec/events.rb
+++ b/lib/datadog/kit/appsec/events.rb
@@ -143,7 +143,6 @@ module Datadog
               end
             end
 
-            ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', event)
           end
 
           private

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -70,8 +70,7 @@ module Datadog
 
               # NOTE: This is a fallback for the case when we don't have an ID,
               #       but need to trigger WAF.
-              user_info = {login: login, framework: 'sdk', event_type: 'login_success'}
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.sdk.set_user', {login: login})
             end
 
             # Attach user login failure information to the service entry span
@@ -121,9 +120,7 @@ module Datadog
               record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)
 
-              user_info = {login: login, framework: 'sdk', event_type: 'login_failure'}
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.login_failure', user_info)
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.sdk.login_failure', {login: login})
             end
 
             private

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -70,8 +70,8 @@ module Datadog
 
               # NOTE: This is a fallback for the case when we don't have an ID,
               #       but need to trigger WAF.
-              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(nil, login)
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+              user_info = {login: login, framework: 'sdk', event_type: 'login_success'}
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
             end
 
             # Attach user login failure information to the service entry span
@@ -121,8 +121,8 @@ module Datadog
               record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)
 
-              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(nil, login)
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+              user_info = {login: login, framework: 'sdk'}
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.login_failure', user_info)
             end
 
             private

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -121,7 +121,8 @@ module Datadog
               record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
               ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)
 
-              user_info = {login: login, framework: 'sdk'}
+              user_info = {login: login, framework: 'sdk', event_type: 'login_failure'}
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
               ::Datadog::AppSec::Instrumentation.gateway.push('identity.login_failure', user_info)
             end
 

--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -64,13 +64,12 @@ module Datadog
               ::Datadog::AppSec::TraceKeeper.keep!(trace)
 
               record_event_telemetry_metric(LOGIN_SUCCESS_EVENT)
-              ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_SUCCESS_EVENT)
 
-              return Kit::Identity.set_user(trace, span, **user_attributes) if user_attributes.key?(:id)
+              Kit::Identity.set_user(trace, span, **user_attributes) if user_attributes.key?(:id)
 
-              # NOTE: This is a fallback for the case when we don't have an ID,
-              #       but need to trigger WAF.
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.sdk.set_user', {login: login})
+              # NOTE: Triggers business logic WAF check and user WAF check
+              #       (when there is no ID, this is the only event that triggers user WAF)
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.sdk.login_success', {login: login})
             end
 
             # Attach user login failure information to the service entry span
@@ -118,7 +117,6 @@ module Datadog
               ::Datadog::AppSec::TraceKeeper.keep!(trace)
 
               record_event_telemetry_metric(LOGIN_FAILURE_EVENT)
-              ::Datadog::AppSec::Instrumentation.gateway.push('appsec.events.user_lifecycle', LOGIN_FAILURE_EVENT)
 
               ::Datadog::AppSec::Instrumentation.gateway.push('identity.sdk.login_failure', {login: login})
             end

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -70,8 +70,9 @@ module Datadog
             if Datadog::AppSec.active_context
               active_span.set_tag('_dd.appsec.user.collection_mode', 'sdk')
 
-              user_info = {id: id, login: others[:login], session_id: session_id, framework: 'sdk'}
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
+              ::Datadog::AppSec::Instrumentation.gateway.push(
+                'identity.sdk.set_user', {id: id, login: others[:login], session_id: session_id}
+              )
             end
           end
         end

--- a/lib/datadog/kit/identity.rb
+++ b/lib/datadog/kit/identity.rb
@@ -70,8 +70,8 @@ module Datadog
             if Datadog::AppSec.active_context
               active_span.set_tag('_dd.appsec.user.collection_mode', 'sdk')
 
-              user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(id, others[:login], session_id)
-              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+              user_info = {id: id, login: others[:login], session_id: session_id, framework: 'sdk'}
+              ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user_info)
             end
           end
         end

--- a/sig/datadog/appsec/instrumentation/gateway/argument.rbs
+++ b/sig/datadog/appsec/instrumentation/gateway/argument.rbs
@@ -6,23 +6,6 @@ module Datadog
           def initialize: (*untyped) -> void
         end
 
-        # FIXME: This sig will be rewritten
-        class User < Argument
-          @id: ::String?
-
-          @login: ::String?
-
-          @session_id: ::String?
-
-          attr_reader id: ::String?
-
-          attr_reader login: ::String?
-
-          attr_reader session_id: ::String?
-
-          def initialize: (?::String? id, ?::String? login, ?::String? session_id) -> void
-        end
-
         class DataContainer < Argument
           @data: untyped
 

--- a/sig/datadog/appsec/monitor/gateway/telemetry_watcher.rbs
+++ b/sig/datadog/appsec/monitor/gateway/telemetry_watcher.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module AppSec
+    module Monitor
+      module Gateway
+        module TelemetryWatcher
+          def self.watch: () -> void
+
+          def self.watch_set_user: (?Instrumentation::Gateway gateway) -> void
+
+          def self.watch_login_failure: (?Instrumentation::Gateway gateway) -> void
+
+          private
+
+          def self.report_missing_user_telemetry: (Hash[Symbol, any] user_info, String event_type) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/appsec/monitor/gateway/telemetry_watcher.rbs
+++ b/sig/datadog/appsec/monitor/gateway/telemetry_watcher.rbs
@@ -5,13 +5,9 @@ module Datadog
         module TelemetryWatcher
           def self.watch: () -> void
 
-          def self.watch_set_user: (?Instrumentation::Gateway gateway) -> void
+          def self.watch_user_lifecycle: (?Instrumentation::Gateway gateway) -> void
 
-          def self.watch_login_failure: (?Instrumentation::Gateway gateway) -> void
-
-          private
-
-          def self.report_missing_user_telemetry: (Hash[Symbol, any] user_info, String event_type) -> void
+          def self.watch_authenticated_request: (?Instrumentation::Gateway gateway) -> void
         end
       end
     end

--- a/sig/datadog/appsec/monitor/gateway/watcher.rbs
+++ b/sig/datadog/appsec/monitor/gateway/watcher.rbs
@@ -5,17 +5,15 @@ module Datadog
         module Watcher
           ARBITRARY_VALUE: ::String
 
-          EVENT_LOGIN_SUCCESS: ::String
+          IDENTITY_EVENTS: ::Array[::String]
 
-          EVENT_LOGIN_FAILURE: ::String
-
-          WATCHED_LOGIN_EVENTS: ::Array[::String]
+          LOGIN_EVENTS: ::Hash[::String, ::String]
 
           def self.watch: () -> untyped
 
           def self.watch_user_id: (?Instrumentation::Gateway gateway) -> void
 
-          def self.watch_user_login: (?Instrumentation::Gateway gateway) -> void
+          def self.watch_user_login_event: (?Instrumentation::Gateway gateway) -> void
         end
       end
     end

--- a/spec/datadog/appsec/integration/contrib/devise/signin_multi_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signin_multi_user_tracking_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -250,7 +250,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => 'admin:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -277,7 +277,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -319,7 +319,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -369,7 +369,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.events.users.login.failure.auto.mode' => 'identification'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_failure')).to be true
     end
   end
 
@@ -440,7 +440,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.events.users.login.failure.auto.mode' => 'identification'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_failure')).to be true
     end
   end
 end

--- a/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
     allow(Datadog::AppSec::Instrumentation).to receive(:gateway).and_return(gateway)
     Datadog::AppSec::Monitor::Gateway::TelemetryWatcher.watch
 
-    allow(Datadog::AppSec.telemetry).to receive(:inc).and_call_original
+    allow(Datadog::AppSec.telemetry).to receive(:inc)
 
     # NOTE: Don't reach the agent in any way
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)

--- a/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
@@ -117,6 +117,9 @@ RSpec.describe 'Devise auto login and signup events tracking' do
 
     allow(Rails).to receive(:application).and_return(app)
     allow(Datadog::AppSec::Instrumentation).to receive(:gateway).and_return(gateway)
+    Datadog::AppSec::Monitor::Gateway::TelemetryWatcher.watch
+
+    allow(Datadog::AppSec.telemetry).to receive(:inc).and_call_original
 
     # NOTE: Don't reach the agent in any way
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
@@ -503,6 +506,43 @@ RSpec.describe 'Devise auto login and signup events tracking' do
       )
 
       expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+    end
+  end
+
+  context 'when login extraction fails during successful login' do
+    before do
+      allow_any_instance_of(Datadog::AppSec::Contrib::Devise::DataExtractor)
+        .to receive(:extract_login).and_return(nil)
+
+      User.create!(username: 'JohnDoe', email: 'john.doe@example.com', password: '123456')
+      post('/users/sign_in', {user: {email: 'john.doe@example.com', password: '123456'}})
+    end
+
+    it 'reports missing_user_login telemetry' do
+      expect(response).to be_redirect
+
+      expect(Datadog::AppSec.telemetry).to have_received(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', 1,
+        tags: {framework: 'devise', event_type: 'login_success'},
+      )
+    end
+  end
+
+  context 'when login extraction fails during failed login' do
+    before do
+      allow_any_instance_of(Datadog::AppSec::Contrib::Devise::DataExtractor)
+        .to receive(:extract_login).and_return(nil)
+
+      post('/users/sign_in', {user: {email: 'john.doe@example.com', password: '123456'}})
+    end
+
+    it 'reports missing_user_login telemetry' do
+      expect(response).to be_unprocessable
+
+      expect(Datadog::AppSec.telemetry).to have_received(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', 1,
+        tags: {framework: 'devise', event_type: 'login_failure'},
+      )
     end
   end
 end

--- a/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signin_single_user_tracking_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -240,7 +240,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
       expect(http_service_entry_span.tags).not_to have_key('usr.id')
       expect(http_service_entry_span.tags).not_to have_key('_dd.appsec.usr.id')
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -267,7 +267,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -317,7 +317,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
       expect(http_service_entry_span.tags).not_to have_key('appsec.events.users.login.success.track')
       expect(http_service_entry_span.tags).not_to have_key('appsec.events.users.login.failure.track')
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be false
+      expect(gateway.pushed?('identity.devise.login_success')).to be false
     end
   end
 
@@ -363,7 +363,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_success')).to be true
     end
   end
 
@@ -384,7 +384,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.events.users.login.failure.auto.mode' => 'identification'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_failure')).to be true
     end
   end
 
@@ -434,7 +434,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.events.users.login.failure.auto.mode' => 'identification'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_failure')).to be true
     end
   end
 
@@ -505,7 +505,7 @@ RSpec.describe 'Devise auto login and signup events tracking' do
         '_dd.appsec.events.users.login.failure.auto.mode' => 'identification'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.login_failure')).to be true
     end
   end
 

--- a/spec/datadog/appsec/integration/contrib/devise/signup_multi_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signup_multi_user_tracking_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -237,7 +237,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => 'admin:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -296,7 +296,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -358,7 +358,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => 'user:1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 end

--- a/spec/datadog/appsec/integration/contrib/devise/signup_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signup_single_user_tracking_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -243,7 +243,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.login' => 'john.doe@example.com'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -302,7 +302,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 
@@ -364,7 +364,7 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
         '_dd.appsec.usr.id' => '1'
       )
 
-      expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+      expect(gateway.pushed?('identity.devise.signup')).to be true
     end
   end
 

--- a/spec/datadog/appsec/integration/contrib/devise/signup_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/signup_single_user_tracking_spec.rb
@@ -105,6 +105,9 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
 
     allow(Rails).to receive(:application).and_return(app)
     allow(Datadog::AppSec::Instrumentation).to receive(:gateway).and_return(gateway)
+    Datadog::AppSec::Monitor::Gateway::TelemetryWatcher.watch
+
+    allow(Datadog::AppSec.telemetry).to receive(:inc).and_call_original
 
     # NOTE: Don't reach the agent in any way
     allow_any_instance_of(Datadog::Tracing::Transport::HTTP::Client).to receive(:send_request)
@@ -362,6 +365,28 @@ RSpec.describe 'Devise sign up tracking with auto user instrumentation' do
       )
 
       expect(gateway.pushed?('appsec.events.user_lifecycle')).to be true
+    end
+  end
+
+  context 'when login extraction fails during signup' do
+    before do
+      allow_any_instance_of(Datadog::AppSec::Contrib::Devise::DataExtractor)
+        .to receive(:extract_login).and_return(nil)
+
+      form_data = {
+        user: {username: 'JohnDoe', email: 'john.doe@example.com', password: '123456', password_confirmation: '123456'}
+      }
+
+      post('/users', form_data)
+    end
+
+    it 'reports missing_user_login telemetry' do
+      expect(response).to be_redirect
+
+      expect(Datadog::AppSec.telemetry).to have_received(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', 1,
+        tags: {framework: 'devise', event_type: 'signup'},
+      )
     end
   end
 end

--- a/spec/datadog/appsec/monitor/gateway/telemetry_watcher_spec.rb
+++ b/spec/datadog/appsec/monitor/gateway/telemetry_watcher_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'datadog/appsec/spec_helper'
+require 'datadog/appsec/monitor/gateway/telemetry_watcher'
+
+RSpec.describe Datadog::AppSec::Monitor::Gateway::TelemetryWatcher do
+  let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+  let(:gateway) { Datadog::AppSec::Instrumentation::Gateway.new }
+
+  before do
+    allow(Datadog::AppSec).to receive(:telemetry).and_return(telemetry)
+    allow(telemetry).to receive(:inc)
+  end
+
+  describe '.watch_set_user' do
+    before { described_class.watch_set_user(gateway) }
+
+    %w[login_success signup].each do |event_type|
+      context "with #{event_type} event_type" do
+        it 'reports missing_user_login when login is nil' do
+          expect(telemetry).to receive(:inc).with(
+            'appsec', 'instrum.user_auth.missing_user_login', 1,
+            tags: {framework: 'devise', event_type: event_type},
+          )
+
+          gateway.push('identity.set_user', {id: '123', framework: 'devise', event_type: event_type})
+        end
+
+        it 'reports both metrics when login and id are nil' do
+          expect(telemetry).to receive(:inc).with(
+            'appsec', 'instrum.user_auth.missing_user_login', 1,
+            tags: {framework: 'devise', event_type: event_type},
+          )
+          expect(telemetry).to receive(:inc).with(
+            'appsec', 'instrum.user_auth.missing_user_id', 1,
+            tags: {framework: 'devise', event_type: event_type},
+          )
+
+          gateway.push('identity.set_user', {framework: 'devise', event_type: event_type})
+        end
+
+        it 'does not report any telemetry when login is present' do
+          expect(telemetry).not_to receive(:inc)
+
+          gateway.push('identity.set_user', {login: 'alice', framework: 'devise', event_type: event_type})
+        end
+      end
+    end
+
+    context 'with authenticated_request event_type' do
+      it 'reports missing_user_id when id is nil' do
+        expect(telemetry).to receive(:inc).with(
+          'appsec', 'instrum.user_auth.missing_user_id', 1,
+          tags: {framework: 'devise', event_type: 'authenticated_request'},
+        )
+
+        gateway.push('identity.set_user', {framework: 'devise', event_type: 'authenticated_request'})
+      end
+
+      it 'does not report missing_user_login even when login is nil' do
+        expect(telemetry).not_to receive(:inc).with(
+          'appsec', 'instrum.user_auth.missing_user_login', anything, anything,
+        )
+
+        gateway.push('identity.set_user', {framework: 'devise', event_type: 'authenticated_request'})
+      end
+
+      it 'does not report any telemetry when id is present' do
+        expect(telemetry).not_to receive(:inc)
+
+        gateway.push('identity.set_user', {id: '123', framework: 'devise', event_type: 'authenticated_request'})
+      end
+    end
+
+    context 'when event_type is not set' do
+      it 'does not report any telemetry' do
+        expect(telemetry).not_to receive(:inc)
+
+        gateway.push('identity.set_user', {id: '123', framework: 'sdk'})
+      end
+    end
+  end
+
+  describe '.watch_login_failure' do
+    before { described_class.watch_login_failure(gateway) }
+
+    it 'reports missing_user_login when login is nil' do
+      expect(telemetry).to receive(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', 1,
+        tags: {framework: 'devise', event_type: 'login_failure'},
+      )
+
+      gateway.push('identity.login_failure', {id: '123', framework: 'devise'})
+    end
+
+    it 'reports both metrics when login and id are nil' do
+      expect(telemetry).to receive(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', 1,
+        tags: {framework: 'devise', event_type: 'login_failure'},
+      )
+      expect(telemetry).to receive(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_id', 1,
+        tags: {framework: 'devise', event_type: 'login_failure'},
+      )
+
+      gateway.push('identity.login_failure', {framework: 'devise'})
+    end
+
+    it 'does not report any telemetry when login is present' do
+      expect(telemetry).not_to receive(:inc)
+
+      gateway.push('identity.login_failure', {login: 'alice', framework: 'devise'})
+    end
+  end
+end

--- a/spec/datadog/appsec/monitor/gateway/telemetry_watcher_spec.rb
+++ b/spec/datadog/appsec/monitor/gateway/telemetry_watcher_spec.rb
@@ -12,104 +12,72 @@ RSpec.describe Datadog::AppSec::Monitor::Gateway::TelemetryWatcher do
     allow(telemetry).to receive(:inc)
   end
 
-  describe '.watch_set_user' do
-    before { described_class.watch_set_user(gateway) }
+  describe '.watch_user_lifecycle' do
+    before { described_class.watch_user_lifecycle(gateway) }
 
-    %w[login_success signup].each do |event_type|
-      context "with #{event_type} event_type" do
+    %w[
+      identity.devise.login_success
+      identity.devise.login_failure
+      identity.devise.signup
+    ].each do |event_name|
+      _, framework, event_type = event_name.split('.')
+
+      context "with #{event_name}" do
         it 'reports missing_user_login when login is nil' do
           expect(telemetry).to receive(:inc).with(
             'appsec', 'instrum.user_auth.missing_user_login', 1,
-            tags: {framework: 'devise', event_type: event_type},
+            tags: {framework: framework, event_type: event_type},
           )
 
-          gateway.push('identity.set_user', {id: '123', framework: 'devise', event_type: event_type})
+          gateway.push(event_name, {id: '123'})
         end
 
         it 'reports both metrics when login and id are nil' do
           expect(telemetry).to receive(:inc).with(
             'appsec', 'instrum.user_auth.missing_user_login', 1,
-            tags: {framework: 'devise', event_type: event_type},
+            tags: {framework: framework, event_type: event_type},
           )
           expect(telemetry).to receive(:inc).with(
             'appsec', 'instrum.user_auth.missing_user_id', 1,
-            tags: {framework: 'devise', event_type: event_type},
+            tags: {framework: framework, event_type: event_type},
           )
 
-          gateway.push('identity.set_user', {framework: 'devise', event_type: event_type})
+          gateway.push(event_name, {})
         end
 
         it 'does not report any telemetry when login is present' do
           expect(telemetry).not_to receive(:inc)
 
-          gateway.push('identity.set_user', {login: 'alice', framework: 'devise', event_type: event_type})
+          gateway.push(event_name, {login: 'alice'})
         end
-      end
-    end
-
-    context 'with authenticated_request event_type' do
-      it 'reports missing_user_id when id is nil' do
-        expect(telemetry).to receive(:inc).with(
-          'appsec', 'instrum.user_auth.missing_user_id', 1,
-          tags: {framework: 'devise', event_type: 'authenticated_request'},
-        )
-
-        gateway.push('identity.set_user', {framework: 'devise', event_type: 'authenticated_request'})
-      end
-
-      it 'does not report missing_user_login even when login is nil' do
-        expect(telemetry).not_to receive(:inc).with(
-          'appsec', 'instrum.user_auth.missing_user_login', anything, anything,
-        )
-
-        gateway.push('identity.set_user', {framework: 'devise', event_type: 'authenticated_request'})
-      end
-
-      it 'does not report any telemetry when id is present' do
-        expect(telemetry).not_to receive(:inc)
-
-        gateway.push('identity.set_user', {id: '123', framework: 'devise', event_type: 'authenticated_request'})
-      end
-    end
-
-    context 'when event_type is not set' do
-      it 'does not report any telemetry' do
-        expect(telemetry).not_to receive(:inc)
-
-        gateway.push('identity.set_user', {id: '123', framework: 'sdk'})
       end
     end
   end
 
-  describe '.watch_login_failure' do
-    before { described_class.watch_login_failure(gateway) }
+  describe '.watch_authenticated_request' do
+    before { described_class.watch_authenticated_request(gateway) }
 
-    it 'reports missing_user_login when login is nil' do
-      expect(telemetry).to receive(:inc).with(
-        'appsec', 'instrum.user_auth.missing_user_login', 1,
-        tags: {framework: 'devise', event_type: 'login_failure'},
-      )
-
-      gateway.push('identity.login_failure', {id: '123', framework: 'devise'})
-    end
-
-    it 'reports both metrics when login and id are nil' do
-      expect(telemetry).to receive(:inc).with(
-        'appsec', 'instrum.user_auth.missing_user_login', 1,
-        tags: {framework: 'devise', event_type: 'login_failure'},
-      )
+    it 'reports missing_user_id when id is nil' do
       expect(telemetry).to receive(:inc).with(
         'appsec', 'instrum.user_auth.missing_user_id', 1,
-        tags: {framework: 'devise', event_type: 'login_failure'},
+        tags: {framework: 'devise', event_type: 'authenticated_request'},
       )
 
-      gateway.push('identity.login_failure', {framework: 'devise'})
+      gateway.push('identity.devise.authenticated_request', {})
     end
 
-    it 'does not report any telemetry when login is present' do
+    it 'does not report missing_user_login even when login is nil' do
+      expect(telemetry).not_to receive(:inc).with(
+        'appsec', 'instrum.user_auth.missing_user_login', anything, anything,
+      )
+
+      gateway.push('identity.devise.authenticated_request', {})
+    end
+
+    it 'does not report any telemetry when id is present' do
       expect(telemetry).not_to receive(:inc)
 
-      gateway.push('identity.login_failure', {login: 'alice', framework: 'devise'})
+      gateway.push('identity.devise.authenticated_request', {id: '123'})
     end
   end
 end

--- a/spec/datadog/kit/identity_spec.rb
+++ b/spec/datadog/kit/identity_spec.rb
@@ -248,8 +248,8 @@ RSpec.describe Datadog::Kit::Identity do
 
         it 'instruments the user information to appsec' do
           expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to receive(:push).with(
-            'identity.set_user',
-            a_hash_including(id: '42', framework: 'sdk')
+            'identity.sdk.set_user',
+            a_hash_including(id: '42')
           )
 
           described_class.set_user(trace_op, id: '42')
@@ -258,7 +258,7 @@ RSpec.describe Datadog::Kit::Identity do
 
       context 'when is disabled' do
         it 'does not instrument the user information to appsec' do
-          expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to_not receive(:push).with('identity.set_user')
+          expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to_not receive(:push).with('identity.sdk.set_user')
 
           trace_op.measure('root') do
             described_class.set_user(trace_op, id: '42')

--- a/spec/datadog/kit/identity_spec.rb
+++ b/spec/datadog/kit/identity_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Datadog::Kit::Identity do
         it 'instruments the user information to appsec' do
           expect_any_instance_of(Datadog::AppSec::Instrumentation::Gateway).to receive(:push).with(
             'identity.set_user',
-            instance_of(Datadog::AppSec::Instrumentation::Gateway::User)
+            a_hash_including(id: '42', framework: 'sdk')
           )
 
           described_class.set_user(trace_op, id: '42')


### PR DESCRIPTION
**What does this PR do?**

- Adds distinct, namespaced events under `identity.<framework>.<action>` (e.g. `identity.devise.login_success`, `identity.sdk.set_user`).
- Removes the `appsec.events.user_lifecycle` gateway event. Its business logic WAF check is now handled by a new `watch_user_login_event `watcher on the `identity.*` login events directly.
- Adds `AppSec::Monitor::Gateway::TelemetryWatcher` that reports `instrum.user_auth.missing_user_login` and `instrum.user_auth.missing_user_id` telemetry metrics when user auth events have incomplete data.
- Removes `Datadog::AppSec::Instrumentation::Gateway::Argument::User` and replaces it with a plain hash.

**Motivation:**
Simplify the AppSec gateway event architecture. We also want to know when we can't extract user login or id during SDK calls and Devise instrumentation, which the new TelemetryWatcher provides.

**Change log entry**
No. This is an internal change.

**Additional Notes:**
New event names:
  - `identity.sdk.set_user` — from `Kit::Identity.set_user `and V2 SDK
  - `identity.sdk.login_success` — from V2 SDK login success (business logic WAF)
  - `identity.sdk.login_failure` — from V2 SDK login failure
  - `identity.devise.login_success` / `login_failure` / `signup` / `authenticated_request` — from Devise auto-instrumentation

APPSEC-60123

**How to test the change?**
CI and manual testing.