### PR TITLE
Fix http.route tag not set on Rails 8.1+ due to removal of find_routes

### DIFF
--- a/lib/datadog/tracing/contrib/action_pack/action_dispatch/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_dispatch/instrumentation.rb
@@ -76,6 +76,23 @@ module Datadog
                   end
                 end
               end
+
+              # Since Rails 8.1, `Router#find_routes` was removed by inlining its body into `recognize`.
+              # https://github.com/rails/rails/commit/e533a32ddf06668dfa3dfbe9b665607e235b06ac
+              module RecognizeRouter
+                def recognize(req)
+                  super do |route, parameters|
+                    if Instrumentation.dispatcher_route?(route)
+                      http_route = route.path.spec.to_s
+                      http_route.delete_suffix!(FORMAT_SUFFIX)
+
+                      Instrumentation.set_http_route_tags(http_route, req.env[SCRIPT_NAME_KEY])
+                    end
+
+                    yield route, parameters
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/datadog/tracing/contrib/action_pack/action_dispatch/patcher.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_dispatch/patcher.rb
@@ -19,7 +19,9 @@ module Datadog
             end
 
             def patch
-              if ::ActionPack.gem_version >= Gem::Version.new('7.1')
+              if ::ActionPack.gem_version >= Gem::Version.new('8.1')
+                ::ActionDispatch::Journey::Router.prepend(ActionDispatch::Instrumentation::Journey::RecognizeRouter)
+              elsif ::ActionPack.gem_version >= Gem::Version.new('7.1')
                 ::ActionDispatch::Journey::Router.prepend(ActionDispatch::Instrumentation::Journey::LazyRouter)
               else
                 ::ActionDispatch::Journey::Router.prepend(ActionDispatch::Instrumentation::Journey::Router)

--- a/sig/datadog/tracing/contrib/action_pack/action_dispatch/instrumentation.rbs
+++ b/sig/datadog/tracing/contrib/action_pack/action_dispatch/instrumentation.rbs
@@ -12,6 +12,9 @@ module Datadog
               module LazyRouter
                 def serve: (untyped req) -> untyped
               end
+              module RecognizeRouter
+                def recognize: (untyped req) -> untyped
+              end
             end
           end
         end


### PR DESCRIPTION
## What does this PR do?

Adds a `RecognizeRouter` module that patches `ActionDispatch::Journey::Router#recognize` for Rails >= 8.1, and updates the version gate in `Patcher#patch` to use it.

Also adds the RBS type signature for `RecognizeRouter`.

## Motivation

Rails 8.1 removed the private `find_routes` method by inlining its body directly into `recognize` ([rails/rails@e533a32](https://github.com/rails/rails/commit/e533a32ddf06668dfa3dfbe9b665607e235b06ac)). As a result, the existing `LazyRouter` override of `find_routes` became a no-op on Rails 8.1+, and `http.route` was never set on the `rack.request` span.

Closes #5516

## Change log entry

## How to test the change?

## Additional Notes

