### PR TITLE
Fix _dd.p.ksr scientific notation for very small sampling rates

### DIFF
--- a/lib/datadog/tracing/transport/trace_formatter.rb
+++ b/lib/datadog/tracing/transport/trace_formatter.rb
@@ -117,7 +117,7 @@ module Datadog
 
           root_span.set_tag(
             Tracing::Metadata::Ext::Distributed::TAG_KNUTH_SAMPLING_RATE,
-            format('%.6g', rate)
+            format('%.6f', (rate * 1e6).round / 1e6.to_f).sub(/\.?0+\z/, '')
           )
         end
 

--- a/spec/datadog/tracing/transport/trace_formatter_spec.rb
+++ b/spec/datadog/tracing/transport/trace_formatter_spec.rb
@@ -518,15 +518,17 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
         end
       end
 
-      context 'value formatting with 6 significant digits' do
+      context 'value formatting with up to 6 decimal digits' do
         [
           [1.0, '1'],
           [0.5, '0.5'],
           [0.1, '0.1'],
           [0.7654321, '0.765432'],
           [0.100000, '0.1'],
-          [0.000001, '1e-06'],
+          [0.000001, '0.000001'],
           [0.123456789, '0.123457'],
+          [0.0000001, '0'],
+          [0.0000005, '0.000001'],
         ].each do |rate, expected|
           context "when rate is #{rate}" do
             let(:trace_options) { {id: trace_id, agent_sample_rate: rate} }


### PR DESCRIPTION
**What does this PR do?**

Fix `_dd.p.ksr` span tag formatting for very small sampling rates. Rates below 0.001 were formatted using Ruby's `%.6g` format which outputs scientific notation (e.g. `0.000001` → `"1e-06"`). Changed to explicit integer-level rounding and `%.6f` formatting to always produce decimal notation with up to 6 decimal digits, trailing zeros stripped.

**Motivation:**

Fixes APMAPI-1869. System tests expect decimal notation for `_dd.p.ksr` values (see DataDog/system-tests#6466).

**Related PRs:**
- dd-trace-py: https://github.com/DataDog/dd-trace-py/pull/17086
- dd-trace-js: https://github.com/DataDog/dd-trace-js/pull/7846
- system-tests: https://github.com/DataDog/system-tests/pull/6466

**Change log entry**

Yes. Fix `_dd.p.ksr` span tag formatting for very small sampling rates to use decimal notation instead of scientific notation.

**Additional Notes:**

Uses `(rate * 1e6).round / 1e6.to_f` for consistent rounding at the integer level, avoiding IEEE 754 precision issues with `%.6f` alone.

**How to test the change?**

Updated unit tests in `spec/datadog/tracing/transport/trace_formatter_spec.rb` covering:
- Rate 0.000001 → `"0.000001"` (was `"1e-06"`)
- Rate 0.0000001 → `"0"` (rounds to zero, new case)
- Rate 0.0000005 → `"0.000001"` (rounds up, new case)