### PR TITLE
ci: add dd-octo-sts policy for GitLab SLO change tracking

### DIFF
--- a/.github/chainguard/gitlab.github-access.slo-change-tracking.contents-read.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.slo-change-tracking.contents-read.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-rb:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: read


### PR DESCRIPTION
**What does this PR do?**

Adds a chainguard policy for GitLab CI to get a short-lived GitHub token (`contents:read`) via dd-octo-sts.

**Motivation:**

Pre-release performance quality gates (#5571) submit SLO metrics that track file changes to SLO threshold files via the GitHub API. This policy enables that access from GitLab CI.

**Change log entry**

None.

**How to test the change?**

Declarative policy file, validated when `check-slo-breaches` job runs.