### PR TITLE
Fix GitLab pipeline creation failure caused by microbenchmarks-pr-comment needs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -271,7 +271,9 @@ microbenchmarks-pr-comment:
   stage: microbenchmarks
   when: on_success
   allow_failure: true
-  needs: [microbenchmarks]
+  needs:
+    - job: microbenchmarks
+      optional: true
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   timeout: 30m


### PR DESCRIPTION
**What does this PR do?**

Adds `optional: true` to the `microbenchmarks-pr-comment` job's `needs` dependency on `microbenchmarks` in `.gitlab/benchmarks.yml`.

**Motivation:**

#5488 added `changes:` rules to the `microbenchmarks` job so it's skipped on PRs that don't touch relevant files — but didn't update `microbenchmarks-pr-comment`, which has `needs: [microbenchmarks]`. When `microbenchmarks` is filtered out, GitLab rejects the entire pipeline because a needed job doesn't exist.

This breaks **any** PR where GitLab's `changes:` evaluation excludes `microbenchmarks` — not just docs-only PRs. Both of these PRs are currently stuck with the identical Mosaic error:

- #5515 — docs-only (`AGENTS.md`). Expected to be excluded by `changes:`.
- #5111 — touches `ext/`, `lib/`, `spec/`, yet `microbenchmarks` is still excluded. GitLab's `changes:` evaluation can exclude jobs even when matching paths are present (e.g. when the diff base is ambiguous or the branch diverged significantly). This means the `needs:` without `optional: true` is a broader failure than just docs-only PRs.

Both show the same Mosaic pipeline creation error:

```
POST .../pipeline: 400 {message: {base: [
  'microbenchmarks-pr-comment' job needs 'microbenchmarks: [profiling]' job,
  but 'microbenchmarks: [profiling]' does not exist in the pipeline.
  ...
  To need a job that sometimes does not exist in the pipeline, use needs:optional.
]}}
```

The causal chain:

1. `microbenchmarks` has `rules:` with `changes:` filters (added in #5488).
2. GitLab evaluates `changes:` and excludes `microbenchmarks` from the pipeline.
3. `microbenchmarks-pr-comment` declares `needs: [microbenchmarks]` without `optional: true`.
4. GitLab validates the DAG and rejects the pipeline with a 400.
5. No pipeline runs → `dd-gitlab/finished` is never posted → required check stays pending → PR is blocked.

The fix:

```yaml
# Before
needs: [microbenchmarks]

# After
needs:
  - job: microbenchmarks
    optional: true
```

When `microbenchmarks` is filtered out, `microbenchmarks-pr-comment` is simply skipped (`when: on_success` with no upstream dependency to satisfy). When `microbenchmarks` does run, behavior is unchanged.

**Change log entry**

None.

**Additional Notes:**

Introduced by #5488 (merged 2026-03-23). Confirmed that docs-only PRs merged before that date (#5491, #5485) had `dd-gitlab/finished: success` with no issues.

**How to test the change?**

Once merged, re-trigger CI on #5515 and #5111 (e.g. push an empty commit). The GitLab pipeline should create successfully and `dd-gitlab/finished` should resolve.
