### PR TITLE
SymDB: Add  data model classes

### DIFF
--- a/lib/datadog/symbol_database.rb
+++ b/lib/datadog/symbol_database.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Datadog
+  # Namespace for Datadog symbol database upload.
+  #
+  # @api private
+  module SymbolDatabase
+    # Sentinel value for unknown or unavailable minimum line number.
+    #
+    # Backend behavior: line=0 means symbol completes in every line of the scope.
+    UNKNOWN_MIN_LINE = 0
+
+    # Sentinel value for unknown or unavailable maximum line number.
+    #
+    # Backend behavior: 2147483647 means "unknown maximum" / "whole remaining scope".
+    UNKNOWN_MAX_LINE = 2147483647
+  end
+end

--- a/lib/datadog/symbol_database/scope.rb
+++ b/lib/datadog/symbol_database/scope.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative 'symbol'
+
+module Datadog
+  module SymbolDatabase
+    # Represents a scope in the hierarchical symbol structure.
+    #
+    # @api private
+    class Scope
+      attr_reader \
+        :scope_type,
+        :name,
+        :source_file,
+        :start_line,
+        :end_line,
+        :has_injectible_lines,
+        :injectible_lines,
+        :language_specifics,
+        :symbols,
+        :scopes
+
+      def initialize(
+        scope_type:,
+        name: nil,
+        source_file: nil,
+        start_line: nil,
+        end_line: nil,
+        has_injectible_lines: false,
+        injectible_lines: nil,
+        language_specifics: nil,
+        symbols: nil,
+        scopes: nil
+      )
+        @scope_type = scope_type
+        @name = name
+        @source_file = source_file
+        @start_line = start_line
+        @end_line = end_line
+        @has_injectible_lines = has_injectible_lines
+        @injectible_lines = injectible_lines
+        @language_specifics = language_specifics || {}
+        @symbols = symbols || []
+        @scopes = scopes || []
+      end
+
+      def to_h
+        hash = {
+          scope_type: scope_type,
+          name: name,
+          source_file: source_file,
+          start_line: start_line,
+          end_line: end_line,
+          language_specifics: language_specifics.empty? ? nil : language_specifics,
+          symbols: symbols.empty? ? nil : symbols.map(&:to_h),
+          scopes: scopes.empty? ? nil : scopes.map(&:to_h),
+        }.compact
+
+        if scope_type == 'METHOD'
+          hash[:has_injectible_lines] = has_injectible_lines # steep:ignore ArgumentTypeMismatch
+          hash[:injectible_lines] = injectible_lines if injectible_lines && !injectible_lines.empty?
+        end
+
+        hash
+      end
+
+      def to_json(_state = nil)
+        JSON.generate(to_h)
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/service_version.rb
+++ b/lib/datadog/symbol_database/service_version.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative 'scope'
+
+module Datadog
+  module SymbolDatabase
+    # Top-level upload payload wrapper.
+    #
+    # @api private
+    class ServiceVersion
+      attr_reader :service, :env, :version, :language, :scopes
+
+      def initialize(service:, env:, version:, scopes:)
+        raise ArgumentError, 'service is required' if service.nil? || service.empty?
+        raise ArgumentError, 'scopes must be an array' unless scopes.is_a?(Array)
+
+        @service = service
+        @env = env.to_s.empty? ? 'none' : env.to_s
+        @version = version.to_s.empty? ? 'none' : version.to_s
+        @language = 'ruby'
+        @scopes = scopes
+      end
+
+      def to_h
+        {
+          service: service,
+          env: env,
+          version: version,
+          language: language,
+          scopes: scopes.map(&:to_h),
+        }
+      end
+
+      def to_json(_state = nil)
+        JSON.generate(to_h)
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/symbol.rb
+++ b/lib/datadog/symbol_database/symbol.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../symbol_database'
+
+module Datadog
+  module SymbolDatabase
+    # Represents a symbol within a scope.
+    #
+    # @api private
+    class Symbol
+      attr_reader :symbol_type, :name, :line, :type, :language_specifics
+
+      def initialize(
+        symbol_type:,
+        name:,
+        line:,
+        type: nil,
+        language_specifics: nil
+      )
+        @symbol_type = symbol_type
+        @name = name
+        @line = line
+        @type = type
+        @language_specifics = language_specifics
+      end
+
+      def to_h
+        {
+          symbol_type: symbol_type,
+          name: name,
+          line: line,
+          type: type,
+          language_specifics: language_specifics,
+        }.compact
+      end
+
+      def to_json(_state = nil)
+        JSON.generate(to_h)
+      end
+    end
+  end
+end

--- a/sig/datadog/symbol_database.rbs
+++ b/sig/datadog/symbol_database.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module SymbolDatabase
+    UNKNOWN_MIN_LINE: Integer
+
+    UNKNOWN_MAX_LINE: Integer
+  end
+end

--- a/sig/datadog/symbol_database/scope.rbs
+++ b/sig/datadog/symbol_database/scope.rbs
@@ -1,0 +1,62 @@
+module Datadog
+  module SymbolDatabase
+    class Scope
+      @scope_type: String
+
+      @name: String?
+
+      @source_file: String?
+
+      @start_line: Integer?
+
+      @end_line: Integer?
+
+      @has_injectible_lines: bool
+
+      @injectible_lines: Array[Hash[::Symbol, Integer]]?
+
+      @language_specifics: Hash[::Symbol, untyped]
+
+      @symbols: Array[Datadog::SymbolDatabase::Symbol]
+
+      @scopes: Array[Scope]
+
+      def initialize: (
+        scope_type: String,
+        ?name: String?,
+        ?source_file: String?,
+        ?start_line: Integer?,
+        ?end_line: Integer?,
+        ?has_injectible_lines: bool,
+        ?injectible_lines: Array[Hash[::Symbol, Integer]]?,
+        ?language_specifics: Hash[::Symbol, untyped]?,
+        ?symbols: Array[Datadog::SymbolDatabase::Symbol]?,
+        ?scopes: Array[Scope]?
+      ) -> void
+
+      attr_reader scope_type: String
+
+      attr_reader name: String?
+
+      attr_reader source_file: String?
+
+      attr_reader start_line: Integer?
+
+      attr_reader end_line: Integer?
+
+      attr_reader has_injectible_lines: bool
+
+      attr_reader injectible_lines: Array[Hash[::Symbol, Integer]]?
+
+      attr_reader language_specifics: Hash[::Symbol, untyped]
+
+      attr_reader symbols: Array[Datadog::SymbolDatabase::Symbol]
+
+      attr_reader scopes: Array[Scope]
+
+      def to_h: () -> Hash[::Symbol, untyped]
+
+      def to_json: (?untyped _state) -> String
+    end
+  end
+end

--- a/sig/datadog/symbol_database/service_version.rbs
+++ b/sig/datadog/symbol_database/service_version.rbs
@@ -1,0 +1,36 @@
+module Datadog
+  module SymbolDatabase
+    class ServiceVersion
+      @service: String
+
+      @env: String
+
+      @version: String
+
+      @language: String
+
+      @scopes: Array[Scope]
+
+      def initialize: (
+        service: String,
+        env: String?,
+        version: String?,
+        scopes: Array[Scope]
+      ) -> void
+
+      attr_reader service: String
+
+      attr_reader env: String
+
+      attr_reader version: String
+
+      attr_reader language: String
+
+      attr_reader scopes: Array[Scope]
+
+      def to_h: () -> Hash[::Symbol, untyped]
+
+      def to_json: (?untyped _state) -> String
+    end
+  end
+end

--- a/sig/datadog/symbol_database/symbol.rbs
+++ b/sig/datadog/symbol_database/symbol.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module SymbolDatabase
+    class Symbol
+      @symbol_type: String
+
+      @name: String
+
+      @line: Integer
+
+      @type: String?
+
+      @language_specifics: Hash[::Symbol, untyped]?
+
+      def initialize: (
+        symbol_type: String,
+        name: String,
+        line: Integer,
+        ?type: String?,
+        ?language_specifics: Hash[::Symbol, untyped]?
+      ) -> void
+
+      attr_reader symbol_type: String
+
+      attr_reader name: String
+
+      attr_reader line: Integer
+
+      attr_reader type: String?
+
+      attr_reader language_specifics: Hash[::Symbol, untyped]?
+
+      def to_h: () -> Hash[::Symbol, untyped]
+
+      def to_json: (?untyped _state) -> String
+    end
+  end
+end

--- a/spec/datadog/symbol_database/scope_spec.rb
+++ b/spec/datadog/symbol_database/scope_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/scope'
+
+RSpec.describe Datadog::SymbolDatabase::Scope do
+  describe '#initialize' do
+    it 'creates scope with required fields' do
+      scope = described_class.new(scope_type: 'CLASS')
+
+      expect(scope.scope_type).to eq('CLASS')
+      expect(scope.name).to be_nil
+      expect(scope.language_specifics).to eq({})
+      expect(scope.symbols).to eq([])
+      expect(scope.scopes).to eq([])
+    end
+  end
+
+  describe '#to_h' do
+    it 'serializes nested symbols and scopes' do
+      symbol = Datadog::SymbolDatabase::Symbol.new(
+        symbol_type: 'FIELD',
+        name: '@field',
+        line: 5,
+      )
+      method_scope = described_class.new(
+        scope_type: 'METHOD',
+        name: 'call',
+        start_line: 10,
+        end_line: 12,
+        has_injectible_lines: true,
+        injectible_lines: [{start: 10, end: 12}],
+      )
+      class_scope = described_class.new(
+        scope_type: 'CLASS',
+        name: 'MyClass',
+        source_file: '/app/my_class.rb',
+        start_line: 1,
+        end_line: 20,
+        language_specifics: {super_classes: ['Base']},
+        symbols: [symbol],
+        scopes: [method_scope],
+      )
+
+      expect(class_scope.to_h).to eq({
+        scope_type: 'CLASS',
+        name: 'MyClass',
+        source_file: '/app/my_class.rb',
+        start_line: 1,
+        end_line: 20,
+        language_specifics: {super_classes: ['Base']},
+        symbols: [
+          {
+            symbol_type: 'FIELD',
+            name: '@field',
+            line: 5,
+          },
+        ],
+        scopes: [
+          {
+            scope_type: 'METHOD',
+            name: 'call',
+            start_line: 10,
+            end_line: 12,
+            has_injectible_lines: true,
+            injectible_lines: [{start: 10, end: 12}],
+          },
+        ],
+      })
+    end
+
+    it 'omits empty collections and nil fields' do
+      scope = described_class.new(
+        scope_type: 'MODULE',
+        name: 'MyModule',
+      )
+
+      expect(scope.to_h).to eq({
+        scope_type: 'MODULE',
+        name: 'MyModule',
+      })
+    end
+
+    it 'emits method injectable line state even when false' do
+      scope = described_class.new(
+        scope_type: 'METHOD',
+        name: 'native_call',
+        has_injectible_lines: false,
+      )
+
+      expect(scope.to_h).to eq({
+        scope_type: 'METHOD',
+        name: 'native_call',
+        has_injectible_lines: false,
+      })
+    end
+
+    it 'does not emit injectable line fields for non-method scopes' do
+      scope = described_class.new(
+        scope_type: 'CLASS',
+        name: 'MyClass',
+        has_injectible_lines: true,
+        injectible_lines: [{start: 1, end: 2}],
+      )
+
+      expect(scope.to_h).to eq({
+        scope_type: 'CLASS',
+        name: 'MyClass',
+      })
+    end
+  end
+
+  describe '#to_json' do
+    it 'serializes scope to JSON' do
+      scope = described_class.new(
+        scope_type: 'METHOD',
+        name: 'perform',
+        start_line: 7,
+        end_line: 9,
+        has_injectible_lines: false,
+      )
+
+      expect(JSON.parse(scope.to_json)).to eq({
+        'scope_type' => 'METHOD',
+        'name' => 'perform',
+        'start_line' => 7,
+        'end_line' => 9,
+        'has_injectible_lines' => false,
+      })
+    end
+  end
+end

--- a/spec/datadog/symbol_database/service_version_spec.rb
+++ b/spec/datadog/symbol_database/service_version_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/service_version'
+
+RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
+  describe '#initialize' do
+    it 'stores required fields and defaults language to ruby' do
+      payload = described_class.new(
+        service: 'my-service',
+        env: 'production',
+        version: '1.0.0',
+        scopes: [],
+      )
+
+      expect(payload.service).to eq('my-service')
+      expect(payload.env).to eq('production')
+      expect(payload.version).to eq('1.0.0')
+      expect(payload.language).to eq('ruby')
+      expect(payload.scopes).to eq([])
+    end
+
+    it 'normalizes blank env and version to none' do
+      payload = described_class.new(
+        service: 'my-service',
+        env: '',
+        version: nil,
+        scopes: [],
+      )
+
+      expect(payload.env).to eq('none')
+      expect(payload.version).to eq('none')
+    end
+
+    it 'rejects missing service' do
+      expect do
+        described_class.new(service: '', env: 'prod', version: '1.0', scopes: [])
+      end.to raise_error(ArgumentError, /service is required/)
+    end
+
+    it 'rejects non-array scopes' do
+      expect do
+        described_class.new(service: 'svc', env: 'prod', version: '1.0', scopes: 'invalid')
+      end.to raise_error(ArgumentError, /scopes must be an array/)
+    end
+  end
+
+  describe '#to_h' do
+    it 'serializes nested scopes' do
+      scope = Datadog::SymbolDatabase::Scope.new(
+        scope_type: 'CLASS',
+        name: 'MyClass',
+      )
+      payload = described_class.new(
+        service: 'my-app',
+        env: 'staging',
+        version: '2.1.0',
+        scopes: [scope],
+      )
+
+      expect(payload.to_h).to eq({
+        service: 'my-app',
+        env: 'staging',
+        version: '2.1.0',
+        language: 'ruby',
+        scopes: [
+          {
+            scope_type: 'CLASS',
+            name: 'MyClass',
+          },
+        ],
+      })
+    end
+  end
+
+  describe '#to_json' do
+    it 'serializes the upload payload to JSON' do
+      payload = described_class.new(
+        service: 'test-service',
+        env: 'test',
+        version: '0.1.0',
+        scopes: [],
+      )
+
+      expect(JSON.parse(payload.to_json)).to eq({
+        'service' => 'test-service',
+        'env' => 'test',
+        'version' => '0.1.0',
+        'language' => 'ruby',
+        'scopes' => [],
+      })
+    end
+  end
+end

--- a/spec/datadog/symbol_database/symbol_spec.rb
+++ b/spec/datadog/symbol_database/symbol_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/symbol'
+
+RSpec.describe Datadog::SymbolDatabase::Symbol do
+  describe '#initialize' do
+    it 'creates symbol with required fields' do
+      symbol = described_class.new(
+        symbol_type: 'FIELD',
+        name: '@my_var',
+        line: 10,
+      )
+
+      expect(symbol.symbol_type).to eq('FIELD')
+      expect(symbol.name).to eq('@my_var')
+      expect(symbol.line).to eq(10)
+      expect(symbol.type).to be_nil
+      expect(symbol.language_specifics).to be_nil
+    end
+
+    it 'creates symbol with all fields' do
+      symbol = described_class.new(
+        symbol_type: 'ARG',
+        name: 'param1',
+        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+        type: 'String',
+        language_specifics: {optional: false},
+      )
+
+      expect(symbol.symbol_type).to eq('ARG')
+      expect(symbol.name).to eq('param1')
+      expect(symbol.line).to eq(Datadog::SymbolDatabase::UNKNOWN_MIN_LINE)
+      expect(symbol.type).to eq('String')
+      expect(symbol.language_specifics).to eq({optional: false})
+    end
+  end
+
+  describe '#to_h' do
+    it 'converts symbol to hash with required fields' do
+      symbol = described_class.new(
+        symbol_type: 'STATIC_FIELD',
+        name: 'CONSTANT',
+        line: 5,
+      )
+
+      expect(symbol.to_h).to eq({
+        symbol_type: 'STATIC_FIELD',
+        name: 'CONSTANT',
+        line: 5,
+      })
+    end
+
+    it 'includes optional fields when present' do
+      symbol = described_class.new(
+        symbol_type: 'LOCAL',
+        name: 'local_var',
+        line: 15,
+        type: 'Integer',
+        language_specifics: {inferred: true},
+      )
+
+      expect(symbol.to_h).to eq({
+        symbol_type: 'LOCAL',
+        name: 'local_var',
+        line: 15,
+        type: 'Integer',
+        language_specifics: {inferred: true},
+      })
+    end
+
+    it 'omits nil values' do
+      symbol = described_class.new(
+        symbol_type: 'FIELD',
+        name: '@var',
+        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+      )
+
+      expect(symbol.to_h).to eq({
+        symbol_type: 'FIELD',
+        name: '@var',
+        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+      })
+    end
+  end
+
+  describe '#to_json' do
+    it 'serializes symbol to JSON' do
+      symbol = described_class.new(
+        symbol_type: 'ARG',
+        name: 'param',
+        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+        type: 'Hash',
+        language_specifics: {required: true},
+      )
+
+      expect(JSON.parse(symbol.to_json)).to eq({
+        'symbol_type' => 'ARG',
+        'name' => 'param',
+        'line' => Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+        'type' => 'Hash',
+        'language_specifics' => {'required' => true},
+      })
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Adds the initial SymDB data model classes for the Ruby tracer: `Symbol`, `Scope`, and `ServiceVersion`.
Includes the matching RBS definitions and focused unit specs for serialization and validation behavior.

**Motivation:**
This is the first split-out review PR from the original SymDB work in #5431.
It lets reviewers validate the payload shape and recursive serialization contract independently from extraction, upload, and runtime integration.

**Change log entry**
None.

**Additional Notes:**
This PR is intentionally limited to the in-memory payload model and its tests.
It does not include extraction, batching, transport, remote config, or lifecycle wiring.
Follow-up split PRs will continue carving reviewable pieces out of #5431.

**How to test the change?**
Unit tests are included.