### PR TITLE
Fix 'load core only and configure library with no settings' spec when run locally

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -10,8 +10,6 @@ module Datadog
       # * Profiling in the trace viewer, as well as scoping a profile down to a span
       # * Endpoint aggregation in the profiler UX, including normalization (resource per endpoint call)
       def self.build_profiler_component(settings:, agent_settings:, optional_tracer:, logger:) # rubocop:disable Metrics/MethodLength
-        return [nil, {profiling_enabled: false}] unless settings.profiling.enabled
-
         # Workaround for weird dependency direction: the Core::Configuration::Components class currently has a
         # dependency on individual products, in this case the Profiler.
         # (Note "currently": in the future we want to change this so core classes don't depend on specific products)
@@ -31,7 +29,7 @@ module Datadog
         # no-op if profiling is already loaded).
         require_relative "../profiling"
 
-        return [nil, {profiling_enabled: false}] unless Profiling.supported?
+        return [nil, {profiling_enabled: false}] unless settings.profiling.enabled && Profiling.supported?
 
         # Activate forking extensions
         Profiling::Tasks::Setup.new.run


### PR DESCRIPTION


<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Fix a spec failing when running the test suite locally:

https://github.com/DataDog/dd-trace-rb/blob/e191a14f8c39972e23f1b666c28e6e6cacecc989/spec/loading_spec.rb#L76-L96

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Be green.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
