### PR TITLE
Update system-tests ref for 2.31.0 release

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: dd-trace-rb  # The name must match the folder name so it extracts to binaries/dd-trace-rb on download
+          name: dd-trace-rb # The name must match the folder name so it extracts to binaries/dd-trace-rb on download
           path: packaged
       - id: compute_forced_tests
         run: |
@@ -77,7 +77,7 @@ jobs:
   test:
     needs:
       - build
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@ec74ba8b7647f5d48432da42295cdf39211fbf6c  # Automated: This reference is automatically updated.
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@335edb089e8c1310e39cb0b06dbd745ac562c8b9 # Automated: This reference is automatically updated.
     permissions:
       contents: read
       id-token: write
@@ -85,10 +85,10 @@ jobs:
     with:
       library: ruby
       binaries_artifact: dd-trace-rb
-      desired_execution_time: 300  # 5 minutes
+      desired_execution_time: 300 # 5 minutes
       scenarios_groups: tracer_release
       skip_empty_scenarios: true
-      ref: ec74ba8b7647f5d48432da42295cdf39211fbf6c  # Automated: This reference is automatically updated.
+      ref: 335edb089e8c1310e39cb0b06dbd745ac562c8b9 # Automated: This reference is automatically updated.
       force_execute: ${{ needs.build.outputs.forced_tests }}
       parametric_job_count: 8
       push_to_test_optimization: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"
       changes:
-        - .gitlab/Dockerfile-*   # these are direct dependencies
-        - .gitlab-ci.yml         # list of images is here so it is a dependency too
+        - .gitlab/Dockerfile-* # these are direct dependencies
+        - .gitlab-ci.yml # list of images is here so it is a dependency too
       allow_failure: true
   image: $DOCKER_REGISTRY/docker:29.4.0-noble
   id_tokens:
@@ -63,12 +63,12 @@ build-image-arm64:
 
 promote-image:
   stage: manual-images
-  rules:                         # same as build-image
+  rules: # same as build-image
     - if: $CI_PIPELINE_SOURCE == "merge_request_event" || $CI_PIPELINE_SOURCE == "push"
       changes:
-        - .gitlab/Dockerfile-*   # these are direct dependencies
-        - .gitlab-ci.yml         # list of images is here so it is a dependency too
-      when: manual               # this one is manual, but it means that install-dependencies may be hitting the wrong <base>:current til this is run
+        - .gitlab/Dockerfile-* # these are direct dependencies
+        - .gitlab-ci.yml # list of images is here so it is a dependency too
+      when: manual # this one is manual, but it means that install-dependencies may be hitting the wrong <base>:current til this is run
       allow_failure: true
   tags: ["docker-in-docker:amd64"]
   image: $DOCKER_REGISTRY/docker:29.4.0-noble
@@ -147,7 +147,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: b38df18ddc8aa6af24e3838cfd91e4232404471b # Automated: This reference is automatically updated.
+    SYSTEM_TESTS_REF: 335edb089e8c1310e39cb0b06dbd745ac562c8b9 # Automated: This reference is automatically updated.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 


### PR DESCRIPTION
**What does this PR do?**
It updates the system-test ref to the latest commit SHA from master.

**Motivation:**
We want to release 2.31.0.

**Change log entry**
None.

**Additional Notes:**
This change was done manually, since "Update System Tests" workflow is currently failing (and being fixed).

**How to test the change?**
CI