### PR TITLE
Migrate DD_API_KEY in test.yml from static secret to dd-sts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,35 +121,20 @@ jobs:
       version: "9.2"
       alias: jruby-92
 
-  dd-sts-credentials:
-    name: dd/sts-credentials
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-    outputs:
-      api_key: ${{ steps.dd-sts.outputs.api_key }}
-    steps:
-      - name: Get Datadog credentials via dd-sts
-        id: dd-sts
-        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
-        with:
-          policy: public-datadog-dd-trace-rb
-
   junit:
     name: dd/junit
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     container:
       image: datadog/ci:v3.7.1
       env:
-        DD_API_KEY: "${{ needs.dd-sts-credentials.outputs.api_key }}"
         DD_ENV: ci
         DATADOG_SITE: datadoghq.com
         DD_SERVICE: dd-trace-rb
         DD_GIT_REPOSITORY_URL: "${{ github.repositoryUrl }}"
     needs:
-      - dd-sts-credentials
       # ADD NEW RUBIES HERE
       - ruby-40
       - ruby-34
@@ -185,15 +170,22 @@ jobs:
           DD_GIT_COMMIT_SHA: ${{ github.sha }}
         run: echo "DD_GIT_COMMIT_SHA=$DD_GIT_COMMIT_SHA" >> "$GITHUB_ENV"
       - run: echo "$DD_GIT_COMMIT_SHA"
+      - name: Get Datadog credentials via dd-sts
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
+        with:
+          policy: public-datadog-dd-trace-rb
       - name: Upload junit reports
-        continue-on-error: true
+        env:
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
         run: datadog-ci junit upload --verbose tmp/rspec/
 
   coverage:
     name: dd/coverage
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     needs:
-      - dd-sts-credentials
       # ADD NEW RUBIES HERE
       - ruby-40
       - ruby-34
@@ -207,7 +199,6 @@ jobs:
     container:
       image: datadog/ci:v5.7.0
       env:
-        DD_API_KEY: "${{ needs.dd-sts-credentials.outputs.api_key }}"
         DD_ENV: ci
         DATADOG_SITE: datadoghq.com
         DD_SERVICE: dd-trace-rb
@@ -220,7 +211,14 @@ jobs:
           path: tmp/coverage
           pattern: coverage-*
           merge-multiple: true
+      - name: Get Datadog credentials via dd-sts
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
+        with:
+          policy: public-datadog-dd-trace-rb
       - name: Upload coverage reports to Datadog
+        env:
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
         run: |
           for container_dir in tmp/coverage/versions/*/*/; do
             alias_name=$(basename "$(dirname "$container_dir")")


### PR DESCRIPTION
**What does this PR do?**

Replaces the static `DD_API_KEY` repo secret with a short-lived API key fetched via `DataDog/dd-sts-action` (OIDC-federated, no stored secrets).

Adds a `dd-sts-credentials` pre-job that exchanges the workflow's OIDC token for a Datadog API key. The `dd/junit` and `dd/coverage` container jobs read the key from the pre-job's output instead of `secrets.DD_API_KEY`.

**Motivation:**

Incident-51987 secrets remediation. `DD_API_KEY` was stored as a general repo secret on a public repo.

**Design decision: pre-job pattern**

The `dd/junit` and `dd/coverage` jobs use `container.env` to pass `DD_API_KEY` into the container. Container env is evaluated at job start, before any steps run. Since `dd-sts-action` runs as a step, the key can't be fetched inside the container job itself.

Solution: a separate `dd-sts-credentials` job fetches the key and exposes it as a job output. The container jobs declare `needs: [dd-sts-credentials]` and read it via `needs.dd-sts-credentials.outputs.api_key`. The key is short-lived (ephemeral, revoked after workflow).

**Blocked on:** [dd-source#400007](https://github.com/DataDog/dd-source/pull/400007) — the dd-sts policy `public-datadog-dd-trace-rb` must be deployed first. Until then, the dd-sts token exchange will 404.

**Change log entry**

None.

**How to test the change?**

After dd-source#400007 is deployed, push this PR and verify:
1. `dd/sts-credentials` job succeeds (OIDC token exchange works)
2. `dd/junit` and `dd/coverage` jobs receive the API key and upload successfully