### PR TITLE
Document one-pipeline source and provenance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,27 @@ Each framework integration (@lib/datadog/*/contrib/) follows a common pattern:
 
 - `Matrixfile` defines testing combinations, and `appraisal/` files declare respective gemsets. `gemfiles/` are tool generated files.
 
+## One-Pipeline (GitLab CI)
+
+The GitLab CI configuration (`.gitlab-ci.yml`) includes a remote template called
+"one-pipeline" via `.gitlab/one-pipeline.locked.yml`. This template defines OCI
+packaging, lib-injection image building, and promotion jobs shared across all Datadog
+tracing libraries.
+
+- **Source repo**: `DataDog/libdatadog-build` on GitHub (`templates/one-pipeline.yml`)
+- **Distribution**: A GitLab CI job publishes the template to
+  `gitlab-templates.ddbuild.io` under a content-addressed hash. A campaigner tool then
+  opens PRs (titled "chore(ci) update one-pipeline") in all consuming repos to update
+  the locked URL in `.gitlab/one-pipeline.locked.yml`.
+- **Local overrides**: `.gitlab-ci.yml` overrides template variables like
+  `OCI_PACKAGE_MAX_SIZE_BYTES` and `LIB_INJECTION_IMAGE_MAX_SIZE_BYTES`. When
+  `package-oci` jobs fail with size limit errors, check the local override values in
+  `.gitlab-ci.yml` — the template's error messages hardcode the default limit, not the
+  actual override value.
+- **Consuming repos**: dd-trace-rb, dd-trace-java, dd-trace-py, dd-trace-dotnet,
+  dd-trace-js, dd-trace-php, auto_inject, httpd-datadog, nginx-datadog,
+  inject-browser-sdk (listed in `libdatadog-build/campaigner-config.yml`).
+
 # Guidelines
 
 ## ⚠️ Ask First


### PR DESCRIPTION
**What does this PR do?**

Adds a "One-Pipeline (GitLab CI)" section to `AGENTS.md` documenting what the
one-pipeline template is, where its source lives, and how it gets distributed
to consuming repos.

**Motivation:**

Investigating a CI failure in #5486 ("chore(ci) update one-pipeline") took
a long time because there was no documentation explaining where one-pipeline
comes from or how it works. The `package-oci` jobs were failing with a
misleading error ("42M is greater than 160MB limit") that turned out to be a
local 40MB override in `.gitlab-ci.yml` — the template hardcodes the default
limit in its error message instead of using the actual variable value.

This section captures the provenance chain so future investigators can go
straight to the source.

**Provenance proof (how we know `DataDog/libdatadog-build` is the source):**

1. `.gitlab/one-pipeline.locked.yml` includes a remote URL at
   `gitlab-templates.ddbuild.io/libdatadog/one-pipeline/ca/<hash>/one-pipeline.yml`.
2. `DataDog/libdatadog-build` contains `templates/one-pipeline.yml` — the
   source template with identical structure and content.
3. `libdatadog-build/campaigner-config.yml` lists dd-trace-rb as a consuming
   repo, with PR title `"chore(ci) update one-pipeline"` and branch name
   `"campaigner/update-one-pipeline"` — matching exactly how these PRs appear.
4. `libdatadog-build/generate_prs.sh` fetches the content-addressed template
   URL from GitLab CI project 2821's `publish-content-addressable-templates`
   job artifacts, then uses the campaigner tool to open PRs updating the
   locked URL in each consuming repo.

**Change log entry**

None.

**Additional Notes:**

None.

**How to test the change?**

Read the new section in `AGENTS.md` and confirm it matches the provenance
chain described above.