### PR TITLE
Reproduce flaky: GVL waiting samples test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -505,17 +505,22 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # So that the below assertions make sense (and are not flaky), we drop these first few samples from our
           # consideration
 
-          found_first_cpu = false
+          # REPRODUCER: Simulate macOS ARM take_while behavior.
+          #
+          # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so
+          # cpu_time_now_ns always returns 0. No sample ever gets state "had cpu" — all
+          # non-GVL samples are "unknown" instead. The original take_while has a boundary
+          # on the first "had cpu", but on macOS that boundary never fires. The take_while
+          # becomes: consume all leading non-"waiting for gvl" samples.
+          #
+          # On Linux, this reproducer consumes 2 extra samples (the "had cpu" that would
+          # normally stop the take_while). On macOS, it faithfully matches the real behavior.
+          # The test should fail on macOS CI when the CPU hog wins the GVL race at profiler
+          # startup, causing ~100ms of "unknown" prefix that the take_while consumes.
           missed_by_profiler_time =
             samples
-              .take_while do |s|
-                if s.labels[:state] == "unknown"
-                  true
-                elsif s.labels[:state] == "had cpu" && !found_first_cpu
-                  found_first_cpu = true
-                  true
-                end
-              end.sum { |sample| sample.values.fetch(:"wall-time") }
+              .take_while { |s| s.labels[:state] != "waiting for gvl" }
+              .sum { |sample| sample.values.fetch(:"wall-time") }
 
           total_time = samples.sum { |sample| sample.values.fetch(:"wall-time") } - missed_by_profiler_time
           waiting_for_gvl_samples = samples.select { |sample| sample.labels[:state] == "waiting for gvl" }


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:466` — "records Waiting for GVL samples". Replaces the `take_while` with the macOS-equivalent behavior to validate the hypothesis in CI.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [Test (macos-15, 3.2)](https://github.com/DataDog/dd-trace-rb/actions/runs/24723797688/job/72319259264?pr=5596).

**Hypothesis:**

On macOS ARM, per-thread cpu_time is not available (no `pthread_getcpuclockid`), so `cpu_time_now_ns` always returns 0. No sample ever gets state "had cpu" — all non-GVL samples are "unknown" instead. The original `take_while` has a boundary on the first "had cpu" that limits prefix consumption. On macOS, that boundary never fires, so the `take_while` consumes ALL leading non-"waiting for gvl" samples. When the CPU hog wins the GVL race at profiler startup, this prefix spans ~100ms of the 200ms profiling window.

**Reproducer technique:**

Replace the `take_while` with `take_while { |s| s.labels[:state] != "waiting for gvl" }` — the macOS-equivalent that consumes all leading non-GVL samples without a "had cpu" boundary. On Linux this is a minor change (consumes 1-2 extra samples). On macOS it faithfully simulates the real failure condition.

**Expected CI results:**

- **Linux jobs:** Should pass (Thread.pass thread gets the GVL quickly, prefix is short, later "had cpu" samples survive)
- **macOS jobs:** Should fail intermittently when the CPU hog wins the GVL race at profiler startup, matching the original flaky failure

**Change log entry**

None.

**How to test the change?**

Watch macOS CI jobs. Failure = hypothesis confirmed. Pass on all runs = the GVL race didn't trigger (possible but doesn't disprove the hypothesis — the failure is inherently intermittent).