### PR TITLE
Validate fix for flaky: shutdown 'executes only once'

### DIFF
--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -591,6 +591,15 @@ RSpec.describe 'Tracer integration tests' do
 
     context 'executes only once' do
       subject!(:multiple_shutdown) do
+        # Force the HTTP round-trip to take longer than DEFAULT_SHUTDOWN_TIMEOUT (1s).
+        # This reproduces the CI flakiness: the worker thread is mid-HTTP-call when
+        # shutdown! joins with a 1-second timeout, so join times out and
+        # traces_flushed is still 0 when the assertion runs.
+        allow(tracer.writer.transport).to receive(:send_traces).and_wrap_original do |original, *args|
+          sleep(2)
+          original.call(*args)
+        end
+
         tracer.trace('my.short.op') do |span|
           span.service = 'my.service'
         end

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -600,6 +600,11 @@ RSpec.describe 'Tracer integration tests' do
         end
 
         threads.each(&:join)
+
+        # The worker thread may still be completing an HTTP call after
+        # shutdown!'s join(DEFAULT_SHUTDOWN_TIMEOUT) timed out. Wait for
+        # the flush to finish so the assertion sees the final stats.
+        try_wait_until { tracer.writer.stats[:traces_flushed] >= 1 }
       end
 
       let(:stats) { tracer.writer.stats }


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the forced failure. This branch merges:
- Reproducer PR: #5584 (forces the race condition — 2s sleep in send_traces)
- Fix PR: #5585 (waits for flush after shutdown threads join)

If CI passes, the fix addresses the exact failure mode the reproducer forces.
If CI fails, the fix does not solve the problem.

**Do not merge** — this PR exists for validation only.

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the forced failure. CI fails = fix is insufficient.