### PR TITLE
Add custom RuboCop cop for consistent exception logging format

### DIFF
--- a/.customcops.yml
+++ b/.customcops.yml
@@ -12,6 +12,14 @@ CustomCops/EnvUsageCop:
     - "lib/datadog/core/configuration/config_helper.rb"
     - "lib/datadog/core/configuration/deprecations.rb"
 
+# Custom cop to enforce consistent exception logging format
+CustomCops/ExceptionMessageCop:
+  Enabled: true
+  Description: 'Enforces consistent exception logging format: use `e` instead of `e.message`, `e.class` instead of `e.class.name`'
+  SafeAutoCorrect: false
+  Include:
+    - "lib/**/*"
+
 # Custom cop to validate environment variable strings
 CustomCops/EnvStringValidationCop:
   Enabled: true

--- a/lib/datadog/appsec/security_engine/runner.rb
+++ b/lib/datadog/appsec/security_engine/runner.rb
@@ -79,7 +79,7 @@ module Datadog
         def try_run(persistent_data, ephemeral_data, timeout)
           waf_context.run(persistent_data, ephemeral_data, timeout)
         rescue WAF::LibDDWAFError => e
-          Datadog.logger.debug { "#{@debug_tag} execution error: #{e} backtrace: #{e.backtrace&.first(3)}" }
+          Datadog.logger.debug { "#{@debug_tag} execution error: #{e.class}: #{e} backtrace: #{e.backtrace&.first(3)}" }
           AppSec.telemetry.report(e, description: 'libddwaf-rb internal low-level error')
 
           WAF::Result.new(

--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -18,7 +18,7 @@ module Datadog
         require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"
         nil
       rescue LoadError => e
-        e.message
+        "#{e.class}: #{e}"
       end
   end
 

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -52,7 +52,9 @@ module Datadog
             log_configuration!('CORE', data.to_json)
           end
         rescue => e
-          logger.warn("Failed to collect core environment information: #{e} Location: #{Array(e.backtrace).first}")
+          logger.warn(
+            "Failed to collect core environment information: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+          )
         end
       end
 

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -57,7 +57,7 @@ module Datadog
 
             contents = Configuration::ContentList.parse(response.target_files)
           rescue Remote::Configuration::Path::ParseError => e
-            raise SyncError, e.message
+            raise SyncError, "#{e.class}: #{e}"
           end
 
           # To make sure steep does not complain

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -63,7 +63,7 @@ module Datadog
           str.encode(::Encoding::UTF_8)
         end
       rescue => e
-        Datadog.logger.debug("Error encoding string in UTF-8: #{e}")
+        Datadog.logger.debug("Error encoding string in UTF-8: #{e.class}: #{e}")
 
         placeholder
       end

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -88,7 +88,7 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
           rescue => exc
             raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
@@ -106,7 +106,7 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
           end
 
           # Important: even if processing fails for this probe config,
@@ -121,7 +121,7 @@ module Datadog
           component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI remote receiver")
 
           # TODO assert content state (errored for this example)
-          content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
+          content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
         end
 
         # This method does not mark +previous_content+ as succeeded or errored,

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -88,7 +88,7 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class.name} #{exc.message}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
           rescue => exc
             raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
@@ -106,7 +106,7 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class.name} #{exc.message}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
           end
 
           # Important: even if processing fails for this probe config,
@@ -121,7 +121,7 @@ module Datadog
           component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI remote receiver")
 
           # TODO assert content state (errored for this example)
-          content.errored("Error applying dynamic instrumentation configuration: #{exc.class.name} #{exc.message}")
+          content.errored("Error applying dynamic instrumentation configuration: #{exc.class} #{exc}")
         end
 
         # This method does not mark +previous_content+ as succeeded or errored,

--- a/lib/datadog/open_feature/evaluation_engine.rb
+++ b/lib/datadog/open_feature/evaluation_engine.rb
@@ -42,7 +42,7 @@ module Datadog
         @telemetry.report(e, description: 'OpenFeature: Failed to fetch flag value')
 
         ResolutionDetails.build_error(
-          value: default_value, error_code: Ext::GENERAL, error_message: e.message
+          value: default_value, error_code: Ext::GENERAL, error_message: "#{e.class}: #{e}"
         )
       end
 
@@ -63,7 +63,7 @@ module Datadog
         @logger.error("#{message}, #{e.class}: #{e}")
         @telemetry.report(e, description: "#{message} (#{e.class})")
 
-        raise ReconfigurationError, e.message
+        raise ReconfigurationError, "#{e.class}: #{e}"
       end
     end
   end

--- a/lib/datadog/open_feature/provider.rb
+++ b/lib/datadog/open_feature/provider.rb
@@ -123,7 +123,7 @@ module Datadog
         ::OpenFeature::SDK::Provider::ResolutionDetails.new(
           value: default_value,
           error_code: Ext::GENERAL,
-          error_message: "#{e.class}: #{e.message}",
+          error_message: "#{e.class}: #{e}",
           reason: Ext::ERROR
         )
       end

--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -5,5 +5,5 @@ begin
 rescue LoadError => e
   raise LoadError,
     "Failed to load the profiling native extension. To fix this, please remove and then reinstall datadog " \
-    "(Details: #{e})"
+    "(Details: #{e.class}: #{e})"
 end

--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -5,5 +5,5 @@ begin
 rescue LoadError => e
   raise LoadError,
     "Failed to load the profiling native extension. To fix this, please remove and then reinstall datadog " \
-    "(Details: #{e.message})"
+    "(Details: #{e})"
 end

--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -121,7 +121,9 @@ module Datadog
                   result
                 # rubocop:disable Lint/RescueException
                 rescue Exception => e
-                  payload[:exception] = [e.class.name, e.message]
+                  # Rails ActiveSupport::Notifications convention — payload[:exception] is
+                  # an array of [class_name_string, message_string] consumed by subscribers.
+                  payload[:exception] = [e.class.name, e.message] # rubocop:disable CustomCops/ExceptionMessageCop
                   payload[:exception_object] = e
                   raise e
                 ensure

--- a/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/active_record/configuration/resolver.rb
@@ -76,7 +76,7 @@ module Datadog
               #
               Datadog.logger.error(
                 'Failed to resolve ActiveRecord database configuration. ' \
-                "Cause: #{e.class.name} Source: #{Array(e.backtrace).first}"
+                "Cause: #{e.class} Source: #{Array(e.backtrace).first}"
               )
               Core::Telemetry::Logger.report(e, description: 'Failed to resolve ActiveRecord database configuration')
 
@@ -96,7 +96,7 @@ module Datadog
             rescue => e
               Datadog.logger.error(
                 "Failed to resolve key #{matcher.inspect}. " \
-                "Cause: #{e.class.name} Source: #{Array(e.backtrace).first}"
+                "Cause: #{e.class} Source: #{Array(e.backtrace).first}"
               )
               Core::Telemetry::Logger.report(e, description: 'Failed to resolve key')
 

--- a/lib/datadog/tracing/contrib/component.rb
+++ b/lib/datadog/tracing/contrib/component.rb
@@ -20,7 +20,7 @@ module Datadog
             @registry.each do |name, callback|
               callback.call(config)
             rescue => e
-              Datadog.logger.warn("Error configuring integration #{name}: #{e}")
+              Datadog.logger.warn("Error configuring integration #{name}: #{e.class}: #{e}")
             end
           end
 

--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -16,7 +16,7 @@ module Datadog
             command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
             Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
           rescue => e
-            Datadog.logger.debug("Error sanitizing Dalli operation: #{e}")
+            Datadog.logger.debug("Error sanitizing Dalli operation: #{e.class}: #{e}")
             placeholder
           end
         end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -90,7 +90,7 @@ module Datadog
               end
               Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue => e
-              Datadog.logger.debug("GRPC client trace failed: #{e}")
+              Datadog.logger.debug("GRPC client trace failed: #{e.class}: #{e}")
             end
 
             def find_deadline(call)
@@ -112,7 +112,7 @@ module Datadog
 
               Core::Utils.extract_host_port(peer_address)
             rescue => e
-              Datadog.logger.debug { "Could not parse host:port from #{call}: #{e}" }
+              Datadog.logger.debug { "Could not parse host:port from #{call}: #{e.class}: #{e}" }
               nil
             end
           end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
@@ -54,7 +54,7 @@ module Datadog
               Tracing.continue_trace!(GRPC.extract(metadata))
             rescue => e
               Datadog.logger.debug(
-                "unable to propagate GRPC metadata to context: #{e}"
+                "unable to propagate GRPC metadata to context: #{e.class}: #{e}"
               )
             end
 
@@ -86,7 +86,7 @@ module Datadog
               # Measure service stats
               Contrib::Analytics.set_measured(span)
             rescue => e
-              Datadog.logger.debug("GRPC server trace failed: #{e}")
+              Datadog.logger.debug("GRPC server trace failed: #{e.class}: #{e}")
             end
           end
         end

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -93,7 +93,7 @@ module Datadog
 
               Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue => e
-              Datadog.logger.error("error preparing span from http request: #{e}")
+              Datadog.logger.error("error preparing span from http request: #{e.class}: #{e}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -108,7 +108,7 @@ module Datadog
                 Datadog.configuration.tracing.header_tags.response_tags(response)
               )
             rescue => e
-              Datadog.logger.error("error preparing span from http response: #{e}")
+              Datadog.logger.error("error preparing span from http response: #{e.class}: #{e}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -41,7 +41,9 @@ module Datadog
                   # Add additional request specific tags to the span.
                   annotate_span_with_request!(span, req, request_options)
                 rescue => e
-                  Datadog.logger.error("error preparing span for httpclient request: #{e}, Source: #{e.backtrace}")
+                  Datadog.logger.error(
+                    "error preparing span for httpclient request: #{e.class}: #{e}, Source: #{e.backtrace}"
+                  )
                   Datadog::Core::Telemetry::Logger.report(e)
                 ensure
                   res = super
@@ -107,7 +109,9 @@ module Datadog
                 Datadog.configuration.tracing.header_tags.response_tags(response.header)
               )
             rescue => e
-              Datadog.logger.error("error preparing span from httpclient response: #{e}, Source: #{e.backtrace}")
+              Datadog.logger.error(
+                "error preparing span from httpclient response: #{e.class}: #{e}, Source: #{e.backtrace}"
+              )
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -41,7 +41,7 @@ module Datadog
                   # Add additional request specific tags to the span.
                   annotate_span_with_request!(span, req, request_options)
                 rescue => e
-                  logger.error("error preparing span for http.rb request: #{e}, Source: #{e.backtrace}")
+                  logger.error("error preparing span for http.rb request: #{e.class}: #{e}, Source: #{e.backtrace}")
                   Datadog::Core::Telemetry::Logger.report(e)
                 ensure
                   res = super(req, options)
@@ -117,7 +117,7 @@ module Datadog
                 Datadog.configuration.tracing.header_tags.response_tags(response.headers)
               )
             rescue => e
-              logger.error("error preparing span from http.rb response: #{e}, Source: #{e.backtrace}")
+              logger.error("error preparing span from http.rb response: #{e.class}: #{e}, Source: #{e.backtrace}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -73,7 +73,7 @@ module Datadog
             # set the resource with the quantized query
             span.resource = serialized_query
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'started' event: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'started' event: #{e.class}: #{e}")
           end
           # rubocop:enable Metrics/AbcSize
 
@@ -85,7 +85,7 @@ module Datadog
             # the framework itself, so we set only the error and the message
             span.set_error(event)
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'failed' event: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'failed' event: #{e.class}: #{e}")
           ensure
             # whatever happens, the Span must be removed from the local storage and
             # it must be finished to prevent any leak
@@ -101,7 +101,7 @@ module Datadog
             rows = event.reply.fetch('n', nil)
             span.set_tag(Ext::TAG_ROWS, rows) unless rows.nil?
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'succeeded' event: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'succeeded' event: #{e.class}: #{e}")
           ensure
             # whatever happens, the Span must be removed from the local storage and
             # it must be finished to prevent any leak

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -28,7 +28,7 @@ module Datadog
                     span.type = Tracing::Metadata::Ext::SQL::TYPE
                     span.set_tag(Ext::TAG_QUERY_ASYNC, false)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
                   end
 
                   super(query)
@@ -46,7 +46,7 @@ module Datadog
                     span.type = Tracing::Metadata::Ext::SQL::TYPE
                     span.set_tag(Ext::TAG_QUERY_ASYNC, !blk.nil?)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
                   end
 
                   super(query, &blk)
@@ -65,7 +65,7 @@ module Datadog
                     # ^ not an SQL type span, since there's no SQL query
                     span.set_tag(Ext::TAG_QUERY_ID, query_id)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
                   end
 
                   super(query_id)

--- a/lib/datadog/tracing/contrib/rack/patcher.rb
+++ b/lib/datadog/tracing/contrib/rack/patcher.rb
@@ -41,7 +41,7 @@ module Datadog
             # context of middleware patching outside a Rails server process (eg. a
             # process that doesn't serve HTTP requests but has Rails environment
             # loaded such as a Resque master process)
-            Datadog.logger.debug("Error patching middleware stack: #{e}")
+            Datadog.logger.debug("Error patching middleware stack: #{e.class}: #{e}")
           end
 
           def retain_middleware_name(middleware)

--- a/lib/datadog/tracing/contrib/rack/request_queue.rb
+++ b/lib/datadog/tracing/contrib/rack/request_queue.rb
@@ -39,7 +39,7 @@ module Datadog
           rescue => e
             # in case of an Exception we don't create a
             # `request.queuing` span
-            Datadog.logger.debug("[rack] unable to parse request queue headers: #{e}")
+            Datadog.logger.debug("[rack] unable to parse request queue headers: #{e.class}: #{e}")
             nil
           end
         end

--- a/lib/datadog/tracing/contrib/redis/quantize.rb
+++ b/lib/datadog/tracing/contrib/redis/quantize.rb
@@ -34,7 +34,7 @@ module Datadog
             str = Core::Utils.utf8_encode(arg, binary: true, placeholder: PLACEHOLDER)
             Core::Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
           rescue => e
-            Datadog.logger.debug("non formattable Redis arg #{str}: #{e}")
+            Datadog.logger.debug("non formattable Redis arg #{str}: #{e.class}: #{e}")
             PLACEHOLDER
           end
 

--- a/lib/datadog/tracing/contrib/sidekiq/utils.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/utils.rb
@@ -25,7 +25,7 @@ module Datadog
               job['class'].to_s
             end
           rescue => e
-            Datadog.logger.debug { "Error retrieving Sidekiq job class name (jid:#{job["jid"]}): #{e}" }
+            Datadog.logger.debug { "Error retrieving Sidekiq job class name (jid:#{job["jid"]}): #{e.class}: #{e}" }
 
             job['class'].to_s
           end

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -24,7 +24,9 @@ module Datadog
             end
           end
         rescue => e
-          logger.warn("Failed to collect tracing environment information: #{e} Location: #{Array(e.backtrace).first}")
+          logger.warn(
+            "Failed to collect tracing environment information: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+          )
         end
       end
 

--- a/lib/datadog/tracing/distributed/datadog_tags_codec.rb
+++ b/lib/datadog/tracing/distributed/datadog_tags_codec.rb
@@ -41,7 +41,7 @@ module Datadog
             "#{key}=#{value.strip}"
           end.join(',')
         rescue => e
-          raise EncodingError, "Error encoding tags `#{tags}`: `#{e}`"
+          raise EncodingError, "Error encoding tags `#{tags}`: `#{e.class}: #{e}`"
         end
 
         # Deserializes a `x-datadog-tags`-formatted String into a {Hash<String,String>}.

--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -76,7 +76,7 @@ module Datadog
           rescue => e
             result = nil
             ::Datadog.logger.error(
-              "Error injecting distributed trace data. Cause: #{e} Location: #{Array(e.backtrace).first}"
+              "Error injecting distributed trace data. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
             )
             ::Datadog::Core::Telemetry::Logger.report(
               e,
@@ -139,7 +139,7 @@ module Datadog
           rescue => e
             # TODO: Not to report Telemetry logs for now
             ::Datadog.logger.error(
-              "Error extracting distributed trace data. Cause: #{e} Location: #{Array(e.backtrace).first}"
+              "Error extracting distributed trace data. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
             )
           end
           # Handle baggage after all other styles if present

--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -52,7 +52,7 @@ module Datadog
             meta[Core::Utils.utf8_encode(key)] = Core::Utils.utf8_encode(value)
           end
         rescue => e
-          Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e}")
+          Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e.class}: #{e}")
         end
 
         # Sets tags from given hash, for each key in hash it sets the tag with that key
@@ -102,7 +102,7 @@ module Datadog
           # Encode strings in UTF-8 to facilitate downstream serialization
           metrics[Core::Utils.utf8_encode(key)] = value
         rescue => e
-          Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e}")
+          Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e.class}: #{e}")
         end
 
         # This method removes a metric for the given key. It acts like {#clear_tag}.

--- a/lib/datadog/tracing/pipeline.rb
+++ b/lib/datadog/tracing/pipeline.rb
@@ -51,7 +51,7 @@ module Datadog
         end
       rescue => e
         Datadog.logger.debug(
-          "trace dropped entirely due to `Pipeline.before_flush` error: #{e}"
+          "trace dropped entirely due to `Pipeline.before_flush` error: #{e.class}: #{e}"
         )
 
         nil

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -61,7 +61,7 @@ module Datadog
                 rescue => e
                   Datadog.logger.warn(
                     "Cannot parse Span Sampling Rule #{hash.inspect}: " \
-                    "#{e.class.name} #{e} at #{Array(e.backtrace).first}"
+                    "#{e.class} #{e} at #{Array(e.backtrace).first}"
                   )
                   return nil
                 end

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -61,7 +61,7 @@ module Datadog
                 rescue => e
                   Datadog.logger.warn(
                     "Cannot parse Span Sampling Rule #{hash.inspect}: " \
-                    "#{e.class} #{e} at #{Array(e.backtrace).first}"
+                    "#{e.class}: #{e} at #{Array(e.backtrace).first}"
                   )
                   return nil
                 end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -158,7 +158,7 @@ module Datadog
           begin
             start
           rescue => e
-            logger.debug { "Failed to start span: #{e}" }
+            logger.debug { "Failed to start span: #{e.class}: #{e}" }
           ensure
             # We should yield to the provided block when possible, as this
             # block is application code that we don't want to hinder.

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -181,7 +181,7 @@ module Datadog
 
         events.trace_resource_change.publish(self)
       rescue => e
-        logger.debug { "Error updating trace resource: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error updating trace resource: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       def name
@@ -322,7 +322,7 @@ module Datadog
           id: id
         )
       rescue => e
-        logger.debug { "Failed to build new span: #{e}" }
+        logger.debug { "Failed to build new span: #{e.class}: #{e}" }
 
         # Return dummy span
         SpanOperation.new(op_name, logger: logger)
@@ -543,7 +543,7 @@ module Datadog
         # Publish :span_before_start event
         events.span_before_start.publish(span_op, self)
       rescue => e
-        logger.debug { "Error starting span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error starting span on trace: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       # For traces with automatic context management (auto_finish),
@@ -572,7 +572,7 @@ module Datadog
         # Publish :trace_finished event
         events.trace_finished.publish(self) if finished?
       rescue => e
-        logger.debug { "Error finishing span on trace: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error finishing span on trace: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       # Track the root {SpanOperation} object from the current execution context.

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -303,7 +303,7 @@ module Datadog
         @sampler.sample!(trace_op) if trace_op.sampling_priority.nil?
       rescue => e
         SAMPLE_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample trace: #{e.class} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample trace: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -315,7 +315,7 @@ module Datadog
       rescue => e
         RECONSIDER_RESOURCE_SAMPLE_TRACE_LOG_ONLY_ONCE.run do
           logger.warn do
-            "Failed to reconsider trace sampling: #{e.class} #{e} at #{Array(e.backtrace).first}"
+            "Failed to reconsider trace sampling: #{e.class}: #{e} at #{Array(e.backtrace).first}"
           end
         end
       end
@@ -563,7 +563,7 @@ module Datadog
         @span_sampler.sample!(trace_op, span)
       rescue => e
         SAMPLE_SPAN_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample span: #{e.class} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample span: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -576,7 +576,7 @@ module Datadog
         write(trace) if trace && !trace.empty?
       rescue => e
         FLUSH_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to flush trace: #{e.class} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to flush trace: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
         end
       end
 

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -153,7 +153,7 @@ module Datadog
             active_trace
           end
         rescue => e
-          logger.debug { "Failed to trace: #{e}" }
+          logger.debug { "Failed to trace: #{e.class}: #{e}" }
 
           # Tracing failed: fallback and run code without tracing.
           return skip_trace(name, &block)

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -303,7 +303,7 @@ module Datadog
         @sampler.sample!(trace_op) if trace_op.sampling_priority.nil?
       rescue => e
         SAMPLE_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample trace: #{e.class.name} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample trace: #{e.class} #{e} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -315,7 +315,7 @@ module Datadog
       rescue => e
         RECONSIDER_RESOURCE_SAMPLE_TRACE_LOG_ONLY_ONCE.run do
           logger.warn do
-            "Failed to reconsider trace sampling: #{e.class.name} #{e} at #{Array(e.backtrace).first}"
+            "Failed to reconsider trace sampling: #{e.class} #{e} at #{Array(e.backtrace).first}"
           end
         end
       end
@@ -563,7 +563,7 @@ module Datadog
         @span_sampler.sample!(trace_op, span)
       rescue => e
         SAMPLE_SPAN_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample span: #{e.class.name} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample span: #{e.class} #{e} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -576,7 +576,7 @@ module Datadog
         write(trace) if trace && !trace.empty?
       rescue => e
         FLUSH_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to flush trace: #{e.class.name} #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to flush trace: #{e.class} #{e} at #{Array(e.backtrace).first}" }
         end
       end
 

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -58,7 +58,8 @@ module Datadog
             # TODO[manu]: findout the reason and reschedule the send if it's not
             # a fatal exception
             logger.warn(
-              "Error during traces flush: dropped #{traces.length} items. Cause: #{e} Location: #{Array(e.backtrace).first}"
+              "Error during traces flush: dropped #{traces.length} items. " \
+              "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
             )
           end
         end

--- a/rubocop/custom_cops.rb
+++ b/rubocop/custom_cops.rb
@@ -3,3 +3,4 @@
 # Load all custom RuboCop cops
 require_relative 'custom_cops/env_usage_cop'
 require_relative 'custom_cops/env_string_validation_cop'
+require_relative 'custom_cops/exception_message_cop'

--- a/rubocop/custom_cops/README.md
+++ b/rubocop/custom_cops/README.md
@@ -149,7 +149,7 @@ The `CustomCops::ExceptionMessageCop` enforces consistent exception logging form
 
 ### Purpose
 
-`Exception#to_s` and `Exception#message` have different contracts in Ruby. Subclasses can override them independently, and `to_s` is the method Ruby calls during string interpolation (`"#{e}"`). Using `e.message` directly can produce different output than `#{e}` when a subclass overrides one without the other. The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by detecting `e.message` and `e.class.name` inside rescue blocks and auto-correcting within string interpolation.
+`Exception#to_s` and `Exception#message` have different contracts in Ruby. Subclasses can override them independently, and `to_s` is the method Ruby calls during string interpolation (`"#{e}"`). Using `e.message` directly can produce different output than `#{e}` when a subclass overrides one without the other. The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by detecting `e.message`, `e.class.name`, and bare `#{e}` without `#{e.class}` inside rescue blocks.
 
 ### Examples
 
@@ -160,6 +160,7 @@ rescue => e
   log("#{e.class.name}: #{e.message}")
   log("#{e.class.name} #{e.message}")
   log("error: #{e.message}")
+  log("error: #{e}")           # missing class name
 ```
 
 #### Good
@@ -167,7 +168,6 @@ rescue => e
 ```ruby
 rescue => e
   log("#{e.class}: #{e}")
-  log("error: #{e}")
 ```
 
 ### Auto-correction

--- a/rubocop/custom_cops/README.md
+++ b/rubocop/custom_cops/README.md
@@ -142,3 +142,47 @@ logger.debug("Processing DD_CUSTOM_METRIC_NAME") # rubocop:disable CustomCops/En
 ### Additional information
 
 See docs/AccessEnvironmentVariables.md for details.
+
+## ExceptionMessageCop
+
+The `CustomCops::ExceptionMessageCop` enforces consistent exception logging format.
+
+### Purpose
+
+In string interpolation, `e.message` is redundant because `e.to_s` (called implicitly by interpolation) returns the same value. Similarly, `e.class.name` is redundant because `e.class.to_s` returns the class name. This cop detects these patterns inside rescue blocks and auto-corrects them within string interpolation.
+
+### Examples
+
+#### Bad
+
+```ruby
+rescue => e
+  log("#{e.class.name}: #{e.message}")
+  log("#{e.class.name} #{e.message}")
+  log("error: #{e.message}")
+```
+
+#### Good
+
+```ruby
+rescue => e
+  log("#{e.class}: #{e}")
+  log("error: #{e}")
+```
+
+### Auto-correction
+
+The cop auto-corrects within string interpolation only:
+
+- `#{e.message}` → `#{e}`
+- `#{e.class.name}` → `#{e.class}`
+
+Outside interpolation (e.g., `log(e.message)`), the cop flags the offense but does not auto-correct, since the replacement may change semantics.
+
+### Testing
+
+Run the cop tests with:
+
+```bash
+bundle exec rspec spec/rubocop/exception_message_cop_spec.rb
+```

--- a/rubocop/custom_cops/README.md
+++ b/rubocop/custom_cops/README.md
@@ -149,7 +149,7 @@ The `CustomCops::ExceptionMessageCop` enforces consistent exception logging form
 
 ### Purpose
 
-In string interpolation, `e.message` is redundant because `e.to_s` (called implicitly by interpolation) returns the same value. Similarly, `e.class.name` is redundant because `e.class.to_s` returns the class name. This cop detects these patterns inside rescue blocks and auto-corrects them within string interpolation.
+`Exception#to_s` and `Exception#message` have different contracts in Ruby. Subclasses can override them independently, and `to_s` is the method Ruby calls during string interpolation (`"#{e}"`). Using `e.message` directly can produce different output than `#{e}` when a subclass overrides one without the other. The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by detecting `e.message` and `e.class.name` inside rescue blocks and auto-correcting within string interpolation.
 
 ### Examples
 

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -127,8 +127,45 @@ module CustomCops
       rescue_node = find_rescue_ancestor(node)
       return false unless rescue_node
 
+      # The lvar is bound to the rescue variable only if no enclosing scope
+      # between this node and the rescue shadows it. A block parameter with
+      # the same name (e.g. `rescue => e; xs.each { |e| ... }`) creates a
+      # new binding for that name. A `def` boundary is a hard scope barrier:
+      # the rescue variable is not visible inside it at all.
+      current = node.parent
+      while current && !current.equal?(rescue_node)
+        case current.type
+        when :def, :defs
+          return false
+        when :block
+          return false if block_args_include?(current, var_name)
+        end
+        current = current.parent
+      end
+
       rescue_node.resbody_branches.any? do |resbody|
         resbody.exception_variable&.name == var_name
+      end
+    end
+
+    # Whether a block node's argument list binds the given name (handles
+    # destructuring like `|(k, v)|` and all arg flavors)
+    def block_args_include?(block_node, var_name)
+      args = block_node.arguments
+      return false unless args
+      collect_arg_names(args).include?(var_name)
+    end
+
+    def collect_arg_names(node)
+      return [] unless node.respond_to?(:type)
+      case node.type
+      when :arg, :optarg, :restarg, :kwarg, :kwoptarg, :kwrestarg, :blockarg, :shadowarg
+        name = node.children.first
+        name ? [name] : []
+      when :args, :mlhs
+        node.children.flat_map { |c| collect_arg_names(c) }
+      else
+        []
       end
     end
 

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -3,16 +3,19 @@
 module CustomCops
   # Custom cop that enforces consistent exception logging format.
   #
-  # In string interpolation, `e.message` is redundant because `e.to_s` (which
-  # interpolation calls) returns the same value. Similarly, `e.class.name` is
-  # redundant because `e.class.to_s` returns the class name.
+  # `Exception#to_s` and `Exception#message` have different contracts in Ruby.
+  # Subclasses can override them independently, and `to_s` is the method Ruby
+  # calls during string interpolation (`"#{e}"`). Using `e.message` directly
+  # can produce different output than `#{e}` when a subclass overrides one
+  # without the other.
   #
-  # This cop detects these patterns inside rescue blocks and auto-corrects them.
+  # The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by
+  # detecting `e.message` and `e.class.name` inside rescue blocks.
   #
   # @safety
   #   This cop's autocorrection is unsafe because `e.message` and `e.to_s`
   #   can differ if a custom exception overrides `to_s` without overriding
-  #   `message`, or vice versa.
+  #   `message`, or vice versa. The convention prefers `to_s` (via interpolation).
   #
   # @example
   #   # bad
@@ -29,10 +32,10 @@ module CustomCops
     extend RuboCop::Cop::AutoCorrector
 
     MSG_MESSAGE = 'Use the exception directly instead of `.message`. ' \
-                  'In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.'
+                  '`to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.'
 
     MSG_CLASS_NAME = 'Use `.class` instead of `.class.name`. ' \
-                     'In string interpolation, `e.class.to_s` (called implicitly) returns the class name.'
+                     '`Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.'
 
     # Detect `e.message` where `e` is a rescue variable
     # @!method on_send

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -31,6 +31,7 @@ module CustomCops
   class ExceptionMessageCop < RuboCop::Cop::Base
     extend RuboCop::Cop::AutoCorrector
 
+    # rubocop:disable Lint/InterpolationCheck
     MSG_MESSAGE = 'Use the exception directly instead of `.message`. ' \
                   '`to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.'
 
@@ -39,6 +40,7 @@ module CustomCops
 
     MSG_MISSING_CLASS = 'Include `#{e.class}` when interpolating an exception. ' \
                         'The convention is `"#{e.class}: #{e}"`.'
+    # rubocop:enable Lint/InterpolationCheck
 
     # Detect bare `#{e}` without `#{e.class}` in the same string
     def on_dstr(node)

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -156,7 +156,7 @@ module CustomCops
 
       # e.class.name
       if node.method_name == :name && node.receiver&.send_type? &&
-         node.receiver.method_name == :class && node.receiver.receiver&.lvar_type?
+          node.receiver.method_name == :class && node.receiver.receiver&.lvar_type?
         return rescue_variable?(node.receiver.receiver)
       end
 

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -23,11 +23,11 @@ module CustomCops
   #     log("#{e.class.name}: #{e.message}")
   #     log("#{e.class.name} #{e.message}")
   #     log("error: #{e.message}")
+  #     log("error: #{e}")           # missing class name
   #
   #   # good
   #   rescue => e
   #     log("#{e.class}: #{e}")
-  #     log("error: #{e}")
   class ExceptionMessageCop < RuboCop::Cop::Base
     extend RuboCop::Cop::AutoCorrector
 
@@ -37,7 +37,39 @@ module CustomCops
     MSG_CLASS_NAME = 'Use `.class` instead of `.class.name`. ' \
                      '`Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.'
 
-    # Detect `e.message` where `e` is a rescue variable
+    MSG_MISSING_CLASS = 'Include `#{e.class}` when interpolating an exception. ' \
+                        'The convention is `"#{e.class}: #{e}"`.'
+
+    # Detect bare `#{e}` without `#{e.class}` in the same string
+    def on_dstr(node)
+      return unless inside_rescue?(node)
+
+      rescue_vars_in_string = []
+      has_class_call = {}
+
+      node.children.each do |child|
+        next unless child.begin_type?
+
+        expr = child.children.first
+        next unless expr
+
+        if expr.lvar_type? && rescue_variable?(expr)
+          rescue_vars_in_string << expr
+        elsif class_reference?(expr)
+          var_node = class_reference_variable(expr)
+          has_class_call[var_node.children.first] = true if var_node
+        end
+      end
+
+      rescue_vars_in_string.each do |var_node|
+        var_name = var_node.children.first
+        next if has_class_call[var_name]
+
+        add_offense(var_node, message: MSG_MISSING_CLASS)
+      end
+    end
+
+    # Detect `e.message` and `e.class.name` where `e` is a rescue variable
     # @!method on_send
     def on_send(node)
       return unless inside_rescue?(node)
@@ -111,6 +143,33 @@ module CustomCops
     # Check if the node is inside a rescue block
     def inside_rescue?(node)
       find_rescue_ancestor(node) != nil
+    end
+
+    # Check if an expression references e.class (either e.class or e.class.name)
+    def class_reference?(node)
+      return false unless node&.send_type?
+
+      # e.class
+      if node.method_name == :class && node.receiver&.lvar_type?
+        return rescue_variable?(node.receiver)
+      end
+
+      # e.class.name
+      if node.method_name == :name && node.receiver&.send_type? &&
+         node.receiver.method_name == :class && node.receiver.receiver&.lvar_type?
+        return rescue_variable?(node.receiver.receiver)
+      end
+
+      false
+    end
+
+    # Extract the rescue variable node from a class reference
+    def class_reference_variable(node)
+      if node.method_name == :class
+        node.receiver
+      elsif node.method_name == :name
+        node.receiver.receiver
+      end
     end
 
     # Check if the node is inside string interpolation (dstr > begin > node)

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module CustomCops
+  # Custom cop that enforces consistent exception logging format.
+  #
+  # In string interpolation, `e.message` is redundant because `e.to_s` (which
+  # interpolation calls) returns the same value. Similarly, `e.class.name` is
+  # redundant because `e.class.to_s` returns the class name.
+  #
+  # This cop detects these patterns inside rescue blocks and auto-corrects them.
+  #
+  # @safety
+  #   This cop's autocorrection is unsafe because `e.message` and `e.to_s`
+  #   can differ if a custom exception overrides `to_s` without overriding
+  #   `message`, or vice versa.
+  #
+  # @example
+  #   # bad
+  #   rescue => e
+  #     log("#{e.class.name}: #{e.message}")
+  #     log("#{e.class.name} #{e.message}")
+  #     log("error: #{e.message}")
+  #
+  #   # good
+  #   rescue => e
+  #     log("#{e.class}: #{e}")
+  #     log("error: #{e}")
+  class ExceptionMessageCop < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+
+    MSG_MESSAGE = 'Use the exception directly instead of `.message`. ' \
+                  'In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.'
+
+    MSG_CLASS_NAME = 'Use `.class` instead of `.class.name`. ' \
+                     'In string interpolation, `e.class.to_s` (called implicitly) returns the class name.'
+
+    # Detect `e.message` where `e` is a rescue variable
+    # @!method on_send
+    def on_send(node)
+      return unless inside_rescue?(node)
+
+      if exception_message_call?(node)
+        variable = node.receiver
+        return unless rescue_variable?(variable)
+
+        add_offense(node, message: MSG_MESSAGE) do |corrector|
+          if inside_interpolation?(node)
+            corrector.replace(node, variable.source)
+          end
+        end
+      elsif exception_class_name_call?(node)
+        class_call = node.receiver
+        variable = class_call.receiver
+        return unless rescue_variable?(variable)
+
+        add_offense(node, message: MSG_CLASS_NAME) do |corrector|
+          if inside_interpolation?(node)
+            corrector.replace(node, class_call.source)
+          end
+        end
+      end
+    end
+
+    private
+
+    # Check if this is `e.message`
+    def exception_message_call?(node)
+      node.send_type? &&
+        node.method_name == :message &&
+        node.arguments.empty? &&
+        node.receiver&.lvar_type?
+    end
+
+    # Check if this is `e.class.name`
+    def exception_class_name_call?(node)
+      node.send_type? &&
+        node.method_name == :name &&
+        node.arguments.empty? &&
+        node.receiver&.send_type? &&
+        node.receiver.method_name == :class &&
+        node.receiver.arguments.empty? &&
+        node.receiver.receiver&.lvar_type?
+    end
+
+    # Check if a variable node is bound by a rescue clause
+    def rescue_variable?(node)
+      return false unless node.lvar_type?
+
+      var_name = node.children.first
+      rescue_node = find_rescue_ancestor(node)
+      return false unless rescue_node
+
+      rescue_node.resbody_branches.any? do |resbody|
+        resbody.exception_variable&.name == var_name
+      end
+    end
+
+    # Walk up to find the enclosing rescue node
+    def find_rescue_ancestor(node)
+      current = node.parent
+      while current
+        return current if current.rescue_type?
+        current = current.parent
+      end
+      nil
+    end
+
+    # Check if the node is inside a rescue block
+    def inside_rescue?(node)
+      find_rescue_ancestor(node) != nil
+    end
+
+    # Check if the node is inside string interpolation (dstr > begin > node)
+    def inside_interpolation?(node)
+      parent = node.parent
+      return false unless parent
+
+      # Direct interpolation: #{e.message}
+      if parent.begin_type? && parent.parent&.dstr_type?
+        return true
+      end
+
+      false
+    end
+  end
+end

--- a/spec/datadog/open_feature/evaluation_engine_spec.rb
+++ b/spec/datadog/open_feature/evaluation_engine_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
 
         expect(result.value).to eq('fallback')
         expect(result.error_code).to eq('GENERAL')
-        expect(result.error_message).to eq('Crash')
+        expect(result.error_message).to eq('RuntimeError: Crash')
         expect(result.reason).to eq('ERROR')
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
         expect(telemetry).to receive(:report)
           .with(error, description: match(/OpenFeature: Failed to reconfigure/))
 
-        expect { engine.reconfigure!('{}') }.to raise_error(described_class::ReconfigurationError, 'Ooops')
+        expect { engine.reconfigure!('{}') }.to raise_error(described_class::ReconfigurationError, 'StandardError: Ooops')
       end
     end
   end

--- a/spec/datadog/tracing/distributed/propagation_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_spec.rb
@@ -322,7 +322,7 @@ RSpec.shared_examples 'Distributed tracing propagator' do
 
               it 'does not propagate error to caller' do
                 trace_digest
-                expect(Datadog.logger).to have_received(:error).with(/Cause: test_err Location: caller:1/)
+                expect(Datadog.logger).to have_received(:error).with(/Cause: StandardError: test_err Location: caller:1/)
               end
 
               it 'extracts values from non-failing propagator (tracecontext)' do

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'rubocop/custom_cops/exception_message_cop'
+
+RSpec.describe CustomCops::ExceptionMessageCop do
+  subject(:cop) { described_class.new }
+
+  describe 'e.message detection' do
+    it 'registers an offense for e.message in string interpolation and auto-corrects' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.message}")
+               ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e}")
+        end
+      RUBY
+    end
+
+    it 'registers an offense for e.message in a longer interpolated string and auto-corrects' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("error: \#{e.class}: \#{e.message}")
+                                   ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("error: \#{e.class}: \#{e}")
+        end
+      RUBY
+    end
+
+    it 'registers an offense for e.message outside interpolation but does not auto-correct' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log(e.message)
+              ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense outside a rescue block' do
+      expect_no_offenses(<<~RUBY)
+        e = SomeObject.new
+        log(e.message)
+      RUBY
+    end
+
+    it 'does not register an offense for message with arguments' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log(e.message(:detailed))
+        end
+      RUBY
+    end
+  end
+
+  describe 'e.class.name detection' do
+    it 'registers an offense for e.class.name in string interpolation and auto-corrects' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.class.name}: \#{e}")
+               ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.class}: \#{e}")
+        end
+      RUBY
+    end
+
+    it 'registers an offense for e.class.name outside interpolation but does not auto-correct' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log(e.class.name)
+              ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'does not register an offense outside a rescue block' do
+      expect_no_offenses(<<~RUBY)
+        e = SomeObject.new
+        log(e.class.name)
+      RUBY
+    end
+  end
+
+  describe 'combined patterns' do
+    it 'registers offenses for both e.class.name and e.message in one string' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.class.name} \#{e.message}")
+                                ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+               ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.class} \#{e}")
+        end
+      RUBY
+    end
+  end
+
+  describe 'inline rescue' do
+    it 'does not register an offense for inline rescue (no rescue variable)' do
+      expect_no_offenses(<<~RUBY)
+        result = something rescue nil
+      RUBY
+    end
+  end
+
+  describe 'different rescue variable names' do
+    it 'registers an offense when the rescue variable is named differently' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => err
+          log("\#{err.message}")
+               ^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => err
+          log("\#{err}")
+        end
+      RUBY
+    end
+
+    it 'registers an offense for err.class.name' do
+      expect_offense(<<~RUBY)
+        begin
+          something
+        rescue => err
+          log("\#{err.class.name}")
+               ^^^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        begin
+          something
+        rescue => err
+          log("\#{err.class}")
+        end
+      RUBY
+    end
+  end
+
+  describe 'good patterns (no offense)' do
+    it 'does not flag e.class (already correct)' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e.class}: \#{e}")
+        end
+      RUBY
+    end
+
+    it 'does not flag e directly in interpolation' do
+      expect_no_offenses(<<~RUBY)
+        begin
+          something
+        rescue => e
+          log("\#{e}")
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -11,50 +11,50 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'e.message detection' do
     it 'registers an offense for e.message in string interpolation and auto-corrects' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.message}")
-               ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+          log("#{e.message}")
+                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e}")
+          log("#{e}")
         end
       RUBY
     end
 
     it 'registers an offense for e.message in a longer interpolated string and auto-corrects' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("error: \#{e.class}: \#{e.message}")
-                                   ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+          log("error: #{e.class}: #{e.message}")
+                                    ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => e
-          log("error: \#{e.class}: \#{e}")
+          log("error: #{e.class}: #{e}")
         end
       RUBY
     end
 
     it 'registers an offense for e.message outside interpolation but does not auto-correct' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
           log(e.message)
-              ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+              ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
         end
       RUBY
 
@@ -62,14 +62,14 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
 
     it 'does not register an offense outside a rescue block' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         e = SomeObject.new
         log(e.message)
       RUBY
     end
 
     it 'does not register an offense for message with arguments' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
@@ -81,31 +81,31 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'e.class.name detection' do
     it 'registers an offense for e.class.name in string interpolation and auto-corrects' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.class.name}: \#{e}")
-               ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+          log("#{e.class.name}: #{e}")
+                 ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.class}: \#{e}")
+          log("#{e.class}: #{e}")
         end
       RUBY
     end
 
     it 'registers an offense for e.class.name outside interpolation but does not auto-correct' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
           log(e.class.name)
-              ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+              ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
 
@@ -113,7 +113,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
 
     it 'does not register an offense outside a rescue block' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         e = SomeObject.new
         log(e.class.name)
       RUBY
@@ -122,21 +122,21 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'combined patterns' do
     it 'registers offenses for both e.class.name and e.message in one string' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.class.name} \#{e.message}")
-                                ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
-               ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+          log("#{e.class.name} #{e.message}")
+                                  ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+                 ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.class} \#{e}")
+          log("#{e.class} #{e}")
         end
       RUBY
     end
@@ -144,7 +144,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'inline rescue' do
     it 'does not register an offense for inline rescue (no rescue variable)' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         result = something rescue nil
       RUBY
     end
@@ -152,39 +152,39 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'different rescue variable names' do
     it 'registers an offense when the rescue variable is named differently' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => err
-          log("\#{err.message}")
-               ^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. In string interpolation, `e.to_s` (called implicitly) returns the same value as `e.message`.
+          log("#{err.message}")
+                 ^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => err
-          log("\#{err}")
+          log("#{err}")
         end
       RUBY
     end
 
     it 'registers an offense for err.class.name' do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         begin
           something
         rescue => err
-          log("\#{err.class.name}")
-               ^^^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. In string interpolation, `e.class.to_s` (called implicitly) returns the class name.
+          log("#{err.class.name}")
+                 ^^^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         begin
           something
         rescue => err
-          log("\#{err.class}")
+          log("#{err.class}")
         end
       RUBY
     end
@@ -192,21 +192,21 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'good patterns (no offense)' do
     it 'does not flag e.class (already correct)' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e.class}: \#{e}")
+          log("#{e.class}: #{e}")
         end
       RUBY
     end
 
     it 'does not flag e directly in interpolation' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
-          log("\#{e}")
+          log("#{e}")
         end
       RUBY
     end

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
           something
         rescue => e
           log("#{e.class.name} #{e.message}")
-                                  ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+                                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
                  ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -150,6 +150,62 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
   end
 
+  describe 'variable shadowing' do
+    it 'does not register an offense when a block parameter shadows the rescue variable' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          errors.each { |e| log("#{e.message}") }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a destructured block parameter shadows the rescue variable' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          pairs.each { |(k, e)| log("#{e.message}") }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for the missing-class check when shadowed' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          errors.each { |e| log("error: #{e}") }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when a method definition uses the same parameter name' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          define_method(:helper) do |e|
+            log("#{e.message}")
+          end
+        end
+      RUBY
+    end
+
+    it 'still registers an offense for the rescue variable used outside the shadowing block' do
+      expect_offense(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          errors.each { |e| log(e) }
+          log("#{e.message}")
+                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+        end
+      RUBY
+    end
+  end
+
   describe 'different rescue variable names' do
     it 'registers an offense when the rescue variable is named differently' do
       expect_offense(<<~'RUBY')

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -190,8 +190,30 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
   end
 
-  describe 'good patterns (no offense)' do
-    it 'does not flag e.class (already correct)' do
+  describe 'missing class detection' do
+    it 'registers an offense for bare exception without class in interpolation' do
+      expect_offense(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          log("error: #{e}")
+                        ^ CustomCops/ExceptionMessageCop: Include `#{e.class}` when interpolating an exception. The convention is `"#{e.class}: #{e}"`.
+        end
+      RUBY
+    end
+
+    it 'registers an offense for bare exception with different variable name' do
+      expect_offense(<<~'RUBY')
+        begin
+          something
+        rescue => err
+          log("error: #{err}")
+                        ^^^ CustomCops/ExceptionMessageCop: Include `#{e.class}` when interpolating an exception. The convention is `"#{e.class}: #{e}"`.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when class is present in the same string' do
       expect_no_offenses(<<~'RUBY')
         begin
           something
@@ -201,12 +223,31 @@ RSpec.describe CustomCops::ExceptionMessageCop do
       RUBY
     end
 
-    it 'does not flag e directly in interpolation' do
+    it 'does not register an offense when class is present elsewhere in the same string' do
       expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
-          log("#{e}")
+          log("#{e.class} happened: #{e}")
+        end
+      RUBY
+    end
+
+    it 'does not register an offense outside a rescue block' do
+      expect_no_offenses(<<~'RUBY')
+        e = SomeObject.new
+        log("error: #{e}")
+      RUBY
+    end
+  end
+
+  describe 'good patterns (no offense)' do
+    it 'does not flag the correct convention' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          log("#{e.class}: #{e}")
         end
       RUBY
     end

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
 
     it 'does not register an offense outside a rescue block' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         e = SomeObject.new
         log(e.message)
       RUBY
     end
 
     it 'does not register an offense for message with arguments' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         begin
           something
         rescue => e
@@ -100,7 +100,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
 
     it 'registers an offense for e.class.name outside interpolation but does not auto-correct' do
-      expect_offense(<<~'RUBY')
+      expect_offense(<<~RUBY)
         begin
           something
         rescue => e
@@ -113,7 +113,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
     end
 
     it 'does not register an offense outside a rescue block' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         e = SomeObject.new
         log(e.class.name)
       RUBY
@@ -144,7 +144,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
 
   describe 'inline rescue' do
     it 'does not register an offense for inline rescue (no rescue variable)' do
-      expect_no_offenses(<<~'RUBY')
+      expect_no_offenses(<<~RUBY)
         result = something rescue nil
       RUBY
     end


### PR DESCRIPTION
**What does this PR do?**
Adds `CustomCops::ExceptionMessageCop` that enforces consistent exception logging format inside rescue blocks.

The cop detects three patterns:
- `e.message` → should be `e` (`to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention)
- `e.class.name` → should be `e.class` (`Class#to_s` already returns the name)
- `#{e}` without `#{e.class}` in the same string → the convention requires the class name

Auto-corrects `e.message` and `e.class.name` within string interpolation. The missing-class check flags but does not auto-correct.

**Motivation:**
Follow-up to #5514 which standardized `#{e.class}: #{e}` across the codebase. This cop prevents the old patterns from being reintroduced. Suggested by @vpellan during review.

**Change log entry**
None.

**Additional Notes:**
Only applies to `lib/**/*` files (same scope as other custom cops).

**How to test the change?**

```bash
bundle exec rake spec:custom_cop
```