### PR TITLE
Add baseline:detect job for microbenchmarks (dd-octo-sts auth)

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -189,6 +189,42 @@ ddprof-benchmark:
 # Microbenchmarks
 # -----------------------------------------------------
 
+# Detect the PR's target branch from GitHub so microbenchmarks can compare
+# against the correct baseline. Uses dd-octo-sts for GitHub auth instead of
+# the benchmarking platform's GitHub App (which may be unavailable).
+# Modeled on dd-trace-py's baseline:detect job.
+microbenchmarks-baseline-detect:
+  stage: package
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  tags: ["arch:amd64"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      when: never
+    - changes:
+        - lib/**/*
+        - ext/**/*
+        - benchmarks/**/*
+        - datadog.gemspec
+        - .gitlab/**/*
+    - when: never
+  script:
+    - |
+      git config --global --add safe.directory "$CI_PROJECT_DIR"
+      git remote set-url origin "https://github.com/DataDog/dd-trace-rb.git"
+    - |
+      dd-octo-sts token --scope DataDog/dd-trace-rb --policy gitlab.github-access.read > /tmp/gh-token
+      gh auth login --with-token < /tmp/gh-token
+      rm /tmp/gh-token
+    - |
+      BASELINE_BRANCH=$(gh pr view --json "baseRefName" --jq ".baseRefName" "$CI_COMMIT_REF_NAME" || echo "master")
+      echo "MANUAL_BASELINE_BRANCH=${BASELINE_BRANCH}" | tee baseline.env
+  artifacts:
+    reports:
+      dotenv: baseline.env
+
 # Configuration for executing microbenchmarks in parallel
 # Choose which benchmarks to execute, with how many CPUs, on what CI job
 include:
@@ -198,7 +234,10 @@ microbenchmarks:
   extends: .execution  # From benchmarks/execution.yml
   stage: microbenchmarks
   when: always
-  needs: []
+  needs:
+    - job: microbenchmarks-baseline-detect
+      optional: true
+      artifacts: true
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
   rules:


### PR DESCRIPTION
**What does this PR do?**

Adds a `microbenchmarks-baseline-detect` job that detects the PR's target branch using `dd-octo-sts` + `gh` CLI, then passes it to the microbenchmarks job as `MANUAL_BASELINE_BRANCH` via a dotenv artifact. This bypasses `github-find-merge-into-branch` inside bp-runner, which crashes because its GitHub App installation is suspended (incident-51987).

This is the more robust alternative to #5538 (which uses a simpler one-line fallback to the default branch). This PR gets the **actual PR target branch** from GitHub, so it's correct even for PRs targeting non-default branches.

**⚠️ Blocked:** Requires `dd-octo-sts` trust policy `gitlab.github-access.read` to be provisioned for `DataDog/dd-trace-rb`. This policy exists for dd-trace-py but not for dd-trace-rb. See [failing job log](https://gitlab.ddbuild.io/datadog/apm-reliability/dd-trace-rb/builds/1559393965):
```
Error: http error with status code 404: {"code":5,"message":"unable to find trust policy for \"gitlab.github-access.read\"","details":[]}
```

**Prerequisites before this can merge:**
1. Provision `dd-octo-sts` trust policy `gitlab.github-access.read` for scope `DataDog/dd-trace-rb` (admin action)

**Motivation:**

All dd-trace-rb PRs that touch code paths are currently failing microbenchmarks because the benchmarking platform's GitHub App is suspended. See #5538 for the full root cause analysis.

This PR models the approach dd-trace-py has used since March 2025: a separate baseline detection job that authenticates via `dd-octo-sts` (independent of the benchmarking platform's GitHub App) and writes the result to a dotenv artifact consumed by the benchmark jobs.

**How it works:**

1. New `microbenchmarks-baseline-detect` job runs in the `package` stage (before `microbenchmarks`):
   - Uses `dd-octo-sts` to get a GitHub token scoped to `DataDog/dd-trace-rb`
   - Calls `gh pr view --json baseRefName` to find the PR's target branch
   - Falls back to `master` if the lookup fails
   - Writes `MANUAL_BASELINE_BRANCH=<branch>` to a dotenv artifact

2. The `microbenchmarks` job now has `needs: [{job: microbenchmarks-baseline-detect, optional: true, artifacts: true}]` instead of `needs: []`:
   - When the detect job runs, `MANUAL_BASELINE_BRANCH` is set from the dotenv artifact
   - The shared `run-microbenchmarks__setup.sh` template checks for this variable and skips `github-find-merge-into-branch` entirely
   - When the detect job is skipped (e.g., on master where we skip detection), `optional: true` ensures microbenchmarks still runs — it falls through to the shared template's default behavior

3. The detect job has the same `rules:` as the `microbenchmarks` job (minus the master rule, since on master we always compare against master anyway), so it only runs when microbenchmarks would run.

**Comparison with #5538:**

| | #5538 (Option A) | This PR (Option C) |
|---|---|---|
| Change size | 1 line | New job (~35 lines) |
| Baseline accuracy | Default branch only | Actual PR target branch |
| Auth dependency | None (detects from git remote) | `dd-octo-sts` (not yet provisioned) |
| PRs targeting non-master | Wrong baseline | Correct baseline |
| Complexity | Minimal | Moderate |

Recommend merging #5538 first to unblock CI immediately, then this PR once `dd-octo-sts` is provisioned.

**Change log entry**

None.

**Additional Notes:**


Cross-tracer analysis of how every tracer handles baseline detection:
- **Python**: Separate `baseline:detect` job with `dd-octo-sts` + `gh pr view ... || echo "main"` (this PR's model)
- **Go, Cpp, PHP**: Custom `run-benchmarks.sh` with `github-find-merge-into-branch || :`
- **Java**: Hardcodes `origin/master`
- **Dotnet**: Downloads baseline from S3
- **JS**: Uses shared template (same bug as rb, but survives accidentally due to bash `set -e` quirk with variable assignments — runs without baseline comparison)

**How to test the change?**

Once `dd-octo-sts` policy is provisioned:
1. Push a PR that touches `lib/` or `ext/` and verify:
   - `microbenchmarks-baseline-detect` job runs and outputs `MANUAL_BASELINE_BRANCH=master` (or the actual target branch)
   - `microbenchmarks` jobs pick up the variable and skip `github-find-merge-into-branch`
   - Baseline comparison runs correctly