### PR TITLE
Fix lock-dependency trust policy

### DIFF
--- a/.github/chainguard/self.lock-dependency.sts.yaml
+++ b/.github/chainguard/self.lock-dependency.sts.yaml
@@ -5,7 +5,7 @@ subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
 claim_pattern:
   event_name: pull_request
   repository: DataDog/dd-trace-rb
-  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/lock-dependency\.yml@refs/heads/master
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/lock-dependency\.yml@refs/pull/[0-9]+/merge
 
 permissions:
   contents: write


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Use the PR ref, not `master`

**Motivation:**
<!-- What inspired you to submit this pull request? -->

The trust policy only allows jobs whose definitions come from `master`, resulting in 403 when dd-octo-sts attempts to perform token exchange.

However the `lock-dependency` workflow runs on `pull_request` events. These do not use the job workflow ref from `master`, but from the pull request.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
