### PR TITLE
Reproduce flaky: GVL waiting samples test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -505,17 +505,25 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # So that the below assertions make sense (and are not flaky), we drop these first few samples from our
           # consideration
 
-          found_first_cpu = false
+          # REPRODUCER: Simulate the macOS ARM failure condition.
+          #
+          # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so
+          # cpu_time_now_ns always returns 0. This means no sample ever gets state "had cpu" —
+          # all non-GVL samples are "unknown" instead. The take_while below consumes all leading
+          # "unknown" samples without limit.
+          #
+          # Between initialize_context (which sets gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY)
+          # and the thread's first GVL acquisition (~100ms at the quantum boundary), ALL samples
+          # are "unknown" (EMPTY is excluded from GVL waiting detection). The take_while consumes
+          # this entire ~100ms prefix. With only 200ms of profiling, the sole remaining situation-1
+          # event at ~200ms is a timing race at the sleep boundary.
+          #
+          # This reproducer forces the condition by removing ALL non-"waiting for gvl" wall-time,
+          # which is what happens when the take_while consumes every "unknown" sample.
           missed_by_profiler_time =
             samples
-              .take_while do |s|
-                if s.labels[:state] == "unknown"
-                  true
-                elsif s.labels[:state] == "had cpu" && !found_first_cpu
-                  found_first_cpu = true
-                  true
-                end
-              end.sum { |sample| sample.values.fetch(:"wall-time") }
+              .select { |s| s.labels[:state] != "waiting for gvl" }
+              .sum { |sample| sample.values.fetch(:"wall-time") }
 
           total_time = samples.sum { |sample| sample.values.fetch(:"wall-time") } - missed_by_profiler_time
           waiting_for_gvl_samples = samples.select { |sample| sample.labels[:state] == "waiting for gvl" }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -508,18 +508,16 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # REPRODUCER: Simulate the macOS ARM failure condition.
           #
           # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so
-          # cpu_time_now_ns always returns 0. This means no sample ever gets state "had cpu" —
-          # all non-GVL samples are "unknown" instead. The take_while below consumes all leading
-          # "unknown" samples without limit.
+          # cpu_time_now_ns always returns 0. All non-GVL samples are "unknown" instead of
+          # "had cpu". When the CPU hog wins the GVL race at profiler startup, the Thread.pass
+          # thread waits ~100ms before its first GVL acquisition. During this time, ALL samples
+          # are "unknown" (gvl_waiting_at is EMPTY). The take_while consumes the entire prefix.
+          # With 200ms of profiling and one situation-1 event at the ~200ms boundary (timing
+          # race), all remaining samples are "waiting for gvl".
           #
-          # Between initialize_context (which sets gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY)
-          # and the thread's first GVL acquisition (~100ms at the quantum boundary), ALL samples
-          # are "unknown" (EMPTY is excluded from GVL waiting detection). The take_while consumes
-          # this entire ~100ms prefix. With only 200ms of profiling, the sole remaining situation-1
-          # event at ~200ms is a timing race at the sleep boundary.
-          #
-          # This reproducer forces the condition by removing ALL non-"waiting for gvl" wall-time,
-          # which is what happens when the take_while consumes every "unknown" sample.
+          # This reproducer forces total_time == waiting_for_gvl_time deterministically by
+          # removing ALL non-"waiting for gvl" wall-time. This exactly matches the macOS
+          # failure where the take_while consumes every "unknown" sample.
           missed_by_profiler_time =
             samples
               .select { |s| s.labels[:state] != "waiting for gvl" }


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:466` — "records Waiting for GVL samples". Forces the suspected failure condition to validate the hypothesis in CI. Expected result: the test fails deterministically.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [Test (macos-15, 3.2)](https://github.com/DataDog/dd-trace-rb/actions/runs/24723797688/job/72319259264?pr=5596).

**Hypothesis:**

On macOS ARM, per-thread cpu_time is not available (no `pthread_getcpuclockid`), so `cpu_time_now_ns` always returns 0. All non-GVL samples have state "unknown" instead of "had cpu". Between `initialize_context` (which sets `gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY`) and the thread's first GVL acquisition (~100ms at the quantum boundary), ALL samples are "unknown" because the EMPTY state is excluded from GVL waiting detection. The `take_while` greedily consumes all leading "unknown" samples — up to ~100ms of profiling data. With only 200ms of profiling (`sleep 0.2`), the sole remaining situation-1 event at ~200ms is a timing race at the sleep boundary. When it's missed, `waiting_for_gvl_time == total_time` and the strict `<` assertion fails.

**Reproducer technique:**

Replace the `take_while` prefix filter with a `select` that removes ALL non-"waiting for gvl" wall-time from `total_time`. This simulates the macOS condition where the `take_while` consumes every "unknown" sample (since there are no "had cpu" samples to provide a boundary), leaving `total_time == waiting_for_gvl_time`.

**Change log entry**

None.

**How to test the change?**

CI should show the test failing deterministically. If it doesn't, the hypothesis is wrong.