### PR TITLE
Bump to version 2.31.0

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
   test:
     needs:
       - build
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@ec74ba8b7647f5d48432da42295cdf39211fbf6c  # Automated: This reference is automatically updated.
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@102cb85728e3dcf4a4e27e8ddb5aba265dbeadb6  # Automated: This reference is automatically updated.
     permissions:
       contents: read
       id-token: write

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: b38df18ddc8aa6af24e3838cfd91e4232404471b # Automated: This reference is automatically updated.
+    SYSTEM_TESTS_REF: 102cb85728e3dcf4a4e27e8ddb5aba265dbeadb6 # Automated: This reference is automatically updated.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 


### PR DESCRIPTION
### Added

* Core: Add `app-extended-heartbeat` telemetry event to resend full configuration every 24h for long-running services. (#5531)
* AI Guard: Add multi-model messages support to AI Guard, enabling text and image URL content parts in evaluation SDK (#5564)
* AI Guard: Add evaluation of images in user prompt and tool output for RubyLLM contrib. (#5573)
* AI Guard: Expose Sensitive Data Scanner findings in AI Guard results via `AIGuard::Evaluation::Result#sds_findings`. (#5579)
* AI Guard: Expose tag probabilities in AI Guard results via `AIGuard::Evaluation::Result#tag_probabilities`. (#5580)
* Tracing: Integrations: Add `rails.application` to the process tags. (#5468)
* Tracing: Report and display all configurations used by a service in the 'SDK & Agent Configurations' tab of a Ruby service page in Datadog UI (#5483)

### Changed

* Core: Upgrade `libdatadog` dependency to version 30.0.0 (#5574)
* AI Guard: **Breaking change:** AIGuard.evaluate now defaults to `allow_raise: true`. Pass `allow_raise: false` to keep the previous non-raising behavior. (#5587)
* Dynamic Instrumentation: Report exception messages in method probe snapshots. Require the libdatadog_api C extension for Dynamic Instrumentation. (#5111)

### Fixed

* Profiling: Detect when `libdatadog` version does not match expected version. (#5484)
* Profiling: Log profiler initialization errors as warnings instead of raising them. (#5509)
* Tracing: Fix `NoMethodError` in `extract_trace_id!` caused by `extract_tags` returning `true`. (#5499)

### Removed

* Core: Removed JRuby from the CI test matrix (#5594)
