### PR TITLE
[NO-TICKET] Profiler: Turn initialization errors into log messages

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../core/telemetry/logger"
+
 module Datadog
   module Profiling
     # Responsible for wiring up the Profiler for execution
@@ -90,6 +92,14 @@ module Datadog
         end
 
         [profiler, {profiling_enabled: true}]
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        logger.warn do
+          "Failed to initialize profiling: #{e.class.name} #{e.message} " \
+          "Location: #{Array(e.backtrace).first}"
+        end
+        Datadog::Core::Telemetry::Logger.report(e, description: "Failed to initialize profiling")
+
+        [nil, {profiling_enabled: false}]
       end
 
       private_class_method def self.build_thread_context_collector(settings, recorder, optional_tracer, timeline_enabled)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe Datadog::Profiling::Component do
         expect(build_profiler_component).to match([instance_of(Datadog::Profiling::Profiler), {profiling_enabled: true}])
       end
 
+      context "when an exception is raised during initialization" do
+        before do
+          expect(Datadog::Profiling::HttpTransport).to receive(:new).and_raise(
+            ArgumentError.new("Failed to initialize transport: something went wrong")
+          )
+        end
+
+        it "logs a warning, reports via telemetry, and returns nil" do
+          expect(logger).to receive(:warn) do |&block|
+            expect(block.call).to match(/Failed to initialize profiling.*ArgumentError/)
+          end
+          expect(Datadog::Core::Telemetry::Logger).to receive(:report)
+            .with(instance_of(ArgumentError), hash_including(description: "Failed to initialize profiling"))
+
+          is_expected.to eq [nil, {profiling_enabled: false}]
+        end
+      end
+
       context "when using the new CPU Profiling 2.0 profiler" do
         it "initializes a ThreadContext collector" do
           allow(Datadog::Profiling::Collectors::CpuAndWallTimeWorker).to receive(:new)


### PR DESCRIPTION
**What does this PR do?**

Turn profiler initialization errors into warning log messages, instead of allowing them to propagate and impact the application.

**Motivation:**

#5508 highlighted that initialization errors (in that case, from libdatadog) were propagating up and impacting the application startup. The profiler should gracefully disable itself when it runs into issues.

**Change log entry**

Yes. Profiler: Turn initialization errors into log messages.

**Additional Notes:**

N/A

**How to test the change?**

New spec added to `spec/datadog/profiling/component_spec.rb`.
