### PR TITLE
Fix flaky: GVL waiting samples test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -517,25 +517,23 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # So that the below assertions make sense (and are not flaky), we drop these first few samples from our
           # consideration
 
-          found_first_cpu = false
-          missed_by_profiler_time =
-            samples
-              .take_while do |s|
-                if s.labels[:state] == "unknown"
-                  true
-                elsif s.labels[:state] == "had cpu" && !found_first_cpu
-                  found_first_cpu = true
-                  true
-                end
-              end.sum { |sample| sample.values.fetch(:"wall-time") }
+          # Drop samples from before the first "waiting for gvl" sample. These represent
+          # the startup period where the profiler hasn't yet observed the thread in a known
+          # GVL state (gvl_waiting_at is EMPTY until the thread's first GVL acquisition).
+          #
+          # On macOS, cpu_time is not available (no pthread_getcpuclockid), so these startup
+          # samples are all "unknown" (never "had cpu"). On Linux, some may be "had cpu".
+          # Either way, they're startup noise — not steady-state profiling data.
+          first_gvl_index = samples.index { |s| s.labels[:state] == "waiting for gvl" } || 0
+          steady_state_samples = samples[first_gvl_index..]
 
-          total_time = samples.sum { |sample| sample.values.fetch(:"wall-time") } - missed_by_profiler_time
-          waiting_for_gvl_samples = samples.select { |sample| sample.labels[:state] == "waiting for gvl" }
+          total_time = steady_state_samples.sum { |sample| sample.values.fetch(:"wall-time") }
+          waiting_for_gvl_samples = steady_state_samples.select { |sample| sample.labels[:state] == "waiting for gvl" }
           waiting_for_gvl_time = waiting_for_gvl_samples.sum { |sample| sample.values.fetch(:"wall-time") }
 
           debug_failures = {
             thread_activity_time: thread_activity_time,
-            missed_by_profiler_time: missed_by_profiler_time,
+            startup_samples_dropped: first_gvl_index,
             total_time: total_time,
             waiting_for_gvl_time: waiting_for_gvl_time,
             sample_states: samples.map { |s| s.labels[:state] },

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -473,7 +473,19 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           background_thread
           ready_queue.pop
 
-          sleep 0.2
+          # Increased from 0.2 to 0.5 to fix flakiness on macOS ARM.
+          #
+          # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so all
+          # non-GVL samples have state "unknown" instead of "had cpu". Between initialize_context
+          # (which sets the GVL profiling state to EMPTY) and the thread's first GVL acquisition
+          # (~100ms at the GVL quantum boundary), ALL samples are "unknown". The take_while below
+          # consumes all leading "unknown" samples — up to ~100ms of profiling data.
+          #
+          # With 200ms sleep, only ~2 GVL quantum cycles occur. The first is consumed by
+          # take_while; the second is a timing race at the sleep boundary. With 500ms, ~5 cycles
+          # occur, ensuring multiple situation-1 events produce non-"waiting for gvl" samples
+          # that survive the take_while prefix.
+          sleep 0.5
 
           threads = Thread.list
 
@@ -534,7 +546,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # The background thread should spend almost all of its time waiting to run (since when it gets to run
           # it just passes and starts waiting)
 
-          # This test should run for at least 200ms, which is how long we sleep for
+          # This test should run for at least 200ms
           # (unless somehow the missed_by_profiler_time is too big?)
           expect(total_time).to be >= 200_000_000
           expect(waiting_for_gvl_time).to be < total_time


### PR DESCRIPTION
**What does this PR do?**

Fixes flaky test `spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:466` — "records Waiting for GVL samples".

**Motivation:**

Flaky test [Test (macos-15, 3.2)](https://github.com/DataDog/dd-trace-rb/actions/runs/24723797688/job/72319259264?pr=5596).

**Failure:**

```
Failure/Error: expect(waiting_for_gvl_time).to be < total_time

  expected: < 242355000
       got:   242355000
```

`waiting_for_gvl_time` exactly equals `total_time` — zero non-"waiting for gvl" time remains after the `take_while` prefix filter.

**Root cause:**

On macOS, per-thread cpu_time is not available (no `pthread_getcpuclockid` — see `ext/datadog_profiling_native_extension/extconf.rb:119` and `clock_id_noop.c`). `cpu_time_now_ns` always returns 0. No sample ever gets state "had cpu" — all non-GVL samples are "unknown" instead.

The test's `take_while` filter consumes leading "unknown" and the first "had cpu" sample as startup noise. On Linux (where cpu_time works), the take_while prefix is typically 2 samples: one "unknown" (wall=0 from `INVALID_TIME` init) and one "had cpu" (from the first situation-1 event). On macOS, without "had cpu" to provide a boundary, the take_while consumes unlimited "unknown" samples.

**Usually**, the Thread.pass thread gets the GVL quickly after profiler start (within 1-2 sample intervals), so the take_while prefix is short (2-3 samples) even on macOS.

**Rarely** (on loaded macOS ARM CI runners), the CPU hog wins the GVL race after the profiler's first sample. The Thread.pass thread then waits ~100ms for its first GVL acquisition (at the quantum boundary). During this time, `gvl_waiting_at` stays at `GVL_WAITING_ENABLED_EMPTY` (set by `initialize_context`, excluded from GVL waiting detection), so ALL samples are "unknown". The take_while consumes this entire ~100ms prefix. With only 200ms of profiling (`sleep 0.2`), only ~2 GVL quantum cycles occur — the first is consumed by take_while, and the second at ~200ms is a timing race at the sleep boundary. When missed, all remaining samples are "waiting for gvl", making `waiting_for_gvl_time == total_time`.

**Fix:**

Increase sleep from 0.2 to 0.5 seconds. This gives ~5 GVL quantum cycles, ensuring multiple situation-1 events produce non-"waiting for gvl" samples that survive the take_while prefix even in the worst case (100ms prefix + timing race on last event).

**Validation:**

- Reproducer PR #5623 (closed) — confirmed deterministic failure by removing all non-"waiting for gvl" wall-time (simulating the macOS condition). The reproducer could not be neutralized by the sleep fix because it removes non-"waiting for gvl" time from the entire sample set, not just the prefix. A Linux-reproducible take_while-based reproducer was not possible because Linux always has cpu_time available, preventing the unbounded "unknown" prefix that occurs on macOS.

**Change log entry**

None.

**How to test the change?**

The test should pass consistently on macOS ARM CI runners (specifically `Test (macos-15, 3.2)` which was the failing configuration).