### PR TITLE
Reproduce flaky: GVL waiting samples test

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -505,6 +505,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # So that the below assertions make sense (and are not flaky), we drop these first few samples from our
           # consideration
 
+          # REPRODUCER: Simulate macOS ARM where cpu_time is always 0.
+          # On macOS, pthread_getcpuclockid is not available, so cpu_time_now_ns always
+          # returns 0. No sample ever gets state "had cpu" — they get "unknown" instead.
+          # This removes the "had cpu" boundary from the take_while, causing it to consume
+          # ALL leading "unknown" samples without limit — potentially spanning ~100ms of
+          # profiling data on a loaded CI runner.
+          samples.each { |s| s.labels[:state] = "unknown" if s.labels[:state] == "had cpu" }
+
           found_first_cpu = false
           missed_by_profiler_time =
             samples


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:466`.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [Test (macos-15, 3.2)](https://github.com/DataDog/dd-trace-rb/actions/runs/24723797688/job/72319259264?pr=5596).

**Hypothesis:**

On macOS, `pthread_getcpuclockid` is not available, so `cpu_time_now_ns` always returns 0. No sample ever gets state "had cpu" — all non-GVL samples are "unknown". The `take_while` has a boundary on the first "had cpu" that limits consumption. On macOS, this boundary never fires, so the `take_while` consumes ALL leading "unknown" samples without limit.

**Reproducer technique:**

Mutate sample labels: `"had cpu"` → `"unknown"` before running the original `take_while`. This simulates the macOS condition on all platforms. On macOS CI, this is a no-op (the labels are already "unknown"). On Linux CI, it removes the "had cpu" boundary, making the `take_while` more aggressive.

The failure is timing-dependent (requires the CPU hog to win the GVL race at profiler startup), so it may not trigger on every CI run.

**Change log entry**

None.

**How to test the change?**

Watch macOS CI jobs for the `< total_time` assertion failure. The failure is intermittent.