### PR TITLE
Fix flaky: shutdown 'executes only once'

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -600,6 +600,11 @@ RSpec.describe 'Tracer integration tests' do
         end
 
         threads.each(&:join)
+
+        # The worker thread may still be completing an HTTP call after
+        # shutdown!'s join(DEFAULT_SHUTDOWN_TIMEOUT) timed out. Wait for
+        # the flush to finish so the assertion sees the final stats.
+        try_wait_until { tracer.writer.stats[:traces_flushed] >= 1 }
       end
 
       let(:stats) { tracer.writer.stats }


### PR DESCRIPTION
**What does this PR do?**

Fixes flaky test `spec/datadog/tracing/integration_spec.rb:592` — the shutdown "executes only once" integration test.

**Motivation:**

Flaky test reported in PR #5581. The test intermittently fails with `traces_flushed: 0` under CI load.

**Failure:** The assertion `expect(stats).to include(traces_flushed: 1)` fails with `traces_flushed: 0`.

**Root cause:** The test asserts `traces_flushed: 1` immediately after concurrent `shutdown!` calls join. `shutdown!` calls `Writer#stop`, which calls `AsyncTransport#stop`, which joins the worker thread with a 1-second timeout (`DEFAULT_SHUTDOWN_TIMEOUT`). When the HTTP round-trip to the agent takes longer than 1 second under CI load, the join times out. The worker thread is still alive completing the HTTP call, but `@traces_flushed` hasn't been incremented yet. The assertion fires and sees 0.

**Fix:** Add `try_wait_until { tracer.writer.stats[:traces_flushed] >= 1 }` AFTER the shutdown threads join, not before them. This preserves the test's coverage: the concurrent shutdowns still race with an in-flight flush (the buffer has data when shutdowns begin), so the shutdown guard and worker stop logic are exercised under real contention. The wait just gives the orphaned worker thread time to complete its HTTP call before the assertion checks final stats.

This is deliberately different from PR #5581's approach (which waits BEFORE shutdowns). Waiting before drains the buffer, so all shutdown flushes are no-ops — making `traces_flushed: 1` tautological regardless of whether the shutdown guard works. Waiting after preserves the race between shutdowns and the flush.

**Change log entry**

None.

**How to test the change?**

Integration test validated via the three-PR reproducer/fix/validation pattern:
- Reproducer PR: #5584 (forces the race — CI should fail)
- Validation PR: #5586 (merges reproducer + fix — CI should pass)