### PR TITLE
Fix publish gem workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,6 +231,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     needs:
       - update-gem-version
     uses: ./.github/workflows/bump-gem-version.yml


### PR DESCRIPTION
**What does this PR do?**
It fixes token permissions for publish gem workflow.

**Motivation:**
Failing workflow: https://github.com/DataDog/dd-trace-rb/actions/runs/24665703226

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
Merge and publish again.