### PR TITLE
Change `AIGuard.evaluate` `allow_raise` default to true

### DIFF
--- a/lib/datadog/ai_guard.rb
+++ b/lib/datadog/ai_guard.rb
@@ -10,7 +10,7 @@ module Datadog
   module AIGuard
     Core::Configuration::Settings.extend(Configuration::Settings)
 
-    # This error is raised when user passes `allow_raise: true` to Evaluation.perform
+    # This error is raised when `allow_raise` is set to true (the default) in Evaluation.perform
     # and AI Guard considers the messages not safe. Intended to be rescued by the user.
     #
     # WARNING: This name must not change, since front-end is using it.
@@ -68,13 +68,14 @@ module Datadog
       #   One or more message objects to be evaluated.
       # @param allow_raise [Boolean]
       #   Whether this method may raise an exception when evaluation result is not ALLOW.
+      #   Defaults to true.
       #
       # @return [Datadog::AIGuard::Evaluation::Result]
       #   The result of AI Guard evaluation.
       # @raise [Datadog::AIGuard::AIGuardAbortError]
       #   If the evaluation results in DENY or ABORT action and `allow_raise` is set to true
       # @public_api
-      def evaluate(*messages, allow_raise: false)
+      def evaluate(*messages, allow_raise: true)
         if enabled?
           Evaluation.perform(messages, allow_raise: allow_raise)
         else

--- a/lib/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rb
+++ b/lib/datadog/ai_guard/contrib/ruby_llm/chat_instrumentation.rb
@@ -20,7 +20,7 @@ module Datadog
                 end
               end
 
-              AIGuard.evaluate(*ai_guard_messages, allow_raise: true)
+              AIGuard.evaluate(*ai_guard_messages)
             end
 
             private

--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -6,7 +6,7 @@ module Datadog
     # and creating `ai_guard` span with required tags
     module Evaluation
       class << self
-        def perform(messages, allow_raise: false)
+        def perform(messages, allow_raise: true)
           raise ArgumentError, "Messages must not be empty" if messages&.empty?
 
           Tracing.trace(Ext::SPAN_NAME) do |span, trace|

--- a/spec/datadog/ai_guard_spec.rb
+++ b/spec/datadog/ai_guard_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Datadog::AIGuard do
           }
         end
 
-        it "returns Datadog::AIGuard::Evaluation::Result when allow_raise is set to false" do
+        it "returns Datadog::AIGuard::Evaluation::Result when allow_raise is set to true" do
           result = described_class.evaluate(*messages, allow_raise: true)
 
           aggregate_failures "result properties" do
@@ -137,7 +137,7 @@ RSpec.describe Datadog::AIGuard do
         end
 
         it "returns Datadog::AIGuard::Evaluation::Result when allow_raise is set to false" do
-          result = described_class.evaluate(*messages)
+          result = described_class.evaluate(*messages, allow_raise: false)
 
           aggregate_failures "result properties" do
             expect(result).to be_a(Datadog::AIGuard::Evaluation::Result)


### PR DESCRIPTION
**What does this PR do?**
This PR changes the default value of `allow_raise` keyword arg in `AIGuard.evaluate` from `false` to `true`. Callers that want the non-raising behavior must now pass `allow_raise: false` explicitly.

**Motivation:**
Product team requirement: AIGuard.evaluate should be safe-by-default, automatically raising `AIGuardAbortError `on `DENY`/`ABORT` actions when blocking is enabled.

This is a breaking change for any caller relying on the previous default. Since AI Guard is still in preview, this will be released in a minor version.

**Change log entry**
Yes. Breaking (AI Guard preview): AIGuard.evaluate now defaults to `allow_raise: true`. Callers relying on the previous default must pass `allow_raise: false` explicitly to preserve the old behavior.

**Additional Notes:**
APPSEC-61804

**How to test the change?**
CI is enough.
