### PR TITLE
Integrate apm-sdks-benchmarks in the CI 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,8 @@ stages:
   - shared-pipeline
   - macrobenchmarks
   - microbenchmarks
+  # These benchmarks should ultimately replace the old macrobenchmarks setup
+  # For now they will run in parallel with the macrobenchmarks setups
   - ruby-acme-parallel
   - ruby-acme-parallel-slo
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,15 @@ stages:
   - shared-pipeline
   - macrobenchmarks
   - microbenchmarks
+  - ruby-acme-parallel
+  - ruby-acme-parallel-slo
 
 include:
   - local: ".gitlab/one-pipeline.locked.yml"
   - local: ".gitlab/benchmarks.yml"
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-ruby-acme-parallel.yml'
+    ref: 'fayssal/integrate'
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - macrobenchmarks
   - microbenchmarks
   # These benchmarks should ultimately replace the old macrobenchmarks setup
-  # For now they will run in parallel with the macrobenchmarks setups
+  # For now they will run in parallel with the macrobenchmarks setup
   - ruby-acme-parallel
   - ruby-acme-parallel-slo
 
@@ -14,7 +14,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-ruby-acme-parallel.yml'
-    ref: 'fayssal/integrate'
+    ref: 'main'
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR integrates the benchmarks from the apm-sdks-benchmarks repo alongside the pre-existing macrobenchmarks before deprecating the legacy setup.
**Motivation:**
<!-- What inspired you to submit this pull request? -->
the new benchmarks are more efficient and easier to apprehend.
**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.
**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Verify the GitLab CI pipeline runs successfully with the new stages included.
<!-- Unsure? Have a question? Request a review! -->
