### PR TITLE
CI: emit synthetic JUnit XML when rake task fails before tests run

### DIFF
--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -124,10 +124,35 @@ namespace :github do
     rng = Random.new(ENV['CI_TEST_SEED'].to_i)
 
     tasks.each do |task|
+      task_name = task["task"]
       env = {'BUNDLE_GEMFILE' => task['gemfile']}
-      cmd = "bundle exec rake spec:#{task["task"]}'[--seed #{rng.rand(0xFFFF)}]'"
+      cmd = "bundle exec rake spec:#{task_name}'[--seed #{rng.rand(0xFFFF)}]'"
 
-      Bundler.with_unbundled_env { sh(env, cmd) }
+      begin
+        Bundler.with_unbundled_env { sh(env, cmd) }
+      rescue RuntimeError => e
+        # When a rake task fails before RSpec runs (wrong task name, missing gem,
+        # syntax error), no JUnit XML is produced for that task. CI artifacts then
+        # contain only results from other tasks in the batch, hiding the failure.
+        #
+        # Write a synthetic JUnit XML so the failure is visible through the normal
+        # artifact pipeline — no log parsing needed.
+        junit_dir = 'tmp/rspec'
+        FileUtils.mkdir_p(junit_dir)
+        safe_name = task_name.tr(':', '-')
+        File.write(
+          "#{junit_dir}/#{safe_name}-rake-failure.xml",
+          <<~XML,
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="spec:#{task_name}" tests="1" failures="1" errors="0" time="0">
+              <testcase classname="rake" name="spec:#{task_name}" time="0">
+                <failure message="#{e.message.encode(xml: :text)}">Rake task failed before any tests ran.</failure>
+              </testcase>
+            </testsuite>
+          XML
+        )
+        raise
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

Wraps the `sh` call in `run_batch_tests` with a rescue block that writes a synthetic
JUnit XML when a rake task fails before RSpec starts. The existing artifact upload step
picks it up — no changes needed to the upload or the `dd/junit` merge job.

The original exception is re-raised, so the job still fails as before. This only adds
visibility.

**Motivation:**

I noticed that when a rake task in a CI batch fails before RSpec runs (wrong task name,
LoadError, syntax error), the JUnit artifacts from that batch only contain results from
the tasks that succeeded. The failing task produces no XML at all.

What caught my eye is that this makes the failure invisible to anything that relies on
JUnit — test failure analysis, Datadog CI Visibility — since the artifacts exist but
show 0 failures. The only way to find the actual error is log parsing.

Ran into this on PR #5111 where 8 jobs failed with "Don't know how to build task
\`spec:di_with_ext\`" but JUnit showed all green. The synthetic XML would have surfaced
the rake error directly in the structured data.

**Change log entry**

None

**Additional Notes:**

Not yet verified locally — \`bundle exec rake standard\` requires full gem setup.
CI will validate.

Worth noting: the synthetic XML uses the same directory (\`tmp/rspec/\`) and naming
convention as real JUnit output, so it flows through the existing pipeline without
any special handling.

**How to test the change?**

- Verify synthetic XML is well-formed
- Verify existing tests still pass (no behavioral change on success path)
- To test the failure path: temporarily change a Matrixfile entry to a nonexistent
  task, push, and confirm the synthetic XML appears in artifacts
- Confirm \`datadog-ci junit upload\` accepts the synthetic XML format