### PR TITLE
Use `dd-octo-sts` consistently

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -8,6 +8,7 @@ jobs:
   add_milestone:
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     runs-on: ubuntu-22.04
@@ -27,11 +28,18 @@ jobs:
           VERSION=$(ruby -e "puts Gem::Specification.load(Dir.glob('*.gemspec').first).version.to_s.split('.').first")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.add-milestone-to-pull-requests
+
       - name: Get project milestones
         id: milestones
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const milestones = await github.rest.issues.listMilestones({
               owner: context.repo.owner,
@@ -44,7 +52,7 @@ jobs:
         # Update the merged pull request with the milestone starts with the major version
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const milestones = ${{steps.milestones.outputs.result}}
             const majorVersion = ${{steps.version.outputs.version}}

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -19,7 +19,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 env:
-  GEM_HOST: 'https://rubygems.pkg.github.com/DataDog'
+  GEM_HOST: "https://rubygems.pkg.github.com/DataDog"
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
       - uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:
-          ruby-version: '3.2'
+          ruby-version: "3.2"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Patch version
         if: ${{ matrix.type != 'final' }}
@@ -65,8 +65,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
-          path: 'pkg/*.gem'
+          name: "datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}"
+          path: "pkg/*.gem"
   test:
     strategy:
       fail-fast: false
@@ -82,14 +82,14 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
-          path: 'pkg'
+          name: "datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}"
+          path: "pkg"
       - name: List gem
         run: |
           find pkg
       - uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:
-          ruby-version: '3.2'
+          ruby-version: "3.2"
       - name: Install gem
         run: |
           gem install pkg/*.gem
@@ -104,21 +104,30 @@ jobs:
     needs:
       - test
     if: ${{ inputs.push }}
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - name: Download artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: 'datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}'
-          path: 'pkg'
+          name: "datadog-gem-${{ matrix.type }}-gha${{ github.run_id }}-g${{ github.sha }}"
+          path: "pkg"
       - name: List gem
         run: |
           find pkg
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.build-gem
       - name: Set up GitHub Packages authentication
         run: |
           mkdir -p ~/.gem
           cat > ~/.gem/credentials <<'CREDENTIALS'
           ---
-          :github: Bearer ${{ secrets.GITHUB_TOKEN }}
+          :github: Bearer ${{ steps.generate-token.outputs.token }}
           CREDENTIALS
           chmod 0600 ~/.gem/credentials
       - name: Push gem

--- a/.github/workflows/bump-gem-version.yml
+++ b/.github/workflows/bump-gem-version.yml
@@ -30,13 +30,19 @@ jobs:
       pull-requests: write
       id-token: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NEXT_VERSION: ${{ inputs.version }}
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.bump-gem-version
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set up Ruby
@@ -50,13 +56,6 @@ jobs:
         run: |
           echo "Updating version to ${NEXT_VERSION}"
           bundle exec rake version:bump["${NEXT_VERSION}]"
-
-      - name: Get GitHub Token via dd-octo-sts
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/dd-trace-rb
-          policy: self.bump-gem-version
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -14,7 +14,14 @@ jobs:
     permissions:
       actions: write
       contents: write
+      id-token: write
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.cache-cleanup
       - name: Cleanup
         run: |
           {
@@ -62,6 +69,6 @@ jobs:
             echo "Cleanup completed at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
           } >> "$GITHUB_STEP_SUMMARY"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,16 +123,24 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.check
       - name: Run zizmor 🌈
         uses: docker://ghcr.io/woodruffw/zizmor:1.4.1
         with:
           args: --min-severity low .
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   actionlint:
     name: actionlint

--- a/.github/workflows/ensure-changelog-entry.yml
+++ b/.github/workflows/ensure-changelog-entry.yml
@@ -8,13 +8,21 @@ jobs:
   check:
     permissions:
       pull-requests: write
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.ensure-changelog-entry
+
       - name: Check membership
         id: membership
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             // Is author of the PR a member of the DataDog Org.
             // NOTE: https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
@@ -38,7 +46,7 @@ jobs:
         id: comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const options = github.rest.issues.listComments.endpoint.merge({
               owner: context.repo.owner,
@@ -56,7 +64,7 @@ jobs:
         id: condition
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const regex = /\*\*Change log entry\*\*\s+(?:<!--.*?-->\s*)?(?:(?<answer_yes>yes|yep|yeah)(?:\s?[.,:-]\s?(?<yes_message>[^\r\n<!-]+))?|(?<answer_no>no|nope|none)\.?.*?)/ims
             const entry = context.payload.pull_request.body.match(regex)
@@ -73,7 +81,7 @@ jobs:
       - name: Write comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const isMember = ${{steps.membership.outputs.result}}
             const username = !isMember ? "@DataDog/ruby-guild" : `@${context.payload.sender.login}`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,16 +186,24 @@ jobs:
       - verify-checks
       - rubygems-release
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
       GEM_VERSION: ${{ needs.verify-checks.outputs.version }}
     permissions:
       contents: write
+      id-token: write
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.publish-github-release
       - name: Download from RubyGems
         run: |
           gem fetch datadog --version "${GEM_VERSION}" --verbose
       - name: Attach to existing release draft
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh release upload "v${GEM_VERSION}" datadog-*.gem --clobber
           gh release edit "v${GEM_VERSION}" --draft=false
@@ -249,17 +257,24 @@ jobs:
       - rubygems-release
       - update-gem-version
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GEM_VERSION: ${{ needs.verify-checks.outputs.version }}
       NEXT_VERSION: ${{ needs.update-gem-version.outputs.next_version }}
     permissions:
       issues: write
       pull-requests: write
+      id-token: write
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.publish-milestone
       - name: list milestones
         id: milestones
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             // https://octokit.github.io/rest.js/v21/#issues-list-milestones
             // https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#list-milestones
@@ -273,6 +288,7 @@ jobs:
       - name: Close milestone
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const milestones = ${{steps.milestones.outputs.result}}
 
@@ -302,6 +318,7 @@ jobs:
       - name: Create milestone
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const milestones = ${{steps.milestones.outputs.result}}
 

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -7,9 +7,16 @@ jobs:
   triage:
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.pull-request-labeler
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ steps.generate-token.outputs.token }}"

--- a/.github/workflows/typing-stats.yml
+++ b/.github/workflows/typing-stats.yml
@@ -12,14 +12,22 @@ on: # yamllint disable-line rule:truthy
 jobs:
   compute-stats:
     permissions:
+      id-token: write
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.typing-stats
+
       - name: Find existing comment
         id: comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const options = github.rest.issues.listComments.endpoint.merge({
               owner: context.repo.owner,
@@ -81,7 +89,7 @@ jobs:
       - name: Write comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             var fs = require('fs')
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Use `dd-octo-sts` consistently unstead of `GITHUB_TOKEN`

**Motivation:**
<!-- What inspired you to submit this pull request? -->

While `GITHUB_TOKEN` is not always a requirement to drop, it has a few flaws:

- `GITHUB_TOKEN` lacks granularity and auditability, `dd-octo-sts` is strictly better and really not complex to add
- choosing safely between `GITHUB_TOKEN` and `dd-octo-sts` is non-obvious; turning it into a non-choice makes it "safe by default"

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

Depends on https://github.com/DataDog/dd-trace-rb/pull/5605 because the policies need to be in `master` first for this to be able to actually run.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
