### PR TITLE
Add Security Data Scanner findings to AI Guard result

### DIFF
--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -36,7 +36,7 @@ module Datadog
               {
                 messages: truncate_content(request.serialized_messages),
                 attack_categories: result.tags,
-                sds_findings: result.sds_findings,
+                sds: result.sds_findings,
               }
             )
 

--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -35,7 +35,8 @@ module Datadog
               Ext::METASTRUCT_TAG,
               {
                 messages: truncate_content(request.serialized_messages),
-                attack_categories: result.tags
+                attack_categories: result.tags,
+                sds_findings: result.sds_findings,
               }
             )
 

--- a/lib/datadog/ai_guard/evaluation/no_op_result.rb
+++ b/lib/datadog/ai_guard/evaluation/no_op_result.rb
@@ -5,12 +5,13 @@ module Datadog
     module Evaluation
       # Class for emulating AI Guard evaluation result when AI Guard is disabled.
       class NoOpResult
-        attr_reader :action, :reason, :tags
+        attr_reader :action, :reason, :tags, :sds_findings
 
         def initialize
           @action = Result::ALLOW_ACTION
           @reason = "AI Guard is disabled"
           @tags = []
+          @sds_findings = []
         end
 
         def allow?

--- a/lib/datadog/ai_guard/evaluation/result.rb
+++ b/lib/datadog/ai_guard/evaluation/result.rb
@@ -9,7 +9,7 @@ module Datadog
         DENY_ACTION = "DENY"
         ABORT_ACTION = "ABORT"
 
-        attr_reader :action, :reason, :tags
+        attr_reader :action, :reason, :tags, :sds_findings
 
         def initialize(raw_response)
           attributes = raw_response.fetch("data").fetch("attributes")
@@ -18,6 +18,7 @@ module Datadog
           @reason = attributes.fetch("reason")
           @tags = attributes.fetch("tags")
           @is_blocking_enabled = attributes.fetch("is_blocking_enabled")
+          @sds_findings = attributes.fetch("sds_findings", [])
         rescue KeyError => e
           raise AIGuardClientError, "Missing key: \"#{e.key}\""
         end

--- a/sig/datadog/ai_guard/evaluation/no_op_result.rbs
+++ b/sig/datadog/ai_guard/evaluation/no_op_result.rbs
@@ -5,6 +5,7 @@ module Datadog
         attr_reader action: ::String
         attr_reader reason: ::String
         attr_reader tags: ::Array[::String]
+        attr_reader sds_findings: ::Array[::String]
 
         def initialize: () -> void
 

--- a/sig/datadog/ai_guard/evaluation/no_op_result.rbs
+++ b/sig/datadog/ai_guard/evaluation/no_op_result.rbs
@@ -5,7 +5,7 @@ module Datadog
         attr_reader action: ::String
         attr_reader reason: ::String
         attr_reader tags: ::Array[::String]
-        attr_reader sds_findings: ::Array[::String]
+        attr_reader sds_findings: ::Array[Result::sds_finding]
 
         def initialize: () -> void
 

--- a/sig/datadog/ai_guard/evaluation/result.rbs
+++ b/sig/datadog/ai_guard/evaluation/result.rbs
@@ -9,7 +9,19 @@ module Datadog
         attr_reader action: ::String
         attr_reader reason: ::String
         attr_reader tags: ::Array[::String]
-        attr_reader sds_findings: ::Array[::String]
+        type sds_finding = {
+          rule_display_name: ::String,
+          rule_tag: ::String,
+          category: ::String,
+          matched_text: ::String,
+          location: {
+            start_index: ::Integer,
+            end_index_exclusive: ::Integer,
+            path: ::String
+          }
+        }
+
+        attr_reader sds_findings: ::Array[sds_finding]
 
         @is_blocking_enabled: bool
 

--- a/sig/datadog/ai_guard/evaluation/result.rbs
+++ b/sig/datadog/ai_guard/evaluation/result.rbs
@@ -9,6 +9,7 @@ module Datadog
         attr_reader action: ::String
         attr_reader reason: ::String
         attr_reader tags: ::Array[::String]
+        attr_reader sds_findings: ::Array[::String]
 
         @is_blocking_enabled: bool
 

--- a/spec/datadog/ai_guard/evaluation/result_spec.rb
+++ b/spec/datadog/ai_guard/evaluation/result_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
           "action" => action,
           "reason" => "Some reason",
           "tags" => ["some", "tags"],
-          "is_blocking_enabled" => is_blocking_enabled
+          "is_blocking_enabled" => is_blocking_enabled,
+          "sds_findings" => ["pii-email", "pii-phone"]
         }
       }
     }
@@ -43,6 +44,31 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
   describe "#tags" do
     it "returns the tags from the response body" do
       expect(described_class.new(raw_response).tags).to eq(raw_response.dig("data", "attributes", "tags"))
+    end
+  end
+
+  describe "#sds_findings" do
+    it "returns the sds_findings from the response body" do
+      expect(described_class.new(raw_response).sds_findings).to eq(["pii-email", "pii-phone"])
+    end
+
+    context "when sds_findings is not present in the response" do
+      let(:raw_response) do
+        {
+          "data" => {
+            "attributes" => {
+              "action" => action,
+              "reason" => "Some reason",
+              "tags" => ["some", "tags"],
+              "is_blocking_enabled" => is_blocking_enabled
+            }
+          }
+        }
+      end
+
+      it "defaults to an empty array" do
+        expect(described_class.new(raw_response).sds_findings).to eq([])
+      end
     end
   end
 

--- a/spec/datadog/ai_guard/evaluation/result_spec.rb
+++ b/spec/datadog/ai_guard/evaluation/result_spec.rb
@@ -20,7 +20,30 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
           "reason" => "Some reason",
           "tags" => ["some", "tags"],
           "is_blocking_enabled" => is_blocking_enabled,
-          "sds_findings" => ["pii-email", "pii-phone"]
+          "sds_findings" => [
+            {
+              "rule_display_name" => "Credit Card Number",
+              "rule_tag" => "credit_card",
+              "category" => "pii",
+              "matched_text" => "4111111111111111",
+              "location" => {
+                "start_index" => 0,
+                "end_index_exclusive" => 26,
+                "path" => "messages[0].content[0].text"
+              }
+            },
+            {
+              "rule_display_name" => "Email Address",
+              "rule_tag" => "email",
+              "category" => "pii",
+              "matched_text" => "test@example.com",
+              "location" => {
+                "start_index" => 30,
+                "end_index_exclusive" => 46,
+                "path" => "messages[0].content[0].text"
+              }
+            }
+          ]
         }
       }
     }
@@ -49,7 +72,9 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
 
   describe "#sds_findings" do
     it "returns the sds_findings from the response body" do
-      expect(described_class.new(raw_response).sds_findings).to eq(["pii-email", "pii-phone"])
+      expect(described_class.new(raw_response).sds_findings).to eq(
+        raw_response.dig("data", "attributes", "sds_findings")
+      )
     end
 
     context "when sds_findings is not present in the response" do

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -159,10 +159,10 @@ RSpec.describe Datadog::AIGuard::Evaluation do
         expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:attack_categories)).to eq([])
       end
 
-      it "sets ai_guard metastruct tag with empty sds_findings" do
+      it "sets ai_guard metastruct tag with empty sds" do
         perform
 
-        expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds_findings)).to eq([])
+        expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds)).to eq([])
       end
     end
 
@@ -231,10 +231,10 @@ RSpec.describe Datadog::AIGuard::Evaluation do
           )
         end
 
-        it "sets ai_guard metastruct tag with sds_findings" do
+        it "sets ai_guard metastruct tag with sds" do
           perform
 
-          expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds_findings)).to eq(
+          expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds)).to eq(
             ["pii-email"]
           )
         end

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Datadog::AIGuard::Evaluation do
             "action" => "ALLOW",
             "reason" => "Because why not",
             "tags" => [],
-            "is_blocking_enabled" => false
+            "is_blocking_enabled" => false,
+            "sds_findings" => []
           }
         }
       }
@@ -109,7 +110,8 @@ RSpec.describe Datadog::AIGuard::Evaluation do
               "action" => "ALLOW",
               "reason" => "Because why not",
               "tags" => [],
-              "is_blocking_enabled" => false
+              "is_blocking_enabled" => false,
+              "sds_findings" => []
             }
           }
         }
@@ -156,6 +158,12 @@ RSpec.describe Datadog::AIGuard::Evaluation do
 
         expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:attack_categories)).to eq([])
       end
+
+      it "sets ai_guard metastruct tag with empty sds_findings" do
+        perform
+
+        expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds_findings)).to eq([])
+      end
     end
 
     %w[DENY ABORT].each do |blocking_action|
@@ -167,7 +175,8 @@ RSpec.describe Datadog::AIGuard::Evaluation do
                 "action" => blocking_action,
                 "reason" => "Rule matches: indirect-prompt-injection, instruction-override",
                 "tags" => ["indirect-prompt-injection", "instruction-override"],
-                "is_blocking_enabled" => blocking_enabled
+                "is_blocking_enabled" => blocking_enabled,
+                "sds_findings" => ["pii-email"]
               }
             }
           }
@@ -219,6 +228,14 @@ RSpec.describe Datadog::AIGuard::Evaluation do
 
           expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:attack_categories)).to eq(
             ["indirect-prompt-injection", "instruction-override"]
+          )
+        end
+
+        it "sets ai_guard metastruct tag with sds_findings" do
+          perform
+
+          expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds_findings)).to eq(
+            ["pii-email"]
           )
         end
 

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -176,7 +176,19 @@ RSpec.describe Datadog::AIGuard::Evaluation do
                 "reason" => "Rule matches: indirect-prompt-injection, instruction-override",
                 "tags" => ["indirect-prompt-injection", "instruction-override"],
                 "is_blocking_enabled" => blocking_enabled,
-                "sds_findings" => ["pii-email"]
+                "sds_findings" => [
+                  {
+                    "rule_display_name" => "Credit Card Number",
+                    "rule_tag" => "credit_card",
+                    "category" => "pii",
+                    "matched_text" => "4111111111111111",
+                    "location" => {
+                      "start_index" => 0,
+                      "end_index_exclusive" => 26,
+                      "path" => "messages[0].content[0].text"
+                    }
+                  }
+                ]
               }
             }
           }
@@ -235,7 +247,19 @@ RSpec.describe Datadog::AIGuard::Evaluation do
           perform
 
           expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds)).to eq(
-            ["pii-email"]
+            [
+              {
+                "rule_display_name" => "Credit Card Number",
+                "rule_tag" => "credit_card",
+                "category" => "pii",
+                "matched_text" => "4111111111111111",
+                "location" => {
+                  "start_index" => 0,
+                  "end_index_exclusive" => 26,
+                  "path" => "messages[0].content[0].text"
+                }
+              }
+            ]
           )
         end
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds `sds_findings` to `AIGuard::Evaluation::Result`, and adds SDS findings to the `ai_guard` metastruct tag.

**Motivation:**
The AI Guard evaluation API now returns sensitive data scanner results in `sds_findings` attribute.

**Change log entry**
Yes. AI Guard: Add `AIGuard::Evaluation::Result#sds_findings` method for getting matched Sensitive Data Scanner results.

**Additional Notes:**
[APPSEC-61446](https://datadoghq.atlassian.net/browse/APPSEC-61446)

**How to test the change?**
CI and manual testing with appsec-app-generator.


[APPSEC-61446]: https://datadoghq.atlassian.net/browse/APPSEC-61446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ