### PR TITLE
CLAUDE.md: add time provider rule with DI exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ actionlint .github/workflows/your-workflow.yml
 - Use `Core::Utils::Array.filter_map` instead of `filter_map` for compatibility with Ruby 2.5 and 2.6 (native `filter_map` requires Ruby 2.7+)
 - Use `Datadog::Core::Utils::Time.now` instead of `Time.now` everywhere — the time provider is configurable (e.g. for Timecop support) and tests can override it via `Core::Utils::Time.now_provider=`
   - Exception: constants initialized at load time (before user configuration) may use `::Time.now` directly; add a comment explaining why (see `lib/datadog/profiling/collectors/info.rb` for an example)
-  - Exception: Dynamic Instrumentation (DI) probe instrumentation code that runs inside customer application methods must use `::Time.now` directly — the time provider is customer-overridable (e.g. via Timecop), and DI must not invoke customer code during instrumentation
+  - Exception: Dynamic Instrumentation (DI) probe instrumentation code that runs inside customer application methods must use `::Time.now` directly — the time provider supports runtime overrides (the API exists even if rarely used in production), and DI must never invoke customer-provided code during instrumentation
 
 ## Documentation
 


### PR DESCRIPTION
**What does this PR do?**
Documents the time provider convention in CLAUDE.md — agents and contributors now have a clear pointer to `Datadog::Core::Utils::Time.now` over raw `Time.now`.

**Motivation:**
`Core::Utils::Time` is configurable via `now_provider=`, which is how Timecop integration works in test environments and how tests can override wall time. Reaching past it with `Time.now` makes components untestable with mocked time. The rule existed implicitly but wasn't written down anywhere, so it was easy to miss.

**Change log entry**
None.

**Additional Notes:**
Two exceptions are called out:
1. Constants initialized at load time (before user config runs) may use `::Time.now` directly — a comment explaining why is expected (see `lib/datadog/profiling/collectors/info.rb`).
2. DI probe instrumentation running inside customer methods must use `::Time.now` — the time provider supports runtime overrides (the API exists even if rarely used in production), and DI must never invoke customer-provided code during instrumentation.

**How to test the change?**
Docs only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)