### PR TITLE
[NO-TICKET] Update C extensions with modern Ruby APIs

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -319,7 +319,6 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   // Hosts methods used for testing the native code using RSpec
   VALUE testing_module = rb_define_module_under(collectors_cpu_and_wall_time_worker_class, "Testing");
   clock_failure_exception_class = rb_define_class_under(collectors_cpu_and_wall_time_worker_class, "ClockFailure", rb_eRuntimeError);
-  rb_gc_register_mark_object(clock_failure_exception_class);
 
   // Instances of the CpuAndWallTimeWorker class are "TypedData" objects.
   // "TypedData" objects are special objects in the Ruby VM that can wrap C structs.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1101,7 +1101,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("gvl_sampling_time_ns_avg")),   /* => */ RUBY_AVG_OR_NIL(state->stats.gvl_sampling_time_ns_total, state->stats.after_gvl_running),
   };
   VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, stats_as_hash);
   return stats_as_hash;
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -354,6 +354,10 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_gvl_profiling_hook_active", _native_gvl_profiling_hook_active, 1);
 }
 
+static size_t cpu_and_wall_time_worker_typed_data_size(DDTRACE_UNUSED const void *data) {
+  return sizeof(cpu_and_wall_time_worker_state);
+}
+
 // This structure is used to define a Ruby object that stores a pointer to a cpu_and_wall_time_worker_state
 // See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
 static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
@@ -361,8 +365,8 @@ static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
   .function = {
     .dmark = cpu_and_wall_time_worker_typed_data_mark,
     .dfree = RUBY_DEFAULT_FREE,
-    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
     //.dcompact = NULL, // FIXME: Add support for compaction
+    .dsize = cpu_and_wall_time_worker_typed_data_size,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1062,7 +1062,6 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
   VALUE allocation_sampler_snapshot = state->allocation_profiling_enabled && state->dynamic_sampling_rate_enabled ?
     discrete_dynamic_sampler_state_snapshot(&state->allocation_sampler) : Qnil;
 
-  VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("trigger_sample_attempts")),                    /* => */ UINT2NUM(state->stats.trigger_sample_attempts),
     ID2SYM(rb_intern("trigger_sample_extra_sleep")),                 /* => */ UINT2NUM(state->stats.trigger_sample_extra_sleep),
@@ -1101,6 +1100,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("gvl_sampling_time_ns_total")), /* => */ RUBY_NUM_OR_NIL(state->stats.gvl_sampling_time_ns_total, > 0, ULL2NUM),
     ID2SYM(rb_intern("gvl_sampling_time_ns_avg")),   /* => */ RUBY_AVG_OR_NIL(state->stats.gvl_sampling_time_ns_total, state->stats.after_gvl_running),
   };
+  VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -192,6 +192,7 @@ typedef struct {
 static VALUE _native_new(VALUE klass);
 static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr);
+static void cpu_and_wall_time_worker_typed_data_compact(void *state_ptr);
 static VALUE _native_sampling_loop(VALUE self, VALUE instance);
 static VALUE _native_stop(DDTRACE_UNUSED VALUE _self, VALUE self_instance, VALUE worker_thread);
 static VALUE stop(VALUE self_instance, VALUE optional_exception, const char *optional_exception_during_operation);
@@ -354,6 +355,18 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_gvl_profiling_hook_active", _native_gvl_profiling_hook_active, 1);
 }
 
+// On Ruby 3.3+, declarative marking lets the GC read this list directly for marking and compaction.
+// On older Rubies, the manual mark/compact callbacks iterate this same list via ddtrace_gc_mark_refs/compact_refs.
+RUBY_REFERENCES(cpu_and_wall_time_worker_refs) = {
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, thread_context_collector_instance),
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, idle_sampling_helper_instance),
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, owner_thread),
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, failure_exception),
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, stop_thread),
+  RUBY_REF_EDGE(cpu_and_wall_time_worker_state, gc_tracepoint),
+  RUBY_REF_END
+};
+
 static size_t cpu_and_wall_time_worker_typed_data_size(DDTRACE_UNUSED const void *data) {
   return sizeof(cpu_and_wall_time_worker_state);
 }
@@ -363,12 +376,19 @@ static size_t cpu_and_wall_time_worker_typed_data_size(DDTRACE_UNUSED const void
 static const rb_data_type_t cpu_and_wall_time_worker_typed_data = {
   .wrap_struct_name = "Datadog::Profiling::Collectors::CpuAndWallTimeWorker",
   .function = {
-    .dmark = cpu_and_wall_time_worker_typed_data_mark,
+    // On Ruby 3.3+, use the declarative reference list; on older Rubies, use manual mark/compact callbacks
+    #ifndef NO_DECL_MARKING
+      .dmark = RUBY_REFS_LIST_PTR(cpu_and_wall_time_worker_refs),
+    #else
+      .dmark = cpu_and_wall_time_worker_typed_data_mark,
+    #endif
     .dfree = RUBY_DEFAULT_FREE,
-    //.dcompact = NULL, // FIXME: Add support for compaction
     .dsize = cpu_and_wall_time_worker_typed_data_size,
+    #ifdef NEEDS_DCOMPACT
+      .dcompact = cpu_and_wall_time_worker_typed_data_compact,
+    #endif
   },
-  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_DECL_MARKING
 };
 
 static VALUE _native_new(VALUE klass) {
@@ -476,16 +496,14 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   return Qtrue;
 }
 
-// Since our state contains references to Ruby objects, we need to tell the Ruby GC about them
+// On Ruby < 3.3, these callbacks are used instead of declarative marking.
+// They iterate the same RUBY_REFERENCES list, so the field list is defined once.
 static void cpu_and_wall_time_worker_typed_data_mark(void *state_ptr) {
-  cpu_and_wall_time_worker_state *state = (cpu_and_wall_time_worker_state *) state_ptr;
+  ddtrace_gc_mark_refs(cpu_and_wall_time_worker_refs, sizeof(cpu_and_wall_time_worker_refs), state_ptr);
+}
 
-  rb_gc_mark(state->thread_context_collector_instance);
-  rb_gc_mark(state->idle_sampling_helper_instance);
-  rb_gc_mark(state->owner_thread);
-  rb_gc_mark(state->failure_exception);
-  rb_gc_mark(state->stop_thread);
-  rb_gc_mark(state->gc_tracepoint);
+static void cpu_and_wall_time_worker_typed_data_compact(void *state_ptr) {
+  ddtrace_gc_compact_refs(cpu_and_wall_time_worker_refs, sizeof(cpu_and_wall_time_worker_refs), state_ptr);
 }
 
 // Called in a background thread created in CpuAndWallTimeWorker#start

--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -355,11 +355,15 @@ void collectors_discrete_dynamic_sampler_init(VALUE profiling_module) {
   rb_define_method(sampler_class, "_native_state_snapshot", _native_state_snapshot, 0);
 }
 
+static size_t sampler_typed_data_size(DDTRACE_UNUSED const void *data) {
+  return sizeof(sampler_state);
+}
+
 static const rb_data_type_t sampler_typed_data = {
   .wrap_struct_name = "Datadog::Profiling::DiscreteDynamicSampler::Testing::Sampler",
   .function = {
     .dfree = RUBY_DEFAULT_FREE,
-    .dsize = NULL,
+    .dsize = sampler_typed_data_size,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -317,7 +317,7 @@ VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler)
     ID2SYM(rb_intern("max_sampling_time_ns")),            /* => */ LONG2NUM(sampler->max_sampling_time_ns),
     ID2SYM(rb_intern("sampling_time_clamps")),            /* => */ ULONG2NUM(sampler->sampling_time_clamps),
   };
-  VALUE hash = rb_hash_new();
+  VALUE hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
   return hash;
 }

--- a/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
+++ b/ext/datadog_profiling_native_extension/collectors_discrete_dynamic_sampler.c
@@ -318,7 +318,7 @@ VALUE discrete_dynamic_sampler_state_snapshot(discrete_dynamic_sampler *sampler)
     ID2SYM(rb_intern("sampling_time_clamps")),            /* => */ ULONG2NUM(sampler->sampling_time_clamps),
   };
   VALUE hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, hash);
   return hash;
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -62,15 +62,17 @@ void collectors_idle_sampling_helper_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_idle_sampling_helper_request_action", _native_idle_sampling_helper_request_action, 1);
 }
 
+static size_t idle_sampling_helper_typed_data_size(DDTRACE_UNUSED const void *data) {
+  return sizeof(idle_sampling_loop_state);
+}
+
 // This structure is used to define a Ruby object that stores a pointer to a idle_sampling_loop_state
 // See also https://github.com/ruby/ruby/blob/master/doc/extension.rdoc for how this works
 static const rb_data_type_t idle_sampling_helper_typed_data = {
   .wrap_struct_name = "Datadog::Profiling::Collectors::IdleSamplingHelper",
   .function = {
-    .dmark = NULL, // We don't store references to Ruby objects so we don't need to mark any of them
     .dfree = RUBY_DEFAULT_FREE,
-    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
-    //.dcompact = NULL, // Not needed -- we don't store references to Ruby objects
+    .dsize = idle_sampling_helper_typed_data_size,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -134,16 +134,16 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
   ENFORCE_BOOLEAN(native_filenames_enabled);
 
   VALUE zero = INT2NUM(0);
-  VALUE heap_sample = rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("heap_sample"), Qfalse);
+  VALUE heap_sample = rb_hash_lookup2(metric_values_hash, rb_str_new_lit("heap_sample"), Qfalse);
   ENFORCE_BOOLEAN(heap_sample);
   sample_values values = {
-    .cpu_time_ns   = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-time"),      zero)),
-    .cpu_or_wall_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-samples"), zero)),
-    .wall_time_ns  = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("wall-time"),     zero)),
-    .alloc_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples"), zero)),
-    .alloc_samples_unscaled = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples-unscaled"), zero)),
-    .timeline_wall_time_ns = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("timeline"), zero)),
-    .heap_sample = heap_sample == Qtrue,
+    .cpu_time_ns            = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("cpu-time"), zero)),
+    .cpu_or_wall_samples    = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("cpu-samples"), zero)),
+    .wall_time_ns           = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("wall-time"), zero)),
+    .alloc_samples          = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("alloc-samples"), zero)),
+    .alloc_samples_unscaled = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("alloc-samples-unscaled"), zero)),
+    .timeline_wall_time_ns  = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_lit("timeline"), zero)),
+    .heap_sample            = heap_sample == Qtrue,
   };
 
   long labels_count = RARRAY_LEN(labels_array) + RARRAY_LEN(numeric_labels_array);
@@ -158,7 +158,7 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
       .str = char_slice_from_ruby_string(rb_ary_entry(key_str_pair, 1))
     };
 
-    if (rb_str_equal(rb_ary_entry(key_str_pair, 0), rb_str_new_cstr("state"))) {
+    if (rb_str_equal(rb_ary_entry(key_str_pair, 0), rb_str_new_lit("state"))) {
       state_label = &labels[i];
     }
   }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1194,9 +1194,6 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
   VALUE thread = (VALUE) key_thread;
   per_thread_context *thread_context = (per_thread_context*) value_context;
   VALUE result = (VALUE) result_hash;
-  VALUE context_as_hash = rb_hash_new();
-  rb_hash_aset(result, thread, context_as_hash);
-
   VALUE arguments[] = {
     ID2SYM(rb_intern("thread_id")),                       /* => */ rb_str_new2(thread_context->thread_id),
     ID2SYM(rb_intern("thread_invoke_location")),          /* => */ rb_str_new2(thread_context->thread_invoke_location),
@@ -1212,6 +1209,8 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
       ID2SYM(rb_intern("gvl_waiting_at")), /* => */ LONG2NUM(gvl_profiling_state_thread_object_get(thread)),
     #endif
   };
+  VALUE context_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
+  rb_hash_aset(result, thread, context_as_hash);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 
   return ST_CONTINUE;
@@ -1219,24 +1218,24 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
 
 static VALUE stats_as_ruby_hash(thread_context_collector_state *state) {
   // Update this when modifying state struct (stats inner struct)
-  VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("gc_samples")),                               /* => */ UINT2NUM(state->stats.gc_samples),
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
   };
+  VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }
 
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state) {
   // Update this when modifying state struct (gc_tracking inner struct)
-  VALUE result = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("accumulated_cpu_time_ns")),               /* => */ ULONG2NUM(state->gc_tracking.accumulated_cpu_time_ns),
     ID2SYM(rb_intern("accumulated_wall_time_ns")),              /* => */ ULONG2NUM(state->gc_tracking.accumulated_wall_time_ns),
     ID2SYM(rb_intern("wall_time_at_previous_gc_ns")),           /* => */ LONG2NUM(state->gc_tracking.wall_time_at_previous_gc_ns),
     ID2SYM(rb_intern("wall_time_at_last_flushed_gc_event_ns")), /* => */ LONG2NUM(state->gc_tracking.wall_time_at_last_flushed_gc_event_ns),
   };
+  VALUE result = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(result, arguments[i], arguments[i+1]);
   return result;
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1155,7 +1155,7 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  VALUE result = rb_str_new2(" (native state)");
+  VALUE result = rb_str_new_lit(" (native state)");
 
   // Update this when modifying state struct
   rb_str_concat(result, rb_sprintf(" max_frames=%d", state->max_frames));
@@ -1195,8 +1195,8 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
   per_thread_context *thread_context = (per_thread_context*) value_context;
   VALUE result = (VALUE) result_hash;
   VALUE arguments[] = {
-    ID2SYM(rb_intern("thread_id")),                       /* => */ rb_str_new2(thread_context->thread_id),
-    ID2SYM(rb_intern("thread_invoke_location")),          /* => */ rb_str_new2(thread_context->thread_invoke_location),
+    ID2SYM(rb_intern("thread_id")),                       /* => */ rb_str_new_cstr(thread_context->thread_id),
+    ID2SYM(rb_intern("thread_invoke_location")),          /* => */ rb_str_new_cstr(thread_context->thread_invoke_location),
     ID2SYM(rb_intern("thread_cpu_time_id_valid?")),       /* => */ thread_context->thread_cpu_time_id.valid ? Qtrue : Qfalse,
     ID2SYM(rb_intern("thread_cpu_time_id")),              /* => */ CLOCKID2NUM(thread_context->thread_cpu_time_id.clock_id),
     ID2SYM(rb_intern("cpu_time_at_previous_sample_ns")),  /* => */ LONG2NUM(thread_context->cpu_time_at_previous_sample_ns),

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -611,7 +611,7 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
 
   const long thread_count = RARRAY_LEN(threads);
   for (long i = 0; i < thread_count; i++) {
-    VALUE thread = RARRAY_AREF(threads, i);
+    VALUE thread = rb_ary_entry(threads, i);
     per_thread_context *thread_context = get_or_create_context_for(thread, state);
 
     // We account for cpu-time for the current thread in a different way -- we use the cpu-time at sampling start, to avoid

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1210,8 +1210,8 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
     #endif
   };
   VALUE context_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, context_as_hash);
   rb_hash_aset(result, thread, context_as_hash);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 
   return ST_CONTINUE;
 }
@@ -1223,7 +1223,7 @@ static VALUE stats_as_ruby_hash(thread_context_collector_state *state) {
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
   };
   VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, stats_as_hash);
   return stats_as_hash;
 }
 
@@ -1236,7 +1236,7 @@ static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state) {
     ID2SYM(rb_intern("wall_time_at_last_flushed_gc_event_ns")), /* => */ LONG2NUM(state->gc_tracking.wall_time_at_last_flushed_gc_event_ns),
   };
   VALUE result = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(result, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, result);
   return result;
 }
 

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -112,3 +112,15 @@ size_t read_ddogerr_string_and_drop(ddog_Error *error, char *string, size_t capa
 static inline int ddtrace_imemo_type(VALUE imemo) {
   return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
 }
+
+// ---
+// Modern Ruby C API compatibility
+//
+// These polyfill newer Ruby C APIs on older Rubies. See extconf.rb for feature detection.
+// ---
+
+// rb_hash_new_capa was added in Ruby 3.2 to pre-size a hash and avoid resizing.
+// On older Rubies we polyfill it with a plain rb_hash_new() -- it still works, just may resize.
+#ifdef NO_RB_HASH_NEW_CAPA
+static inline VALUE rb_hash_new_capa(long capa) { (void)capa; return rb_hash_new(); }
+#endif

--- a/ext/datadog_profiling_native_extension/encoded_profile.c
+++ b/ext/datadog_profiling_native_extension/encoded_profile.c
@@ -15,7 +15,6 @@ void encoded_profile_init(VALUE profiling_module) {
   encoded_profile_class = rb_define_class_under(profiling_module, "EncodedProfile", rb_cObject);
 
   rb_undef_alloc_func(encoded_profile_class); // Class cannot be created from Ruby code
-  rb_global_variable(&encoded_profile_class);
 
   rb_define_method(encoded_profile_class, "_native_bytes", _native_bytes, 0);
 }

--- a/ext/datadog_profiling_native_extension/encoded_profile.c
+++ b/ext/datadog_profiling_native_extension/encoded_profile.c
@@ -26,8 +26,8 @@ static const rb_data_type_t encoded_profile_typed_data = {
   .function = {
     .dmark = NULL, // We don't store references to Ruby objects so we don't need to mark any of them
     .dfree = encoded_profile_typed_data_free,
-    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
     //.dcompact = NULL, // Not needed -- we don't store references to Ruby objects
+    .dsize = NULL, // Opaque libdatadog type -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -207,6 +207,9 @@ $defs << "-DNO_IMEMO_NAME" if RUBY_VERSION < "3"
 # On older Rubies, objects would not move
 $defs << "-DNO_T_MOVED" if RUBY_VERSION < "2.7"
 
+# On older Rubies, rb_hash_bulk_insert did not exist (we polyfill it in ruby_helpers.h)
+$defs << "-DNO_RB_HASH_BULK_INSERT" if RUBY_VERSION < "2.6"
+
 # On older Rubies, rb_global_vm_lock_struct did not include the owner field
 $defs << "-DNO_GVL_OWNER" if RUBY_VERSION < "2.6"
 

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -208,7 +208,7 @@ $defs << "-DNO_IMEMO_NAME" if RUBY_VERSION < "3"
 $defs << "-DNO_T_MOVED" if RUBY_VERSION < "2.7"
 
 # On older Rubies, rb_hash_bulk_insert did not exist (we polyfill it in ruby_helpers.h)
-$defs << "-DNO_RB_HASH_BULK_INSERT" if RUBY_VERSION < "2.6"
+$defs << "-DNO_RB_HASH_BULK_INSERT" if RUBY_VERSION < "2.7"
 
 # On older Rubies, rb_global_vm_lock_struct did not include the owner field
 $defs << "-DNO_GVL_OWNER" if RUBY_VERSION < "2.6"

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -167,6 +167,9 @@ $defs << "-DNO_RACTOR_HEADER_INCLUDE" if RUBY_VERSION < "3.3"
 # On older Rubies, some of the Ractor internal APIs were directly accessible
 $defs << "-DUSE_RACTOR_INTERNAL_APIS_DIRECTLY" if RUBY_VERSION < "3.3"
 
+# On older Rubies, rb_hash_new_capa did not exist (we polyfill it in datadog_ruby_common.h)
+$defs << "-DNO_RB_HASH_NEW_CAPA" if RUBY_VERSION < "3.2"
+
 # On older Rubies, there was no GVL instrumentation API and APIs created to support it
 $defs << "-DNO_GVL_INSTRUMENTATION" if RUBY_VERSION < "3.2"
 

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -139,6 +139,8 @@ if have_header("dlfcn.h")
     have_func("dladdr")
 end
 
+# NOTE: Feature flags below are ordered by Ruby version (newest first), please keep them sorted.
+
 # On older Rubies, there was no primitive mutex and condition variable implemented in `thread_sync.rb` (internal)
 $defs << "-DNO_PRIMITIVE_MUTEX_AND_CONDITION_VARIABLE" if RUBY_VERSION < "4"
 
@@ -166,6 +168,9 @@ $defs << "-DNO_RACTOR_HEADER_INCLUDE" if RUBY_VERSION < "3.3"
 
 # On older Rubies, some of the Ractor internal APIs were directly accessible
 $defs << "-DUSE_RACTOR_INTERNAL_APIS_DIRECTLY" if RUBY_VERSION < "3.3"
+
+# On older Rubies, declarative marking (RUBY_TYPED_DECL_MARKING / RUBY_REFERENCES) did not exist
+$defs << "-DNO_DECL_MARKING" if RUBY_VERSION < "3.3"
 
 # On older Rubies, rb_hash_new_capa did not exist (we polyfill it in datadog_ruby_common.h)
 $defs << "-DNO_RB_HASH_NEW_CAPA" if RUBY_VERSION < "3.2"

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -686,7 +686,7 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder) {
     ID2SYM(rb_intern("lifetime_deferred_recordings_finalized")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_finalized),
   };
   VALUE hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, hash);
 
   return hash;
 }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -685,7 +685,7 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder) {
     ID2SYM(rb_intern("lifetime_deferred_recordings_skipped_buffer_full")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full),
     ID2SYM(rb_intern("lifetime_deferred_recordings_finalized")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_finalized),
   };
-  VALUE hash = rb_hash_new();
+  VALUE hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
 
   return hash;

--- a/ext/datadog_profiling_native_extension/profiling.c
+++ b/ext/datadog_profiling_native_extension/profiling.c
@@ -257,7 +257,7 @@ static VALUE _native_trigger_holding_the_gvl_signal_handler_on(DDTRACE_UNUSED VA
 
   if (holding_the_gvl_signal_handler_result[0] == Qfalse) raise_error(rb_eRuntimeError, "Could not signal background_thread");
 
-  VALUE result = rb_hash_new();
+  VALUE result = rb_hash_new_capa(2);
   rb_hash_aset(result, ID2SYM(rb_intern("ruby_thread_has_gvl_p")), holding_the_gvl_signal_handler_result[1]);
   rb_hash_aset(result, ID2SYM(rb_intern("is_current_thread_holding_the_gvl")), holding_the_gvl_signal_handler_result[2]);
   return result;

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -233,7 +233,7 @@ int rb_objspace_internal_object_p(VALUE obj);
 #endif
 
 VALUE ruby_safe_inspect(VALUE obj) {
-  if (!ruby_is_obj_with_class(obj))       return rb_str_new_cstr("(Not an object)");
+  if (!ruby_is_obj_with_class(obj))       return rb_str_new_lit("(Not an object)");
   if (rb_objspace_internal_object_p(obj)) return rb_sprintf("(VM Internal, %s)", safe_object_info(obj));
   // @ivoanjo: I saw crashes on Ruby 3.1.4 when trying to #inspect matchdata objects. I'm not entirely sure why this
   // is needed, but since we only use this method for debug purposes I put in this alternative and decided not to
@@ -242,5 +242,5 @@ VALUE ruby_safe_inspect(VALUE obj) {
   if (rb_respond_to(obj, inspect_id)) return rb_sprintf("%+"PRIsVALUE, obj);
   if (rb_respond_to(obj, to_s_id))    return rb_sprintf("%"PRIsVALUE, obj);
 
-  return rb_str_new_cstr("(Not inspectable)");
+  return rb_str_new_lit("(Not inspectable)");
 }

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -13,9 +13,9 @@ static ID inspect_id = Qnil;
 static ID to_s_id = Qnil;
 
 void ruby_helpers_init(void) {
-  rb_global_variable(&module_object_space);
-
   module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
+  // This module should already be immortal, but just-in-case let's prevent it from being GC'd
+  rb_gc_register_mark_object(module_object_space);
   _id2ref_id = rb_intern("_id2ref");
   inspect_id = rb_intern("inspect");
   to_s_id = rb_intern("to_s");

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -40,6 +40,49 @@ static inline int check_if_pending_exception(void) {
 
 #define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))
 
+// rb_gc_mark_movable and rb_gc_location were added in Ruby 2.7 for GC compaction support.
+// On older Rubies we polyfill: mark_movable falls back to rb_gc_mark (pins objects),
+// and rb_gc_location is a no-op since objects never move.
+#ifdef NO_T_MOVED
+  #define rb_gc_mark_movable(obj) rb_gc_mark(obj)
+  #define rb_gc_location(obj) (obj)
+#endif
+
+// Declarative marking (RUBY_TYPED_DECL_MARKING, RUBY_REFERENCES, etc.) was added in Ruby 3.3.
+// On older Rubies we polyfill the macros so the reference lists can be defined unconditionally.
+// The RUBY_TYPED_DECL_MARKING flag becomes 0 so it's a no-op when OR'd into flags.
+// NOTE: The .dmark field still needs to select the correct value (refs list vs callback) via ifdef,
+// since passing a refs list as a function pointer on older Rubies would crash.
+#ifdef NO_DECL_MARKING
+  #define RUBY_TYPED_DECL_MARKING  0
+  #define RUBY_REFERENCES(name)    static const size_t name[]
+  #define RUBY_REF_EDGE(type, member) offsetof(type, member)
+  #define RUBY_REF_END             /* empty -- on old Rubies the helpers use the array size instead */
+#endif
+
+// Ruby 2.7-3.2: has .dcompact in the struct but no declarative marking, so we need manual dcompact callbacks.
+// Ruby < 2.7: no .dcompact field at all. Ruby 3.3+: declarative marking handles compaction automatically.
+#if defined(NO_DECL_MARKING) && !defined(NO_T_MOVED)
+  #define NEEDS_DCOMPACT 1
+#endif
+
+// Generic mark/compact helpers that iterate a RUBY_REFERENCES list.
+// On Ruby < 3.3, these are used by the manual dmark/dcompact callbacks. The field list is defined once
+// in a RUBY_REFERENCES array and reused here, by dcompact, and (on 3.3+) by declarative marking.
+// Pass sizeof(refs_array) so the count is computed at compile time with no sentinel needed.
+static inline void ddtrace_gc_mark_refs(const size_t *refs, size_t refs_sizeof, void *data) {
+  for (size_t i = 0; i < refs_sizeof / sizeof(size_t); i++) {
+    rb_gc_mark_movable(*(VALUE *)((char *)data + refs[i]));
+  }
+}
+
+static inline void ddtrace_gc_compact_refs(const size_t *refs, size_t refs_sizeof, void *data) {
+  for (size_t i = 0; i < refs_sizeof / sizeof(size_t); i++) {
+    VALUE *field = (VALUE *)((char *)data + refs[i]);
+    *field = rb_gc_location(*field);
+  }
+}
+
 // rb_hash_bulk_insert was added in Ruby 2.6 to insert key-value pairs from a flat array
 // into a hash in one call. On older Rubies we polyfill it with a simple loop.
 #ifdef NO_RB_HASH_BULK_INSERT

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -40,6 +40,14 @@ static inline int check_if_pending_exception(void) {
 
 #define VALUE_COUNT(array) (sizeof(array) / sizeof(VALUE))
 
+// rb_hash_bulk_insert was added in Ruby 2.6 to insert key-value pairs from a flat array
+// into a hash in one call. On older Rubies we polyfill it with a simple loop.
+#ifdef NO_RB_HASH_BULK_INSERT
+static inline void rb_hash_bulk_insert(long argc, const VALUE *argv, VALUE hash) {
+  for (long i = 0; i < argc; i += 2) rb_hash_aset(hash, argv[i], argv[i + 1]);
+}
+#endif
+
 // Raises a SysErr exception with the formatted string as its message.
 // See `raise_error` for details about telemetry messages.
 #define raise_syserr(syserr_errno, fmt, ...) \

--- a/ext/datadog_profiling_native_extension/setup_signal_handler.c
+++ b/ext/datadog_profiling_native_extension/setup_signal_handler.c
@@ -133,5 +133,4 @@ void setup_signal_handler_init(VALUE profiling_module) {
     "ExistingSignalHandler",
     rb_eRuntimeError
   );
-  rb_gc_register_mark_object(existing_signal_handler_exception_class);
 }

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -308,7 +308,7 @@ static const rb_data_type_t stack_recorder_typed_data = {
   .function = {
     .dmark = stack_recorder_typed_data_mark,
     .dfree = stack_recorder_typed_data_free,
-    .dsize = NULL, // We don't track profile memory usage (although it'd be cool if we did!)
+    .dsize = NULL, // State includes opaque libdatadog types -- libdatadog does not expose their internal sizes
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -993,7 +993,6 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE recorder_instance) {
   VALUE heap_recorder_snapshot = state->heap_recorder ?
     heap_recorder_state_snapshot(state->heap_recorder) : Qnil;
 
-  VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("serialization_successes")), /* => */ ULL2NUM(state->stats_lifetime.serialization_successes),
     ID2SYM(rb_intern("serialization_failures")),  /* => */ ULL2NUM(state->stats_lifetime.serialization_failures),
@@ -1005,18 +1004,19 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE recorder_instance) {
 
     ID2SYM(rb_intern("heap_recorder_snapshot")), /* => */ heap_recorder_snapshot,
   };
+  VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }
 
 static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns, long heap_iteration_prep_time_ns, long heap_profile_build_time_ns) {
-  VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("recorded_samples")), /* => */ ULL2NUM(slot->stats.recorded_samples),
     ID2SYM(rb_intern("serialization_time_ns")), /* => */ LONG2NUM(serialization_time_ns),
     ID2SYM(rb_intern("heap_iteration_prep_time_ns")), /* => */ LONG2NUM(heap_iteration_prep_time_ns),
     ID2SYM(rb_intern("heap_profile_build_time_ns")), /* => */ LONG2NUM(heap_profile_build_time_ns),
   };
+  VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;
 }

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -1005,7 +1005,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE recorder_instance) {
     ID2SYM(rb_intern("heap_recorder_snapshot")), /* => */ heap_recorder_snapshot,
   };
   VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, stats_as_hash);
   return stats_as_hash;
 }
 
@@ -1017,7 +1017,7 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
     ID2SYM(rb_intern("heap_profile_build_time_ns")), /* => */ LONG2NUM(heap_profile_build_time_ns),
   };
   VALUE stats_as_hash = rb_hash_new_capa(VALUE_COUNT(arguments) / 2);
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
+  rb_hash_bulk_insert(VALUE_COUNT(arguments), arguments, stats_as_hash);
   return stats_as_hash;
 }
 

--- a/ext/libdatadog_api/crashtracker_report_exception.c
+++ b/ext/libdatadog_api/crashtracker_report_exception.c
@@ -65,7 +65,7 @@ static bool process_crash_frames(VALUE frames_data, ddog_crasht_Handle_StackTrac
   }
 
   for (size_t i = 0; i < frame_count; i++) {
-    VALUE frame_array = RARRAY_AREF(frames_data, i);
+    VALUE frame_array = rb_ary_entry(frames_data, i);
 
     // ruby should guarantee [String, String, Integer]
     if (!RB_TYPE_P(frame_array, T_ARRAY) || RARRAY_LEN(frame_array) != 3) {
@@ -73,9 +73,9 @@ static bool process_crash_frames(VALUE frames_data, ddog_crasht_Handle_StackTrac
       return false;
     }
 
-    VALUE file_val = RARRAY_AREF(frame_array, 0);
-    VALUE func_val = RARRAY_AREF(frame_array, 1);
-    VALUE line_val = RARRAY_AREF(frame_array, 2);
+    VALUE file_val = rb_ary_entry(frame_array, 0);
+    VALUE func_val = rb_ary_entry(frame_array, 1);
+    VALUE line_val = rb_ary_entry(frame_array, 2);
 
     // validate types; Ruby should guarantee these
     if (!RB_TYPE_P(file_val, T_STRING) || !RB_TYPE_P(func_val, T_STRING) || !RB_TYPE_P(line_val, T_FIXNUM)) {

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -112,3 +112,15 @@ size_t read_ddogerr_string_and_drop(ddog_Error *error, char *string, size_t capa
 static inline int ddtrace_imemo_type(VALUE imemo) {
   return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
 }
+
+// ---
+// Modern Ruby C API compatibility
+//
+// These polyfill newer Ruby C APIs on older Rubies. See extconf.rb for feature detection.
+// ---
+
+// rb_hash_new_capa was added in Ruby 3.2 to pre-size a hash and avoid resizing.
+// On older Rubies we polyfill it with a plain rb_hash_new() -- it still works, just may resize.
+#ifdef NO_RB_HASH_NEW_CAPA
+static inline VALUE rb_hash_new_capa(long capa) { (void)capa; return rb_hash_new(); }
+#endif

--- a/ext/libdatadog_api/ddsketch.c
+++ b/ext/libdatadog_api/ddsketch.c
@@ -28,8 +28,8 @@ static const rb_data_type_t ddsketch_typed_data = {
   .function = {
     .dmark = NULL, // We don't store references to Ruby objects so we don't need to mark any of them
     .dfree = ddsketch_free,
-    .dsize = NULL, // We don't track memory usage (although it'd be cool if we did!)
     //.dcompact = NULL, // Not needed -- we don't store references to Ruby objects
+    .dsize = NULL, // Opaque libdatadog type -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/libdatadog_api/extconf.rb
+++ b/ext/libdatadog_api/extconf.rb
@@ -74,6 +74,9 @@ if ENV['DDTRACE_DEBUG'] == 'true'
   CONFIG['debugflags'] = '-ggdb3'
 end
 
+# On older Rubies, rb_hash_new_capa did not exist (we polyfill it in datadog_ruby_common.h)
+$defs << "-DNO_RB_HASH_NEW_CAPA" if RUBY_VERSION < "3.2"
+
 # If we got here, libdatadog is available and loaded
 $stderr.puts("Using libdatadog #{Libdatadog::VERSION} from #{Libdatadog.pkgconfig_folder}")
 

--- a/ext/libdatadog_api/extconf.rb
+++ b/ext/libdatadog_api/extconf.rb
@@ -77,6 +77,9 @@ end
 # On older Rubies, rb_hash_new_capa did not exist (we polyfill it in datadog_ruby_common.h)
 $defs << "-DNO_RB_HASH_NEW_CAPA" if RUBY_VERSION < "3.2"
 
+# On older Rubies, rb_ext_ractor_safe did not exist
+$defs << "-DNO_RB_EXT_RACTOR_SAFE" if RUBY_VERSION < "3"
+
 # If we got here, libdatadog is available and loaded
 $stderr.puts("Using libdatadog #{Libdatadog::VERSION} from #{Libdatadog.pkgconfig_folder}")
 

--- a/ext/libdatadog_api/feature_flags.c
+++ b/ext/libdatadog_api/feature_flags.c
@@ -86,7 +86,6 @@ static inline VALUE str_from_borrow(ddog_ffe_BorrowedStr str) {
 void feature_flags_init(VALUE core_module) {
   VALUE feature_flags_module = rb_define_module_under(core_module, "FeatureFlags");
 
-  rb_gc_register_address(&feature_flags_error_class);
   feature_flags_error_class = rb_define_class_under(feature_flags_module, "Error", rb_eStandardError);
 
   VALUE configuration_class = rb_define_class_under(feature_flags_module, "Configuration", rb_cObject);
@@ -94,7 +93,6 @@ void feature_flags_init(VALUE core_module) {
   rb_define_singleton_method(configuration_class, "new", configuration_new, 1);
   rb_define_method(configuration_class, "get_assignment", configuration_get_assignment, 3);
 
-  rb_gc_register_address(&resolution_details_class);
   resolution_details_class = rb_define_class_under(feature_flags_module, "ResolutionDetails", rb_cObject);
   rb_undef_alloc_func(resolution_details_class);
   rb_define_method(resolution_details_class, "raw_value", resolution_details_get_raw_value, 0);

--- a/ext/libdatadog_api/feature_flags.c
+++ b/ext/libdatadog_api/feature_flags.c
@@ -32,7 +32,7 @@ static const rb_data_type_t configuration_data_type = {
   .function = {
     .dmark = NULL,
     .dfree = configuration_free,
-    .dsize = NULL,
+    .dsize = NULL, // Opaque handle managed by libdatadog -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
@@ -42,7 +42,7 @@ static const rb_data_type_t resolution_details_typed_data = {
   .function = {
     .dmark = NULL,
     .dfree = resolution_details_free,
-    .dsize = NULL,
+    .dsize = NULL, // Opaque handle managed by libdatadog -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };

--- a/ext/libdatadog_api/init.c
+++ b/ext/libdatadog_api/init.c
@@ -11,6 +11,10 @@ void ddsketch_init(VALUE core_module);
 void di_init(VALUE datadog_module);
 
 void DDTRACE_EXPORT Init_libdatadog_api(void) {
+  #ifndef NO_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+  #endif
+
   VALUE datadog_module = rb_define_module("Datadog");
 
   // MUST be called before all other initialization

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -24,7 +24,7 @@ static const rb_data_type_t configurator_typed_data = {
   .wrap_struct_name = "Datadog::Core::Configuration::StableConfig::Configurator",
   .function = {
     .dfree = configurator_free,
-    .dsize = NULL,
+    .dsize = NULL, // Opaque handle managed by libdatadog -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };
@@ -41,7 +41,7 @@ static const rb_data_type_t config_logged_result_typed_data = {
   .wrap_struct_name = "Datadog::Core::Configuration::StableConfigLoggedResult",
   .function = {
     .dfree = config_logged_result_free,
-    .dsize = NULL,
+    .dsize = NULL, // Opaque libdatadog type -- libdatadog does not expose its internal size
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -47,7 +47,6 @@ static const rb_data_type_t config_logged_result_typed_data = {
 };
 
 void library_config_init(VALUE core_module) {
-  rb_global_variable(&config_logged_result_class);
   VALUE configuration_module = rb_define_module_under(core_module, "Configuration");
   VALUE stable_config_module = rb_define_module_under(configuration_module, "StableConfig");
   VALUE configurator_class = rb_define_class_under(stable_config_module, "Configurator", rb_cObject);

--- a/ext/libdatadog_api/library_config.c
+++ b/ext/libdatadog_api/library_config.c
@@ -132,8 +132,8 @@ static VALUE _native_configurator_get(VALUE self) {
 
   bool local_config_id_set = false;
   bool fleet_config_id_set = false;
-  VALUE local_hash = rb_hash_new();
-  VALUE fleet_hash = rb_hash_new();
+  VALUE local_hash = rb_hash_new_capa(2);
+  VALUE fleet_hash = rb_hash_new_capa(2);
   for (uintptr_t i = 0; i < config_vec.len; i++) {
     ddog_LibraryConfig config = config_vec.ptr[i];
     VALUE selected_hash;
@@ -162,7 +162,7 @@ static VALUE _native_configurator_get(VALUE self) {
   rb_hash_aset(local_hash, ID2SYM(rb_intern("config")), local_config_hash);
   rb_hash_aset(fleet_hash, ID2SYM(rb_intern("config")), fleet_config_hash);
 
-  VALUE result = rb_hash_new();
+  VALUE result = rb_hash_new_capa(3);
   rb_hash_aset(result, ID2SYM(rb_intern("logs")), logs);
   rb_hash_aset(result, ID2SYM(rb_intern("local")), local_hash);
   rb_hash_aset(result, ID2SYM(rb_intern("fleet")), fleet_hash);

--- a/ext/libdatadog_api/process_discovery.c
+++ b/ext/libdatadog_api/process_discovery.c
@@ -17,11 +17,15 @@ static void tracer_memfd_free(void *ptr) {
   ruby_xfree(ptr);
 }
 
+static size_t tracer_memfd_size(DDTRACE_UNUSED const void *data) {
+  return sizeof(int); // Wraps a single file descriptor
+}
+
 static const rb_data_type_t tracer_memfd_type = {
   .wrap_struct_name = "Datadog::Core::ProcessDiscovery::TracerMemfd",
   .function = {
     .dfree = tracer_memfd_free,
-    .dsize = NULL,
+    .dsize = tracer_memfd_size,
   },
   .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };


### PR DESCRIPTION
**What does this PR do?**

This PR is the first of a handful I have planned to clean up usage of legacy patterns and APIs in our C extensions.

I've been experimenting with these changes while preparing my [RubyKaigi talk on the topic](https://rubykaigi.org/2026/presentations/KnuX.html). I was hoping to have a PR with the full set of changes before the talk but... ran out of time ;)

**I'm opening this PR as draft** since I didn't have as much time to validate these changes as I was expecting, but I hope to soon give a last pass, unmark it, and get it merged.

**Motivation:**

As explained in <https://github.com/ivoanjo/modern-ruby-c-extensions/blob/main/README.md>, our use of some old APIs can create a bit more work for Ruby.

That I am aware of, our use of old APIs is not on the "hot path", and we don't create lots of objects in our C extensions so not supporting e.g. compaction is not expected to make a huge impact.

Yet, we have plans to add more C code and we have more people working on this codebase, so I want to make sure that the codebase itself documents the best practices so that both new people as well as LLMs copy the good examples rather than going `// TODO compaction` yet again (for instance).

As much as possible, our motto should be -- do the right thing for the latest stable Ruby (4), then gracefully degrade to the others (e.g. using the polyfill-like macros and functions I added), rather than "do the thing that works on all Rubies, but that can negatively impact modern Rubies" (even if very small).

(It occurred to me that it may possible to extract a bunch of polyfills as a separate library even, so I'm very open to the idea if anyone wants to run with it, but have no plans to do it right now...)

**Change log entry**

None. 

**Additional Notes:**

N/A

**How to test the change?**

The changes are equivalent as far as our tests go, so green CI is what to look for.
