### PR TITLE
Add tag probabilities to AI Guard evaluation result

### DIFF
--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -37,6 +37,7 @@ module Datadog
                 messages: truncate_content(request.serialized_messages),
                 attack_categories: result.tags,
                 sds: result.sds_findings,
+                tag_probs: result.tag_probabilities
               }
             )
 

--- a/lib/datadog/ai_guard/evaluation/no_op_result.rb
+++ b/lib/datadog/ai_guard/evaluation/no_op_result.rb
@@ -5,13 +5,14 @@ module Datadog
     module Evaluation
       # Class for emulating AI Guard evaluation result when AI Guard is disabled.
       class NoOpResult
-        attr_reader :action, :reason, :tags, :sds_findings
+        attr_reader :action, :reason, :tags, :sds_findings, :tag_probabilities
 
         def initialize
           @action = Result::ALLOW_ACTION
           @reason = "AI Guard is disabled"
           @tags = []
           @sds_findings = []
+          @tag_probabilities = {}
         end
 
         def allow?

--- a/lib/datadog/ai_guard/evaluation/result.rb
+++ b/lib/datadog/ai_guard/evaluation/result.rb
@@ -9,7 +9,7 @@ module Datadog
         DENY_ACTION = "DENY"
         ABORT_ACTION = "ABORT"
 
-        attr_reader :action, :reason, :tags, :sds_findings
+        attr_reader :action, :reason, :tags, :sds_findings, :tag_probabilities
 
         def initialize(raw_response)
           attributes = raw_response.fetch("data").fetch("attributes")
@@ -17,6 +17,7 @@ module Datadog
           @action = attributes.fetch("action")
           @reason = attributes.fetch("reason")
           @tags = attributes.fetch("tags")
+          @tag_probabilities = attributes.fetch("tag_probs")
           @is_blocking_enabled = attributes.fetch("is_blocking_enabled")
           @sds_findings = attributes.fetch("sds_findings", [])
         rescue KeyError => e

--- a/sig/datadog/ai_guard/evaluation/no_op_result.rbs
+++ b/sig/datadog/ai_guard/evaluation/no_op_result.rbs
@@ -6,6 +6,7 @@ module Datadog
         attr_reader reason: ::String
         attr_reader tags: ::Array[::String]
         attr_reader sds_findings: ::Array[Result::sds_finding]
+        attr_reader tag_probabilities: ::Hash[::String, ::Float]
 
         def initialize: () -> void
 

--- a/sig/datadog/ai_guard/evaluation/result.rbs
+++ b/sig/datadog/ai_guard/evaluation/result.rbs
@@ -22,6 +22,7 @@ module Datadog
         }
 
         attr_reader sds_findings: ::Array[sds_finding]
+        attr_reader tag_probabilities: ::Hash[::String, ::Float]
 
         @is_blocking_enabled: bool
 

--- a/spec/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation_spec.rb
+++ b/spec/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "RubyLLM chat instrumentation" do
               "action" => "ALLOW",
               "reason" => "No rule matching",
               "tags" => [],
+              "tag_probs" => {},
               "is_blocking_enabled" => false
             }
           }
@@ -81,6 +82,7 @@ RSpec.describe "RubyLLM chat instrumentation" do
               "action" => "DENY",
               "reason" => "Rule matching: instruction-override",
               "tags" => ["instruction-override"],
+              "tag_probs" => {"instruction-override" => 0.95},
               "is_blocking_enabled" => false
             }
           }
@@ -112,6 +114,7 @@ RSpec.describe "RubyLLM chat instrumentation" do
               "action" => "DENY",
               "reason" => "Rule matching: instruction-override",
               "tags" => ["instruction-override"],
+              "tag_probs" => {"instruction-override" => 0.95},
               "is_blocking_enabled" => true
             }
           }
@@ -143,6 +146,7 @@ RSpec.describe "RubyLLM chat instrumentation" do
             "action" => "ALLOW",
             "reason" => "No rule matching",
             "tags" => [],
+            "tag_probs" => {},
             "is_blocking_enabled" => false
           }
         }

--- a/spec/datadog/ai_guard/evaluation/request_spec.rb
+++ b/spec/datadog/ai_guard/evaluation/request_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Datadog::AIGuard::Evaluation::Request do
             "action" => "ALLOW",
             "reason" => "Because why not",
             "tags" => [],
+            "tag_probs" => {},
             "is_blocking_enabled" => false
           }
         }

--- a/spec/datadog/ai_guard/evaluation/result_spec.rb
+++ b/spec/datadog/ai_guard/evaluation/result_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
           "action" => action,
           "reason" => "Some reason",
           "tags" => ["some", "tags"],
-          "is_blocking_enabled" => is_blocking_enabled,
           "sds_findings" => [
             {
               "rule_display_name" => "Credit Card Number",
@@ -43,7 +42,9 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
                 "path" => "messages[0].content[0].text"
               }
             }
-          ]
+          ],
+          "tag_probs" => {"some" => 0.95, "tags" => 0.1},
+          "is_blocking_enabled" => is_blocking_enabled
         }
       }
     }
@@ -85,6 +86,7 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
               "action" => action,
               "reason" => "Some reason",
               "tags" => ["some", "tags"],
+              "tag_probs" => {"some" => 0.95, "tags" => 0.1},
               "is_blocking_enabled" => is_blocking_enabled
             }
           }
@@ -94,6 +96,14 @@ RSpec.describe Datadog::AIGuard::Evaluation::Result do
       it "defaults to an empty array" do
         expect(described_class.new(raw_response).sds_findings).to eq([])
       end
+    end
+  end
+
+  describe "#tag_probabilities" do
+    it "returns the tag_probs from the response body" do
+      expect(described_class.new(raw_response).tag_probabilities).to eq(
+        raw_response.dig("data", "attributes", "tag_probs")
+      )
     end
   end
 

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Datadog::AIGuard::Evaluation do
             "action" => "ALLOW",
             "reason" => "Because why not",
             "tags" => [],
-            "is_blocking_enabled" => false,
-            "sds_findings" => []
+            "sds_findings" => [],
+            "tag_probs" => {},
+            "is_blocking_enabled" => false
           }
         }
       }
@@ -110,8 +111,9 @@ RSpec.describe Datadog::AIGuard::Evaluation do
               "action" => "ALLOW",
               "reason" => "Because why not",
               "tags" => [],
-              "is_blocking_enabled" => false,
-              "sds_findings" => []
+              "sds_findings" => [],
+              "tag_probs" => {},
+              "is_blocking_enabled" => false
             }
           }
         }
@@ -164,6 +166,12 @@ RSpec.describe Datadog::AIGuard::Evaluation do
 
         expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:sds)).to eq([])
       end
+
+      it "sets ai_guard metastruct tag with empty tag_probs" do
+        perform
+
+        expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:tag_probs)).to eq({})
+      end
     end
 
     %w[DENY ABORT].each do |blocking_action|
@@ -175,7 +183,6 @@ RSpec.describe Datadog::AIGuard::Evaluation do
                 "action" => blocking_action,
                 "reason" => "Rule matches: indirect-prompt-injection, instruction-override",
                 "tags" => ["indirect-prompt-injection", "instruction-override"],
-                "is_blocking_enabled" => blocking_enabled,
                 "sds_findings" => [
                   {
                     "rule_display_name" => "Credit Card Number",
@@ -188,7 +195,9 @@ RSpec.describe Datadog::AIGuard::Evaluation do
                       "path" => "messages[0].content[0].text"
                     }
                   }
-                ]
+                ],
+                "tag_probs" => {"indirect-prompt-injection" => 0.95, "instruction-override" => 0.87},
+                "is_blocking_enabled" => blocking_enabled
               }
             }
           }
@@ -260,6 +269,14 @@ RSpec.describe Datadog::AIGuard::Evaluation do
                 }
               }
             ]
+          )
+        end
+
+        it "sets ai_guard metastruct tag with tag_probs" do
+          perform
+
+          expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:tag_probs)).to eq(
+            {"indirect-prompt-injection" => 0.95, "instruction-override" => 0.87}
           )
         end
 

--- a/spec/datadog/ai_guard_spec.rb
+++ b/spec/datadog/ai_guard_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Datadog::AIGuard do
                 "action" => "ALLOW",
                 "reason" => "No rule match",
                 "tags" => [],
+                "tag_probs" => {},
                 "is_blocking_enabled" => false
               }
             }
@@ -122,6 +123,7 @@ RSpec.describe Datadog::AIGuard do
                 "action" => "DENY",
                 "reason" => "Rule match",
                 "tags" => ["indirect-prompt-injection"],
+                "tag_probs" => {"indirect-prompt-injection" => 0.95},
                 "is_blocking_enabled" => true
               }
             }


### PR DESCRIPTION
**What does this PR do?**
This PR adds `AIGuard::Evaluation::Result#tag_probabilities` attribute, exposing the `tag_probs` field from the AI Guard API response.

**Motivation:**
We want to add evaluation result tag probabilities to our SDK, and attach tag probabilities to metastruct.

**Change log entry**
Yes. AI Guard evaluation results now include tag probabilities from the API response.

**Additional Notes:**
[APPSEC-61897](https://datadoghq.atlassian.net/browse/APPSEC-61897)

**How to test the change?**
CI and manual testing


[APPSEC-61897]: https://datadoghq.atlassian.net/browse/APPSEC-61897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ