### PR TITLE
Improve instructions on how to run tests for AI agents

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -31,9 +31,39 @@ alwaysApply: false
 
 ## Running Tests
 
-- Run core library tests: `bundle exec rake test:main`
-- Run a specific test/file from core library tests: `bundle exec rspec <relative path to the file>`
-  - You can't run `shared_examples` directly, run the tests that use it instead.
+Tests MUST be run via rake tasks, not bare `bundle exec rspec`, because most test suites require specific Gemfiles (appraisals). The rake task selects the correct Gemfile automatically.
+
+```bash
+bundle exec rake test:TASK_KEY          # Correct - always use this
+bundle exec rspec spec/path/file.rb     # ONLY for specs covered by test:main
+```
+
+**When modifying Rakefile, Matrixfile, or `appraisal/` files, also update this section and `CLAUDE.md`.**
+
+### File → rake task mapping
+
+`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then:
+
+- **Products with namespaced tasks** (`test:PRODUCT:SUBTASK`): appsec, profiling, di, ai_guard
+  - `spec/datadog/PRODUCT/contrib/CONTRIB/**` → `test:PRODUCT:CONTRIB`
+  - `spec/datadog/PRODUCT/**` (everything else) → `test:PRODUCT:main` (or `test:di:di_with_ext` for DI)
+- **Tracing contribs**: `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (flat name, e.g. `test:redis`, `test:rack`)
+- **Core/main**: `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
+  - Some core specs are excluded from `test:main` — check the Rakefile if a spec is unexpectedly skipped
+- **Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop`
+
+When any AppSec integration changes, also run: `docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration`
+
+See `CLAUDE.md` "Running Tests" for more detail. When unsure: `bundle exec rake -T test | grep KEYWORD`
+
+### Docker requirement
+
+- Contrib/integration tests need Docker: `docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside
+- `test:main` can run locally on any Ruby for quick feedback
+
+### Other notes
+
+- You can't run `shared_examples` directly; run the tests that use them instead
 - Re-run impacted tests after modifying `lib/` or `ext/`
 
 ## Appraisal Groups

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -38,23 +38,13 @@ bundle exec rake test:TASK_KEY          # Correct - always use this
 bundle exec rspec spec/path/file.rb     # ONLY for specs covered by test:main
 ```
 
-**When modifying Rakefile, Matrixfile, or `appraisal/` files, also update this section and `CLAUDE.md`.**
+### Finding the right rake task
 
-### File → rake task mapping
+1. **Identify the component**: determine which product or contrib the changed files belong to based on their path under `lib/datadog/` or `spec/datadog/` (e.g. `appsec`, `profiling`, `redis`, `sinatra`)
+2. **Search for a matching task**: `bundle exec rake -T test | grep KEYWORD` using the component name as KEYWORD
+3. **Verify the task**: check the Rakefile `spec:TASK` definition to confirm which spec files are included/excluded, and check the Matrixfile for Ruby version compatibility
 
-`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then:
-
-- **Products with namespaced tasks** (`test:PRODUCT:SUBTASK`): appsec, profiling, di, ai_guard
-  - `spec/datadog/PRODUCT/contrib/CONTRIB/**` → `test:PRODUCT:CONTRIB`
-  - `spec/datadog/PRODUCT/**` (everything else) → `test:PRODUCT:main` (or `test:di:di_with_ext` for DI)
-- **Tracing contribs**: `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (flat name, e.g. `test:redis`, `test:rack`)
-- **Core/main**: `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
-  - Some core specs are excluded from `test:main` — check the Rakefile if a spec is unexpectedly skipped
-- **Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop`
-
-When any AppSec integration changes, also run: `docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration`
-
-See `CLAUDE.md` "Running Tests" for more detail. When unsure: `bundle exec rake -T test | grep KEYWORD`
+The `test:main` task uses the default Gemfile and its specs can also be run individually with `bundle exec rspec`.
 
 ### Docker requirement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,26 +59,19 @@ Each framework integration (@lib/datadog/*/contrib/) follows a common pattern:
 ## Testing matrix
 
 - `Matrixfile` defines testing combinations, and `appraisal/` files declare respective gemsets. `gemfiles/` are tool generated files.
-- **The Matrixfile and Rakefile are the authoritative sources of truth.** When modifying them or `appraisal/` files, also update this section and `CLAUDE.md`.
+- **The Matrixfile and Rakefile are the authoritative sources of truth.**
 
 ### Always use rake tasks
 
 Tests MUST be run via `bundle exec rake test:TASK_KEY`, not bare `bundle exec rspec`. Contrib/integration tests require specific Gemfiles managed by appraisals; running them with `bundle exec rspec` will fail due to missing dependencies. The only exception: specs under `test:main` can also be run individually with `bundle exec rspec`.
 
-### File → rake task mapping
+### Finding the right rake task
 
-`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then:
+1. **Identify the component**: determine which product or contrib the changed files belong to based on their path under `lib/datadog/` or `spec/datadog/` (e.g. `appsec`, `profiling`, `redis`, `sinatra`)
+2. **Search for a matching task**: `bundle exec rake -T test | grep KEYWORD` using the component name as KEYWORD
+3. **Verify the task**: check the Rakefile `spec:TASK` definition to confirm which spec files are included/excluded, and check the Matrixfile for Ruby version compatibility
 
-- **Products with namespaced tasks** (`test:PRODUCT:SUBTASK`): appsec, profiling, di, ai_guard
-  - `spec/datadog/PRODUCT/contrib/CONTRIB/**` → `test:PRODUCT:CONTRIB`
-  - `spec/datadog/PRODUCT/**` (everything else) → `test:PRODUCT:main` (or `test:di:di_with_ext` for DI)
-- **Tracing contribs**: `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (flat name, e.g. `test:redis`, `test:rack`)
-- **Core/main**: `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
-- **Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop`
-
-When any AppSec integration changes, also run: `docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration`
-
-When unsure: `bundle exec rake -T test | grep KEYWORD`, or check the Rakefile `spec:TASK` definition. See `CLAUDE.md` for full detail including rails sub-tasks and `test:main` exceptions.
+The `test:main` task uses the default Gemfile and its specs can also be run individually with `bundle exec rspec`.
 
 ## One-Pipeline (GitLab CI)
 
@@ -131,4 +124,4 @@ tracing libraries.
   - Writing code: `.cursor/rules/code-style.mdc`.
   - Writing tests: `.cursor/rules/testing.mdc`.
 - `docs/GettingStarted.md` is the public documentation of this repo (2900+ lines). All user-facing product documentation lives there.
-- This AGENTS.md is a living document: update it when rake tasks, CI, or scripts evolve. Update specialized personas as well.
+- This AGENTS.md is a living document: update it when CI or scripts evolve. Update specialized personas as well.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository is the source code of a Ruby gem created by Datadog to provide D
 - Smoke verification: `bundle exec rake test:main`. Baseline general testing (no native or integration testing).
 - Lint and type check: `bundle exec rake standard typecheck`.
 - Discover tasks: `bundle exec rake -T`.
-- Targeted test runs: `bundle exec rspec spec/path/to/file_spec.rb[:line]` or `BUNDLE_GEMFILE=$(pwd)/gemfiles/<name>.gemfile bundle exec rspec spec/path/to/file_spec.rb[:line]`.
+- Targeted test runs (only for `test:main` specs): `bundle exec rspec spec/path/to/file_spec.rb[:line]`. For contrib/integration tests, always use `bundle exec rake test:TASK_KEY` (see "Testing matrix" below).
 - Native extension compilation: `bundle exec rake compile` or `bundle exec rake clean compile`. See `docs/ProfilingDevelopment.md` & `docs/LibdatadogDevelopment.md`.
 
 # Project Structure
@@ -59,6 +59,26 @@ Each framework integration (@lib/datadog/*/contrib/) follows a common pattern:
 ## Testing matrix
 
 - `Matrixfile` defines testing combinations, and `appraisal/` files declare respective gemsets. `gemfiles/` are tool generated files.
+- **The Matrixfile and Rakefile are the authoritative sources of truth.** When modifying them or `appraisal/` files, also update this section and `CLAUDE.md`.
+
+### Always use rake tasks
+
+Tests MUST be run via `bundle exec rake test:TASK_KEY`, not bare `bundle exec rspec`. Contrib/integration tests require specific Gemfiles managed by appraisals; running them with `bundle exec rspec` will fail due to missing dependencies. The only exception: specs under `test:main` can also be run individually with `bundle exec rspec`.
+
+### File → rake task mapping
+
+`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then:
+
+- **Products with namespaced tasks** (`test:PRODUCT:SUBTASK`): appsec, profiling, di, ai_guard
+  - `spec/datadog/PRODUCT/contrib/CONTRIB/**` → `test:PRODUCT:CONTRIB`
+  - `spec/datadog/PRODUCT/**` (everything else) → `test:PRODUCT:main` (or `test:di:di_with_ext` for DI)
+- **Tracing contribs**: `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (flat name, e.g. `test:redis`, `test:rack`)
+- **Core/main**: `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
+- **Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop`
+
+When any AppSec integration changes, also run: `docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration`
+
+When unsure: `bundle exec rake -T test | grep KEYWORD`, or check the Rakefile `spec:TASK` definition. See `CLAUDE.md` for full detail including rails sub-tasks and `test:main` exceptions.
 
 ## One-Pipeline (GitLab CI)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,52 +87,18 @@ bundle exec rake test:TASK_KEY          # Correct - always use this
 bundle exec rspec spec/path/file.rb     # ONLY for specs covered by test:main
 ```
 
-**When modifying the Rakefile (spec task definitions), Matrixfile (task keys or appraisal groups), or appraisal/ files, also update this section.**
+### Finding the right rake task
 
-### File → rake task mapping
+1. **Identify the component**: determine which product or contrib the changed files belong to based on their path under `lib/datadog/` or `spec/datadog/` (e.g. `appsec`, `profiling`, `redis`, `sinatra`)
+2. **Search for a matching task**: `bundle exec rake -T test | grep KEYWORD` using the component name as KEYWORD
+3. **Verify the task**: check the Rakefile `spec:TASK` definition to confirm which spec files are included/excluded, and check the Matrixfile for Ruby version compatibility
 
-`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then determine the rake task:
-
-**Products with namespaced tasks** (`test:PRODUCT:SUBTASK`):
-
-| Product | Spec path | Rake task |
-|---|---|---|
-| AppSec | `spec/datadog/appsec/contrib/CONTRIB/**` | `test:appsec:CONTRIB` (also run `test:appsec:integration`, see below) |
-| AppSec | `spec/datadog/appsec/**` (everything else) | `test:appsec:main` |
-| Profiling | `spec/datadog/profiling/**` | `test:profiling:main` |
-| DI | `spec/datadog/di/contrib/CONTRIB/**` | `test:di:CONTRIB` |
-| DI | `spec/datadog/di/**` (everything else) | `test:di:di_with_ext` |
-| AI Guard | `spec/datadog/ai_guard/contrib/CONTRIB/**` | `test:ai_guard:CONTRIB` |
-| AI Guard | `spec/datadog/ai_guard/**` (everything else) | `test:ai_guard:main` |
-
-**Tracing contribs** — flat task names (`test:CONTRIB`, not `test:tracing:CONTRIB`):
-- `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (e.g. `test:redis`, `test:rack`, `test:sinatra`)
-- Rails has sub-tasks based on filename pattern — check the Rakefile `spec:rails*` definitions
-
-**Core/main** — `test:main` uses the default Gemfile; specs CAN also be run individually with `bundle exec rspec`:
-- `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
-- Some core specs are **excluded** from `test:main` and need their own task (e.g. `test:core_with_libdatadog_api`, `test:core_with_rails`, `test:environment`). Check the `spec:main` exclude pattern and `CORE_WITH_LIBDATADOG_API` constant in the Rakefile if a spec is unexpectedly skipped.
-
-**Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop` — task name matches the product/directory name.
-
-### AppSec integration tests
-
-When any AppSec integration (`appsec/contrib/`) changes, you MUST also run `test:appsec:integration` as a separate command on Ruby 3.3:
-```bash
-docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration
-```
+The `test:main` task uses the default Gemfile and its specs can also be run individually with `bundle exec rspec`.
 
 ### Docker requirement
 
 - Contrib/integration tests need Docker: `docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside
 - `test:main` can run locally on any Ruby for quick feedback
-
-### Finding the right task
-
-When unsure, use these to discover the correct task:
-- `bundle exec rake -T test | grep KEYWORD` — list matching test tasks
-- Check the Matrixfile for the task key and its Ruby version compatibility
-- Check the Rakefile `spec:TASK` definition to see which spec files are included/excluded
 
 ## Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,62 @@ actionlint .github/workflows/your-workflow.yml
   - Exception: constants initialized at load time (before user configuration) may use `::Time.now` directly; add a comment explaining why (see `lib/datadog/profiling/collectors/info.rb` for an example)
   - Exception: Dynamic Instrumentation (DI) probe instrumentation code that runs inside customer application methods must use `::Time.now` directly — the time provider supports runtime overrides (the API exists even if rarely used in production), and DI must never invoke customer-provided code during instrumentation
 
+## Running Tests
+
+Tests MUST be run via rake tasks, not bare `bundle exec rspec`, because most test suites require specific Gemfiles (appraisals) for third-party dependencies. The rake task selects the correct Gemfile for the current Ruby version automatically.
+
+```bash
+bundle exec rake test:TASK_KEY          # Correct - always use this
+bundle exec rspec spec/path/file.rb     # ONLY for specs covered by test:main
+```
+
+**When modifying the Rakefile (spec task definitions), Matrixfile (task keys or appraisal groups), or appraisal/ files, also update this section.**
+
+### File → rake task mapping
+
+`lib/datadog/X/...` maps to `spec/datadog/X/..._spec.rb` (1:1 mirroring). Then determine the rake task:
+
+**Products with namespaced tasks** (`test:PRODUCT:SUBTASK`):
+
+| Product | Spec path | Rake task |
+|---|---|---|
+| AppSec | `spec/datadog/appsec/contrib/CONTRIB/**` | `test:appsec:CONTRIB` (also run `test:appsec:integration`, see below) |
+| AppSec | `spec/datadog/appsec/**` (everything else) | `test:appsec:main` |
+| Profiling | `spec/datadog/profiling/**` | `test:profiling:main` |
+| DI | `spec/datadog/di/contrib/CONTRIB/**` | `test:di:CONTRIB` |
+| DI | `spec/datadog/di/**` (everything else) | `test:di:di_with_ext` |
+| AI Guard | `spec/datadog/ai_guard/contrib/CONTRIB/**` | `test:ai_guard:CONTRIB` |
+| AI Guard | `spec/datadog/ai_guard/**` (everything else) | `test:ai_guard:main` |
+
+**Tracing contribs** — flat task names (`test:CONTRIB`, not `test:tracing:CONTRIB`):
+- `spec/datadog/tracing/contrib/CONTRIB/**` → `test:CONTRIB` (e.g. `test:redis`, `test:rack`, `test:sinatra`)
+- Rails has sub-tasks based on filename pattern — check the Rakefile `spec:rails*` definitions
+
+**Core/main** — `test:main` uses the default Gemfile; specs CAN also be run individually with `bundle exec rspec`:
+- `spec/datadog/core/**`, `spec/datadog/tracing/**` (excluding `contrib/`), `spec/datadog/kit/**` → `test:main`
+- Some core specs are **excluded** from `test:main` and need their own task (e.g. `test:core_with_libdatadog_api`, `test:core_with_rails`, `test:environment`). Check the `spec:main` exclude pattern and `CORE_WITH_LIBDATADOG_API` constant in the Rakefile if a spec is unexpectedly skipped.
+
+**Other**: `test:error_tracking`, `test:opentelemetry`, `test:open_feature`, `test:autoinstrument`, `test:custom_cop` — task name matches the product/directory name.
+
+### AppSec integration tests
+
+When any AppSec integration (`appsec/contrib/`) changes, you MUST also run `test:appsec:integration` as a separate command on Ruby 3.3:
+```bash
+docker compose run --rm tracer-3.3 bundle exec rake test:appsec:integration
+```
+
+### Docker requirement
+
+- Contrib/integration tests need Docker: `docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside
+- `test:main` can run locally on any Ruby for quick feedback
+
+### Finding the right task
+
+When unsure, use these to discover the correct task:
+- `bundle exec rake -T test | grep KEYWORD` — list matching test tasks
+- Check the Matrixfile for the task key and its Ruby version compatibility
+- Check the Rakefile `spec:TASK` definition to see which spec files are included/excluded
+
 ## Documentation
 
 - **Dynamic Instrumentation docs**: Never mention telemetry in customer-facing documentation (e.g., `docs/DynamicInstrumentation.md`)
@@ -110,7 +166,7 @@ See `docs/` for:
 bundle exec rake test:main              # Smoke tests
 bundle exec rake standard typecheck     # Lint and type check
 bundle exec steep check [sources]       # Type check (sources = files or dirs, optional)
-bundle exec rspec spec/path/file_spec.rb:123  # Run specific test
+bundle exec rspec spec/path/file_spec.rb:123  # Run specific test (only works for test:main specs; see "Running Tests")
 ```
 
 ## Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,18 @@ The `test:main` task uses the default Gemfile and its specs can also be run indi
 
 - Contrib/integration tests need Docker: `docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside
 - `test:main` can run locally on any Ruby for quick feedback
+- If Bundler fails inside the container (e.g. after a dependency update), run `bundle install` and retry the rake task once before investigating further
+
+### Verifying across Ruby versions
+
+Before marking a task complete, run the relevant test task on both the earliest and latest supported Ruby versions. Regressions in older Rubies are easy to miss when only testing on the latest. Check the component's entry in `Matrixfile` for the supported range, then:
+
+```bash
+docker compose run --rm tracer-2.5 bundle exec rake test:TASK_KEY
+docker compose run --rm tracer-4.0 bundle exec rake test:TASK_KEY
+```
+
+Skip versions the Matrixfile marks as unsupported for that task. For `test:main`, the same applies — swap in the tracer container matching each end of the supported range.
 
 ## Documentation
 


### PR DESCRIPTION
**What does this PR do?**
This PR aims to improve the identification of a correct test task for AI agents.

**Motivation:**
AI agents (Claude Code, Cursor, etc.) currently try running isolated spec files with `bundle exec rspec ...`, which fails for contrib/integration tests that require specific appraisal Gemfiles. This change teaches the agents the `lib/` → `spec/` → `rake test:TASK_KEY` mapping, including the product-level pattern (namespaced tasks for appsec/profiling/di/ai_guard, flat tasks for tracing contribs), and how to self-serve edge cases by checking the `Rakefile` and `Matrixfile`.

**Change log entry**
None.

**Additional Notes:**
I used AI to write these changes, used AI to test if these instructions actually improve anything.

**How to test the change?**
Try to do some simple change using your favorite coding agent, see if it can correctly identify the test tasks it needs to run.
