### PR TITLE
Add pull_request workflow to verify check runs

### DIFF
--- a/.github/scripts/publish/verify_check_runs.js
+++ b/.github/scripts/publish/verify_check_runs.js
@@ -36,6 +36,7 @@
 // Environment variables:
 //   APP_ID          - GitHub App ID to filter check suites (e.g. 15368 for GitHub Actions)
 //   CURRENT_RUN_ID  - (optional) current workflow run ID; enables self-exclusion
+//   TARGET_SHA      - (optional) commit SHA to check; defaults to context.sha
 //
 // API:
 // - https://docs.github.com/en/rest/checks/suites#list-check-suites-for-a-git-reference
@@ -43,10 +44,12 @@
 // - https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run
 // - https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
 module.exports = async ({github, context, core}) => {
+  const sha = process.env.TARGET_SHA || context.sha;
+
   const checkSuites = await github.paginate(github.rest.checks.listSuitesForRef, {
     owner: context.repo.owner,
     repo: context.repo.repo,
-    ref: context.sha,
+    ref: sha,
     app_id: parseInt(process.env.APP_ID),
     per_page: 100
   });
@@ -101,7 +104,7 @@ module.exports = async ({github, context, core}) => {
         owner: context.repo.owner,
         repo: context.repo.repo,
         workflow_id: workflowId,
-        head_sha: context.sha,
+        head_sha: sha,
         per_page: 100,
       });
 

--- a/.github/workflows/verify-checks.yml
+++ b/.github/workflows/verify-checks.yml
@@ -1,0 +1,30 @@
+name: Verify check runs
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  verify-checks:
+    name: Verify commit check runs
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      checks: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Verify check runs
+        env:
+          APP_ID: 15368 # Github Actions app ID
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/scripts/publish/verify_check_runs.js')
+            await script({github, context, core})

--- a/.github/workflows/verify-checks.yml
+++ b/.github/workflows/verify-checks.yml
@@ -28,3 +28,4 @@ jobs:
           script: |
             const script = require('./.github/scripts/publish/verify_check_runs.js')
             await script({github, context, core})
+            core.setFailed("Intentional test failure — remove this line")


### PR DESCRIPTION
**What does this PR do?**

Adds a `pull_request`-triggered workflow that runs the `verify_check_runs.js` script against the PR's head SHA. This lets the script be tested from a PR without merging anything to master.

Also adds `TARGET_SHA` env var support to the script so callers can override which commit to check (defaults to `context.sha` for backwards compatibility with the publish workflow).

**Motivation:**

Test the verify_check_runs.js changes from PR #5613 without requiring a merge to master. `pull_request` workflows run using the workflow file from the PR branch.

**Change log entry**

None.

**Additional Notes:**

Stacked on #5613. The `TARGET_SHA` change is backwards-compatible — the publish workflow doesn't set it, so it continues using `context.sha`.

**How to test the change?**

1. Open this PR — the workflow should trigger automatically
2. Check the "Verify commit check runs" job in the Actions tab
3. Verify the script runs against the PR head SHA and reports check run results