### PR TITLE
ci: skip microbenchmarks on PRs that don't touch relevant files

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -215,9 +215,7 @@ microbenchmarks:
         - ext/**/*
         - benchmarks/**/*
         - datadog.gemspec
-        - Gemfile
-        - Gemfile.lock
-        - .gitlab/benchmarks.yml
+        - .gitlab/**/*
       interruptible: true
     # Terminating rule: if no rule above matched, skip the job.
     # Without this, GitLab falls through to its default (run the job), making the changes: rule above pointless.


### PR DESCRIPTION
**What does this PR do?**

Adds `changes:` path filtering to the `microbenchmarks` GitLab CI job so benchmarks only run on PR branches when files that could affect benchmark results are modified. PRs that only touch docs, specs, or CI config (like #5485, a docs-only PR that still triggered a full ~23 min benchmark run) are skipped.

The path list:
- `lib/**/*`, `ext/**/*` — library and native extension code; the actual thing being benchmarked
- `benchmarks/**/*` — benchmark scripts and `execution.yml` (group config, repetitions)
- `datadog.gemspec`, `Gemfile`, `Gemfile.lock` — dependency changes that could affect benchmark results
- `.gitlab/benchmarks.yml` — the job definition itself

`spec/**/*` is intentionally excluded. The `validate_benchmarks_spec` files load benchmark scripts as smoke tests, but they only change alongside `benchmarks/**/*`, which is already covered.

The terminating `when: never` rule is required — without it, GitLab falls through to its default behavior (run the job) for any PR that doesn't match the `changes:` filter, making the filtering pointless.

On the first push of a new branch (no diff base), GitLab evaluates `changes:` as `true`, so benchmarks run once — conservative behavior.

This is one of several incremental improvements to microbenchmark CI reliability. Full investigation: https://github.com/p-datadog/datadog-docs/blob/master/microbenchmarks-ci-investigation.md (see Option D / §5a).

**Motivation:**

Microbenchmarks are currently the longest-running CI job (~23 min after #5481) and run on every PR regardless of what changed. #5485 (a single markdown file addition) triggered a full benchmark run — exactly the case this fixes.

**Change log entry**

None.

**How to test the change?**

Two separate things to verify:

1. **This PR doesn't break the job:** `.gitlab/benchmarks.yml` is in the path list, so benchmarks run on this PR's own pipeline. A passing benchmark report confirms the config change didn't break anything.

2. **Filtering actually skips benchmarks when it should:** open a docs-only or spec-only PR against master and verify the `microbenchmarks` jobs are skipped in its GitLab pipeline.