### PR TITLE
Fix base service logic and make it future proof

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -48,10 +48,6 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_SQL)
 
-              if service_name != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               # Set analytics sample rate
               if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
                 Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])

--- a/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
@@ -82,10 +82,6 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CACHE)
 
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.set_tag(Ext::TAG_CACHE_BACKEND, cache_backend(store))
 
                 span.set_tag('EVENT', event)

--- a/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/instrumentation.rb
@@ -54,10 +54,6 @@ module Datadog
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
                 span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CACHE)
 
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.set_tag(Ext::TAG_CACHE_BACKEND, store) if store
 
                 set_cache_key(span, key, multi_key) if Datadog.configuration.tracing[:active_support][:cache_key].enabled

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -61,11 +61,6 @@ module Datadog
               )
             end
 
-            # Tag original global service name if not used
-            if span.service != Datadog.configuration.service
-              span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-            end
-
             span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/dalli/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/dalli/instrumentation.rb
@@ -31,11 +31,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -66,11 +66,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.type = Datadog::Tracing::Contrib::Elasticsearch::Ext::SPAN_TYPE_QUERY
 
                 span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/ethon/easy_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/easy_patch.rb
@@ -144,11 +144,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(span, analytics_sample_rate) if analytics_enabled?
 

--- a/lib/datadog/tracing/contrib/ethon/multi_patch.rb
+++ b/lib/datadog/tracing/contrib/ethon/multi_patch.rb
@@ -69,14 +69,6 @@ module Datadog
 
               @datadog_multi_span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
-              # Tag original global service name if not used
-              if @datadog_multi_span.service != Datadog.configuration.service
-                @datadog_multi_span.set_tag(
-                  Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE,
-                  Datadog.configuration.service
-                )
-              end
-
               # Set analytics sample rate
               Contrib::Analytics.set_sample_rate(@datadog_multi_span, analytics_sample_rate) if analytics_enabled?
 

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -128,11 +128,6 @@ module Datadog
               )
             end
 
-            # Tag original global service name if not used
-            if span.service != Datadog.configuration.service
-              span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-            end
-
             span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -62,9 +62,6 @@ module Datadog
 
           # Value of tag from which peer.service value was remapped from
           TAG_PEER_SERVICE_REMAP = '_dd.peer.service.remapped_from'
-
-          # Set equal to the global service when contrib span.service is overriden
-          TAG_BASE_SERVICE = Tracing::Metadata::Ext::TAG_BASE_SERVICE
         end
       end
     end

--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../metadata/ext'
+
 module Datadog
   module Tracing
     module Contrib
@@ -62,7 +64,7 @@ module Datadog
           TAG_PEER_SERVICE_REMAP = '_dd.peer.service.remapped_from'
 
           # Set equal to the global service when contrib span.service is overriden
-          TAG_BASE_SERVICE = '_dd.base_service'
+          TAG_BASE_SERVICE = Tracing::Metadata::Ext::TAG_BASE_SERVICE
         end
       end
     end

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -56,11 +56,6 @@ module Datadog
               )
             end
 
-            # Tag original global service name if not used
-            if span.service != Datadog.configuration.service
-              span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-            end
-
             span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
             span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -59,11 +59,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CLIENT)

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
@@ -66,11 +66,6 @@ module Datadog
                 span.set_tag(header, value)
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_SERVER)
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_SERVICE)

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -63,11 +63,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -66,11 +66,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -66,11 +66,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_REQUEST)
 

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -41,11 +41,6 @@ module Datadog
               )
             end
 
-            # Tag original global service name if not used
-            if span.service != Datadog.configuration.service
-              span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-            end
-
             span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
 
             span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)

--- a/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/mysql2/instrumentation.rb
@@ -34,11 +34,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
                 span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 

--- a/lib/datadog/tracing/contrib/opensearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/opensearch/patcher.rb
@@ -62,11 +62,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 # Set url tags
                 span.set_tag(OpenSearch::Ext::TAG_URL, url)
                 span.set_tag(OpenSearch::Ext::TAG_HOST, host)

--- a/lib/datadog/tracing/contrib/pg/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/pg/instrumentation.rb
@@ -160,11 +160,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
               span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -92,11 +92,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 if (host_port = @options[:server])
                   host, port = Core::Utils.extract_host_port(host_port)
                   if host && port

--- a/lib/datadog/tracing/contrib/racecar/event.rb
+++ b/lib/datadog/tracing/contrib/racecar/event.rb
@@ -48,11 +48,6 @@ module Datadog
               # Measure service stats
               Contrib::Analytics.set_measured(span)
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Ext::TAG_TOPIC, payload[:topic])
               span.set_tag(Ext::TAG_CONSUMER, payload[:consumer_class])
               span.set_tag(Ext::TAG_PARTITION, payload[:partition])

--- a/lib/datadog/tracing/contrib/redis/tags.rb
+++ b/lib/datadog/tracing/contrib/redis/tags.rb
@@ -21,11 +21,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_COMMAND)
 

--- a/lib/datadog/tracing/contrib/rest_client/request_patch.rb
+++ b/lib/datadog/tracing/contrib/rest_client/request_patch.rb
@@ -46,11 +46,6 @@ module Datadog
                 )
               end
 
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -51,11 +51,6 @@ module Datadog
             end
 
             def set_common_tags(span, db)
-              # Tag original global service name if not used
-              if span.service != Datadog.configuration.service
-                span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-              end
-
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_QUERY)
 

--- a/lib/datadog/tracing/contrib/trilogy/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/trilogy/instrumentation.rb
@@ -33,11 +33,6 @@ module Datadog
                   )
                 end
 
-                # Tag original global service name if not used
-                if span.service != Datadog.configuration.service
-                  span.set_tag(Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE, Datadog.configuration.service)
-                end
-
                 span.set_tag(Contrib::Ext::DB::TAG_SYSTEM, Ext::TAG_SYSTEM)
                 span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
 

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -33,6 +33,9 @@ module Datadog
 
         TAG_APM_ENABLED = '_dd.apm.enabled'
 
+        # Set to the global service name when a span's service is overridden
+        TAG_BASE_SERVICE = '_dd.base_service'
+
         # Defines constants for trace analytics
         # @public_api
         module Analytics

--- a/lib/datadog/tracing/metadata/ext.rb
+++ b/lib/datadog/tracing/metadata/ext.rb
@@ -33,7 +33,10 @@ module Datadog
 
         TAG_APM_ENABLED = '_dd.apm.enabled'
 
-        # Set to the global service name when a span's service is overridden
+        # Set to the global (root) service name when a span's service is overridden.
+        # This allows the APM backend to associate spans from sub-services back to the
+        # top-level service they belong to, enabling correct service catalog correlation
+        # and service-level aggregations.
         TAG_BASE_SERVICE = '_dd.base_service'
 
         # Defines constants for trace analytics

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -270,6 +270,9 @@ module Datadog
         # Stop timing
         stop(end_time)
 
+        # Set _dd.base_service when service overrides the global service
+        set_base_service_tag
+
         # Build span
         # Memoize for performance reasons
         @span = build_span
@@ -524,6 +527,16 @@ module Datadog
           events: @span_events,
           service_entry: parent.nil? || (service && parent.service != service)
         )
+      end
+
+      def set_base_service_tag
+        global_service = Datadog.configuration.service
+        return unless global_service
+        return unless service
+        return if service == global_service
+        return if get_tag(Tracing::Metadata::Ext::TAG_BASE_SERVICE)
+
+        set_tag(Tracing::Metadata::Ext::TAG_BASE_SERVICE, global_service)
       end
 
       # Set this span's parent, setting this span's trace_id to the parent's trace_id.

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -531,12 +531,12 @@ module Datadog
 
       def set_base_service_tag
         global_service = Datadog.configuration.service
-        return unless global_service
-        return unless service
-        return if service == global_service
-        return if get_tag(Tracing::Metadata::Ext::TAG_BASE_SERVICE)
 
-        set_tag(Tracing::Metadata::Ext::TAG_BASE_SERVICE, global_service)
+        if global_service && service && service != global_service
+          set_tag(Tracing::Metadata::Ext::TAG_BASE_SERVICE, global_service)
+        else
+          meta.delete(Tracing::Metadata::Ext::TAG_BASE_SERVICE)
+        end
       end
 
       # Set this span's parent, setting this span's trace_id to the parent's trace_id.

--- a/sig/datadog/tracing/contrib/ext.rbs
+++ b/sig/datadog/tracing/contrib/ext.rbs
@@ -35,7 +35,6 @@ module Datadog
         end
 
         module Metadata
-          TAG_BASE_SERVICE: "_dd.base_service"
           TAG_PEER_SERVICE_SOURCE: "_dd.peer.service.source"
           TAG_PEER_SERVICE_REMAP: "_dd.peer.service.remapped_from"
         end

--- a/sig/datadog/tracing/metadata/ext.rbs
+++ b/sig/datadog/tracing/metadata/ext.rbs
@@ -9,6 +9,7 @@ module Datadog
         TAG_KIND: ::String
         TAG_TOP_LEVEL: ::String
         TAG_APM_ENABLED: ::String
+        TAG_BASE_SERVICE: ::String
 
         module Analytics
           DEFAULT_SAMPLE_RATE: ::Float

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -157,6 +157,8 @@ module Datadog
       module RefineNil
       end
 
+      def set_base_service_tag: () -> void
+
       def build_span: () -> untyped
 
       def parent=: (untyped parent) -> untyped

--- a/spec/datadog/tracing/contrib/environment_service_name_examples.rb
+++ b/spec/datadog/tracing/contrib/environment_service_name_examples.rb
@@ -11,6 +11,10 @@ RSpec.shared_examples_for 'environment service name' do |env_service_name_key, e
         expect { subject }.to raise_error error
       else
         subject
+        # _dd.base_service is set in SpanOperation#finish. If the integration
+        # test uses an open SpanOperation as `span` (e.g. because the complete
+        # callback is mocked out), finish it now so the tag is available.
+        span.finish if span.respond_to?(:finished?) && !span.finished?
       end
     end
 

--- a/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
+++ b/spec/datadog/tracing/contrib/span_attribute_schema_examples.rb
@@ -1,6 +1,10 @@
 RSpec.shared_examples 'schema version span' do
   before do
     subject
+    # _dd.base_service is set in SpanOperation#finish. If the integration
+    # test uses an open SpanOperation as `span` (e.g. because the complete
+    # callback is mocked out), finish it now so the tag is available.
+    span.finish if span.respond_to?(:finished?) && !span.finished?
   end
 
   context 'service name env var testing' do

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -824,6 +824,62 @@ RSpec.describe Datadog::Tracing::SpanOperation do
         expect(span_op.finish).to be(original_span)
       end
     end
+
+    describe '_dd.base_service tag' do
+      let(:global_service) { 'global-app' }
+
+      before do
+        allow(Datadog.configuration).to receive(:service).and_return(global_service)
+      end
+
+      context 'when span service differs from the global service' do
+        let(:options) { {service: 'other-service'} }
+
+        it 'sets _dd.base_service to the global service' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to eq(global_service)
+        end
+      end
+
+      context 'when span service equals the global service' do
+        let(:options) { {service: global_service} }
+
+        it 'does not set _dd.base_service' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to be_nil
+        end
+      end
+
+      context 'when span service is nil' do
+        let(:options) { {service: nil} }
+
+        it 'does not set _dd.base_service' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to be_nil
+        end
+      end
+
+      context 'when the global service is nil' do
+        let(:global_service) { nil }
+        let(:options) { {service: 'some-service'} }
+
+        it 'does not set _dd.base_service' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to be_nil
+        end
+      end
+
+      context 'when _dd.base_service is already set' do
+        let(:options) { {service: 'other-service'} }
+
+        before { span_op.set_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE, 'pre-existing') }
+
+        it 'does not overwrite the existing value' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to eq('pre-existing')
+        end
+      end
+    end
   end
 
   describe '#finished?' do

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -869,14 +869,25 @@ RSpec.describe Datadog::Tracing::SpanOperation do
         end
       end
 
-      context 'when _dd.base_service is already set' do
+      context 'when _dd.base_service is already set and service still differs' do
         let(:options) { {service: 'other-service'} }
 
-        before { span_op.set_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE, 'pre-existing') }
+        before { span_op.set_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE, 'stale-value') }
 
-        it 'does not overwrite the existing value' do
+        it 'overwrites with the current global service' do
           span = finish
-          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to eq('pre-existing')
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to eq(global_service)
+        end
+      end
+
+      context 'when _dd.base_service is already set but service no longer differs' do
+        let(:options) { {service: global_service} }
+
+        before { span_op.set_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE, 'stale-value') }
+
+        it 'clears the tag' do
+          span = finish
+          expect(span.get_tag(Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE)).to be_nil
         end
       end
     end

--- a/spec/datadog/tracing/transport/io/client_spec.rb
+++ b/spec/datadog/tracing/transport/io/client_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Datadog::Tracing::Transport::IO::Client do
             # Match complete encoded span structure
             expect(encoded_span).to match(
               'error' => 0,
-              'meta' => {},
+              'meta' => be_a(Hash),
               'metrics' => be_a(Hash),
               'meta_struct' => {},
               'name' => 'client.testing',


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Moves `_dd.base_service` tag logic from 25 individual integration files into `SpanOperation#finish`, making it apply universally to every span in the system.

**Motivation:**

The `_dd.base_service` tag was previously set by copy-pasted boilerplate in each integration. This meant it was absent for spans created via the manual tracing API (e.g. `Datadog::Tracing.trace('op', service: 'custom')`), if the service name was manually changed, and any new integration had to remember to add it manually. Centralizing in `SpanOperation#finish` closes the gap, removes the duplication, and makes future integrations correct by default.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
