### PR TITLE
Prevent reporting telemetry from custom instrumentations configurations

### DIFF
--- a/lib/datadog/core/telemetry/event/app_started.rb
+++ b/lib/datadog/core/telemetry/event/app_started.rb
@@ -260,11 +260,9 @@ module Datadog
           end
 
           def collect_integration_configuration_options(tracing_settings)
-            return [] unless tracing_settings.respond_to?(:instrumented_integrations)
+            return [] unless tracing_settings.respond_to?(:instrumented_built_in_integrations)
 
-            tracing_settings.instrumented_integrations.each_value.with_object([]) do |integration, entries|
-              next unless Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS.include?(integration)
-
+            tracing_settings.instrumented_built_in_integrations.each_with_object([]) do |integration, entries|
               integration.configurations.each_value do |configuration|
                 entries.concat(collect_configuration_options_from(configuration))
               end

--- a/lib/datadog/core/telemetry/event/app_started.rb
+++ b/lib/datadog/core/telemetry/event/app_started.rb
@@ -263,6 +263,8 @@ module Datadog
             return [] unless tracing_settings.respond_to?(:instrumented_integrations)
 
             tracing_settings.instrumented_integrations.each_value.with_object([]) do |integration, entries|
+              next unless Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS.include?(integration)
+
               integration.configurations.each_value do |configuration|
                 entries.concat(collect_configuration_options_from(configuration))
               end

--- a/lib/datadog/tracing/contrib.rb
+++ b/lib/datadog/tracing/contrib.rb
@@ -84,6 +84,6 @@ require_relative 'contrib/trilogy/integration'
 
 # This list is used to determine if an integration is a built-in integration,
 # and prevent sending telemetry for custom integrations.
-# .uniq to handle aliases.
+# .uniq to handle aliases, as we can register the same integration multiple times with different names.
 Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS =
   Datadog::Tracing::Contrib::REGISTRY.map { |entry| entry.klass }.uniq.freeze

--- a/lib/datadog/tracing/contrib.rb
+++ b/lib/datadog/tracing/contrib.rb
@@ -84,6 +84,8 @@ require_relative 'contrib/trilogy/integration'
 
 # This list is used to determine if an integration is a built-in integration,
 # and prevent sending telemetry for custom integrations.
+# To do this, we get the list of registered integrations at this point and freeze it.
+# Later, when custom integrations are registered, they will not be included in this list.
 # .uniq to handle aliases, as we can register the same integration multiple times with different names.
 Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS =
   Datadog::Tracing::Contrib::REGISTRY.map { |entry| entry.klass }.uniq.freeze

--- a/lib/datadog/tracing/contrib.rb
+++ b/lib/datadog/tracing/contrib.rb
@@ -81,3 +81,9 @@ require_relative 'contrib/sneakers/integration'
 require_relative 'contrib/stripe/integration'
 require_relative 'contrib/sucker_punch/integration'
 require_relative 'contrib/trilogy/integration'
+
+# This list is used to determine if an integration is a built-in integration,
+# and prevent sending telemetry for custom integrations.
+# .uniq to handle aliases.
+Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS =
+  Datadog::Tracing::Contrib::REGISTRY.map { |entry| entry.klass }.uniq.freeze

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -227,6 +227,15 @@ module Datadog
               end
             end
 
+            # Returns the subset of built-in integrations that are instrumented,
+            # excluding custom integrations registered through the public contrib API.
+            # This method is only for telemetry reporting.
+            # @!visibility private
+            def instrumented_built_in_integrations
+              instrumented = Set.new(instrumented_integrations.each_value)
+              Contrib::BUILT_IN_INTEGRATIONS.select { |integration| instrumented.include?(integration) }.freeze
+            end
+
             # @!visibility private
             def reset!
               INSTRUMENTED_INTEGRATIONS_LOCK.synchronize do

--- a/sig/datadog/tracing/contrib.rbs
+++ b/sig/datadog/tracing/contrib.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Tracing
     module Contrib
       REGISTRY: untyped
-      BUILT_IN_INTEGRATIONS: ::Array[untyped]
+      BUILT_IN_INTEGRATIONS: ::Array[Integration]
     end
   end
 end

--- a/sig/datadog/tracing/contrib.rbs
+++ b/sig/datadog/tracing/contrib.rbs
@@ -2,6 +2,7 @@ module Datadog
   module Tracing
     module Contrib
       REGISTRY: untyped
+      BUILT_IN_INTEGRATIONS: ::Array[untyped]
     end
   end
 end

--- a/sig/datadog/tracing/contrib/extensions.rbs
+++ b/sig/datadog/tracing/contrib/extensions.rbs
@@ -15,6 +15,7 @@ module Datadog
             def []: (untyped integration_name, ?::Symbol key) -> untyped
             def integrations_pending_activation: () -> untyped
             def instrumented_integrations: () -> untyped
+            def instrumented_built_in_integrations: () -> untyped
             def reset!: () -> untyped
             def fetch_integration: (untyped name) -> untyped
             def ignore_integration_load_errors?: () -> (untyped | false)

--- a/spec/datadog/core/telemetry/event/app_started_spec.rb
+++ b/spec/datadog/core/telemetry/event/app_started_spec.rb
@@ -294,5 +294,62 @@ RSpec.describe Datadog::Core::Telemetry::Event::AppStarted do
         )
       end
     end
+
+    context 'with a custom integration configured through the config DSL' do
+      let(:custom_integration_name) { :httpx }
+      let(:custom_registry) { Datadog::Tracing::Contrib::Registry.new }
+      let(:custom_integration) { custom_integration_class.new(custom_integration_name) }
+      let(:custom_integration_class) do
+        custom_settings_class = Class.new(Datadog::Tracing::Contrib::Configuration::Settings) do
+          option :split_by_domain, default: false
+        end
+        custom_patcher = Module.new do
+          def self.patch
+            true
+          end
+        end
+
+        Class.new do
+          include Datadog::Tracing::Contrib::Integration
+
+          def self.version
+            Gem::Version.new('1.0.0')
+          end
+
+          define_method(:new_configuration) do
+            custom_settings_class.new
+          end
+
+          define_method(:patcher) do
+            custom_patcher
+          end
+        end
+      end
+
+      before do
+        Datadog.registry.each do |entry|
+          custom_registry.add(entry.name, entry.klass, entry.auto_patch)
+        end
+        custom_registry.add(custom_integration_name, custom_integration)
+        stub_const('Datadog::Tracing::Contrib::REGISTRY', custom_registry)
+
+        Datadog.configure do |c|
+          c.tracing.instrument custom_integration_name, split_by_domain: true
+        end
+      end
+
+      after do
+        Datadog.shutdown!
+        Datadog.configuration.reset!
+      end
+
+      it 'does not report custom integration configuration' do
+        custom_configuration = event.payload[:configuration].select do |entry|
+          entry[:name].start_with?('tracing.httpx.')
+        end
+
+        expect(custom_configuration).to be_empty
+      end
+    end
   end
 end

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -278,6 +278,31 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
 
           it { is_expected.to be_frozen }
         end
+
+        describe '#instrumented_built_in_integrations' do
+          subject(:instrumented_built_in_integrations) { settings.instrumented_built_in_integrations }
+
+          include_context 'registry with integration'
+
+          let(:alias_name) { :example_alias }
+          let(:custom_integration_name) { :custom }
+          let(:custom_integration) { integration_class.new(custom_integration_name) }
+
+          before do
+            stub_const('Datadog::Tracing::Contrib::BUILT_IN_INTEGRATIONS', [integration])
+            registry.add(alias_name, integration)
+            registry.add(custom_integration_name, custom_integration)
+
+            settings.send(:instrument, integration_name)
+            settings.send(:instrument, alias_name)
+            settings.send(:instrument, custom_integration_name)
+          end
+
+          it 'returns instrumented built-in integrations only once' do
+            expect(instrumented_built_in_integrations).to contain_exactly(integration)
+            expect(instrumented_built_in_integrations).to be_frozen
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR prevents reporting telemetry for custom instrumentations configs.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
With the recent changes on telemetry, we currently report telemetry for instrumentations such as httpx, that we don't officially supports. We should only send telemetry for instrumentations we support.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
