### PR TITLE
test(sampling): verify _dd.p.ksr formatting is locale-independent

### DIFF
--- a/spec/datadog/tracing/transport/trace_formatter_spec.rb
+++ b/spec/datadog/tracing/transport/trace_formatter_spec.rb
@@ -564,6 +564,35 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
           )
         end
       end
+
+      context 'locale independence' do
+        let(:trace_options) { {id: trace_id, agent_sample_rate: 0.3} }
+
+        it 'uses period decimal separator regardless of C locale' do
+          require 'fiddle'
+
+          setlocale = Fiddle::Function.new(
+            Fiddle::Handle::DEFAULT['setlocale'],
+            [Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP],
+            Fiddle::TYPE_VOIDP
+          )
+
+          # LC_ALL is 6 on Linux glibc, 0 on macOS
+          lc_all = RUBY_PLATFORM.include?('darwin') ? 0 : 6
+          original_locale = setlocale.call(lc_all, nil).to_s
+
+          begin
+            result = setlocale.call(lc_all, 'de_DE.UTF-8')
+            skip 'de_DE.UTF-8 locale not available' if result.null?
+
+            format!
+
+            expect(root_span.meta[Datadog::Tracing::Metadata::Ext::Distributed::TAG_KNUTH_SAMPLING_RATE]).to eq('0.3')
+          ensure
+            setlocale.call(lc_all, original_locale)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Adds a unit test to verify that `_dd.p.ksr` (Knuth sampling rate) formatting uses a period as the decimal separator regardless of the C locale setting. The test temporarily switches to `de_DE.UTF-8` (which uses comma as decimal separator) and confirms the formatted value still uses a period.

**Motivation:**

Locale-dependent float formatting can silently produce values like `0,3` instead of `0.3`, which would break downstream consumers expecting a period-delimited decimal. This test guards against regressions if the formatting implementation ever changes to use locale-sensitive conversion.

**Change log entry**

N/A (test-only change)

**Additional Notes:**

The test uses Ruby's `Fiddle` to call the C `setlocale` function directly, since Ruby's standard library does not expose LC_ALL manipulation. The test gracefully skips on systems where `de_DE.UTF-8` is not installed.

AI was used to generate this PR. The code has been reviewed and understood.

**How to test the change?**

Run the trace formatter spec:
```
bundle exec rspec spec/datadog/tracing/transport/trace_formatter_spec.rb
```

The new test will pass on systems with `de_DE.UTF-8` locale available, and will be skipped otherwise.