### PR TITLE
[NO-TICKET] Try to fix rare profiling flaky spec

### DIFF
--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -693,7 +693,7 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder) {
 
 typedef struct {
   heap_recorder *recorder;
-  VALUE debug_str;
+  VALUE debug_ary;
 } debug_context;
 
 VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder) {
@@ -701,12 +701,12 @@ VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder) {
     raise_error(rb_eArgError, "heap_recorder is NULL");
   }
 
-  VALUE debug_str = rb_str_new2("");
-  debug_context context = (debug_context) {.recorder = heap_recorder, .debug_str = debug_str};
+  VALUE debug_ary = rb_ary_new();
+  debug_context context = (debug_context) {.recorder = heap_recorder, .debug_ary = debug_ary};
   st_foreach(heap_recorder->object_records, st_object_records_debug, (st_data_t) &context);
 
   return rb_ary_new_from_args(2,
-    rb_ary_new_from_args(2, ID2SYM(rb_intern("records")), debug_str),
+    rb_ary_new_from_args(2, ID2SYM(rb_intern("records")), debug_ary),
     rb_ary_new_from_args(2, ID2SYM(rb_intern("state")), heap_recorder_state_snapshot(heap_recorder))
   );
 }
@@ -828,11 +828,10 @@ static int st_object_records_iterate(DDTRACE_UNUSED st_data_t key, st_data_t val
 
 static int st_object_records_debug(DDTRACE_UNUSED st_data_t key, st_data_t value, st_data_t extra) {
   debug_context *context = (debug_context*) extra;
-  VALUE debug_str = context->debug_str;
 
   object_record *record = (object_record*) value;
 
-  rb_str_catf(debug_str, "%"PRIsVALUE"\n", object_record_inspect(context->recorder, record));
+  rb_ary_push(context->debug_ary, object_record_inspect(context->recorder, record));
 
   return ST_CONTINUE;
 }

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -1033,14 +1033,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
       end
 
-      after do |example|
-        # This is here to facilitate troubleshooting when this test fails. Otherwise
-        # it's very hard to understand what may be happening.
-        if example.exception
-          puts("Heap recorder debugging info: #{described_class::Testing._native_debug_heap_recorder(stack_recorder).inspect}")
-        end
-      end
-
       def sample_allocation(obj)
         # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
         described_class::Testing._native_track_object(stack_recorder, obj, 1, obj.class.name)
@@ -1063,9 +1055,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         # and so the test causes flakiness.
         # See also the discussion on commit 2fc03d5ae5860d4e9a75ce3825fba95ed288a1 for an earlier attempt at fixing this.
         dead_heap_samples = 10
-        dead_heap_samples.times do |_i|
-          obj = []
-          sample_allocation(obj)
+        dead_heap_samples.times do |i|
+          sample_allocation([i])
         end
 
         live_heap_samples = 6
@@ -1091,24 +1082,20 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           GC.enable
         end
 
-        expect(stack_recorder.stats).to match(
-          hash_including(
-            heap_recorder_snapshot: hash_including(
-              # Records for dead objects should have gone away
-              num_object_records: live_heap_samples + age0_heap_samples,
-              # We allocate from 3 different locations in this test but only 2
-              # of them are for objects which should be alive at serialization time
-              num_heap_records: 2,
+        expect(stack_recorder.stats.fetch(:heap_recorder_snapshot)).to include(
+          # Records for dead objects should have gone away
+          num_object_records: live_heap_samples + age0_heap_samples,
+          # We allocate from 3 different locations in this test but only 2
+          # of them are for objects which should be alive at serialization time
+          num_heap_records: 2,
 
-              # The update done during serialization should reflect the
-              # state of the tracked heap objects at that time
-              last_update_objects_alive: live_heap_samples,
-              last_update_objects_dead: dead_heap_samples,
-              last_update_objects_skipped: age0_heap_samples,
-              last_update_objects_frozen: live_heap_samples / 2,
-            )
-          )
-        )
+          # The update done during serialization should reflect the
+          # state of the tracked heap objects at that time
+          last_update_objects_alive: live_heap_samples,
+          last_update_objects_dead: dead_heap_samples,
+          last_update_objects_skipped: age0_heap_samples,
+          last_update_objects_frozen: live_heap_samples / 2,
+        ), "Heap recorder debugging info: #{described_class::Testing._native_debug_heap_recorder(stack_recorder)}"
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

This PR tries to address this flaky spec
<https://github.com/DataDog/dd-trace-rb/actions/runs/23146538608/job/67236144507?pr=5462> (details below).

This was a very rare failure (I've not seen it before) and was not related to the PR where it showed up (that PR was adding tests for something unrelated!).

This specific spec has been problematic in the past, in part because it's a rather tight integration spec that relies on the Ruby garbage collector behaving very specifically, which is not always the case.

Looking at the failure, the "Heap recorder debug info" (scroll up) includes an array:

```
obj_id=23040 weight=1 size=40 location=/home/runner/work/dd-trace-rb/dd-trace-rb/spec/datadog/profiling/stack_recorder_spec.rb:1047 alloc_gen=260 gen_age=1 frozen=0 class=Array value=0x00007f7637fc06c0 object=[]
```

which is not supposed to happen -- all sampled arrays are expected to be garbage collected.

But, we've seen before (e.g. <https://bugs.ruby-lang.org/issues/19460>) that sometimes Ruby may not collect an object immediately.

So what this PR does is:

1. Try to both improve debug info so in the future we may be able to better debug this by:

   * Including iteration number in array so we can see if there's a pattern for which one keeps alive)
   * Improve `expect` so rspec diff looks more readable
   * Making it so the heap recorder debug info gets printed directly with the failure, not somewhere random in the logs

2. Remove the `obj` local variable "just in case" this was the source of the issue. This is a very speculative fix, so it's possible I'm just rearranging chairs without any impact.

**Motivation:**

Zero profiling flaky specs!

**Change log entry**

None. (Only test code touched)

**Additional Notes:**

The stats matching code is unchanged, it's just indentation changes so reviewing this ignoring whitespace makes it look better.

**How to test the change?**

Hopefully we'll never see a failure here again; if we do, we'll have a bit more info than last time to debug.
