### PR TITLE
Fix NoMethodError in extract_trace_id! caused by extract_tags returning true

### DIFF
--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -142,6 +142,7 @@ module Datadog
           ::Datadog.logger.warn(
             "Failed to inject x-datadog-tags: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
           )
+          nil
         end
 
         # Import `x-datadog-tags` tags as trace distributed tags.
@@ -168,6 +169,7 @@ module Datadog
           ::Datadog.logger.warn(
             "Failed to extract x-datadog-tags: #{e.class.name} #{e.message} at #{Array(e.backtrace).first}"
           )
+          nil
         end
 
         def set_tags_propagation_error(reason:)

--- a/spec/datadog/tracing/distributed/datadog_spec.rb
+++ b/spec/datadog/tracing/distributed/datadog_spec.rb
@@ -397,6 +397,25 @@ RSpec.shared_examples 'Datadog distributed format' do
               extract
             end
           end
+
+          context 'with tags that cause a decoding error' do
+            let(:tags) { 'not a valid tag' }
+
+            it 'does not raise NoMethodError from extract_trace_id!' do
+              # Regression test: the rescue block in extract_tags must return nil,
+              # not the return value of Logger#warn (true). When true is passed to
+              # extract_trace_id!, it calls .delete on it, raising NoMethodError.
+              # This test intentionally does NOT mock the logger, to exercise the
+              # real return value path.
+              allow(active_trace).to receive(:set_tag)
+              expect { extract }.not_to raise_error
+            end
+
+            it 'returns a valid TraceDigest' do
+              allow(active_trace).to receive(:set_tag)
+              expect(extract).to be_a(Datadog::Tracing::TraceDigest)
+            end
+          end
         end
 
         context '{ _dd.p.upstream_services: "any" }' do


### PR DESCRIPTION
## Description

The rescue blocks in `Datadog::Tracing::Distributed::Datadog#extract_tags` and `#inject_tags!` implicitly return `true` (the return value of `Logger#warn`) instead of `nil`.

For `extract_tags`, this `true` is passed to `extract_trace_id!`, which calls `.delete` on it, raising:

```
NoMethodError: undefined method 'delete' for true
```

### Root cause

In `lib/datadog/tracing/distributed/datadog.rb` lines 166-171, the rescue block's last expression is `::Datadog.logger.warn(...)`, which returns `true` in Ruby. This becomes the method's implicit return value.

The caller chain:
1. `#extract` (line 69): `trace_distributed_tags = extract_tags(fetcher)` → gets `true`
2. `#extract` (line 73): `extract_trace_id!(trace_id, trace_distributed_tags)` → passes `true`
3. `#extract_trace_id!` (line 117): `tags.delete(...)` → `NoMethodError` on `true`

### Why existing tests didn't catch this

The spec for "with invalid tags" mocks `Datadog.logger` with `expect(...).to receive(:warn)`, which returns `nil` from the mock instead of `true` from the real logger, masking the bug.

## Changes

- Add explicit `nil` after `logger.warn` in rescue blocks of both `extract_tags` and `inject_tags!`
- Add regression test that exercises `#extract` with invalid tags **without mocking the logger**

## Impact

In our production environment, this generates ~30,000+ error logs per day. Any application receiving requests with malformed `x-datadog-tags` headers hits this.