### PR TITLE
Add AI Guard support for images for Ruby LLM

### DIFF
--- a/lib/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rb
+++ b/lib/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rb
@@ -14,13 +14,51 @@ module Datadog
                     AIGuard.assistant(id: tool_call_id, tool_name: tool_call.name, arguments: tool_call.arguments.to_s)
                   end
                 elsif message.tool_result?
-                  AIGuard.tool(tool_call_id: message.tool_call_id, content: message.content)
+                  build_ai_guard_tool(message)
                 else
-                  AIGuard.message(role: message.role, content: message.content)
+                  build_ai_guard_message(message)
                 end
               end
 
               AIGuard.evaluate(*ai_guard_messages, allow_raise: true)
+            end
+
+            private
+
+            def build_ai_guard_message(message)
+              content = message.content
+
+              case content
+              when ::RubyLLM::Content
+                AIGuard.message(role: message.role) do |m|
+                  m.text(content.text.to_s) if content.text
+
+                  # Calling attachment.for_llm triggers lazy loading of file contents.
+                  # The result is memoized, so providers won't re-read.
+                  content.attachments.each do |attachment|
+                    case attachment.type
+                    when :image
+                      m.image_url(attachment.for_llm)
+                    when :text
+                      m.text(attachment.for_llm)
+                    end
+                    # Skip :pdf, :audio, :video, :unknown — not supported by AIGuard
+                  end
+                end
+              else
+                AIGuard.message(role: message.role, content: content)
+              end
+            end
+
+            def build_ai_guard_tool(message)
+              content = message.content
+              # Tools can return Content or Content::Raw objects (e.g. with attachments),
+              # but AIGuard.tool expects a String. Extract text when content is a Content object.
+              case content
+              when ::RubyLLM::Content
+                content = content.text.to_s
+              end
+              AIGuard.tool(tool_call_id: message.tool_call_id, content: content)
             end
           end
 

--- a/sig/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rbs
+++ b/sig/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rbs
@@ -5,6 +5,12 @@ module Datadog
         module ChatInstrumentation : RubyLLM::Chat
           def self.evaluate!: (::Array[::RubyLLM::Message] messages) -> (AIGuard::Evaluation::Result | AIGuard::Evaluation::NoOpResult)
 
+          private
+
+          def self.build_ai_guard_message: (::RubyLLM::Message message) -> AIGuard::Evaluation::Message
+
+          def self.build_ai_guard_tool: (::RubyLLM::Message message) -> AIGuard::Evaluation::Message
+
           def complete: () ?{ () -> ::Array[::RubyLLM::Message] } -> (::RubyLLM::Message | ::RubyLLM::Tool::Halt)
         end
       end

--- a/spec/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation_spec.rb
+++ b/spec/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation_spec.rb
@@ -135,6 +135,104 @@ RSpec.describe "RubyLLM chat instrumentation" do
     end
   end
 
+  context "messages with attachments" do
+    let(:raw_response) do
+      {
+        "data" => {
+          "attributes" => {
+            "action" => "ALLOW",
+            "reason" => "No rule matching",
+            "tags" => [],
+            "is_blocking_enabled" => false
+          }
+        }
+      }
+    end
+
+    before do
+      allow_any_instance_of(RubyLLM::Provider).to receive(:complete).and_return(
+        RubyLLM::Message.new(role: "assistant", content: "I see an image")
+      )
+    end
+
+    it "sends text and image_url parts for a message with an image attachment" do
+      content = RubyLLM::Content.new("Describe this")
+      content.add_attachment(StringIO.new(Base64.decode64("iVBORw0KGgo=")), filename: "photo.png")
+
+      user_message = RubyLLM::Message.new(role: :user, content: content)
+
+      chat = RubyLLM.chat
+      allow(chat).to receive(:messages).and_return([user_message])
+
+      chat.complete
+
+      messages = ai_guard_span.get_metastruct_tag("ai_guard").fetch(:messages)
+      parts = messages.first[:content]
+
+      expect(parts.size).to eq(2)
+      expect(parts[0]).to eq(type: "text", text: "Describe this")
+      expect(parts[1][:type]).to eq("image_url")
+      expect(parts[1][:image_url][:url]).to start_with("data:image/png;base64,")
+    end
+
+    it "sends text parts for a message with a text file attachment" do
+      content = RubyLLM::Content.new("Summarize this file")
+      content.add_attachment(StringIO.new("some notes"), filename: "notes.txt")
+
+      user_message = RubyLLM::Message.new(role: :user, content: content)
+
+      chat = RubyLLM.chat
+      allow(chat).to receive(:messages).and_return([user_message])
+
+      chat.complete
+
+      messages = ai_guard_span.get_metastruct_tag("ai_guard").fetch(:messages)
+      parts = messages.first[:content]
+
+      expect(parts.size).to eq(2)
+      expect(parts[0]).to eq(type: "text", text: "Summarize this file")
+      expect(parts[1][:type]).to eq("text")
+      expect(parts[1][:text]).to include("some notes")
+    end
+
+    it "skips unsupported attachment types without error" do
+      content = RubyLLM::Content.new("Transcribe this")
+      content.add_attachment(StringIO.new("\xFF\xFB".b), filename: "audio.mp3")
+
+      user_message = RubyLLM::Message.new(role: :user, content: content)
+
+      chat = RubyLLM.chat
+      allow(chat).to receive(:messages).and_return([user_message])
+
+      chat.complete
+
+      messages = ai_guard_span.get_metastruct_tag("ai_guard").fetch(:messages)
+      parts = messages.first[:content]
+
+      expect(parts).to eq([{type: "text", text: "Transcribe this"}])
+    end
+
+    it "sends only attachment parts when text is nil" do
+      content = RubyLLM::Content.new("placeholder")
+      content.add_attachment(StringIO.new(Base64.decode64("iVBORw0KGgo=")), filename: "photo.png")
+      allow(content).to receive(:text).and_return(nil)
+
+      user_message = RubyLLM::Message.new(role: :user, content: content)
+
+      chat = RubyLLM.chat
+      allow(chat).to receive(:messages).and_return([user_message])
+
+      chat.complete
+
+      messages = ai_guard_span.get_metastruct_tag("ai_guard").fetch(:messages)
+      parts = messages.first[:content]
+
+      expect(parts.size).to eq(1)
+      expect(parts[0][:type]).to eq("image_url")
+      expect(parts[0][:image_url][:url]).to start_with("data:image/png;base64,")
+    end
+  end
+
   context "tool calls" do
     let(:shell_tool) do
       Class.new(RubyLLM::Tool) do

--- a/vendor/rbs/ruby_llm/0/ruby_llm.rbs
+++ b/vendor/rbs/ruby_llm/0/ruby_llm.rbs
@@ -5,10 +5,22 @@ module RubyLLM
     def handle_tool_calls: (Message response) ?{ () -> untyped } -> (Message | Tool::Halt)
   end
 
+  class Content
+    def text: () -> ::String?
+
+    def attachments: () -> ::Array[Attachment]
+  end
+
+  class Attachment
+    def type: () -> ::Symbol
+
+    def for_llm: () -> ::String
+  end
+
   class Message
     def role: () -> ::String
 
-    def content: () -> ::String
+    def content: () -> (::String | Content)
 
     def tool_calls: () -> ::Hash[::String, ToolCall]
 


### PR DESCRIPTION
**What does this PR do?**
It adds evaluation of images in RubyLLM chat messages and tool outputs.

**Motivation:**
We want to evaluate images in the user prompt and tool output.

**Change log entry**
Yes. AI Guard: add evaluation of images in user prompt and tool output.

**Additional Notes:**
Yes, Claude helped me to get a good overview of RubyLLM library.

**How to test the change?**
CI and manual testing
