### PR TITLE
Validate fix for flaky: GVL waiting samples test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -505,17 +505,22 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # So that the below assertions make sense (and are not flaky), we drop these first few samples from our
           # consideration
 
-          found_first_cpu = false
+          # REPRODUCER: Simulate macOS ARM take_while behavior.
+          #
+          # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so
+          # cpu_time_now_ns always returns 0. No sample ever gets state "had cpu" — all
+          # non-GVL samples are "unknown" instead. The original take_while has a boundary
+          # on the first "had cpu", but on macOS that boundary never fires. The take_while
+          # becomes: consume all leading non-"waiting for gvl" samples.
+          #
+          # On Linux, this reproducer consumes 2 extra samples (the "had cpu" that would
+          # normally stop the take_while). On macOS, it faithfully matches the real behavior.
+          # The test should fail on macOS CI when the CPU hog wins the GVL race at profiler
+          # startup, causing ~100ms of "unknown" prefix that the take_while consumes.
           missed_by_profiler_time =
             samples
-              .take_while do |s|
-                if s.labels[:state] == "unknown"
-                  true
-                elsif s.labels[:state] == "had cpu" && !found_first_cpu
-                  found_first_cpu = true
-                  true
-                end
-              end.sum { |sample| sample.values.fetch(:"wall-time") }
+              .take_while { |s| s.labels[:state] != "waiting for gvl" }
+              .sum { |sample| sample.values.fetch(:"wall-time") }
 
           total_time = samples.sum { |sample| sample.values.fetch(:"wall-time") } - missed_by_profiler_time
           waiting_for_gvl_samples = samples.select { |sample| sample.labels[:state] == "waiting for gvl" }

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -473,7 +473,19 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           background_thread
           ready_queue.pop
 
-          sleep 0.2
+          # Increased from 0.2 to 0.5 to fix flakiness on macOS ARM.
+          #
+          # On macOS, per-thread cpu_time is not available (no pthread_getcpuclockid), so all
+          # non-GVL samples have state "unknown" instead of "had cpu". Between initialize_context
+          # (which sets the GVL profiling state to EMPTY) and the thread's first GVL acquisition
+          # (~100ms at the GVL quantum boundary), ALL samples are "unknown". The take_while below
+          # consumes all leading "unknown" samples — up to ~100ms of profiling data.
+          #
+          # With 200ms sleep, only ~2 GVL quantum cycles occur. The first is consumed by
+          # take_while; the second is a timing race at the sleep boundary. With 500ms, ~5 cycles
+          # occur, ensuring multiple situation-1 events produce non-"waiting for gvl" samples
+          # that survive the take_while prefix.
+          sleep 0.5
 
           threads = Thread.list
 
@@ -534,7 +546,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # The background thread should spend almost all of its time waiting to run (since when it gets to run
           # it just passes and starts waiting)
 
-          # This test should run for at least 200ms, which is how long we sleep for
+          # This test should run for at least 200ms
           # (unless somehow the missed_by_profiler_time is too big?)
           expect(total_time).to be >= 200_000_000
           expect(waiting_for_gvl_time).to be < total_time


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the reproducer. This branch merges:
- Reproducer PR: #5625 (macOS-simulating take_while — consumes all leading non-"waiting for gvl" samples)
- Fix PR: #5624 (increases sleep from 0.2 to 0.5 seconds)

With the longer profiling window (500ms), even the aggressive macOS-simulating take_while should leave multiple situation-1 events in the remaining sample set, keeping `total_time > waiting_for_gvl_time`.

**Do not merge** — this PR exists for validation only.

**Expected CI results:**

- **All jobs should pass.** The 500ms sleep gives ~5 GVL quantum cycles. Even with the aggressive take_while consuming the first ~100ms, there are 3-4 remaining cycles producing non-"waiting for gvl" samples.
- **macOS jobs are the key validation target** — they have the real macOS condition (no cpu_time) combined with the fix (longer sleep).

If CI fails, the fix is insufficient for the reproducer's failure mode.

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the reproducer. CI fails = fix is insufficient.