### PR TITLE
Remove secrets.DD_API_KEY from system-tests.yml

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -78,9 +78,9 @@ jobs:
     needs:
       - build
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@b38df18ddc8aa6af24e3838cfd91e4232404471b  # Automated: This reference is automatically updated.
-    secrets:
-      TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}  # key used to pushed test results to test optim
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}  # key used in tests runs
+    # DD_API_KEY and TEST_OPTIMIZATION_API_KEY are now fetched via dd-sts-action
+    # inside the system-tests reusable workflow (run-end-to-end.yml).
+    # See: https://github.com/DataDog/system-tests/pull/6680
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
**What does this PR do?**

Removes the `secrets: DD_API_KEY` and `secrets: TEST_OPTIMIZATION_API_KEY` parameters from the system-tests reusable workflow call. The system-tests workflow now fetches its own API key via dd-sts (OIDC token exchange) instead of receiving it from callers.

**Motivation:**

`DD_API_KEY` was deleted from this repo as part of [incident-51987 secrets rotation](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6490424964). The `test.yml` workflow was migrated to dd-sts in [#5547](https://github.com/DataDog/dd-trace-rb/pull/5547), but `system-tests.yml` was missed — it still passes `${{ secrets.DD_API_KEY }}` to the reusable workflow, which resolves to an empty string since the secret no longer exists.

This breaks system tests on **every PR** with `Internal Error: API key is missing`.

**Change log entry**

N/A — internal CI workflow change, no customer-visible behavior change.

**Additional Notes:**

Dependencies (must merge in this order):
1. [DataDog/dd-source#400821](https://github.com/DataDog/dd-source/pull/400821) — dd-sts policy for system-tests (must deploy first)
2. [DataDog/system-tests#6680](https://github.com/DataDog/system-tests/pull/6680) — adds dd-sts-action to run-end-to-end.yml
3. This PR — removes the now-unnecessary `secrets:` parameters from the caller

This repo pins system-tests to a specific SHA (`b38df18...`). After system-tests#6680 merges, this PR must be updated to pin to the new SHA that includes the dd-sts changes. The `update-system-tests.yml` workflow would normally do this automatically, but it's currently broken ([dd-octo-sts PR creation failure](https://github.com/DataDog/dd-trace-rb/pull/5544#issuecomment-4176223165)) — the ref may need a manual update.

**How to test the change?**

Cannot fully verify until the dd-source policy deploys and system-tests#6680 merges. After both:
1. System tests on this PR should pass (currently all failing on every dd-trace-rb PR)
2. Check dd-sts-action step in CI logs for successful OIDC token exchange
3. Check e2e scenario steps for successful execution with API key