### PR TITLE
Exclude current workflow check runs from publish verification

### DIFF
--- a/.github/scripts/publish/verify_check_runs.js
+++ b/.github/scripts/publish/verify_check_runs.js
@@ -1,11 +1,45 @@
 // This script runs in the context of `actions/github-script` from GitHub Action workflow.
 // It checks the conclusion for check suites of a commit (SHA) from a specifc Github App.
 // It fails the workflow if any of the check suites are not 'success', 'neutral' or 'skipped'.
+//
+// Check suites belonging to the current workflow are excluded to prevent a cascade where
+// a failed publish run blocks all subsequent publish attempts.
 
 // API:
 // - https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference
 // - https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite
 module.exports = async ({github, context, core}) => {
+  // Identify check suites belonging to the current workflow so we can exclude them.
+  // Each workflow run gets its own check suite; we look up our own run's workflow ID,
+  // then find all runs of that workflow on this commit and collect their check suite IDs.
+  const currentWorkflowRunId = parseInt(process.env.CURRENT_RUN_ID);
+  let excludedRunIds = new Set();
+
+  if (currentWorkflowRunId) {
+    // Get the workflow ID for the current run
+    const { data: currentRun } = await github.rest.actions.getWorkflowRun({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: currentWorkflowRunId,
+    });
+    const workflowId = currentRun.workflow_id;
+
+    // List all runs of this workflow to find their check suite IDs
+    const { data: workflowRuns } = await github.rest.actions.listWorkflowRuns({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      workflow_id: workflowId,
+      head_sha: context.sha,
+      per_page: 100,
+    });
+
+    const workflowRunIds = new Set(workflowRuns.workflow_runs.map(r => r.id));
+    console.log(`Found ${workflowRunIds.size} runs of current workflow (ID: ${workflowId})`);
+
+    // We'll filter by run ID extracted from check run html_url below
+    excludedRunIds = workflowRunIds;
+  }
+
   const checkSuites = await github.paginate(github.rest.checks.listSuitesForRef, {
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -43,18 +77,36 @@ module.exports = async ({github, context, core}) => {
     });
 
     const failedChecksArrays = await Promise.all(failedChecksPromises);
-    const failedChecks = failedChecksArrays.flat();
+    let failedChecks = failedChecksArrays.flat();
 
-    console.log(`Found a total of ${failedChecks.length} failed check runs`);
+    // Exclude check runs from the current workflow to prevent self-referential cascades.
+    // html_url format: https://github.com/OWNER/REPO/actions/runs/RUN_ID/job/JOB_ID
+    if (excludedRunIds.size > 0) {
+      const before = failedChecks.length;
+      failedChecks = failedChecks.filter(check => {
+        const match = (check.html_url || '').match(/\/actions\/runs\/(\d+)\//);
+        if (match) {
+          return !excludedRunIds.has(parseInt(match[1]));
+        }
+        return true;
+      });
+      const excluded = before - failedChecks.length;
+      if (excluded > 0) {
+        console.log(`Excluded ${excluded} check runs from current workflow`);
+      }
+    }
 
-    failedChecks.forEach(failedCheck => {
-      const { name, conclusion, html_url } = failedCheck;
-      const message = JSON.stringify({ name, conclusion, url: html_url }, null, 2);
+    console.log(`Found a total of ${failedChecks.length} failed check runs (after exclusions)`);
 
-      core.error(message);
-    });
+    if (failedChecks.length > 0) {
+      failedChecks.forEach(failedCheck => {
+        const { name, conclusion, html_url } = failedCheck;
+        const message = JSON.stringify({ name, conclusion, url: html_url }, null, 2);
 
-    // Set job failure
-    core.setFailed(`Found ${failedSuites.length} failed check suites`);
+        core.error(message);
+      });
+
+      core.setFailed(`Found ${failedChecks.length} failed check runs`);
+    }
   }
 }

--- a/.github/scripts/publish/verify_check_runs.js
+++ b/.github/scripts/publish/verify_check_runs.js
@@ -1,13 +1,47 @@
-// This script runs in the context of `actions/github-script` from GitHub Action workflow.
-// It checks the conclusion for check suites of a commit (SHA) from a specifc Github App.
-// It fails the workflow if any of the check suites are not 'success', 'neutral' or 'skipped'.
+// Verify that all GitHub Actions check runs for a commit are passing.
 //
-// Check suites belonging to the current workflow are excluded to prevent a cascade where
-// a failed publish run blocks all subsequent publish attempts.
-
+// Runs inside `actions/github-script` in the publish workflow. Lists every check suite
+// for the commit SHA from a specific GitHub App (APP_ID), then inspects individual check
+// runs inside any suite that isn't success/neutral/skipped. Fails the workflow if any
+// non-excluded check run has a failing conclusion.
+//
+// Self-exclusion (CURRENT_RUN_ID):
+//
+//   When a publish attempt fails, its check suite stays attached to the commit as a
+//   permanent failure. A subsequent publish dispatch on the same SHA creates a *new*
+//   workflow run (and check suite) — it does not reuse the old one. Without exclusion,
+//   the new run's verification step sees the old run's failed check suite and fails
+//   itself, creating a cascade where a single publish failure blocks all retries.
+//
+//   To break this cycle, the script accepts CURRENT_RUN_ID (the current workflow run ID).
+//   It looks up which workflow the run belongs to, finds all runs of that workflow on
+//   this SHA, and excludes their check runs from the failure list. This means publish
+//   runs only evaluate CI check runs — not other publish runs.
+//
+//   The lookup is deferred: workflow run API calls only happen when there are actual
+//   failures to investigate. On the happy path (all suites green), no extra calls are made.
+//
+// Limitation — aggregate status endpoint:
+//
+//   The publish workflow has a separate "Verify deferred commit data" step that hits
+//   GitHub's internal aggregate status endpoint (commit/<sha>/deferred_commit_data).
+//   This is the same data that drives the green checkmark / red X in the GitHub UI.
+//   That aggregate includes ALL check suites for the SHA with no way to filter individual
+//   runs. If old failed publish check suites exist, the aggregate stays red even though
+//   this script correctly passes. The `force: true` input bypasses that step.
+//
+//   "Re-run all jobs" on the *same* workflow run reuses its check suite and can turn it
+//   green. A *new* workflow dispatch cannot — the old failure remains.
+//
+// Environment variables:
+//   APP_ID          - GitHub App ID to filter check suites (e.g. 15368 for GitHub Actions)
+//   CURRENT_RUN_ID  - (optional) current workflow run ID; enables self-exclusion
+//
 // API:
-// - https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference
-// - https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite
+// - https://docs.github.com/en/rest/checks/suites#list-check-suites-for-a-git-reference
+// - https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite
+// - https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run
+// - https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
 module.exports = async ({github, context, core}) => {
   const checkSuites = await github.paginate(github.rest.checks.listSuitesForRef, {
     owner: context.repo.owner,

--- a/.github/scripts/publish/verify_check_runs.js
+++ b/.github/scripts/publish/verify_check_runs.js
@@ -9,37 +9,6 @@
 // - https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference
 // - https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-in-a-check-suite
 module.exports = async ({github, context, core}) => {
-  // Identify check suites belonging to the current workflow so we can exclude them.
-  // Each workflow run gets its own check suite; we look up our own run's workflow ID,
-  // then find all runs of that workflow on this commit and collect their check suite IDs.
-  const currentWorkflowRunId = parseInt(process.env.CURRENT_RUN_ID);
-  let excludedRunIds = new Set();
-
-  if (currentWorkflowRunId) {
-    // Get the workflow ID for the current run
-    const { data: currentRun } = await github.rest.actions.getWorkflowRun({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      run_id: currentWorkflowRunId,
-    });
-    const workflowId = currentRun.workflow_id;
-
-    // List all runs of this workflow to find their check suite IDs
-    const { data: workflowRuns } = await github.rest.actions.listWorkflowRuns({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      workflow_id: workflowId,
-      head_sha: context.sha,
-      per_page: 100,
-    });
-
-    const workflowRunIds = new Set(workflowRuns.workflow_runs.map(r => r.id));
-    console.log(`Found ${workflowRunIds.size} runs of current workflow (ID: ${workflowId})`);
-
-    // We'll filter by run ID extracted from check run html_url below
-    excludedRunIds = workflowRunIds;
-  }
-
   const checkSuites = await github.paginate(github.rest.checks.listSuitesForRef, {
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -80,6 +49,32 @@ module.exports = async ({github, context, core}) => {
     let failedChecks = failedChecksArrays.flat();
 
     // Exclude check runs from the current workflow to prevent self-referential cascades.
+    // Only load workflow runs when there are actual failures to avoid unnecessary API calls.
+    const currentWorkflowRunId = parseInt(process.env.CURRENT_RUN_ID);
+    let excludedRunIds = new Set();
+
+    if (currentWorkflowRunId) {
+      // Get the workflow ID for the current run
+      const { data: currentRun } = await github.rest.actions.getWorkflowRun({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: currentWorkflowRunId,
+      });
+      const workflowId = currentRun.workflow_id;
+
+      // List all runs of this workflow to find their check suite IDs
+      const { data: workflowRuns } = await github.rest.actions.listWorkflowRuns({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        workflow_id: workflowId,
+        head_sha: context.sha,
+        per_page: 100,
+      });
+
+      excludedRunIds = new Set(workflowRuns.workflow_runs.map(r => r.id));
+      console.log(`Found ${excludedRunIds.size} runs of current workflow (ID: ${workflowId})`);
+    }
+
     // html_url format: https://github.com/OWNER/REPO/actions/runs/RUN_ID/job/JOB_ID
     if (excludedRunIds.size > 0) {
       const before = failedChecks.length;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,7 @@ jobs:
         continue-on-error: ${{ inputs.force }}
         env:
           APP_ID: 15368 # Github Actions app ID
+          CURRENT_RUN_ID: ${{ github.run_id }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           retries: 3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     name: Verify commit status checks
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       checks: read
       contents: write
     outputs:


### PR DESCRIPTION
**What does this PR do?**

Fixes a self-referential cascade in the publish gem workflow where a failed publish attempt blocks all subsequent publish attempts indefinitely.

The `verify_check_runs.js` script checks all GitHub Actions check suites on the commit before publishing. When a publish attempt fails for any reason (e.g. pending status checks), it leaves a failed "Verify commit status checks" check run on the commit. Subsequent publish attempts then find that failed check run and also fail — creating more failed check runs and making the situation worse with each retry.

This PR adds self-exclusion: the script looks up its own workflow ID via `CURRENT_RUN_ID`, finds all runs of that workflow on the current commit, and excludes their check runs from the failure check.

**Motivation:**

[Run 24673839631](https://github.com/DataDog/dd-trace-rb/actions/runs/24673839631) failed because prior publish attempts ([24672402225](https://github.com/DataDog/dd-trace-rb/actions/runs/24672402225), [24673568485](https://github.com/DataDog/dd-trace-rb/actions/runs/24673568485)) had already failed and left failed check runs on master. The original failure was a `pending` commit status — the publish was triggered before external CI finished. That status has since resolved, but the cascade of 6 failed check suites now blocks any new publish attempt.

**Change log entry**

None.

**Additional Notes:**

The exclusion works by:
1. Getting the current run's workflow ID via the Actions API
2. Listing all runs of that workflow on the same commit SHA
3. Matching check run `html_url` (format: `/actions/runs/RUN_ID/job/JOB_ID`) against the collected run IDs
4. Filtering out matches before checking for failures

This adds 2 extra API calls (get current run + list workflow runs) but runs only during the publish workflow, so the overhead is negligible.

**How to test the change?**

1. Trigger the publish workflow on a commit that has failed publish check runs from prior attempts
2. Verify the script logs show "Excluded N check runs from current workflow"
3. Verify the workflow passes the check runs step (assuming no other non-publish failures exist)