### PR TITLE
[APMLP-1301] Implement "first writer wins" logic in TraceKeeper

### DIFF
--- a/lib/datadog/appsec/trace_keeper.rb
+++ b/lib/datadog/appsec/trace_keeper.rb
@@ -7,16 +7,28 @@ module Datadog
       def self.keep!(trace)
         return unless trace
 
+        previous_dm = trace.get_tag(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER)
+
         # NOTE: This action will not set correct decision maker value, so the
         #       trace keeping must be done with additional steps below
         trace.keep!
 
-        # Propagate to downstream services the information that
-        # the current distributed trace is containing at least one ASM event.
-        trace.set_tag(
-          Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
-          Tracing::Sampling::Ext::Decision::ASM
-        )
+        # NOTE: Preserve decision maker if already set by another product.
+        #       As `trace.keep!` resets `_dd.p.dm` to `MANUAL`, we restore the
+        #       previous value when another product has already claimed the
+        #       decision maker.
+        if previous_dm.nil? || previous_dm == Tracing::Sampling::Ext::Decision::MANUAL
+          trace.set_tag(
+            Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
+            Tracing::Sampling::Ext::Decision::ASM
+          )
+        else
+          trace.set_tag(
+            Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
+            previous_dm,
+          )
+        end
+
         trace.set_distributed_source(Ext::PRODUCT_BIT)
       end
     end

--- a/spec/datadog/appsec/trace_keeper_spec.rb
+++ b/spec/datadog/appsec/trace_keeper_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Datadog::AppSec::TraceKeeper do
         expect { described_class.keep!(trace) }
           .to change { trace.get_tag('_dd.p.dm') }.from(nil).to('-5')
       end
+
+      context 'when another product has already set the decision maker' do
+        before do
+          trace.keep!
+          trace.set_tag(
+            Datadog::Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
+            Datadog::Tracing::Sampling::Ext::Decision::AI_GUARD,
+          )
+        end
+
+        it 'preserves the existing decision maker' do
+          expect { described_class.keep!(trace) }
+            .not_to change { trace.get_tag('_dd.p.dm') }.from('-13')
+        end
+
+        it 'still sets trace source tag' do
+          expect { described_class.keep!(trace) }
+            .to change { trace.get_tag('_dd.p.ts') }.from(nil).to('02')
+        end
+      end
     end
 
     context 'when trace is not given' do


### PR DESCRIPTION
**What does this PR do?**

Restores decision maker value to previous if any other product already claimed it.

**Motivation:**

This fixes issue spotted in intermittent failed [ST](https://github.com/DataDog/dd-trace-rb/actions/runs/24657987274/job/72099975964).

**Change log entry**

No.

**Additional Notes:**

This still require confirmation from @y9v 

**How to test the change?**

CI + ST