### PR TITLE
Reduce microbenchmark runtime and fix pr-comment retry behavior

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -254,7 +254,8 @@ microbenchmarks:
 
 microbenchmarks-pr-comment:
   stage: microbenchmarks
-  when: always
+  when: on_success
+  allow_failure: true
   needs: [microbenchmarks]
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE

--- a/benchmarks/execution.yml
+++ b/benchmarks/execution.yml
@@ -34,7 +34,7 @@
 .execution:
   variables:
     # Benchmark execution settings
-    REPETITIONS: "6"        # How many times to run each benchmark
+    REPETITIONS: "4"        # How many times to run each benchmark
     CPU_AFFINITY: "24-47"    # Which CPUs to use for all benchmarks
     CPUS_PER_BENCHMARK: "2"  # How many CPUs to use for each benchmark
 


### PR DESCRIPTION
**What does this PR do?**

Two targeted improvements to microbenchmark CI reliability. Full investigation at https://github.com/p-datadog/datadog-docs/blob/master/microbenchmarks-ci-investigation.md.

**1. Reduce REPETITIONS from 6 to 4** (`benchmarks/execution.yml`)

The `[other]` benchmark group (error_tracking, tracing, DI, gem loading) currently takes ~34 min per run. The cost model is `1.5 + 5.33 × REPETITIONS`, so reducing repetitions has a meaningful impact. At REPETITIONS=4 the `[other]` job runs in ~23 min — 32% faster and still 7 min under the old pre-parallelization single-job runtime of 30 min.

PR #5313 (which introduced parallelization) validated stability at 6 and 10 reps with CPU isolation, showing 0/46 unstable metrics. No data exists at 4 reps, but CPU isolation independently reduces variance and is unchanged here. This PR's own benchmark report serves as the stability validation — if unstable metrics appear we can adjust before merging. Reducing further to 3 (18 min) is worth considering if the report looks clean.

Shorter runs also reduce the window during which a job can be cancelled by a new push on active PR branches.

**2. Improve `microbenchmarks-pr-comment` retry behavior** (`.gitlab/benchmarks.yml`)

Changed `when: always` → `when: on_success` and added `allow_failure: true`.

With `when: always`, if an upstream benchmark job is cancelled, `pr-comment` still attempts to run with partial/missing artifacts and fails — resulting in two jobs needing attention instead of one. It's not immediately obvious which job to retry first (the upstream benchmark, not the downstream comment job).

With `when: on_success`:
- If benchmarks are cancelled: `pr-comment` is skipped (not failed), making it clear which job needs a retry
- When the benchmark is retried and succeeds: `pr-comment` auto-triggers via `needs:` — no manual retry needed (behavior confirmed in pipeline 102673493)
- `allow_failure: true` ensures a comment-posting issue (network blip, bp-runner bug) never blocks the pipeline

**3. Per-benchmark completion timestamps** (DataDog/benchmarking-platform#249)

Companion PR in benchmarking-platform adds a completion timestamp log line after each parallel benchmark finishes. This will help identify which of the 4 `[other]` benchmarks takes the longest — useful context for any future splitting or rebalancing of the group.

**Motivation:**

Microbenchmarks are currently the longest-running CI job (~34 min) and run on every PR regardless of what changed. On active branches, they can be cancelled mid-run due to `interruptible: true`, which sometimes leads to a multi-step retry process. These two changes reduce runtime and simplify recovery when cancellations do happen.

**Change log entry**

None.

**How to test the change?**

The benchmark report from this PR's CI run is the stability validation for REPETITIONS=4. Check the report for "unstable metrics" — a no-change comparison should show 0 improvements, 0 regressions, 0 unstable metrics. The `pr-comment` behavior change can be verified by observing that a cancelled `[other]` job leaves `pr-comment` in `skipped` state rather than `failed`/`cancelled`.