### PR TITLE
Remove AI Guard message list truncation for API calls

### DIFF
--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -64,7 +64,6 @@ module Datadog
 
         private
 
-        # Truncates the list of serialized messages to the configured maximum length.
         def truncate_messages(serialized_messages)
           max_length = Datadog.configuration.ai_guard.max_messages_length
           serialized_messages.first(max_length)

--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -40,7 +40,7 @@ module Datadog
             span.set_metastruct_tag(
               Ext::METASTRUCT_TAG,
               {
-                messages: truncate_content(request.serialized_messages),
+                messages: truncate_messages(truncate_content(request.serialized_messages)),
                 attack_categories: result.tags,
                 sds: result.sds_findings,
                 tag_probs: result.tag_probabilities
@@ -63,6 +63,12 @@ module Datadog
         end
 
         private
+
+        # Truncates the list of serialized messages to the configured maximum length.
+        def truncate_messages(serialized_messages)
+          max_length = Datadog.configuration.ai_guard.max_messages_length
+          serialized_messages.first(max_length)
+        end
 
         # Truncates content in serialized messages to stay within the configured byte limit.
         # For multi-modal messages, only text parts are truncated; image URLs are left intact.

--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -40,7 +40,7 @@ module Datadog
             span.set_metastruct_tag(
               Ext::METASTRUCT_TAG,
               {
-                messages: truncate_messages(truncate_content(request.serialized_messages)),
+                messages: truncate_content(truncate_messages(request.serialized_messages)),
                 attack_categories: result.tags,
                 sds: result.sds_findings,
                 tag_probs: result.tag_probabilities

--- a/lib/datadog/ai_guard/evaluation/request.rb
+++ b/lib/datadog/ai_guard/evaluation/request.rb
@@ -44,15 +44,7 @@ module Datadog
         end
 
         def serialize_messages(messages)
-          serialized_messages = []
-
-          messages.each do |message|
-            serialized_messages << serialize_message(message)
-
-            break if serialized_messages.count == Datadog.configuration.ai_guard.max_messages_length
-          end
-
-          serialized_messages
+          messages.map { |message| serialize_message(message) }
         end
 
         def serialize_message(message)

--- a/sig/datadog/ai_guard/evaluation.rbs
+++ b/sig/datadog/ai_guard/evaluation.rbs
@@ -7,6 +7,8 @@ module Datadog
 
       private
 
+      def self.truncate_messages: (::Array[Request::serialized_message]) -> ::Array[Request::serialized_message]
+
       def self.truncate_content: (::Array[Request::serialized_message]) -> ::Array[Request::serialized_message]
     end
   end

--- a/spec/datadog/ai_guard/evaluation/request_spec.rb
+++ b/spec/datadog/ai_guard/evaluation/request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Datadog::AIGuard::Evaluation::Request do
       ])
     end
 
-    it "limits the maximum amount of messages" do
+    it "serializes all messages without truncation" do
       allow(Datadog.configuration.ai_guard).to receive(:max_messages_length).and_return(2)
 
       request = described_class.new([
@@ -127,7 +127,8 @@ RSpec.describe Datadog::AIGuard::Evaluation::Request do
 
       expect(request.serialized_messages).to eq([
         {role: :user, content: "Message 1"},
-        {role: :user, content: "Message 2"}
+        {role: :user, content: "Message 2"},
+        {role: :user, content: "Message 3"}
       ])
     end
   end

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -155,6 +155,21 @@ RSpec.describe Datadog::AIGuard::Evaluation do
         )
       end
 
+      it "truncates metastruct messages to max_messages_length" do
+        allow(Datadog.configuration.ai_guard).to receive(:max_messages_length).and_return(2)
+
+        described_class.perform([
+          Datadog::AIGuard.message(role: :system, content: "System prompt"),
+          Datadog::AIGuard.message(role: :user, content: "User message"),
+          Datadog::AIGuard.message(role: :assistant, content: "Assistant reply"),
+        ])
+
+        expect(ai_guard_span.get_metastruct_tag("ai_guard").fetch(:messages)).to eq([
+          {content: "System prompt", role: :system},
+          {content: "User message", role: :user},
+        ])
+      end
+
       it "truncates metastruct messages content" do
         allow(Datadog.configuration.ai_guard).to receive(:max_content_size_bytes).and_return(8)
 


### PR DESCRIPTION
**What does this PR do?**
It fixes messages list truncation - only the messages list stored in metastruct is truncated, messages list sent to the AI Guard API is not truncated.

**Motivation:**
We want to evaluate all chat messages in AI Guard.

**Change log entry**
Yes. AI Guard. Fix messages list truncation - all messages are now sent to AI Guard API.

**Additional Notes:**
APPSEC-62363

**How to test the change?**
CI and manual testing.
