### PR TITLE
[APMLP-1088] Add post-install message about JRuby deprecation

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -87,6 +87,10 @@ Gem::Specification.new do |spec|
   # ADD NEW DEPENDENCIES HERE
   # to find out a few more places that need to be kept in-sync.
 
+  # DEV-3.0 Remove this message
+  spec.post_install_message =
+    'JRuby support in the datadog gem is deprecated. Details: https://dtdg.co/jruby-deprecation'
+
   spec.extensions = [
     'ext/datadog_profiling_native_extension/extconf.rb',
     'ext/libdatadog_api/extconf.rb'


### PR DESCRIPTION
**What does this PR do?**

Adds post-install message (unfortunately on all platforms) that we are deprecating JRuby support.

**Motivation:**

Part of RFC: 

**Change log entry**

Yes. Core: Add JRuby deprecation post-install message

**Additional Notes:**

```console
root@8682c3575a23:DataDog/dd-trace-rb# gem install pkg/datadog-2.31.0.gem --no-document
Fetching libdatadog-29.0.0.1.0.gem
Fetching datadog-ruby_core_source-3.5.2.gem
Fetching libddwaf-1.30.0.0.2.gem
Fetching msgpack-1.8.0-java.gem
Successfully installed libdatadog-29.0.0.1.0
Successfully installed libddwaf-1.30.0.0.2
Successfully installed datadog-ruby_core_source-3.5.2
Successfully installed msgpack-1.8.0-java
Building native extensions. This could take a while...
JRuby support in the datadog gem is deprecated. Details: https://dtdg.co/jruby-deprecation
Successfully installed datadog-2.31.0
5 gems installed
```

**How to test the change?**

CI