### PR TITLE
Update CHANGELOG.md for 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## [2.31.0] - 2026-04-20
+
+### Added
+
+* Core: Add `app-extended-heartbeat` telemetry event to resend full configuration every 24h for long-running services. ([#5531][])
+* AI Guard: Add multi-model messages support to AI Guard, enabling text and image URL content parts in evaluation SDK ([#5564][])
+* AI Guard: Add evaluation of images in user prompt and tool output for RubyLLM contrib. ([#5573][])
+* AI Guard: Expose Sensitive Data Scanner findings in AI Guard results via `AIGuard::Evaluation::Result#sds_findings`. ([#5579][])
+* AI Guard: Expose tag probabilities in AI Guard results via `AIGuard::Evaluation::Result#tag_probabilities`. ([#5580][])
+* Tracing: Integrations: Add `rails.application` to the process tags. ([#5468][])
+* Tracing: Report and display all configurations used by a service in the 'SDK & Agent Configurations' tab of a Ruby service page in Datadog UI ([#5483][])
+
+### Changed
+
+* Core: Upgrade `libdatadog` dependency to version 30.0.0 ([#5574][])
+* AI Guard: **Breaking change:** AIGuard.evaluate now defaults to `allow_raise: true`. Pass `allow_raise: false` to keep the previous non-raising behavior. ([#5587][])
+* Dynamic Instrumentation: Report exception messages in method probe snapshots. Require the libdatadog_api C extension for Dynamic Instrumentation. ([#5111][])
+
+### Fixed
+
+* Profiling: Detect when `libdatadog` version does not match expected version. ([#5484][])
+* Profiling: Log profiler initialization errors as warnings instead of raising them. ([#5509][])
+* Tracing: Fix `NoMethodError` in `extract_trace_id!` caused by `extract_tags` returning `true`. ([#5499][])
+
+### Removed
+
+* Core: Removed JRuby from the CI test matrix ([#5594][])
+
 ## [2.30.0] - 2026-03-19
 
 ### Added
@@ -3539,7 +3567,8 @@ Release notes: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.3.1
 Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 
 
-[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.30.0...master
+[Unreleased]: https://github.com/DataDog/dd-trace-rb/compare/v2.31.0...master
+[2.31.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.30.0...v2.31.0
 [2.30.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.29.0...v2.30.0
 [2.29.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.28.0...v2.29.0
 [2.28.0]: https://github.com/DataDog/dd-trace-rb/compare/v2.27.0...v2.28.0
@@ -5193,6 +5222,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#5076]: https://github.com/DataDog/dd-trace-rb/issues/5076
 [#5086]: https://github.com/DataDog/dd-trace-rb/issues/5086
 [#5091]: https://github.com/DataDog/dd-trace-rb/issues/5091
+[#5111]: https://github.com/DataDog/dd-trace-rb/issues/5111
 [#5122]: https://github.com/DataDog/dd-trace-rb/issues/5122
 [#5144]: https://github.com/DataDog/dd-trace-rb/issues/5144
 [#5145]: https://github.com/DataDog/dd-trace-rb/issues/5145
@@ -5251,7 +5281,20 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#5448]: https://github.com/DataDog/dd-trace-rb/issues/5448
 [#5449]: https://github.com/DataDog/dd-trace-rb/issues/5449
 [#5461]: https://github.com/DataDog/dd-trace-rb/issues/5461
+[#5468]: https://github.com/DataDog/dd-trace-rb/issues/5468
 [#5469]: https://github.com/DataDog/dd-trace-rb/issues/5469
+[#5483]: https://github.com/DataDog/dd-trace-rb/issues/5483
+[#5484]: https://github.com/DataDog/dd-trace-rb/issues/5484
+[#5499]: https://github.com/DataDog/dd-trace-rb/issues/5499
+[#5509]: https://github.com/DataDog/dd-trace-rb/issues/5509
+[#5531]: https://github.com/DataDog/dd-trace-rb/issues/5531
+[#5564]: https://github.com/DataDog/dd-trace-rb/issues/5564
+[#5573]: https://github.com/DataDog/dd-trace-rb/issues/5573
+[#5574]: https://github.com/DataDog/dd-trace-rb/issues/5574
+[#5579]: https://github.com/DataDog/dd-trace-rb/issues/5579
+[#5580]: https://github.com/DataDog/dd-trace-rb/issues/5580
+[#5587]: https://github.com/DataDog/dd-trace-rb/issues/5587
+[#5594]: https://github.com/DataDog/dd-trace-rb/issues/5594
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot


### PR DESCRIPTION
**What does this PR do?**
This PR updates the CHANGELOG with 2.31.0 changes.

**Motivation:**
We had to update system-tests ref manually, and the PR did not contain CHANGELOG changes.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
CI