### PR TITLE
Add require-green option to system-tests update workflow

### DIFF
--- a/.github/scripts/find_green_commit.sh
+++ b/.github/scripts/find_green_commit.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Finds the most recent commit on a GitHub repository's default branch
+# where the full CI pipeline ran and passed.
+#
+# "Full CI pipeline" = commit has more than MIN_STATUS_COUNT status contexts.
+# Most commits only have ~5 housekeeping statuses; full pipeline runs produce
+# 2000+ statuses.
+#
+# Usage:
+#   REPO=DataDog/system-tests ./find_green_commit.sh
+#
+# Outputs:
+#   ref=<sha> to $GITHUB_OUTPUT (for use in GitHub Actions)
+#   Prints the found SHA to stdout.
+#   Exits 1 if no green commit is found.
+#
+# Requires: gh (GitHub CLI), authenticated
+
+set -euo pipefail
+
+REPO="${REPO:?REPO environment variable is required (e.g. DataDog/system-tests)}"
+MAX_COMMITS="${MAX_COMMITS:-20}"
+MIN_STATUS_COUNT="${MIN_STATUS_COUNT:-100}"
+
+echo "Searching last ${MAX_COMMITS} commits on ${REPO} for a green full-pipeline commit..."
+echo "Minimum status count for full pipeline: ${MIN_STATUS_COUNT}"
+
+found=""
+
+while IFS=$'\t' read -r sha date message; do
+  status_json=$(gh api "repos/${REPO}/commits/${sha}/status" --jq '"\(.state)\t\(.total_count)"')
+  state=$(echo "$status_json" | cut -f1)
+  total=$(echo "$status_json" | cut -f2)
+
+  echo "  ${sha:0:7} (${date}) — ${state}, ${total} checks — ${message:0:80}"
+
+  if [ "$total" -lt "$MIN_STATUS_COUNT" ]; then
+    continue
+  fi
+
+  if [ "$state" = "success" ]; then
+    found="$sha"
+    break
+  fi
+done < <(gh api "repos/${REPO}/commits?per_page=${MAX_COMMITS}" --jq '.[] | [.sha, .commit.author.date, .commit.message | split("\n") | .[0]] | @tsv')
+
+if [ -z "$found" ]; then
+  echo "No green full-pipeline commit found in last ${MAX_COMMITS} commits."
+  exit 1
+fi
+
+echo ""
+echo "Found green commit: ${found}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "ref=${found}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/update-system-tests.yml
+++ b/.github/workflows/update-system-tests.yml
@@ -17,6 +17,15 @@ on: # yamllint disable-line rule:truthy
         description: Reference to be updated (commit hash, branch, or tag)
         required: false
         type: string
+      require-green:
+        description: >-
+          Checked: pin to the most recent ST commit that passed full ST CI.
+          Unchecked: pin to HEAD of ST main regardless of CI status —
+          use if you need changes that just landed or no recent commit is green.
+          Ignored when a specific ref is provided.
+        required: false
+        type: boolean
+        default: true
       dry-run:
         description: Skip PR creation and only show changes
         required: false
@@ -39,6 +48,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Find green system-tests commit
+        id: find-green
+        if: >-
+          ${{
+            (github.event.client_payload.ref || github.event.inputs.ref || '') == '' &&
+            (
+              github.event_name == 'schedule' ||
+              github.event.inputs.require-green == 'true' ||
+              github.event.client_payload.require-green == 'true'
+            )
+          }}
+        run: .github/scripts/find_green_commit.sh
+        env:
+          REPO: DataDog/system-tests
+          GH_TOKEN: ${{ github.token }}
+
       - name: Checkout System Test
         id: system-test-ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,8 +71,7 @@ jobs:
           repository: "DataDog/system-tests"
           path: system-tests
           persist-credentials: false
-          # Use ref from repository_dispatch payload if available, otherwise from workflow_dispatch
-          ref: ${{ github.event.client_payload.ref || github.event.inputs.ref || '' }}
+          ref: ${{ steps.find-green.outputs.ref || github.event.client_payload.ref || github.event.inputs.ref || '' }}
 
       - run: .github/scripts/update_reference.sh
         env:


### PR DESCRIPTION
**What does this PR do?**

Adds a `require-green` option to the "Update System Tests" workflow. When enabled
(the new default), the workflow walks back from HEAD of system-tests `main` to find
the latest commit where the full ST CI pipeline ran (~2500+ checks) and passed,
instead of blindly pinning to whatever is at HEAD.

The scheduled (cron) runs always use green pinning. Manual runs default to green but
can opt out by unchecking the option — useful when you need changes that just landed
on ST main or when no recent commit has a green full pipeline.

**Motivation:**

The current workflow pins to HEAD of system-tests `main` without verifying CI status.
System-tests CI runs ~3000 checks and takes ~10 hours to complete. The bot opens the
bump PR immediately, long before CI finishes.

Looking at the last 15 full-pipeline commits, about a third are red. The previous pin
on dd-trace-rb master ([`ebcc9bc`](https://github.com/DataDog/system-tests/commit/ebcc9bcbcf135574439bf9e91ee55e4d92adea85))
has been in a `failure` state for 3 days.


**Change log entry**

None.

**Additional Notes:**

Two new files:
- `.github/scripts/find_green_commit.sh` — iterates recent commits on a repo, skips
  those without a full pipeline (< 100 status contexts), returns the first with
  aggregated `success` state.
- Updated `.github/workflows/update-system-tests.yml` — new `require-green` boolean
  input (default `true`), wired to run the script before checkout when no explicit
  `ref` is provided.

When `require-green` is active and no green commit is found in the last 20 commits,
the workflow fails rather than pinning to an unverified commit. The search window is
configurable via `MAX_COMMITS`.

**How to test the change?**

1. Trigger manually with `gh workflow run "Update System Tests" -f dry-run=true` —
   should find a green commit and show the diff.
2. Trigger with `gh workflow run "Update System Tests" -f dry-run=true -f require-green=false` —
   should pin to HEAD as before.
3. Trigger with an explicit ref — should ignore `require-green` entirely.