### PR TITLE
Adds explicit description RSpec examples

### DIFF
--- a/spec/datadog/appsec/context_spec.rb
+++ b/spec/datadog/appsec/context_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Datadog::AppSec::Context do
     context 'when active context is set' do
       before { described_class.activate(context) }
 
-      it { expect(described_class.active).to eq(context) }
+      it 'returns the active context' do
+        expect(described_class.active).to eq(context)
+      end
     end
   end
 
@@ -45,7 +47,9 @@ RSpec.describe Datadog::AppSec::Context do
     it { expect { described_class.activate(double) }.to raise_error(ArgumentError) }
 
     context 'when no active context is set' do
-      it { expect { described_class.activate(context) }.to change { described_class.active }.from(nil).to(context) }
+      it 'sets the active context' do
+        expect { described_class.activate(context) }.to change { described_class.active }.from(nil).to(context)
+      end
     end
 
     context 'when active context is already set' do

--- a/spec/datadog/core/buffer/shared_examples.rb
+++ b/spec/datadog/core/buffer/shared_examples.rb
@@ -181,7 +181,9 @@ RSpec.shared_examples 'thread-safe buffer' do
       items.each { |i| buffer.push(i) }
     end
 
-    it { is_expected.to eq(items) }
+    it 'returns all pushed items' do
+      is_expected.to eq(items)
+    end
   end
 end
 

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
       context 'is defined' do
         let(:api_key_env) { SecureRandom.uuid.delete('-') }
 
-        it { is_expected.to eq(api_key_env) }
+        it 'returns the api key from the environment' do
+          is_expected.to eq(api_key_env)
+        end
       end
     end
   end
@@ -49,7 +51,9 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
       before { set_api_key }
 
-      it { expect(settings.api_key).to eq(api_key) }
+      it 'sets the api key' do
+        expect(settings.api_key).to eq(api_key)
+      end
     end
   end
 

--- a/spec/datadog/core/environment/identity_spec.rb
+++ b/spec/datadog/core/environment/identity_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Datadog::Core::Environment::Identity do
       let(:inside_fork_id) { described_class.id }
       let(:after_fork_id) { described_class.id }
 
-      it do
+      it 'generates a different id inside the fork and preserves the original id after' do
         # Check before forking
         expect(before_fork_id).to be_a_kind_of(String)
 

--- a/spec/datadog/core/environment/platform_spec.rb
+++ b/spec/datadog/core/environment/platform_spec.rb
@@ -17,14 +17,18 @@ RSpec.describe Datadog::Core::Environment::Platform do
 
     context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
       it { is_expected.to be_a_kind_of(String) }
-      it { is_expected.to eql(`uname -n`.strip) }
+      it 'returns the system hostname' do
+        is_expected.to eql(`uname -n`.strip)
+      end
     end
   end
 
   describe '::kernel_name' do
     subject(:kernel_name) { described_class.kernel_name }
     it { is_expected.to be_a_kind_of(String) }
-    it { is_expected.to eql(`uname -s`.strip) }
+    it 'returns the system kernel name' do
+      is_expected.to eql(`uname -s`.strip)
+    end
   end
 
   describe '::kernel_release' do
@@ -36,7 +40,9 @@ RSpec.describe Datadog::Core::Environment::Platform do
 
     context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
       it { is_expected.to be_a_kind_of(String) }
-      it { is_expected.to eql(`uname -r`.strip) }
+      it 'returns the system kernel release' do
+        is_expected.to eql(`uname -r`.strip)
+      end
     end
   end
 
@@ -54,7 +60,9 @@ RSpec.describe Datadog::Core::Environment::Platform do
 
       context 'when Ruby version >= 2.2', if: Datadog::Core::Environment::Ext::LANG_VERSION >= '2.2' do
         it { is_expected.to be_a_kind_of(String) }
-        it { is_expected.to eql(`uname -v`.strip) }
+        it 'returns the system kernel version' do
+          is_expected.to eql(`uname -v`.strip)
+        end
       end
     end
   end

--- a/spec/datadog/core/runtime/metrics_spec.rb
+++ b/spec/datadog/core/runtime/metrics_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
       context 'when available' do
         before { allow(runtime_metrics).to receive(:gauge) }
 
-        it do
+        it 'flushes the metric via gauge' do
           allow(metric).to receive(:available?)
             .and_return(true)
           allow(metric).to receive(:value)
@@ -87,7 +87,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
       end
 
       context 'when unavailable' do
-        it do
+        it 'does not flush the metric' do
           allow(metric).to receive(:available?)
             .and_return(false)
           expect(metric).to_not receive(:value)
@@ -101,7 +101,7 @@ RSpec.describe Datadog::Core::Runtime::Metrics do
       context 'when an error is thrown' do
         before { allow(Datadog.logger).to receive(:warn) }
 
-        it do
+        it 'logs a warning' do
           allow(metric).to receive(:available?)
             .and_raise(RuntimeError)
 

--- a/spec/datadog/tracing/flush_spec.rb
+++ b/spec/datadog/tracing/flush_spec.rb
@@ -21,7 +21,9 @@ RSpec.shared_examples_for 'a trace flusher' do
   context 'given a finished trace operation' do
     let(:finished) { true }
 
-    it { is_expected.to eq(trace) }
+    it 'returns the flushed trace' do
+      is_expected.to eq(trace)
+    end
   end
 
   context 'with a single sampled span' do
@@ -94,7 +96,9 @@ RSpec.describe Datadog::Tracing::Flush::Partial do
 
       context 'containing at least the minimum required spans' do
         let(:finished_span_count) { min_spans_for_partial }
-        it { is_expected.to eq(trace) }
+        it 'returns the flushed trace' do
+          is_expected.to eq(trace)
+        end
       end
     end
   end

--- a/spec/datadog/tracing/span_operation_spec.rb
+++ b/spec/datadog/tracing/span_operation_spec.rb
@@ -673,7 +673,10 @@ RSpec.describe Datadog::Tracing::SpanOperation do
       context 'when already started' do
         let!(:start_time) { span_op.start_time = Time.now }
 
-        it { expect { stop }.to_not change { span_op.start_time }.from(start_time) }
+        it 'does not change the start time' do
+          expect { stop }.to_not change { span_op.start_time }.from(start_time)
+        end
+
         it { expect { stop }.to change { span_op.end_time }.from(nil).to(end_time) }
         it { expect { stop }.to change { span_op.duration }.from(nil).to(kind_of(Float)) }
 
@@ -695,8 +698,13 @@ RSpec.describe Datadog::Tracing::SpanOperation do
       context 'when already stopped' do
         let!(:original_end_time) { span_op.end_time = Time.now }
 
-        it { expect { stop }.to_not change { span_op.start_time }.from(original_end_time) }
-        it { expect { stop }.to_not change { span_op.end_time }.from(original_end_time) }
+        it 'does not change the start time' do
+          expect { stop }.to_not change { span_op.start_time }.from(original_end_time)
+        end
+
+        it 'does not change the end time' do
+          expect { stop }.to_not change { span_op.end_time }.from(original_end_time)
+        end
         it { expect { stop }.to_not change { span_op.duration }.from(0) }
 
         it { expect { stop }.to_not change { span_op.started? }.from(true) }

--- a/spec/datadog/tracing/span_spec.rb
+++ b/spec/datadog/tracing/span_spec.rb
@@ -153,7 +153,9 @@ RSpec.describe Datadog::Tracing::Span do
         span.end_time = end_time
       end
 
-      it { is_expected.to eq(end_time - start_time) }
+      it 'returns the duration between start and end time' do
+        is_expected.to eq(end_time - start_time)
+      end
     end
   end
 

--- a/spec/datadog/tracing/transport/http/traces_spec.rb
+++ b/spec/datadog/tracing/transport/http/traces_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Datadog::Tracing::Transport::HTTP::Client do
       end
     end
 
-    it { is_expected.to eq(response) }
+    it 'returns the response' do
+      is_expected.to eq(response)
+    end
   end
 end
 


### PR DESCRIPTION
**What does this PR do?**

Adds explicit description strings to RSpec examples whose names were being auto-generated from runtime values, causing test fingerprint to change between runs.

**Motivation:**

Test count monitoring sees spurious churn when test names are non-deterministic. RSpec auto-generates descriptions for unnamed `it {}` one-liners and `it do...end` blocks by calling `inspect` on matcher arguments. When those arguments contain runtime values, the  generated name embeds that value — a new UUID, float, timestamp, memory address, or hostname — making it look like a different test each run.

The affected patterns found across the codebase:

  | Value type | Example | File(s) |
  |---|---|---|
  | `SecureRandom.uuid` in `eq()` | `is expected to eq "a1b2c3..."` | `settings_spec.rb` |
  | `rand` float in `have_received` | `is expected to have received gauge(..., 0.037...)` | `runtime/metrics_spec.rb` |
  | `Time.now` in `change{}.from()` | `is expected not to change from 2026-04-01 ...` | `span_operation_spec.rb`, `span_spec.rb` |
  | `Object.new` memory address in `eq()` | `is expected to eq [#<Object:0x...>]` | `buffer/shared_examples.rb` |
  | Real object instance in `eq()` / `change{}.to()` | `is expected to eq #<Datadog::AppSec::Context:0x...>` |
  `appsec/context_spec.rb` |
  | Shell output in `eql()` | `is expected to eql "08d828c2e7b6"` | `platform_spec.rb` |
  | `described_class.id` UUID in unnamed `it do` | `is expected to eq "0a01cbe7-..."` | `identity_spec.rb` |
  | RSpec double in `eq()` | `is expected to eq #<InstanceDouble(...)>` | `flush_spec.rb`, `http/traces_spec.rb` |

  **Change log entry**

  None.

  **Additional Notes:**

  No behaviour changes — only test description strings added.

