### PR TITLE
Reproduce flaky: rc boot tags test

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -86,6 +86,7 @@ module Datadog
         # Then, waits for one client sync to be executed if `kind` is `:once`.
         def barrier(_kind)
           start
+          sleep 2 # REPRODUCER: force worker to complete before wait_once runs
           @barrier.wait_once
         end
 


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/tracing/contrib/rack/integration_test_spec.rb:328`.

**Motivation:**

Validating hypothesis before applying fix. The test failed on Ruby 2.5 in [CI](https://github.com/DataDog/dd-trace-rb/actions/runs/23870094583/job/69599631993?pr=5543) while passing on other Ruby versions.

**Hypothesis:** Race condition in `Component#barrier` — the worker thread can complete and call `@barrier.lift` (setting `@once = true`) between `start` and `@barrier.wait_once`. The TTAS optimization in `wait_once` then returns `:pass` instead of `:lift`, causing boot tags to be skipped.

**Reproducer:** `sleep 2` between `start` and `@barrier.wait_once` forces the worker to complete first. Reproduces locally on Ruby 3.2 with the same failure message as CI.

Fix will follow in PR #5545 once this reproducer is validated in CI.

**Change log entry**

None.

**How to test the change?**

This PR should FAIL — the reproducer forces the race condition. The `standard` CI jobs running the rack integration tests should show the failure.