### PR TITLE
Updated workflow permissions

### DIFF
--- a/.github/chainguard/self.update-system-tests.sts.yaml
+++ b/.github/chainguard/self.update-system-tests.sts.yaml
@@ -10,3 +10,4 @@ claim_pattern:
 permissions:
   contents: write
   pull_requests: write
+  workflows: write


### PR DESCRIPTION
Adds `workflows: write` to the `update-system-tests` trust policy so the vended token can modify `.github/workflows/system-tests.yml`.