### PR TITLE
fix(http): honor per-host distributed_tracing in describes: overrides

### DIFF
--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -37,7 +37,7 @@ module Datadog
 
                 if Tracing::Distributed::PropagationPolicy.enabled?(
                   pin_config: client_config,
-                  global_config: Datadog.configuration.tracing[:http],
+                  global_config: request_options,
                   trace: trace
                 )
                   Contrib::HTTP.inject(trace, req)

--- a/spec/datadog/tracing/contrib/http/request_spec.rb
+++ b/spec/datadog/tracing/contrib/http/request_spec.rb
@@ -419,6 +419,25 @@ RSpec.describe 'net/http requests' do
         expect_request_without_distributed_headers
       end
     end
+
+    context 'when disabled via a per-host describes: override' do
+      before do
+        Datadog.configure do |c|
+          c.tracing.instrument :http
+          c.tracing.instrument :http, describes: /127\.0\.0\.1/ do |http|
+            http.distributed_tracing = false
+          end
+        end
+        client.get(path)
+      end
+
+      let(:span) { spans.last }
+
+      it 'does not add distributed tracing headers for the matched host' do
+        expect(span.name).to eq('http.request')
+        expect_request_without_distributed_headers
+      end
+    end
   end
 
   describe 'request exceptions' do


### PR DESCRIPTION
**What does this PR do?**

The `Net::HTTP` integration silently ignores per-host `distributed_tracing` configuration set via `describes:` blocks; Datadog distributed headers continue to be injected on requests to the matched host.

`Instrumentation::InstanceMethods#request` computes `request_options = datadog_configuration(host)` and uses it for span tagging on lines 34, 47, and 52, but passes the non-host-scoped `Datadog.configuration.tracing[:http]` to `PropagationPolicy.enabled?` on line 40. The host-scoped `distributed_tracing` setting is therefore never consulted on the propagation path.

This PR passes `request_options` (the host-scoped `IntegrationSettings` already computed two lines above) as `global_config` instead. `PropagationPolicy.enabled?` only calls `#key?` on `pin_config`, not `global_config`, so passing an `IntegrationSettings` object as `global_config` is safe.

The regression was introduced in 0cbcd34531 (Mar 12, 2025) when `should_skip_distributed_tracing?` was extracted from the prior `Contrib::HTTP.should_skip_distributed_tracing?(client_config, trace)` form into a keyword-arg call that added a `datadog_config` parameter; the new parameter pulled the base `Datadog.configuration.tracing[:http]` instead of the host-scoped `request_options`. Subsequent renames (`datadog_config` → `contrib_datadog_config` → `global_config`) did not catch it.

**Motivation:**

Per-host `distributed_tracing` is listed in the `Net::HTTP` integration options table in `docs/GettingStarted.md` and `describes:` is the documented per-host override mechanism, but combining them has no effect on distributed tracing injection. A user writing:

```ruby
Datadog.configure do |c|
  c.tracing.instrument :http
  c.tracing.instrument :http, describes: /api\.example\.com/ do |http|
    http.distributed_tracing = false
  end
end
```

reasonably expects no Datadog distributed headers on requests to `api.example.com`, but they are injected anyway with no error or warning.

**Change log entry**

Yes. Fix `Net::HTTP` integration silently ignoring per-host `distributed_tracing` configuration set via `describes:` blocks.

**Additional Notes:**

AI-assisted: I authored, reviewed, and verified the change end-to-end, including a red→green run of the included regression spec against the `ruby_3.4_http` gemfile.

The same code pattern may exist in other contrib HTTP integrations (Faraday, HTTPClient, Excon); not audited in this PR. Happy to follow up in a separate PR if maintainers confirm interest.

**How to test the change?**

A regression spec is included at `spec/datadog/tracing/contrib/http/request_spec.rb` under the existing `'distributed tracing'` describe block, as `'when disabled via a per-host describes: override'`. It uses `WebMock` and the existing `expect_request_without_distributed_headers` helper already defined in the file.

```
docker compose run --rm tracer-3.4 bash -lc \
  'BUNDLE_GEMFILE=$(pwd)/gemfiles/ruby_3.4_http.gemfile bundle install && \
   bundle exec rspec spec/datadog/tracing/contrib/http/request_spec.rb -e "per-host describes"'
```

Fails on `master`, passes with this PR. The full `'distributed tracing'` describe block (5 examples) continues to pass with no regressions.
