### PR TITLE
Reproduce flaky: shutdown 'executes only once'

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -591,6 +591,15 @@ RSpec.describe 'Tracer integration tests' do
 
     context 'executes only once' do
       subject!(:multiple_shutdown) do
+        # Force the HTTP round-trip to take longer than DEFAULT_SHUTDOWN_TIMEOUT (1s).
+        # This reproduces the CI flakiness: the worker thread is mid-HTTP-call when
+        # shutdown! joins with a 1-second timeout, so join times out and
+        # traces_flushed is still 0 when the assertion runs.
+        allow(tracer.writer.transport).to receive(:send_traces).and_wrap_original do |original, *args|
+          sleep(2)
+          original.call(*args)
+        end
+
         tracer.trace('my.short.op') do |span|
           span.service = 'my.service'
         end


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/tracing/integration_spec.rb:592` — the shutdown "executes only once" integration test. Forces the suspected race condition to validate the hypothesis in CI. Expected result: the test fails deterministically.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test reported in PR #5581. The test intermittently fails with `traces_flushed: 0` under CI load.

**Hypothesis:** The test fails when the HTTP round-trip to the agent takes longer than `DEFAULT_SHUTDOWN_TIMEOUT` (1 second). The worker thread is mid-HTTP-call when `shutdown!` calls `join(1)`, the join times out, and `traces_flushed` is still 0 when the assertion runs.

**Reproducer technique:** Stubs `tracer.writer.transport.send_traces` with `and_wrap_original` to add a 2-second sleep before the real HTTP call. This exceeds the 1-second shutdown timeout, forcing the join to time out deterministically.

**Change log entry**

None.

**How to test the change?**

CI should show the "executes only once" / "flushed trace" test failing deterministically with `traces_flushed: 0`. If it doesn't, the hypothesis is wrong.