### PR TITLE
[PROF-14464] Record the total time spent waiting for the GVL as a metric

### DIFF
--- a/benchmarks/profiling_http_transport.rb
+++ b/benchmarks/profiling_http_transport.rb
@@ -57,6 +57,7 @@ class ProfilerHttpTransportBenchmark
       encoded_profile: @stack_recorder.serialize!,
       code_provenance_file_name: 'example_code_provenance_file_name.json',
       code_provenance_data: '',
+      metrics: [],
       tags_as_array: [],
       internal_metadata: {no_signals_workaround_enabled: false},
       info_json: JSON.generate({profiler: {benchmarking: true}}),

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -186,6 +186,11 @@ typedef struct {
     uint64_t gvl_sampling_time_ns_min;
     uint64_t gvl_sampling_time_ns_max;
     uint64_t gvl_sampling_time_ns_total;
+
+    struct vm_metrics {
+      // Total time spent waiting for the GVL
+      uint64_t gvl_waiting_time_ns_total;
+    } vm_metrics;
   } stats;
 } cpu_and_wall_time_worker_state;
 
@@ -1101,6 +1106,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("gvl_sampling_time_ns_max")),   /* => */ RUBY_NUM_OR_NIL(state->stats.gvl_sampling_time_ns_max, > 0, ULL2NUM),
     ID2SYM(rb_intern("gvl_sampling_time_ns_total")), /* => */ RUBY_NUM_OR_NIL(state->stats.gvl_sampling_time_ns_total, > 0, ULL2NUM),
     ID2SYM(rb_intern("gvl_sampling_time_ns_avg")),   /* => */ RUBY_AVG_OR_NIL(state->stats.gvl_sampling_time_ns_total, state->stats.after_gvl_running),
+    ID2SYM(rb_intern("gvl_waiting_time_ns_total")),  /* => */ state->gvl_profiling_enabled ? ULL2NUM(state->stats.vm_metrics.gvl_waiting_time_ns_total) : Qnil,
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
@@ -1141,6 +1147,7 @@ static void reset_stats_not_thread_safe(cpu_and_wall_time_worker_state *state) {
     .cpu_sampling_time_ns_min        = UINT64_MAX,
     .allocation_sampling_time_ns_min = UINT64_MAX,
     .gvl_sampling_time_ns_min        = UINT64_MAX,
+    // Other fields are reset to 0
   };
 }
 
@@ -1407,19 +1414,22 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
         target_thread = gvl_profiling_state_maybe_initialize();
       #endif
 
+      cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
+      if (state == NULL) return; // This should not happen, but just in case...
+
       on_gvl_running_result result = thread_context_collector_on_gvl_running(target_thread);
 
-      if (result == ON_GVL_RUNNING_SAMPLE) {
+      if (result.waiting_for_gvl_duration_ns > 0) {
+        state->stats.vm_metrics.gvl_waiting_time_ns_total += (uint64_t) result.waiting_for_gvl_duration_ns;
+      }
+
+      if (result.action == ON_GVL_RUNNING_SAMPLE) {
         #ifndef NO_POSTPONED_TRIGGER
           rb_postponed_job_trigger(after_gvl_running_from_postponed_job_handle);
         #else
           rb_postponed_job_register_one(0, after_gvl_running_from_postponed_job, NULL);
         #endif
-      } else if (result == ON_GVL_RUNNING_DONT_SAMPLE) {
-        cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
-
-        if (state == NULL) return; // This should not happen, but just in case...
-
+      } else if (result.action == ON_GVL_RUNNING_DONT_SAMPLE) {
         state->stats.gvl_dont_sample++;
       }
     } else {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1924,10 +1924,14 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     intptr_t gvl_waiting_at = gvl_profiling_state_get(thread);
 
     // Thread was not being profiled / not waiting on gvl
-    if (gvl_waiting_at == 0 || gvl_waiting_at == GVL_WAITING_ENABLED_EMPTY) return ON_GVL_RUNNING_UNKNOWN;
+    if (gvl_waiting_at == 0 || gvl_waiting_at == GVL_WAITING_ENABLED_EMPTY) {
+      return (on_gvl_running_result) {.action = ON_GVL_RUNNING_UNKNOWN, .waiting_for_gvl_duration_ns = 0};
+    }
 
     // @ivoanjo: I'm not sure if this can happen -- It means we should've sampled already but haven't gotten the chance yet?
-    if (gvl_waiting_at < 0) return ON_GVL_RUNNING_SAMPLE;
+    if (gvl_waiting_at < 0) {
+      return (on_gvl_running_result) {.action = ON_GVL_RUNNING_SAMPLE, .waiting_for_gvl_duration_ns = 0};
+    }
 
     long waiting_for_gvl_duration_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - gvl_waiting_at;
 
@@ -1943,7 +1947,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
       gvl_profiling_state_set(thread, GVL_WAITING_ENABLED_EMPTY);
     }
 
-    return should_sample ? ON_GVL_RUNNING_SAMPLE : ON_GVL_RUNNING_DONT_SAMPLE;
+    return (on_gvl_running_result) {
+      .action = should_sample ? ON_GVL_RUNNING_SAMPLE : ON_GVL_RUNNING_DONT_SAMPLE,
+      .waiting_for_gvl_duration_ns = waiting_for_gvl_duration_ns,
+    };
   }
 
   __attribute__((warn_unused_result))
@@ -2146,7 +2153,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     debug_enter_unsafe_context();
 
-    VALUE result = thread_context_collector_on_gvl_running(thread_from_thread_object(thread)) == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
+    VALUE result = thread_context_collector_on_gvl_running(thread_from_thread_object(thread)).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
 
     debug_leave_unsafe_context();
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -2,6 +2,7 @@
 
 #include <ruby.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "gvl_profiling_helper.h"
 
@@ -25,6 +26,11 @@ VALUE enforce_thread_context_collector_instance(VALUE object);
     ON_GVL_RUNNING_UNKNOWN, // Thread is not known, it may not even be from the current Ractor
     ON_GVL_RUNNING_DONT_SAMPLE, // Thread is known, but "Waiting for GVL" period was too small to be sampled
     ON_GVL_RUNNING_SAMPLE, // Thread is known, and "Waiting for GVL" period should be sampled
+  } on_gvl_running_enum;
+
+  typedef struct {
+    on_gvl_running_enum action;
+    long waiting_for_gvl_duration_ns;
   } on_gvl_running_result;
 
   void thread_context_collector_on_gvl_waiting(gvl_profiling_thread thread);

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -200,6 +200,7 @@ static VALUE _native_do_export(
   VALUE encoded_profile = rb_funcall(flush, rb_intern("encoded_profile"), 0);
   VALUE code_provenance_file_name = rb_funcall(flush, rb_intern("code_provenance_file_name"), 0);
   VALUE code_provenance_data = rb_funcall(flush, rb_intern("code_provenance_data"), 0);
+  VALUE metrics_json = rb_funcall(flush, rb_intern("metrics"), 0);
   VALUE tags_as_array = rb_funcall(flush, rb_intern("tags_as_array"), 0);
   VALUE internal_metadata_json = rb_funcall(flush, rb_intern("internal_metadata_json"), 0);
   VALUE info_json = rb_funcall(flush, rb_intern("info_json"), 0);
@@ -207,6 +208,7 @@ static VALUE _native_do_export(
 
   enforce_encoded_profile_instance(encoded_profile);
   ENFORCE_TYPE(code_provenance_file_name, T_STRING);
+  ENFORCE_TYPE(metrics_json, T_STRING);
   ENFORCE_TYPE(tags_as_array, T_ARRAY);
   ENFORCE_TYPE(internal_metadata_json, T_STRING);
   ENFORCE_TYPE(info_json, T_STRING);
@@ -216,12 +218,17 @@ static VALUE _native_do_export(
   bool have_code_provenance = !NIL_P(code_provenance_data);
   if (have_code_provenance) ENFORCE_TYPE(code_provenance_data, T_STRING);
 
-  int to_compress_length = have_code_provenance ? 1 : 0;
+  int to_compress_length = 1 + (have_code_provenance ? 1 : 0);
   ddog_prof_Exporter_File to_compress[to_compress_length];
   ddog_prof_Exporter_Slice_File files_to_compress_and_export = {.ptr = to_compress, .len = to_compress_length};
 
+  to_compress[0] = (ddog_prof_Exporter_File) {
+    .name = DDOG_CHARSLICE_C("metrics.json"),
+    .file = byte_slice_from_ruby_string(metrics_json),
+  };
+
   if (have_code_provenance) {
-    to_compress[0] = (ddog_prof_Exporter_File) {
+    to_compress[1] = (ddog_prof_Exporter_File) {
       .name = char_slice_from_ruby_string(code_provenance_file_name),
       .file = byte_slice_from_ruby_string(code_provenance_data),
     };

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -85,6 +85,13 @@ module Datadog
             collector.refresh.generate_json
           end
 
+        metrics = [] #: Array[[::String, ::Numeric]]
+
+        # The key is always there, but the value might be nil if GVL profiling is disabled.
+        # We delete it to avoid reporting the same data point twice.
+        gvl_waiting_time_ns_total = worker_stats.delete(:gvl_waiting_time_ns_total)
+        metrics << ["ruby_global_lock_wait_time_total", gvl_waiting_time_ns_total] if gvl_waiting_time_ns_total
+
         process_tags = Datadog.configuration.experimental_propagate_process_tags_enabled ?
           Core::Environment::Process.serialized : ''
 
@@ -94,6 +101,7 @@ module Datadog
           encoded_profile: encoded_profile,
           code_provenance_file_name: Datadog::Profiling::Ext::Transport::HTTP::CODE_PROVENANCE_FILENAME,
           code_provenance_data: uncompressed_code_provenance,
+          metrics: metrics,
           tags_as_array: Datadog::Profiling::TagBuilder.call(
             settings: Datadog.configuration,
             profile_seq: sequence_tracker.get_next,

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -11,6 +11,7 @@ module Datadog
       attr_reader :encoded_profile #: Datadog::Profiling::EncodedProfile
       attr_reader :code_provenance_file_name #: ::String
       attr_reader :code_provenance_data #: ::String?
+      attr_reader :metrics #: ::String
       attr_reader :tags_as_array #: Array[[::String, ::String]]
       attr_reader :process_tags #: ::String
       attr_reader :internal_metadata_json #: ::String
@@ -21,6 +22,7 @@ module Datadog
       # @rbs encoded_profile: Datadog::Profiling::EncodedProfile
       # @rbs code_provenance_file_name: ::String
       # @rbs code_provenance_data: ::String?
+      # @rbs metrics: Array[[::String, ::Numeric]]
       # @rbs tags_as_array: Array[[::String, ::String]]
       # @rbs process_tags: ::String
       # @rbs internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric]
@@ -32,6 +34,7 @@ module Datadog
         encoded_profile:,
         code_provenance_file_name:,
         code_provenance_data:,
+        metrics:,
         tags_as_array:,
         process_tags:,
         internal_metadata:,
@@ -42,6 +45,7 @@ module Datadog
         @encoded_profile = encoded_profile
         @code_provenance_file_name = code_provenance_file_name
         @code_provenance_data = code_provenance_data
+        @metrics = JSON.generate(metrics)
         @tags_as_array = tags_as_array
         @process_tags = process_tags
         @internal_metadata_json = JSON.generate(internal_metadata)

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -548,6 +548,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
               gvl_sampling_time_ns_max: be > 0,
               gvl_sampling_time_ns_total: be > 0,
               gvl_sampling_time_ns_avg: be > 0,
+              gvl_waiting_time_ns_total: be > 0,
             )
           )
         end
@@ -584,6 +585,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
                 gvl_sampling_time_ns_max: nil,
                 gvl_sampling_time_ns_total: nil,
                 gvl_sampling_time_ns_avg: nil,
+                gvl_waiting_time_ns_total: be >= 0,
               )
             )
           end
@@ -1376,6 +1378,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           gvl_sampling_time_ns_max: nil,
           gvl_sampling_time_ns_total: nil,
           gvl_sampling_time_ns_avg: nil,
+          gvl_waiting_time_ns_total: nil,
         }
       )
     end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Datadog::Profiling::Exporter do
         code_provenance_file_name: "code-provenance.json",
         code_provenance_data: code_provenance_data,
         tags_as_array: array_including(%w[language ruby], ["process_id", Process.pid.to_s]),
+        metrics: "[]",
       )
       expect(JSON.parse(flush.internal_metadata_json, symbolize_names: true)).to match(
         {

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Datadog::Profiling::Flush do
     let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
     let(:process_tags) { 'process_tag_a:value_a,process_tag_b:value_b' }
     let(:internal_metadata) { {no_signals_workaround_enabled: false} }
+    let(:metrics) { [["ruby_global_lock_wait_time_total", 12_345]] }
     let(:info_json) do
       JSON.generate(
         {
@@ -31,6 +32,7 @@ RSpec.describe Datadog::Profiling::Flush do
         encoded_profile: encoded_profile,
         code_provenance_file_name: code_provenance_file_name,
         code_provenance_data: code_provenance_data,
+        metrics: metrics,
         tags_as_array: tags_as_array,
         process_tags: process_tags,
         internal_metadata: internal_metadata,
@@ -45,6 +47,7 @@ RSpec.describe Datadog::Profiling::Flush do
         encoded_profile: encoded_profile,
         code_provenance_file_name: code_provenance_file_name,
         code_provenance_data: code_provenance_data,
+        metrics: '[["ruby_global_lock_wait_time_total",12345]]',
         tags_as_array: tags_as_array,
         process_tags: process_tags,
         internal_metadata_json: '{"no_signals_workaround_enabled":false}',

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe Datadog::Profiling::HttpTransport do
   let(:upload_timeout_seconds) { 10 }
   let(:use_system_dns) { false }
 
+  let(:metrics) {
+    [
+      ["ruby_global_lock_wait_time_total", 123]
+    ]
+  }
+
   let(:flush) do
     Datadog::Profiling::Flush.new(
       start: start,
@@ -55,6 +61,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       encoded_profile: encoded_profile,
       code_provenance_file_name: code_provenance_file_name,
       code_provenance_data: code_provenance_data,
+      metrics: metrics,
       tags_as_array: tags_as_array,
       process_tags: process_tags,
       internal_metadata: {no_signals_workaround_enabled: true},
@@ -339,7 +346,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     shared_examples "correctly reports profiling data" do
       let(:expected_data_in_payload) {
         {
-          "attachments" => contain_exactly(pprof_file_name, code_provenance_file_name),
+          "attachments" => contain_exactly(pprof_file_name, "metrics.json", code_provenance_file_name),
           "tags_profiler" => start_with("tag_a:value_a,tag_b:value_b,runtime_platform:#{RUBY_PLATFORM.split("-").first.sub("arm", "aarch")}"),
           "start" => start_timestamp,
           "end" => end_timestamp,
@@ -383,6 +390,8 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         expect(body.fetch(pprof_file_name)).to eq encoded_profile_bytes
         # This one needs to be compressed
         expect(Zstd.decompress(body.fetch(code_provenance_file_name))).to eq code_provenance_data
+
+        expect(Zstd.decompress(body.fetch("metrics.json"))).to eq '[["ruby_global_lock_wait_time_total",123]]'
       end
     end
 
@@ -423,7 +432,9 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
         event_data = JSON.parse(body.fetch("event"))
 
-        expect(event_data).to match(expected_data_in_payload.merge("attachments" => [pprof_file_name]))
+        expect(event_data).to match(
+          expected_data_in_payload.merge("attachments" => contain_exactly(pprof_file_name, "metrics.json"))
+        )
 
         expect(body[code_provenance_file_name]).to be nil
       end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Record the total time spent waiting for the GVL as a metric.
See https://github.com/DataDog/dd-trace-rb/issues/3433.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
That issue.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Added metric for total time spent waiting for the GVL.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->
Yes, I'm experimenting with Cursor.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
