### PR TITLE
Add policies for using `dd-octo-sts` consistently

### DIFF
--- a/.github/chainguard/self.add-milestone-to-pull-requests.sts.yaml
+++ b/.github/chainguard/self.add-milestone-to-pull-requests.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/add-milestone-to-pull-requests\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.build-gem.sts.yaml
+++ b/.github/chainguard/self.build-gem.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-rb:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/build-gem\.yml@refs/heads/master
+
+permissions:
+  packages: write

--- a/.github/chainguard/self.cache-cleanup.sts.yaml
+++ b/.github/chainguard/self.cache-cleanup.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/cache-cleanup\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  actions: write

--- a/.github/chainguard/self.check.sts.yaml
+++ b/.github/chainguard/self.check.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:(pull_request|ref:refs/heads/master)"
+
+claim_pattern:
+  event_name: push|pull_request
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/check\.yml@refs/(heads/master|pull/[0-9]+/merge)
+
+permissions:
+  contents: read

--- a/.github/chainguard/self.ensure-changelog-entry.sts.yaml
+++ b/.github/chainguard/self.ensure-changelog-entry.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/ensure-changelog-entry\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/self.publish-github-release.sts.yaml
+++ b/.github/chainguard/self.publish-github-release.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/*"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/publish\.yml@refs/heads/*
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.publish-milestone.sts.yaml
+++ b/.github/chainguard/self.publish-milestone.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-rb:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/publish\.yml@refs/heads/master
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.pull-request-labeler.sts.yaml
+++ b/.github/chainguard/self.pull-request-labeler.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/.*"
+
+claim_pattern:
+  event_name: pull_request_target
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/pull-request-labeler\.yml@refs/heads/.*
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/chainguard/self.typing-stats.sts.yaml
+++ b/.github/chainguard/self.typing-stats.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/typing-stats\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Prepare for https://github.com/DataDog/dd-trace-rb/pull/5604

**Motivation:**
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/dd-trace-rb/pull/5604 needs the policies in `master` 

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
