### PR TITLE
Fix job_workflow_ref for Publish Gem workflow

### DIFF
--- a/.github/chainguard/self.publish.sts.yaml
+++ b/.github/chainguard/self.publish.sts.yaml
@@ -5,9 +5,9 @@ subject: repo:DataDog/dd-trace-rb:environment:rubygems.org
 claim_pattern:
   event_name: workflow_dispatch
   environment: rubygems.org
-  ref: refs/heads/*
+  ref: refs/heads/[^/]+
   repository: DataDog/dd-trace-rb
-  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/publish\.yml@refs/heads/*
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/publish\.yml@refs/heads/[^/]+
 
 permissions:
   contents: write


### PR DESCRIPTION
**What does this PR do?**
This PR attempts to fix "Publish Gem" workflow by fixing the `job_workflow_ref`.

**Motivation:**
The "Publish Gem" workflow is still failing:
https://github.com/DataDog/dd-trace-rb/actions/runs/24670617318/job/72140158672

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
Merge and publish.