### PR TITLE
Add symbol database data models and extractor

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -1,0 +1,917 @@
+# frozen_string_literal: true
+
+require_relative 'scope'
+require_relative 'symbol'
+require_relative 'file_hash'
+require_relative '../core/utils/array'
+
+module Datadog
+  module SymbolDatabase
+    # Extracts symbol metadata from loaded Ruby modules and classes via introspection.
+    #
+    # Instance created by Component with injected dependencies (logger, settings,
+    # telemetry). All methods are instance methods accessing @logger, @settings,
+    # @telemetry directly — no parameter threading needed.
+    #
+    # Uses Ruby's reflection APIs (Module#constants, Class#instance_methods, Method#parameters)
+    # to build hierarchical Scope structures representing code organization.
+    # Filters to user code only (excludes gems, stdlib, test files).
+    #
+    # Extraction flow:
+    # 1. ObjectSpace.each_object(Module) - Iterate all loaded modules/classes
+    # 2. Filter to user code (user_code_module?)
+    # 3. Build MODULE or CLASS scope with nested METHOD scopes
+    # 4. Extract symbols: constants, class variables, method parameters
+    #
+    # Called by: Component.extract_and_upload (during upload trigger)
+    # Produces: Scope objects passed to ScopeContext for batching
+    # File hashing: Calls FileHash.compute for MODULE scopes
+    #
+    # Error handling strategy (defense-in-depth):
+    #
+    # The extractor introspects arbitrary Ruby objects via ObjectSpace. Ruby's
+    # reflection APIs (Module#name, #instance_methods, #const_get, #source_location,
+    # #parameters) can fail unpredictably on third-party code: NameError from removed
+    # constants, LoadError from autoload, ArgumentError from overridden #name methods,
+    # SecurityError in restricted contexts, and more.
+    #
+    # Rescue blocks are organized in three layers:
+    #
+    # 1. **Inner per-item rescues** (bare `rescue` in const_get loops, method.name):
+    #    Skip one constant or name lookup without aborting the enclosing collection.
+    #    These are expected failures — no logging needed.
+    #
+    # 2. **Method-level rescues** (`rescue => e` with logging):
+    #    Catch failures in extract_method_scope, find_source_file, etc. Log at debug
+    #    for post-hoc diagnosis, return nil or empty array. One bad method/module
+    #    doesn't kill the entire class extraction.
+    #
+    # 3. **Top-level entry rescues** (`rescue => e` with logging + telemetry):
+    #    extract() and extract_all() are the error boundaries. Any exception that
+    #    escapes layers 1-2 is caught here, logged, and tracked via telemetry.
+    #    These are the only rescue blocks that increment telemetry counters.
+    #
+    # @api private
+    class Extractor
+      # Common Ruby core modules to exclude from included_modules extraction.
+      # These are ubiquitous mix-ins that don't provide meaningful context about the class structure.
+      # Kernel: Mixed into Object, appears in nearly all classes
+      # PP: Pretty-printing module, loaded by many tools
+      # JSON: JSON serialization module, loaded by many tools
+      # Enumerable: Core iteration protocol, extremely common
+      # Comparable: Core comparison protocol, extremely common
+      EXCLUDED_COMMON_MODULES = ['Kernel', 'PP::', 'JSON::', 'Enumerable', 'Comparable'].freeze
+
+      # RubyVM::InstructionSequence#trace_points event types included when
+      # computing injectable lines on METHOD scopes.
+      # :line — any line with executable bytecode (primary line probe target)
+      # :return — last expression before method returns (DI instruments return events)
+      # :call excluded — method entry is handled by method probes, not line probes
+      INJECTABLE_LINE_EVENTS = [:line, :return].freeze
+
+      # @param logger [Logger] Logger instance (SymbolDatabase::Logger facade or compatible)
+      # @param settings [Configuration::Settings] Tracer settings
+      # @param telemetry [Telemetry, nil] Optional telemetry for metrics
+      def initialize(logger:, settings:, telemetry: nil)
+        @logger = logger
+        @settings = settings
+        @telemetry = telemetry
+      end
+
+      # Extract symbols from a single module or class.
+      # Returns nil if module should be skipped (anonymous, gem code, stdlib).
+      #
+      # Returns a FILE scope wrapping the extracted CLASS or MODULE scope.
+      # The backend requires root-level scopes to be in ROOT_SCOPES (MODULE, JAR,
+      # ASSEMBLY, PACKAGE, FILE). FILE is the natural root for Ruby — one per source file.
+      #
+      # For full extraction with proper FQN-based nesting and per-file method grouping,
+      # use extract_all instead. This method is kept for single-module extraction in tests.
+      #
+      # @param mod [Module, Class] The module or class to extract from
+      # @return [Scope, nil] FILE scope wrapping extracted scope, or nil if filtered out
+      def extract(mod)
+        return nil unless mod.is_a?(Module)
+        mod_name = safe_mod_name(mod)
+        return nil unless mod_name
+
+        return nil unless user_code_module?(mod)
+
+        source_file = find_source_file(mod)
+        return nil unless source_file
+
+        inner_scope = if mod.is_a?(Class)
+          extract_class_scope(mod)
+        else
+          extract_module_scope(mod)
+        end
+
+        wrap_in_file_scope(source_file, [inner_scope])
+      rescue => e
+        mod_name = safe_mod_name(mod) || '<unknown>'
+        @logger.debug { "symdb: failed to extract #{mod_name}: #{e.class}: #{e}" }
+        @telemetry&.inc('tracers', 'symbol_database.extract_error', 1)
+        nil
+      end
+
+      # Extract symbols from all loaded modules and classes.
+      # Returns an array of FILE scopes with proper FQN-based nesting.
+      #
+      # Two-pass algorithm:
+      # Pass 1: Iterate ObjectSpace, collect all extractable modules with methods grouped by file
+      # Pass 2: Build FILE scope trees with nested MODULE/CLASS hierarchy from FQN splitting
+      #
+      # This is the production path used by Component. Methods are split by source file,
+      # so a class reopened across two files produces two FILE scopes, each with only
+      # the methods defined in that file.
+      #
+      # @return [Array<Scope>] Array of FILE scopes
+      def extract_all
+        entries = collect_extractable_modules
+        file_trees = build_file_trees(entries)
+        convert_trees_to_scopes(file_trees)
+      rescue => e
+        @logger.debug { "symdb: error in extract_all: #{e.class}: #{e}" }
+        @telemetry&.inc('tracers', 'symbol_database.extract_all_error', 1)
+        []
+      end
+
+      private
+
+      # Safe Module#name lookup — some classes override the singleton `name` method
+      # (e.g. Faker::Travel::Airport defines `def name(size:, region:)` in class << self,
+      # which shadows Module#name and raises ArgumentError when called without args).
+      # @param mod [Module] The module
+      # @return [String, nil] Module name or nil
+      def safe_mod_name(mod)
+        Module.instance_method(:name).bind(mod).call
+      rescue => e
+        @logger.debug { "symdb: safe_mod_name failed: #{e.class}: #{e}" }
+        nil
+      end
+
+      # Check if module is from user code (not gems or stdlib)
+      # @param mod [Module] The module to check
+      # @return [Boolean] true if user code
+      def user_code_module?(mod)
+        mod_name = safe_mod_name(mod)
+        return false unless mod_name
+
+        # CRITICAL: Exclude entire Datadog namespace (prevents circular extraction)
+        # Matches Java: className.startsWith("com/datadog/")
+        # Matches Python: packages.is_user_code() excludes ddtrace.*
+        return false if mod_name.start_with?('Datadog::')
+
+        source_file = find_source_file(mod)
+        return false unless source_file
+
+        user_code_path?(source_file)
+      end
+
+      # Check if path is user code
+      # @param path [String] File path
+      # @return [Boolean] true if user code
+      def user_code_path?(path)
+        # Only absolute paths are real source files. Pseudo-paths like '<main>',
+        # '<internal:...>', '(eval)' are not user code.
+        return false unless path.start_with?('/')
+        # Exclude gem paths
+        return false if path.include?('/gems/')
+        # Exclude Ruby stdlib
+        return false if path.include?('/ruby/')
+        return false if path.start_with?('<internal:')
+        return false if path.include?('(eval)')
+        # Exclude test code (not application code)
+        return false if path.include?('/spec/')
+        return false if path.include?('/test/')
+        # Exclude Datadog's own library code (e.g., monkey-patched methods from tracing contrib).
+        # Without this, stdlib classes like Net::HTTP appear as user code when dd-trace-rb
+        # instruments them, because the patched method source points to lib/datadog/tracing/contrib/.
+        return false if path.include?('/lib/datadog/')
+
+        true
+      end
+
+      # Find source file for a module.
+      # Prefers user code paths over gem/stdlib paths. ActiveRecord models have
+      # generated methods (autosave callbacks) whose source is in the gem, but
+      # user-defined methods point to app/models/. Without this preference,
+      # AR models get filtered out as gem code.
+      #
+      # For namespace-only modules (no instance or singleton methods), falls back to
+      # Module#const_source_location (Ruby 2.7+) to locate the module via its constants.
+      # This handles patterns like `module ApplicationCable; class Channel...; end; end`
+      # where the namespace module itself has no methods but defines user-code classes.
+      #
+      # On Ruby 2.6 (where const_source_location is unavailable), namespace-only modules
+      # and classes whose only methods are generated (e.g., AR models with only associations)
+      # may not be found — the extraction silently omits them. This is a graceful degradation:
+      # fewer symbols uploaded, no errors.
+      #
+      # @param mod [Module] The module
+      # @return [String, nil] Source file path or nil
+      def find_source_file(mod)
+        fallback = nil
+
+        # Try instance methods first
+        mod.instance_methods(false).each do |method_name|
+          method = mod.instance_method(method_name)
+          location = method.source_location
+          next unless location
+
+          path = location[0]
+          return path if user_code_path?(path)
+
+          fallback ||= path # steep:ignore
+        end
+
+        # Try singleton methods
+        mod.singleton_methods(false).each do |method_name|
+          method = mod.method(method_name)
+          location = method.source_location
+          next unless location
+
+          path = location[0]
+          return path if user_code_path?(path)
+
+          fallback ||= path # steep:ignore
+        end
+
+        # Try const_source_location (Ruby 2.7+) to find where this class/module is declared.
+        # This handles two cases:
+        #   1. Classes with no user-defined methods (e.g. AR models with only associations) whose
+        #      generated methods point to gem code — we find the `class Foo` declaration instead.
+        #   2. Namespace-only modules (`module Foo; class Bar; end; end`) with no methods at all.
+        if Module.method_defined?(:const_source_location) && mod.name
+          # Look up the class/module by its last name component in its enclosing namespace.
+          parts = mod.name.split('::')
+          const_name = parts.last
+          namespace = if parts.length > 1
+            begin
+              Object.const_get(parts[0..-2].join('::')) # steep:ignore
+            rescue NameError
+              nil
+            end
+          else
+            Object
+          end
+
+          if namespace
+            location = begin
+              namespace.const_source_location(const_name)
+            rescue => e
+              @logger.debug { "symdb: const_source_location(#{const_name}) failed: #{e.class}: #{e}" }
+              nil
+            end
+
+            if location && !location.empty?
+              path = location[0]
+              return path if path && !path.empty? && user_code_path?(path)
+              fallback ||= ((path && !path.empty?) ? path : nil)
+            end
+          end
+
+          # Also scan constants defined by mod itself (namespace-only modules).
+          mod.constants(false).each do |child_const_name|
+            location = begin
+              mod.const_source_location(child_const_name)
+            rescue => e
+              @logger.debug { "symdb: const_source_location(#{child_const_name}) failed: #{e.class}: #{e}" }
+              nil
+            end
+            next unless location && !location.empty?
+
+            path = location[0]
+            next unless path && !path.empty?
+
+            return path if user_code_path?(path)
+
+            fallback ||= path
+          end
+        end
+
+        fallback
+      rescue => e
+        @logger.debug { "symdb: error finding source file for #{safe_mod_name(mod) || '<unknown>'}: #{e.class}: #{e}" }
+        nil
+      end
+
+      # Wrap inner scopes in a FILE root scope.
+      # FILE is the per-source-file root scope for Ruby uploads, analogous to
+      # Python's MODULE-per-file or Java's JAR.
+      #
+      # @param file_path [String] Source file path
+      # @param inner_scopes [Array<Scope>] Child scopes to nest under FILE
+      # @return [Scope] FILE scope wrapping the inner scopes
+      def wrap_in_file_scope(file_path, inner_scopes)
+        file_hash = FileHash.compute(file_path, logger: @logger)
+        lang = {}
+        lang[:file_hash] = file_hash if file_hash
+
+        Scope.new(
+          scope_type: 'FILE',
+          name: file_path,
+          source_file: file_path,
+          start_line: SymbolDatabase::UNKNOWN_MIN_LINE,
+          end_line: SymbolDatabase::UNKNOWN_MAX_LINE,
+          language_specifics: lang,
+          scopes: inner_scopes
+        )
+      end
+
+      # Extract MODULE scope (without file_hash — that belongs on the FILE root scope).
+      # Does not include nested classes — nesting is handled by extract_all via FQN splitting.
+      # @param mod [Module] The module
+      # @return [Scope] The module scope
+      def extract_module_scope(mod)
+        source_file = find_source_file(mod)
+
+        Scope.new(
+          scope_type: 'MODULE',
+          name: mod.name,
+          source_file: source_file,
+          start_line: SymbolDatabase::UNKNOWN_MIN_LINE,
+          end_line: SymbolDatabase::UNKNOWN_MAX_LINE,
+          symbols: extract_module_symbols(mod)
+        )
+      end
+
+      # Extract CLASS scope
+      # @param klass [Class] The class
+      # @return [Scope] The class scope
+      def extract_class_scope(klass)
+        methods = klass.instance_methods(false)
+        start_line, end_line = calculate_class_line_range(klass, methods)
+        source_file = find_source_file(klass)
+
+        Scope.new(
+          scope_type: 'CLASS',
+          name: klass.name,
+          source_file: source_file,
+          start_line: start_line,
+          end_line: end_line,
+          language_specifics: build_class_language_specifics(klass),
+          scopes: extract_method_scopes(klass),
+          symbols: extract_class_symbols(klass)
+        )
+      end
+
+      # Calculate class line range from method locations
+      # @param klass [Class] The class
+      # @param methods [Array<Symbol>] Method names
+      # @return [Array<Integer, Integer>] [start_line, end_line]
+      def calculate_class_line_range(klass, methods)
+        lines = Core::Utils::Array.filter_map(methods) do |method_name|
+          method = klass.instance_method(method_name)
+          location = method.source_location
+          location[1] if location && location[0]
+        end
+
+        return [SymbolDatabase::UNKNOWN_MIN_LINE, SymbolDatabase::UNKNOWN_MAX_LINE] if lines.empty?
+
+        [lines.min, lines.max]
+      rescue => e
+        @logger.debug { "symdb: error calculating line range for #{klass.name}: #{e.class}: #{e}" }
+        [SymbolDatabase::UNKNOWN_MIN_LINE, SymbolDatabase::UNKNOWN_MAX_LINE]
+      end
+
+      # Build language specifics for CLASS
+      # @param klass [Class] The class
+      # @return [Hash] Language-specific metadata
+      def build_class_language_specifics(klass)
+        specifics = {}
+
+        # Superclass chain (exclude Object and BasicObject).
+        # Emitted as an array named super_classes — consistent with Java, .NET, and Python.
+        # Array allows for multiple entries if future Ruby versions or mixins expand the chain.
+        if klass.superclass && klass.superclass != Object && klass.superclass != BasicObject
+          # steep:ignore:start
+          specifics[:super_classes] = [klass.superclass.name]
+          # steep:ignore:end
+        end
+
+        # Included modules (exclude common ones)
+        included = klass.included_modules.map(&:name).reject do |name|
+          name.nil? || EXCLUDED_COMMON_MODULES.any? { |prefix| name.start_with?(prefix) }
+        end
+        specifics[:included_modules] = included unless included.empty?
+
+        # Prepended modules
+        # Take all ancestors before the class itself (prepending inserts modules before the class in ancestor chain).
+        # This code path is taken when a class has prepended modules (e.g., class Foo; prepend Bar; end).
+        # Test coverage: spec/datadog/symbol_database/extractor_spec.rb tests prepend behavior.
+        prepended = klass.ancestors.take_while { |a| a != klass }.map(&:name).compact
+        specifics[:prepended_modules] = prepended unless prepended.empty?
+
+        specifics
+      rescue => e
+        @logger.debug { "symdb: error building language specifics for #{klass.name}: #{e.class}: #{e}" }
+        {}
+      end
+
+      # Extract MODULE-level symbols (constants, module functions)
+      # @param mod [Module] The module
+      # @return [Array<Symbol>] Module symbols
+      def extract_module_symbols(mod)
+        symbols = []
+
+        # Constants (STATIC_FIELD)
+        mod.constants(false).each do |const_name|
+          const_value = mod.const_get(const_name)
+          # Skip classes (they're scopes, not symbols)
+          next if const_value.is_a?(Module)
+
+          symbols << Symbol.new(
+            symbol_type: 'STATIC_FIELD',
+            name: const_name.to_s,
+            line: SymbolDatabase::UNKNOWN_MIN_LINE,  # Available in entire module
+            type: const_value.class.name
+          )
+        rescue => e
+          # Skip constants that can't be accessed due to:
+          # - NameError: constant removed or not yet defined (race condition during loading)
+          # - LoadError: constant triggers autoload that fails
+          # - NoMethodError: constant value doesn't respond to expected methods
+          @logger.debug { "symdb: skipping constant #{const_name}: #{e.class}: #{e}" }
+          # - SecurityError: restricted access in safe mode
+          # - Circular dependency errors during const_get
+        end
+
+        symbols
+      rescue => e
+        @logger.debug { "symdb: failed to extract module symbols from #{mod.name}: #{e.class}: #{e}" }
+        []
+      end
+
+      # Extract CLASS-level symbols (class variables, constants)
+      # @param klass [Class] The class
+      # @return [Array<Symbol>] Class symbols
+      def extract_class_symbols(klass)
+        symbols = []
+
+        # Class variables (STATIC_FIELD)
+        klass.class_variables(false).each do |var_name|
+          symbols << Symbol.new(
+            symbol_type: 'STATIC_FIELD',
+            name: var_name.to_s,
+            line: SymbolDatabase::UNKNOWN_MIN_LINE
+          )
+        end
+
+        # Constants (STATIC_FIELD) - excluding nested classes
+        klass.constants(false).each do |const_name|
+          const_value = klass.const_get(const_name)
+          next if const_value.is_a?(Module)  # Skip classes/modules
+
+          symbols << Symbol.new(
+            symbol_type: 'STATIC_FIELD',
+            name: const_name.to_s,
+            line: SymbolDatabase::UNKNOWN_MIN_LINE,
+            type: const_value.class.name
+          )
+        rescue => e
+          @logger.debug { "symdb: skipping class constant #{const_name}: #{e.class}: #{e}" }
+        end
+
+        symbols
+      rescue => e
+        @logger.debug { "symdb: failed to extract class symbols from #{klass.name}: #{e.class}: #{e}" }
+        []
+      end
+
+      # Extract method scopes from a class
+      # @param klass [Class] The class
+      # @return [Array<Scope>] Method scopes
+      def extract_method_scopes(klass)
+        scopes = []
+
+        # Get all instance methods (public, protected, private)
+        all_instance_methods = klass.instance_methods(false) +
+          klass.protected_instance_methods(false) +
+          klass.private_instance_methods(false)
+        all_instance_methods.uniq!
+
+        all_instance_methods.each do |method_name|
+          method_scope = extract_method_scope(klass, method_name, :instance)
+          scopes << method_scope if method_scope
+        end
+
+        scopes
+      rescue => e
+        @logger.debug { "symdb: failed to extract methods from #{klass.name}: #{e.class}: #{e}" }
+        []
+      end
+
+      # Extract a single method scope
+      # @param klass [Class] The class
+      # @param method_name [Symbol] Method name
+      # @param method_type [Symbol] :instance or :class
+      # @return [Scope, nil] Method scope or nil
+      def extract_method_scope(klass, method_name, method_type)
+        method = klass.instance_method(method_name)
+        location = method.source_location
+
+        return nil unless location  # Skip methods without source location
+
+        source_file, line = location
+        return nil unless user_code_path?(source_file)  # Skip gem/stdlib methods
+
+        injectable_lines, end_line = extract_injectable_lines(method, line)
+
+        Scope.new(
+          scope_type: 'METHOD',
+          name: method_name.to_s,
+          source_file: source_file,
+          start_line: line,
+          end_line: end_line,
+          injectible_lines: injectable_lines,
+          language_specifics: {
+            visibility: method_visibility(klass, method_name),
+            method_type: method_type.to_s,
+            arity: method.arity
+          },
+          symbols: extract_method_parameters(method, method_type)
+        )
+      rescue => e
+        @logger.debug { "symdb: failed to extract method #{klass.name}##{method_name}: #{e.class}: #{e}" }
+        nil
+      end
+
+      # Get method visibility
+      # @param klass [Class] The class
+      # @param method_name [Symbol] Method name
+      # @return [String] 'public', 'private', or 'protected'
+      def method_visibility(klass, method_name)
+        if klass.private_instance_methods(false).include?(method_name)
+          'private'
+        elsif klass.protected_instance_methods(false).include?(method_name)
+          'protected'
+        else
+          'public'
+        end
+      end
+
+      # Extract injectable lines and end_line from a method's bytecode.
+      # Returns [ranges, end_line] where ranges is an array of {start:, end:} hashes
+      # or nil if iseq is unavailable (C-extension methods).
+      # @param method [Method, UnboundMethod] The method
+      # @param start_line [Integer] Fallback end_line if iseq unavailable
+      # @return [Array(Array<Hash>, Integer), Array(nil, Integer)]
+      def extract_injectable_lines(method, start_line)
+        iseq = RubyVM::InstructionSequence.of(method) # steep:ignore
+        unless iseq
+          @logger.debug { "symdb: no iseq for #{method.name} (C extension or native), skipping injectable lines" }
+          return [nil, start_line]
+        end
+
+        lines = iseq.trace_points
+          .select { |_, event| INJECTABLE_LINE_EVENTS.include?(event) }
+          .map(&:first)
+          .uniq
+          .sort
+
+        end_line = lines.max || start_line
+        ranges = build_injectable_ranges(lines)
+        result = ranges.empty? ? nil : ranges
+        @logger.debug { "symdb: #{method.name} injectable lines: #{result ? "#{ranges.size} range(s), lines #{lines.first}..#{lines.last}" : 'none (no matching events)'}" }
+        [result, end_line]
+      end
+
+      # Compress sorted line numbers into consecutive ranges.
+      # [4, 5, 6, 8, 10, 11] => [{start: 4, end: 6}, {start: 8, end: 8}, {start: 10, end: 11}]
+      # @param lines [Array<Integer>] Sorted, deduplicated line numbers
+      # @return [Array<Hash>] Array of {start:, end:} range hashes
+      def build_injectable_ranges(lines)
+        return [] if lines.empty?
+
+        ranges = []
+        range_start = lines[0]
+        prev = range_start
+
+        lines[1..-1].each do |line| # steep:ignore
+          if line == prev + 1
+            prev = line
+          else
+            ranges << {start: range_start, end: prev}
+            range_start = line
+            prev = line
+          end
+        end
+        ranges << {start: range_start, end: prev}
+        ranges
+      end
+
+      # Extract method parameters as symbols.
+      # Does NOT include `self` — Ruby's implicit receiver is not a declared parameter.
+      # Java skips slot 0 (this) for the same reason. .NET uploads `this` but the web-ui
+      # filters it for dotnet. Ruby follows Java's approach: don't upload it.
+      # @param method [UnboundMethod] The method
+      # @param method_type [Symbol] :instance or :class (unused, kept for API compatibility)
+      # @return [Array<Symbol>] Parameter symbols
+      def extract_method_parameters(method, method_type = :instance)
+        method_name = begin
+          method.name.to_s
+        rescue => e
+          @logger.debug { "symdb: method.name failed: #{e.class}: #{e}" }
+          'unknown'
+        end
+        params = method.parameters
+
+        return [] if params.nil? || params.empty?
+
+        Core::Utils::Array.filter_map(params) do |param_type, param_name|
+          # Skip block parameters for MVP
+          next if param_type == :block
+
+          # Skip if param_name is nil — normal for generated methods (attr_writer, attr_accessor).
+          # See pitfall 37 and specs/json-schema.md "Discovered During Implementation".
+          next if param_name.nil?
+
+          Symbol.new(
+            symbol_type: 'ARG',
+            name: param_name.to_s,
+            line: SymbolDatabase::UNKNOWN_MIN_LINE,  # Parameters available in entire method
+          )
+        end
+      rescue => e
+        @logger.debug { "symdb: failed to extract parameters from #{method_name}: #{e.class}: #{e}" }
+        []
+      end
+
+      # ── extract_all helpers ──────────────────────────────────────────────
+
+      # Pass 1: Collect all extractable modules with methods grouped by source file.
+      # @return [Hash] { mod_name => { mod:, methods_by_file: { path => [{name:, method:, type:}] } } }
+      def collect_extractable_modules
+        entries = {}
+
+        ObjectSpace.each_object(Module) do |mod|
+          mod_name = safe_mod_name(mod)
+          next unless mod_name
+          next unless user_code_module?(mod)
+
+          methods_by_file = group_methods_by_file(mod)
+
+          # For modules/classes with no methods but valid source, use find_source_file as fallback.
+          # This handles namespace modules and classes with only constants.
+          if methods_by_file.empty?
+            source_file = find_source_file(mod)
+            methods_by_file[source_file] = [] if source_file
+          end
+
+          next if methods_by_file.empty?
+
+          entries[mod_name] = {mod: mod, methods_by_file: methods_by_file}
+        rescue => e
+          @logger.debug { "symdb: error collecting #{mod_name || '<unknown>'}: #{e.class}: #{e}" }
+        end
+
+        entries
+      end
+
+      # Group a module's methods by their source file path.
+      # @param mod [Module] The module
+      # @return [Hash] { file_path => [{name:, method:, type:}] }
+      def group_methods_by_file(mod)
+        result = Hash.new { |h, k| h[k] = [] } # steep:ignore
+
+        # Instance methods (public, protected, private)
+        all_methods = mod.instance_methods(false) +
+          mod.protected_instance_methods(false) +
+          mod.private_instance_methods(false)
+        all_methods.uniq!
+
+        all_methods.each do |method_name|
+          method = mod.instance_method(method_name)
+          loc = method.source_location
+          next unless loc
+          next unless user_code_path?(loc[0])
+
+          result[loc[0]] << {name: method_name, method: method, type: :instance}
+        rescue => e
+          @logger.debug { "symdb: error grouping method #{method_name}: #{e.class}: #{e}" }
+        end
+
+        result
+      rescue => e
+        @logger.debug { "symdb: error grouping methods: #{e.class}: #{e}" }
+        {}
+      end
+
+      # Pass 2: Build per-file trees from collected entries.
+      # Uses hash nodes during construction, converted to Scope objects at the end.
+      #
+      # Node structure: { name:, type:, children: {name => node}, methods: [], mod:, source_file:, fqn: }
+      #
+      # @param entries [Hash] Output from collect_extractable_modules
+      # @return [Hash] { file_path => root_node }
+      def build_file_trees(entries)
+        file_trees = {}
+
+        # Sort by FQN depth so parents are placed before children.
+        # This ensures intermediate nodes created for parents have correct scope_type.
+        sorted = entries.sort_by { |name, _| name.count(':') }
+
+        sorted.each do |mod_name, entry|
+          entry[:methods_by_file].each do |file_path, methods|
+            root = file_trees[file_path] ||= {
+              name: file_path, type: 'FILE', children: {},
+              methods: [], mod: nil, source_file: file_path, fqn: nil
+            }
+            parts = mod_name.split('::')
+            place_in_tree(root, parts, entry[:mod], methods, file_path)
+          end
+        rescue => e
+          @logger.debug { "symdb: error building tree for #{mod_name}: #{e.class}: #{e}" }
+        end
+
+        file_trees
+      end
+
+      # Place a module/class in the file tree at the correct nesting depth.
+      # Creates intermediate namespace nodes as needed.
+      def place_in_tree(root, name_parts, mod, methods, file_path)
+        current = root
+
+        # Create/find intermediate nodes for each namespace segment except the last
+        name_parts[0..-2].each_with_index do |part, idx| # steep:ignore
+          fqn = name_parts[0..idx].join('::') # steep:ignore
+          current[:children][part] ||= {
+            name: part, type: resolve_scope_type(fqn),
+            children: {}, methods: [], mod: nil,
+            source_file: file_path, fqn: fqn
+          }
+          current = current[:children][part]
+        end
+
+        # Create or find the leaf node
+        leaf_name = name_parts.last
+        leaf = current[:children][leaf_name]
+        if leaf
+          # Node exists (was created as intermediate or from another entry).
+          # Update type and mod — the actual module object is authoritative.
+          leaf[:type] = mod.is_a?(Class) ? 'CLASS' : 'MODULE'
+          leaf[:mod] = mod
+        else
+          leaf = {
+            name: leaf_name,
+            type: mod.is_a?(Class) ? 'CLASS' : 'MODULE',
+            children: {}, methods: [],
+            mod: mod, source_file: file_path,
+            fqn: mod.name
+          }
+          current[:children][leaf_name] = leaf
+        end
+
+        # Add methods for this file
+        leaf[:methods].concat(methods)
+      end
+
+      # Determine scope type (CLASS or MODULE) for a fully-qualified name.
+      # Looks up the actual Ruby constant to check if it's a Class.
+      # @param fqn [String] Fully-qualified name (e.g. "Authentication::Strategies")
+      # @return [String] 'CLASS' or 'MODULE'
+      def resolve_scope_type(fqn)
+        const = Object.const_get(fqn)
+        const.is_a?(Class) ? 'CLASS' : 'MODULE'
+      rescue => e
+        @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e}, defaulting to MODULE" }
+        'MODULE'
+      end
+
+      # Convert hash-based file trees to Scope objects.
+      # @param file_trees [Hash] { file_path => root_node }
+      # @return [Array<Scope>] Array of FILE scopes
+      def convert_trees_to_scopes(file_trees)
+        file_trees.map do |file_path, root|
+          file_hash = FileHash.compute(file_path, logger: @logger)
+          lang = {}
+          lang[:file_hash] = file_hash if file_hash
+
+          Scope.new(
+            scope_type: 'FILE',
+            name: file_path,
+            source_file: file_path,
+            start_line: SymbolDatabase::UNKNOWN_MIN_LINE,
+            end_line: SymbolDatabase::UNKNOWN_MAX_LINE,
+            language_specifics: lang,
+            scopes: root[:children].values.map { |child| convert_node_to_scope(child) }
+          )
+        end
+      end
+
+      # Convert a single hash node to a Scope object (recursive).
+      # @param node [Hash] Tree node
+      # @return [Scope] Scope object
+      def convert_node_to_scope(node)
+        # Build method scopes from collected method entries
+        method_scopes = Core::Utils::Array.filter_map(node[:methods]) do |method_info|
+          build_instance_method_scope(node[:mod], method_info[:name], method_info[:method])
+        end
+
+        # Recurse into child scopes (nested modules/classes)
+        child_scopes = node[:children].values.map { |child| convert_node_to_scope(child) }
+
+        # Compute line range from method start lines
+        lines = method_scopes.map(&:start_line).reject { |l| l == SymbolDatabase::UNKNOWN_MIN_LINE } # steep:ignore
+        start_line = lines.empty? ? SymbolDatabase::UNKNOWN_MIN_LINE : lines.min
+        end_line = lines.empty? ? SymbolDatabase::UNKNOWN_MAX_LINE : lines.max
+
+        # Extract symbols (constants, class variables) if we have the actual module object
+        symbols = node[:mod] ? extract_scope_symbols(node[:mod]) : []
+
+        # Build language specifics
+        lang = if node[:type] == 'CLASS' && node[:mod]
+          build_class_language_specifics(node[:mod])
+        else
+          {}
+        end
+
+        Scope.new(
+          scope_type: node[:type],
+          name: node[:name],
+          source_file: node[:source_file],
+          start_line: start_line,
+          end_line: end_line,
+          language_specifics: lang,
+          scopes: method_scopes + child_scopes,
+          symbols: symbols
+        )
+      end
+
+      # Build a METHOD scope from a pre-resolved instance method.
+      # Used by extract_all path where methods are collected in Pass 1.
+      # @param klass [Module] The class/module (for visibility lookup)
+      # @param method_name [Symbol] Method name
+      # @param method [UnboundMethod] The method object
+      # @return [Scope, nil] Method scope or nil
+      def build_instance_method_scope(klass, method_name, method)
+        location = method.source_location
+        return nil unless location
+
+        source_file, line = location
+
+        injectable_lines, end_line = extract_injectable_lines(method, line)
+
+        Scope.new(
+          scope_type: 'METHOD',
+          name: method_name.to_s,
+          source_file: source_file,
+          start_line: line,
+          end_line: end_line,
+          injectible_lines: injectable_lines,
+          language_specifics: {
+            visibility: klass ? method_visibility(klass, method_name) : 'public', # steep:ignore
+            method_type: 'instance',
+            arity: method.arity
+          },
+          symbols: extract_method_parameters(method, :instance)
+        )
+      rescue => e
+        klass_name = klass ? (safe_mod_name(klass) || '<unknown>') : '<unknown>'
+        @logger.debug { "symdb: failed to build method scope #{klass_name}##{method_name}: #{e.class}: #{e}" }
+        nil
+      end
+
+      # Extract symbols (constants, class variables) from a module or class.
+      # Unified version of extract_module_symbols and extract_class_symbols.
+      # @param mod [Module] The module or class
+      # @return [Array<Symbol>] Symbols
+      def extract_scope_symbols(mod)
+        symbols = []
+
+        # Class variables (only for classes)
+        if mod.is_a?(Class)
+          mod.class_variables(false).each do |var_name|
+            symbols << Symbol.new(
+              symbol_type: 'STATIC_FIELD',
+              name: var_name.to_s,
+              line: SymbolDatabase::UNKNOWN_MIN_LINE
+            )
+          end
+        end
+
+        # Constants (excluding nested modules/classes)
+        mod.constants(false).each do |const_name|
+          const_value = mod.const_get(const_name)
+          next if const_value.is_a?(Module)
+
+          symbols << Symbol.new(
+            symbol_type: 'STATIC_FIELD',
+            name: const_name.to_s,
+            line: SymbolDatabase::UNKNOWN_MIN_LINE,
+            type: const_value.class.name
+          )
+        rescue => e
+          @logger.debug { "symdb: skipping module constant #{const_name}: #{e.class}: #{e}" }
+        end
+
+        symbols
+      rescue => e
+        mod_name = safe_mod_name(mod) || '<unknown>'
+        @logger.debug { "symdb: failed to extract symbols from #{mod_name}: #{e.class}: #{e}" }
+        []
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/file_hash.rb
+++ b/lib/datadog/symbol_database/file_hash.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'digest/sha1'
+
+module Datadog
+  module SymbolDatabase
+    # Computes Git-style SHA-1 hashes of Ruby source files for backend commit inference.
+    #
+    # Uses Git's blob hash algorithm: SHA1("blob <size>\0<content>")
+    # Hashes enable the backend to correlate runtime code with Git repository history,
+    # identifying which commit is actually deployed.
+    #
+    # Called by: Extractor (when building MODULE scopes)
+    # Stores result in: Scope's language_specifics[:file_hash]
+    # Returns: 40-character hex string or nil if file unreadable
+    #
+    # @api private
+    module FileHash
+      module_function
+
+      # Compute Git-style SHA-1 hash of a file.
+      # Uses Git's blob hash algorithm: SHA1("blob <size>\0<content>")
+      # Returns nil on any error (file not found, permission denied, etc.)
+      #
+      # @param file_path [String] Path to the file
+      # @param logger [#debug] Logger for error reporting
+      # @return [String, nil] 40-character hex-encoded SHA-1 hash, or nil if error
+      def compute(file_path, logger:)
+        return nil unless file_path
+        return nil unless File.exist?(file_path)
+
+        content = File.read(file_path, mode: 'rb')
+        size = content.bytesize
+        git_blob = "blob #{size}\0#{content}"
+
+        # SHA-1 is required here to match Git's blob hash format for commit inference.
+        # This is not a security vulnerability - we're computing file content hashes
+        # to match against Git objects, not using SHA-1 for authentication/integrity.
+        Digest::SHA1.hexdigest(git_blob)  # nosemgrep: ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
+      rescue => e
+        logger.debug { "symdb: file hash failed for #{file_path}: #{e.class}: #{e}" }
+        nil
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/logger.rb
+++ b/lib/datadog/symbol_database/logger.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Datadog
+  module SymbolDatabase
+    # Logger facade that adds a config-gated +trace+ method.
+    #
+    # Wraps any logger (customer-provided or default) and delegates
+    # standard methods. The +trace+ method is a sub-debug level that
+    # is a no-op unless DD_TRACE_DEBUG is set, avoiding overhead for
+    # high-frequency log sites (per-module filtering, dedup checks).
+    #
+    # @api private
+    class Logger
+      extend Forwardable
+
+      # @param settings [Configuration::Settings] Tracer settings (reads trace_logging flag)
+      # @param target [::Logger] Underlying logger to delegate to
+      def initialize(settings, target)
+        @settings = settings
+        @target = target
+      end
+
+      attr_reader :settings
+      attr_reader :target
+
+      def_delegators :target, :debug, :warn
+
+      # Log at trace level (sub-debug). No-op unless DD_TRACE_DEBUG is set.
+      # @yield Block that returns the log message string
+      # @return [void]
+      def trace(&block)
+        if settings.symbol_database.internal.trace_logging
+          debug(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/scope.rb
+++ b/lib/datadog/symbol_database/scope.rb
@@ -18,7 +18,13 @@ module Datadog
     # @api private
     class Scope
       attr_reader :scope_type, :name, :source_file, :start_line, :end_line,
-        :has_injectible_lines, :injectible_lines,
+        # Ranges of executable lines [{start:, end:}]. Three states:
+        # - nil: not computed (source unreadable, native/C-extension method)
+        # - []: computed but no executable lines found (comments/whitespace only)
+        # - non-empty: computed, contains executable line ranges
+        # nil and [] both serialize as injectible_lines?: false on METHOD
+        # scopes. Key is absent on non-METHOD scopes.
+        :injectible_lines,
         :language_specifics, :symbols, :scopes
 
       # Initialize a new Scope
@@ -27,7 +33,6 @@ module Datadog
       # @param source_file [String, nil] Path to source file
       # @param start_line [Integer, nil] Starting line number (UNKNOWN_MIN_LINE for unknown)
       # @param end_line [Integer, nil] Ending line number (UNKNOWN_MAX_LINE for entire file)
-      # @param has_injectible_lines [Boolean] Whether injectable lines data is present
       # @param injectible_lines [Array<Hash>, nil] Ranges of executable lines [{start:, end:}]
       # @param language_specifics [Hash, nil] Ruby-specific metadata
       # @param symbols [Array<Symbol>, nil] Symbols defined in this scope
@@ -38,7 +43,6 @@ module Datadog
         source_file: nil,
         start_line: nil,
         end_line: nil,
-        has_injectible_lines: false,
         injectible_lines: nil,
         language_specifics: nil,
         symbols: nil,
@@ -49,11 +53,15 @@ module Datadog
         @source_file = source_file
         @start_line = start_line
         @end_line = end_line
-        @has_injectible_lines = has_injectible_lines
         @injectible_lines = injectible_lines
         @language_specifics = language_specifics || {}
         @symbols = symbols || []
         @scopes = scopes || []
+      end
+
+      # @return [Boolean] true when injectible_lines is non-nil and non-empty
+      def injectible_lines?
+        !injectible_lines.nil? && !injectible_lines.empty?
       end
 
       # Convert scope to Hash for JSON serialization.
@@ -74,7 +82,7 @@ module Datadog
         # Injectable lines only on METHOD scopes (per spec — not on CLASS/MODULE/FILE).
         # Always emit has_injectible_lines (even when false) on METHOD scopes.
         if scope_type == 'METHOD'
-          h[:has_injectible_lines] = has_injectible_lines # steep:ignore ArgumentTypeMismatch
+          h[:has_injectible_lines] = injectible_lines? # steep:ignore ArgumentTypeMismatch
           h[:injectible_lines] = injectible_lines if injectible_lines && !injectible_lines.empty?
         end
         h

--- a/lib/datadog/symbol_database/scope_context.rb
+++ b/lib/datadog/symbol_database/scope_context.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Datadog
+  module SymbolDatabase
+    # Batches extracted scopes and triggers uploads at appropriate times.
+    #
+    # Implements two upload triggers:
+    # 1. Size-based: Immediate upload when 400 scopes collected (MAX_SCOPES)
+    # 2. Time-based: Upload after 1 second of inactivity (debounce timer, not periodic)
+    #
+    # Also provides:
+    # - Deduplication: Tracks uploaded module names to prevent re-uploads
+    # - File limiting: Stops after 10,000 files to prevent runaway extraction
+    # - Thread safety: Mutex-protected state for concurrent access
+    #
+    # Timer implementation: A single long-lived thread waits on a ConditionVariable
+    # with a timeout. Each add_scope signals the CV to reset the deadline. When the
+    # timeout expires without a signal, the timer fires and flushes the batch.
+    # This avoids creating/destroying a thread per add_scope call.
+    #
+    # Flow: Extractor → add_scope → (batch or timer) → Uploader
+    # Created by: Component (during initialization)
+    # Calls: Uploader.upload_scopes when batch full or timer fires
+    #
+    # @api private
+    class ScopeContext
+      # Maximum scopes per batch before triggering immediate upload.
+      # This matches the batch size used in Java and Python tracers to ensure
+      # consistent upload behavior across languages.
+      MAX_SCOPES = 400
+      INACTIVITY_TIMEOUT = 1.0  # seconds
+      # Maximum unique files to track before stopping extraction.
+      # This prevents runaway memory usage in applications with very large
+      # numbers of loaded classes (e.g., heavily modularized Rails apps).
+      MAX_FILES = 10_000
+
+      # Initialize batching context.
+      # @param uploader [Uploader] Uploader instance for triggering uploads
+      # @param telemetry [Telemetry, nil] Optional telemetry for metrics
+      # @param on_upload [Proc, nil] Optional callback called after upload (for testing)
+      # @param timer_enabled [Boolean] Enable async timer (default true, false for tests)
+      def initialize(uploader, logger:, telemetry: nil, on_upload: nil, timer_enabled: true)
+        @uploader = uploader
+        @logger = logger
+        @telemetry = telemetry
+        @on_upload = on_upload
+        @timer_enabled = timer_enabled
+        @scopes = []
+        @mutex = Mutex.new
+        @file_count = 0
+        @uploaded_modules = Set.new
+
+        # Timer state: single long-lived thread + ConditionVariable for debounce.
+        # @timer_signaled is set to true on each add_scope and cleared by the timer
+        # thread after waking. This flag is needed because ConditionVariable#wait
+        # does not distinguish signal vs timeout on Ruby < 3.2 (returns self in both
+        # cases). The flag gives a portable way to detect whether the wakeup was a
+        # signal (reset deadline) or a timeout (fire the timer).
+        @timer_cv = ConditionVariable.new
+        @timer_thread = nil
+        @timer_stopped = false
+        @timer_signaled = false
+      end
+
+      # Add a scope to the batch.
+      # Triggers immediate upload if batch reaches 400 scopes.
+      # Resets inactivity timer if batch not full.
+      # @param scope [Scope] The scope to add
+      # @return [void]
+      def add_scope(scope)
+        scopes_to_upload = nil
+
+        @mutex.synchronize do
+          # Check file limit
+          if @file_count >= MAX_FILES
+            @logger.debug { "symdb: file limit (#{MAX_FILES}) reached, ignoring scope: #{scope.name}" }
+            return
+          end
+
+          @file_count += 1
+
+          # Check if already uploaded
+          if @uploaded_modules.include?(scope.name)
+            @logger.trace { "symdb: skipping #{scope.name}: already uploaded" }
+            return
+          end
+
+          @uploaded_modules.add(scope.name)
+
+          # Add the scope
+          @scopes << scope
+
+          # Check if batch size reached (AFTER adding)
+          if @scopes.size >= MAX_SCOPES
+            # Prepare for upload (clear within mutex)
+            # steep:ignore:start
+            scopes_to_upload = @scopes.dup
+            @scopes.clear
+            # steep:ignore:end
+          end
+
+          # Signal the timer thread to reset its inactivity deadline.
+          # If batch was full, this is harmless — the timer will just
+          # re-check and find an empty batch if it fires.
+          ensure_timer_running
+          @timer_signaled = true
+          @timer_cv.signal
+        end
+
+        # Upload outside mutex (if batch was full)
+        perform_upload(scopes_to_upload) if scopes_to_upload
+      rescue => e
+        @logger.debug { "symdb: failed to add scope: #{e.class}: #{e}" }
+        @telemetry&.inc('tracers', 'symbol_database.add_scope_error', 1)
+        # Don't propagate, continue operation
+      end
+
+      # Force upload of current batch immediately.
+      # @return [void]
+      def flush
+        scopes_to_upload = nil
+
+        # steep:ignore:start
+        @mutex.synchronize do
+          return if @scopes.empty?
+
+          scopes_to_upload = @scopes.dup
+          @scopes.clear
+        end
+
+        perform_upload(scopes_to_upload)
+        # steep:ignore:end
+      end
+
+      # Shutdown and upload remaining scopes.
+      # @return [void]
+      def shutdown
+        scopes_to_upload = nil
+
+        # steep:ignore:start
+        @mutex.synchronize do
+          @timer_stopped = true
+          @timer_cv.signal  # Wake the timer thread so it exits
+
+          scopes_to_upload = @scopes.dup
+          @scopes.clear
+        end
+
+        # Join the timer thread outside the mutex.
+        # The thread checks @timer_stopped and exits when signaled.
+        @timer_thread&.join(5)  # 5-second timeout to avoid hanging
+        @timer_thread = nil
+
+        # Upload outside mutex
+        perform_upload(scopes_to_upload) unless scopes_to_upload.empty?
+        # steep:ignore:end
+      end
+
+      # Reset state (for testing).
+      # @return [void]
+      # @api private
+      def reset
+        @mutex.synchronize do
+          @scopes.clear
+          @timer_stopped = true
+          @timer_cv.signal
+          @file_count = 0
+          @uploaded_modules.clear
+        end
+
+        @timer_thread&.join(5)
+        @timer_thread = nil
+
+        # Allow timer to be restarted after reset
+        @mutex.synchronize do
+          @timer_stopped = false
+          @timer_signaled = false
+        end
+      end
+
+      # Check if scopes are pending upload.
+      # @return [Boolean] true if scopes waiting in batch
+      def scopes_pending?
+        @mutex.synchronize { @scopes.any? }
+      end
+
+      # Get current batch size.
+      # @return [Integer] Number of scopes in current batch
+      def size
+        @mutex.synchronize { @scopes.size }
+      end
+
+      private
+
+      # Start the timer thread if not already running.
+      # Must be called from within @mutex.synchronize.
+      # @return [void]
+      def ensure_timer_running
+        return unless @timer_enabled
+        return if @timer_thread&.alive?
+
+        @timer_stopped = false
+        @timer_signaled = false
+
+        @timer_thread = Thread.new do
+          timer_loop
+        end
+      end
+
+      # Timer thread main loop. Waits on the ConditionVariable with a timeout.
+      # Each signal resets the deadline (debounce). When the wait times out
+      # (no signal within INACTIVITY_TIMEOUT), the batch is flushed.
+      #
+      # Uses @timer_signaled flag instead of ConditionVariable#wait return value
+      # because Ruby < 3.2 returns self for both signal and timeout (no way to
+      # distinguish). The flag is set by add_scope before signaling, and cleared
+      # by the timer thread after waking.
+      # @return [void]
+      def timer_loop
+        loop do
+          should_flush = false
+
+          @mutex.synchronize do
+            return if @timer_stopped
+
+            @timer_signaled = false
+            @timer_cv.wait(@mutex, INACTIVITY_TIMEOUT)
+
+            return if @timer_stopped
+
+            if @timer_signaled
+              # Woke up because add_scope signaled — loop back to re-wait with
+              # a fresh timeout. This implements the debounce: the timeout resets
+              # on every scope addition.
+              next # steep:ignore BreakTypeMismatch
+            end
+
+            # Timed out (no signal within INACTIVITY_TIMEOUT). If there are
+            # scopes pending, flush them. Otherwise, loop back and wait again.
+            should_flush = !@scopes.empty?
+          end
+
+          if should_flush
+            flush
+          end
+        end
+      rescue => e
+        @logger.debug { "symdb: timer thread error: #{e.class}: #{e}" }
+      end
+
+      # Perform upload via uploader.
+      # @param scopes [Array<Scope>] Scopes to upload
+      # @return [void]
+      def perform_upload(scopes)
+        return if scopes.nil? || scopes.empty?
+
+        @uploader.upload_scopes(scopes)
+        @on_upload&.call(scopes)  # Notify tests after upload
+      rescue => e
+        @logger.debug { "symdb: upload failed: #{e.class}: #{e}" }
+        @telemetry&.inc('tracers', 'symbol_database.perform_upload_error', 1)
+        # Don't propagate, uploader handles retries
+      end
+    end
+  end
+end

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -1,0 +1,72 @@
+module Datadog
+  module SymbolDatabase
+    class Extractor
+      EXCLUDED_COMMON_MODULES: Array[String]
+      INJECTABLE_LINE_EVENTS: Array[::Symbol]
+
+      @logger: untyped
+      @settings: untyped
+      @telemetry: untyped?
+
+      def initialize: (logger: untyped, settings: untyped, ?telemetry: untyped?) -> void
+
+      def extract: (Module mod) -> Scope?
+
+      def extract_all: () -> Array[Scope]
+
+      private
+
+      def safe_mod_name: (Module mod) -> String?
+
+      def user_code_module?: (Module mod) -> bool
+
+      def user_code_path?: (String path) -> bool
+
+      def find_source_file: (Module mod) -> String?
+
+      def wrap_in_file_scope: (String file_path, Array[Scope] inner_scopes) -> Scope
+
+      def extract_module_scope: (Module mod) -> Scope
+
+      def extract_class_scope: (Class klass) -> Scope
+
+      def calculate_class_line_range: (Class klass, Array[::Symbol] methods) -> [Integer, Integer]
+
+      def build_class_language_specifics: (Class klass) -> Hash[::Symbol, untyped]
+
+      def extract_module_symbols: (Module mod) -> Array[Symbol]
+
+      def extract_class_symbols: (Class klass) -> Array[Symbol]
+
+      def extract_method_scopes: (Class klass) -> Array[Scope]
+
+      def extract_method_scope: (Class klass, ::Symbol method_name, ::Symbol method_type) -> Scope?
+
+      def method_visibility: (Class klass, ::Symbol method_name) -> String
+
+      def extract_injectable_lines: (Method | UnboundMethod method, Integer start_line) -> [Array[Hash[::Symbol, Integer]]?, Integer]
+
+      def build_injectable_ranges: (Array[Integer] lines) -> Array[Hash[::Symbol, Integer]]
+
+      def extract_method_parameters: (UnboundMethod method, ?::Symbol method_type) -> Array[Symbol]
+
+      def collect_extractable_modules: () -> Hash[String, untyped]
+
+      def group_methods_by_file: (Module mod) -> Hash[String, Array[untyped]]
+
+      def build_file_trees: (Hash[String, untyped] entries) -> Hash[String, untyped]
+
+      def place_in_tree: (untyped root, Array[String] name_parts, Module mod, Array[untyped] methods, String file_path) -> void
+
+      def resolve_scope_type: (String fqn) -> String
+
+      def convert_trees_to_scopes: (Hash[String, untyped] file_trees) -> Array[Scope]
+
+      def convert_node_to_scope: (untyped node) -> Scope
+
+      def build_instance_method_scope: (Module? klass, ::Symbol method_name, UnboundMethod method) -> Scope?
+
+      def extract_scope_symbols: (Module mod) -> Array[Symbol]
+    end
+  end
+end

--- a/sig/datadog/symbol_database/file_hash.rbs
+++ b/sig/datadog/symbol_database/file_hash.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module SymbolDatabase
+    module FileHash
+      def self.compute: (String? file_path, logger: untyped) -> String?
+
+      def compute: (String? file_path, logger: untyped) -> String?
+    end
+  end
+end

--- a/sig/datadog/symbol_database/logger.rbs
+++ b/sig/datadog/symbol_database/logger.rbs
@@ -1,0 +1,22 @@
+module Datadog
+  module SymbolDatabase
+    class Logger
+      extend Forwardable
+
+      @settings: untyped
+
+      @target: ::Logger
+
+      def initialize: (untyped settings, ::Logger target) -> void
+
+      attr_reader settings: untyped
+
+      attr_reader target: ::Logger
+
+      # debug/warn accept either a positional message or a block (delegated to ::Logger)
+      def debug: (?untyped? message) ?{ () -> untyped } -> void
+      def warn: (?untyped? message) ?{ () -> untyped } -> void
+      def trace: () { () -> untyped } -> void
+    end
+  end
+end

--- a/sig/datadog/symbol_database/scope.rbs
+++ b/sig/datadog/symbol_database/scope.rbs
@@ -11,8 +11,6 @@ module Datadog
 
       @end_line: Integer?
 
-      @has_injectible_lines: bool
-
       @injectible_lines: Array[Hash[::Symbol, Integer]]?
 
       @language_specifics: Hash[::Symbol, untyped]
@@ -27,7 +25,6 @@ module Datadog
         ?source_file: String?,
         ?start_line: Integer?,
         ?end_line: Integer?,
-        ?has_injectible_lines: bool,
         ?injectible_lines: Array[Hash[::Symbol, Integer]]?,
         ?language_specifics: Hash[::Symbol, untyped]?,
         ?symbols: Array[Datadog::SymbolDatabase::Symbol]?,
@@ -44,7 +41,7 @@ module Datadog
 
       attr_reader end_line: Integer?
 
-      attr_reader has_injectible_lines: bool
+      def injectible_lines?: () -> bool
 
       attr_reader injectible_lines: Array[Hash[::Symbol, Integer]]?
 

--- a/sig/datadog/symbol_database/scope_context.rbs
+++ b/sig/datadog/symbol_database/scope_context.rbs
@@ -1,0 +1,59 @@
+module Datadog
+  module SymbolDatabase
+    class ScopeContext
+      MAX_SCOPES: Integer
+
+      INACTIVITY_TIMEOUT: Float
+
+      MAX_FILES: Integer
+
+      @uploader: Uploader
+
+      @logger: Logger
+
+      @telemetry: untyped
+
+      @on_upload: Proc?
+
+      @timer_enabled: bool
+
+      @scopes: Array[Scope]
+
+      @mutex: Mutex
+
+      @timer_cv: Thread::ConditionVariable
+
+      @timer_thread: Thread?
+
+      @timer_stopped: bool
+
+      @timer_signaled: bool
+
+      @file_count: Integer
+
+      @uploaded_modules: Set[String?]
+
+      def initialize: (Uploader uploader, logger: Logger, ?telemetry: untyped, ?on_upload: Proc?, ?timer_enabled: bool) -> void
+
+      def add_scope: (Scope scope) -> void
+
+      def flush: () -> void
+
+      def shutdown: () -> void
+
+      def reset: () -> void
+
+      def perform_upload: (Array[Scope]? scopes) -> void
+
+      def scopes_pending?: () -> bool
+
+      def size: () -> Integer
+
+      private
+
+      def ensure_timer_running: () -> void
+
+      def timer_loop: () -> void
+    end
+  end
+end

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -1,0 +1,2174 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/extractor'
+require 'fileutils'
+
+RSpec.describe Datadog::SymbolDatabase::Extractor do
+  let(:settings) do
+    s = double('settings')
+    symdb = double('symbol_database')
+    internal = double('internal')
+    allow(symdb).to receive(:internal).and_return(internal)
+    allow(s).to receive(:symbol_database).and_return(symdb)
+    s
+  end
+  let(:logger) { instance_double(Logger, debug: nil) }
+  let(:extractor) { described_class.new(logger: logger, settings: settings, telemetry: nil) }
+
+  # Temporary directory for user code test files
+  around do |example|
+    Dir.mktmpdir('symbol_db_extractor_test') do |dir|
+      @test_dir = dir
+      example.run
+    end
+  end
+
+  # Helper to create test files in user code location
+  def create_user_code_file(content)
+    filename = File.join(@test_dir, "test_#{Time.now.to_i}_#{rand(10000)}.rb")
+    File.write(filename, content)
+    filename
+  end
+
+  def cleanup_user_code_file(filename)
+    File.unlink(filename) if File.exist?(filename)
+  end
+
+  describe '.extract' do
+    it 'returns nil for non-Module input' do
+      expect(extractor.extract("not a module")).to be_nil
+      expect(extractor.extract(42)).to be_nil
+      expect(extractor.extract(nil)).to be_nil
+    end
+
+    it 'returns nil for anonymous module' do
+      anonymous_mod = Module.new
+      expect(extractor.extract(anonymous_mod)).to be_nil
+    end
+
+    it 'returns nil for anonymous class' do
+      anonymous_class = Class.new
+      expect(extractor.extract(anonymous_class)).to be_nil
+    end
+
+    it 'returns nil for class with overridden singleton name method requiring keyword args' do
+      # Reproduces Faker::Travel::Airport: defines `def name(size:, region:)` in class << self,
+      # shadowing Module#name. Bare `mod.name` raises ArgumentError; safe bind avoids it.
+      mod = Class.new
+      mod.define_singleton_method(:name) { |size:, region:| "#{size}-#{region}" }
+      expect(extractor.extract(mod)).to be_nil
+    end
+
+    context 'with gem code' do
+      it 'returns nil for RSpec module (gem code)' do
+        expect(extractor.extract(RSpec)).to be_nil
+      end
+    end
+
+    context 'with stdlib code' do
+      it 'returns nil for File class (stdlib)' do
+        expect(extractor.extract(File)).to be_nil
+      end
+    end
+
+    context 'with user code module' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestUserModule
+            SOME_CONSTANT = 42
+
+            def self.module_method
+              "result"
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestUserModule) if defined?(TestUserModule)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'wraps MODULE in a FILE scope' do
+        file_scope = extractor.extract(TestUserModule)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        expect(file_scope.name).to eq(@filename)
+        expect(file_scope.source_file).to eq(@filename)
+
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestUserModule')
+      end
+
+      it 'includes file hash on FILE scope language_specifics' do
+        file_scope = extractor.extract(TestUserModule)
+
+        expect(file_scope.language_specifics).to have_key(:file_hash)
+        expect(file_scope.language_specifics[:file_hash]).to be_a(String)
+        expect(file_scope.language_specifics[:file_hash].length).to eq(40)
+      end
+
+      it 'extracts module-level constants' do
+        file_scope = extractor.extract(TestUserModule)
+        module_scope = file_scope.scopes.first
+
+        constant_symbol = module_scope.symbols.find { |s| s.name == 'SOME_CONSTANT' }
+        expect(constant_symbol).not_to be_nil
+        expect(constant_symbol.symbol_type).to eq('STATIC_FIELD')
+      end
+    end
+
+    context 'with user code class' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestUserClass
+            CONSTANT = "value"
+            @@class_var = 123
+
+            def public_method(arg1, arg2 = nil)
+              arg1 + arg2.to_s
+            end
+
+            private
+
+            def private_method
+              "private"
+            end
+
+            def self.class_method(param)
+              param * 2
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestUserClass) if defined?(TestUserClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'wraps top-level CLASS in a FILE scope named after source file' do
+        file_scope = extractor.extract(TestUserClass)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        expect(file_scope.name).to eq(@filename)
+        expect(file_scope.source_file).to eq(@filename)
+        expect(file_scope.scopes.size).to eq(1)
+
+        class_scope = file_scope.scopes.first
+        expect(class_scope.scope_type).to eq('CLASS')
+        expect(class_scope.name).to eq('TestUserClass')
+        expect(class_scope.source_file).to eq(@filename)
+      end
+
+      it 'extracts class variables' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+
+        class_var = class_scope.symbols.find { |s| s.name == '@@class_var' }
+        expect(class_var).not_to be_nil
+        expect(class_var.symbol_type).to eq('STATIC_FIELD')
+      end
+
+      it 'extracts constants' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+
+        constant = class_scope.symbols.find { |s| s.name == 'CONSTANT' }
+        expect(constant).not_to be_nil
+        expect(constant.symbol_type).to eq('STATIC_FIELD')
+      end
+
+      it 'extracts instance methods as METHOD scopes' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+
+        method_scopes = class_scope.scopes.select { |s| s.scope_type == 'METHOD' }
+        method_names = method_scopes.map(&:name)
+
+        expect(method_names).to include('public_method')
+        expect(method_names).to include('private_method')
+      end
+
+      it 'captures method visibility' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+
+        public_method = class_scope.scopes.find { |s| s.name == 'public_method' }
+        expect(public_method.language_specifics[:visibility]).to eq('public')
+
+        private_method = class_scope.scopes.find { |s| s.name == 'private_method' }
+        expect(private_method.language_specifics[:visibility]).to eq('private')
+      end
+
+      it 'does not emit self ARG for instance methods' do
+        # self is implicit in Ruby (not a declared parameter). Java skips slot 0 for the
+        # same reason. The web-ui would need a filter for it anyway — don't upload it.
+        class_scope = extractor.extract(TestUserClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'public_method' }
+
+        expect(method_scope.symbols.map(&:name)).not_to include('self')
+      end
+
+      it 'extracts method parameters' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'public_method' }
+
+        arg1 = method_scope.symbols.find { |s| s.name == 'arg1' }
+        expect(arg1).not_to be_nil
+        expect(arg1.symbol_type).to eq('ARG')
+
+        arg2 = method_scope.symbols.find { |s| s.name == 'arg2' }
+        expect(arg2).not_to be_nil
+        expect(arg2.symbol_type).to eq('ARG')
+      end
+
+      it 'includes injectable lines on instance METHOD scopes via extract() path' do
+        class_scope = extractor.extract(TestUserClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'public_method' }
+
+        expect(method_scope.injectible_lines?).to eq(true)
+        expect(method_scope.injectible_lines).to be_an(Array)
+        expect(method_scope.injectible_lines).not_to be_empty
+        expect(method_scope.end_line).to be >= method_scope.start_line
+      end
+    end
+
+    context 'with namespaced class (namespace module has no methods)' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestNamespace
+            class TestInnerClass
+              def inner_method; end
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestNamespace) if defined?(TestNamespace)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts namespaced class as its own root FILE scope' do
+        # TestNamespace::TestInnerClass is a user class and must be searchable.
+        # Even though the parent TestNamespace has no methods (so it can't be extracted
+        # itself), the class is extracted as a standalone FILE-wrapped scope.
+        file_scope = extractor.extract(TestNamespace::TestInnerClass)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        expect(file_scope.name).to eq(file_scope.source_file)
+        class_scope = file_scope.scopes.first
+        expect(class_scope.scope_type).to eq('CLASS')
+        expect(class_scope.name).to eq('TestNamespace::TestInnerClass')
+      end
+
+      it 'extracts namespace-only module via const_source_location fallback (Ruby 2.7+)' do
+        # TestNamespace has no methods but has a constant (TestInnerClass).
+        # On Ruby 2.7+, const_source_location finds the module's source via its constants.
+        file_scope = extractor.extract(TestNamespace)
+
+        if Module.method_defined?(:const_source_location) || TestNamespace.respond_to?(:const_source_location)
+          expect(file_scope).not_to be_nil
+          expect(file_scope.scope_type).to eq('FILE')
+          module_scope = file_scope.scopes.first
+          expect(module_scope.scope_type).to eq('MODULE')
+          expect(module_scope.name).to eq('TestNamespace')
+        else
+          # Ruby < 2.7: const_source_location unavailable, module not extractable
+          expect(file_scope).to be_nil
+        end
+      end
+    end
+
+    context 'with namespaced module with methods' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestNsModule
+            def self.module_func; end
+            class TestNsClass
+              def ns_method; end
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestNsModule) if defined?(TestNsModule)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts the parent MODULE without nested classes (nesting is via extract_all)' do
+        file_scope = extractor.extract(TestNsModule)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestNsModule')
+        # extract does not nest classes — extract_all handles nesting via FQN splitting
+        inner_class = module_scope.scopes.find { |s| s.scope_type == 'CLASS' }
+        expect(inner_class).to be_nil
+      end
+
+      it 'also extracts the nested class as its own root FILE scope' do
+        # The nested class is extractable independently — it has a user code source file.
+        file_scope = extractor.extract(TestNsModule::TestNsClass)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        expect(file_scope.name).to eq(file_scope.source_file)
+      end
+    end
+
+    context 'with class inheritance' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestBaseClass
+            def base_method
+            end
+          end
+
+          class TestDerivedClass < TestBaseClass
+            def derived_method
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestDerivedClass) if defined?(TestDerivedClass)
+        Object.send(:remove_const, :TestBaseClass) if defined?(TestBaseClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'captures superclass in language_specifics as super_classes array' do
+        class_scope = extractor.extract(TestDerivedClass).scopes.first
+
+        expect(class_scope.language_specifics[:super_classes]).to eq(['TestBaseClass'])
+      end
+
+      it 'excludes Object from super_classes' do
+        class_scope = extractor.extract(TestBaseClass).scopes.first
+
+        expect(class_scope.language_specifics).not_to have_key(:super_classes)
+      end
+    end
+
+    context 'with mixins' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestMixin
+          end
+
+          class TestClassWithMixin
+            include TestMixin
+
+            def test_method
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestClassWithMixin) if defined?(TestClassWithMixin)
+        Object.send(:remove_const, :TestMixin) if defined?(TestMixin)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'captures included modules in language_specifics' do
+        class_scope = extractor.extract(TestClassWithMixin).scopes.first
+
+        expect(class_scope.language_specifics[:included_modules]).to include('TestMixin')
+      end
+
+      it 'excludes Kernel from included_modules (EXCLUDED_COMMON_MODULES)' do
+        class_scope = extractor.extract(TestClassWithMixin).scopes.first
+
+        expect(class_scope.language_specifics[:included_modules]).not_to include('Kernel')
+      end
+    end
+  end
+
+  describe '.extract edge cases' do
+    context 'empty and minimal classes' do
+      it 'extracts empty top-level class as a CLASS scope with no methods (Ruby 2.7+)' do
+        # Matches Java/NET: empty classes are uploaded so they appear in the probe modal.
+        # const_source_location finds the class declaration even with no methods.
+        filename = create_user_code_file("class TestEmptyClass; end")
+        load filename
+        scope = extractor.extract(TestEmptyClass)
+        if Module.method_defined?(:const_source_location)
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+          expect(scope.scopes.first.scope_type).to eq('CLASS')
+          expect(scope.scopes.first.scopes).to be_empty
+        else
+          expect(scope).to be_nil
+        end
+        Object.send(:remove_const, :TestEmptyClass)
+        cleanup_user_code_file(filename)
+      end
+
+      it 'extracts empty top-level module as a MODULE scope with no methods (Ruby 2.7+)' do
+        filename = create_user_code_file("module TestEmptyModule; end")
+        load filename
+        scope = extractor.extract(TestEmptyModule)
+        if Module.method_defined?(:const_source_location)
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+          expect(scope.scopes.first.scope_type).to eq('MODULE')
+        else
+          expect(scope).to be_nil
+        end
+        Object.send(:remove_const, :TestEmptyModule)
+        cleanup_user_code_file(filename)
+      end
+
+      it 'handles top-level class with only constants on Ruby 2.7+' do
+        filename = create_user_code_file(<<~RUBY)
+          class TestConstOnlyClass
+            SOME_CONST = 42
+          end
+        RUBY
+        load filename
+
+        scope = extractor.extract(TestConstOnlyClass)
+        if TestConstOnlyClass.respond_to?(:const_source_location)
+          # Ruby 2.7+: const_source_location finds source via constants
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+        else
+          # Ruby 2.5/2.6: no const_source_location, cannot find source
+          expect(scope).to be_nil
+        end
+
+        Object.send(:remove_const, :TestConstOnlyClass)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    context 'deeply nested namespaces' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestA
+            module TestB
+              class TestC
+                def deep_method; end
+              end
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestA) if defined?(TestA)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts deeply nested class (A::B::C) as standalone root scope' do
+        scope = extractor.extract(TestA::TestB::TestC)
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.name).to eq(scope.source_file)
+        expect(scope.scopes.first.scope_type).to eq('CLASS')
+      end
+
+      it 'extracts namespace modules via const_source_location when they have nested constants' do
+        # On Ruby 2.7+: TestA has const TestB (a module), TestA::TestB has const TestC (a class).
+        # const_source_location finds the source file via these constants, so both modules ARE extracted.
+        if TestA.respond_to?(:const_source_location)
+          expect(extractor.extract(TestA)).not_to be_nil
+          expect(extractor.extract(TestA::TestB)).not_to be_nil
+        else
+          # Ruby < 2.7: no const_source_location, namespace modules without methods return nil
+          expect(extractor.extract(TestA)).to be_nil
+          expect(extractor.extract(TestA::TestB)).to be_nil
+        end
+      end
+
+      it 'extracts all scopes in the namespace chain (Ruby 2.7+)' do
+        # TestA, TestA::TestB, TestA::TestB::TestC all get extracted on Ruby 2.7+
+        # because const_source_location propagates source file through the chain.
+        # Use explicit module list rather than ObjectSpace to avoid cross-test pollution.
+        mods = [TestA, TestA::TestB, TestA::TestB::TestC]
+        extracted = Datadog::Core::Utils::Array.filter_map(mods) { |mod| extractor.extract(mod) }
+
+        # All scopes are FILE-wrapped. Inner scope names distinguish modules from classes.
+        if TestA.respond_to?(:const_source_location)
+          expect(extracted.size).to eq(3)
+          # All root scopes are FILE
+          expect(extracted.map(&:scope_type).uniq).to eq(['FILE'])
+          # Inner scopes: TestA and TestA::TestB are modules, TestA::TestB::TestC is a class
+          inner_names = extracted.map { |s| s.scopes.first&.name }
+          expect(inner_names).to include('TestA', 'TestA::TestB')
+          tc_file = extracted.find { |s| s.scopes.first&.name == 'TestA::TestB::TestC' }
+          expect(tc_file).not_to be_nil
+          expect(tc_file.scopes.first.scope_type).to eq('CLASS')
+        else
+          expect(extracted.size).to eq(1)
+          expect(extracted.first.scope_type).to eq('FILE')
+        end
+      end
+    end
+
+    context 'AR-style model with no user-defined methods' do
+      it 'extracts class whose only methods come from gem paths — finds declaration via const_source_location' do
+        # Simulates ActiveRecord model with only associations (belongs_to, has_many).
+        # Methods are all gem-generated with gem source paths. The class declaration
+        # is in user code. On Ruby 2.7+ we find it via const_source_location and upload
+        # an empty CLASS scope, matching Java/.NET behavior.
+        filename = create_user_code_file(<<~RUBY)
+          class TestARStyleModel
+          end
+        RUBY
+        load filename
+
+        gem_path = '/fake/gems/activerecord-7.0/lib/active_record/autosave.rb'
+        gem_method = instance_double(Method, source_location: [gem_path, 1], arity: 0, parameters: [])
+
+        allow(TestARStyleModel).to receive(:instance_methods).with(false).and_return([:gem_generated_method])
+        allow(TestARStyleModel).to receive(:instance_method).with(:gem_generated_method).and_return(gem_method)
+        allow(TestARStyleModel).to receive(:protected_instance_methods).with(false).and_return([])
+        allow(TestARStyleModel).to receive(:private_instance_methods).with(false).and_return([])
+        allow(TestARStyleModel).to receive(:singleton_methods).with(false).and_return([])
+
+        scope = extractor.extract(TestARStyleModel)
+        if Module.method_defined?(:const_source_location)
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+          expect(scope.scopes.first.scope_type).to eq('CLASS')
+          expect(scope.scopes.first.scopes).to be_empty
+        else
+          expect(scope).to be_nil
+        end
+
+        Object.send(:remove_const, :TestARStyleModel)
+        cleanup_user_code_file(filename)
+      end
+
+      it 'extracts class with only Forwardable-delegated methods (def_delegators)' do
+        # def_delegators creates methods whose source_location points to forwardable.rb (stdlib).
+        # The class declaration is in user code. Should extract as empty CLASS scope on Ruby 2.7+.
+        filename = create_user_code_file(<<~RUBY)
+          require 'forwardable'
+          class TestForwardableModel
+            extend Forwardable
+            def_delegators :@target, :name, :email
+          end
+        RUBY
+        load filename
+
+        scope = extractor.extract(TestForwardableModel)
+        if Module.method_defined?(:const_source_location)
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+          inner = scope.scopes.first
+          expect(inner.scope_type).to eq('CLASS')
+          # Delegated methods point to forwardable.rb (stdlib) — not user code, not extracted
+          method_names = inner.scopes.map(&:name)
+          expect(method_names).not_to include('name', 'email')
+        else
+          expect(scope).to be_nil
+        end
+
+        Object.send(:remove_const, :TestForwardableModel)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    context 'class with only class variables (no methods)' do
+      it 'extracts class with only class variables on Ruby 2.7+ via const_source_location' do
+        # @@class_var is not a constant, so constants(false) returns nothing.
+        # But const_source_location on the class name itself finds the declaration.
+        filename = create_user_code_file(<<~RUBY)
+          class TestClassVarOnly
+            @@count = 0
+          end
+        RUBY
+        load filename
+        scope = extractor.extract(TestClassVarOnly)
+        if Module.method_defined?(:const_source_location)
+          expect(scope).not_to be_nil
+          expect(scope.scope_type).to eq('FILE')
+          expect(scope.scopes.first.scope_type).to eq('CLASS')
+        else
+          expect(scope).to be_nil
+        end
+        Object.send(:remove_const, :TestClassVarOnly)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    context 'module with only non-class-value constants' do
+      it 'is extracted on Ruby 2.7+ via const_source_location (non-class constants count)' do
+        # const_source_location works for any constant including VALUE constants (FOO = 42),
+        # not just class/module constants. So a module with only value constants IS found.
+        filename = create_user_code_file(<<~RUBY)
+          module TestValueConstModule
+            MAX_SIZE = 100
+            DEFAULT_NAME = "test"
+          end
+        RUBY
+        load filename
+        file_scope = extractor.extract(TestValueConstModule)
+        if TestValueConstModule.respond_to?(:const_source_location)
+          expect(file_scope).not_to be_nil
+          expect(file_scope.scope_type).to eq('FILE')
+          module_scope = file_scope.scopes.first
+          expect(module_scope.scope_type).to eq('MODULE')
+          expect(module_scope.name).to eq('TestValueConstModule')
+        else
+          expect(file_scope).to be_nil
+        end
+        Object.send(:remove_const, :TestValueConstModule)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    context 'namespace module found via const_source_location has file_hash' do
+      it 'computes file_hash from the const_source_location-derived source file' do
+        filename = create_user_code_file(<<~RUBY)
+          module TestNsFileHash
+            class TestNsChild
+              def child_method; end
+            end
+          end
+        RUBY
+        load filename
+
+        scope = extractor.extract(TestNsFileHash)
+
+        if Module.method_defined?(:const_source_location)
+          # Ruby 2.7+: const_source_location finds the module via its constants
+          expect(scope).not_to be_nil
+          expect(scope.language_specifics[:file_hash]).not_to be_nil
+          expect(scope.language_specifics[:file_hash]).to match(/\A[0-9a-f]{40}\z/)
+        else
+          # Ruby < 2.7: namespace module with no methods is not extractable
+          expect(scope).to be_nil
+        end
+
+        Object.send(:remove_const, :TestNsFileHash)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    context 'concern-style modules' do
+      it 'extracts a module with only an included block (no direct def methods)' do
+        # A concern using `included do ... end` — the `included` call is a singleton method
+        # on ActiveSupport::Concern (or a no-op here). Without direct `def` methods,
+        # find_source_file falls through to const_source_location or returns nil.
+        filename = create_user_code_file(<<~RUBY)
+          module TestConcernNoMethods
+            def self.included(base)
+              base.extend(ClassMethods)
+            end
+
+            module ClassMethods
+              def searchable?; true; end
+            end
+          end
+        RUBY
+        load filename
+
+        # TestConcernNoMethods has a singleton method (self.included) → source_location
+        # points to the file → extracted
+        file_scope = extractor.extract(TestConcernNoMethods)
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestConcernNoMethods')
+
+        Object.send(:remove_const, :TestConcernNoMethods)
+        cleanup_user_code_file(filename)
+      end
+    end
+
+    # === Tests ported from Java SymbolExtractionTransformerTest ===
+    # Java tests bytecode-level variable scoping (if/for/while blocks).
+    # Ruby uses reflection, not bytecode — we test the Ruby equivalents.
+
+    context 'with protected methods' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestProtectedClass
+            def public_method; end
+
+            protected
+
+            def protected_method; end
+
+            private
+
+            def private_method; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestProtectedClass) if defined?(TestProtectedClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'captures protected visibility' do
+        class_scope = extractor.extract(TestProtectedClass).scopes.first
+
+        protected_method = class_scope.scopes.find { |s| s.name == 'protected_method' }
+        expect(protected_method.language_specifics[:visibility]).to eq('protected')
+      end
+
+      it 'extracts all three visibility levels' do
+        class_scope = extractor.extract(TestProtectedClass).scopes.first
+
+        visibilities = class_scope.scopes.map { |s| s.language_specifics[:visibility] }
+        expect(visibilities).to include('public', 'protected', 'private')
+      end
+    end
+
+    context 'with attr_accessor methods' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestAttrClass
+            attr_reader :read_only
+            attr_writer :write_only
+            attr_accessor :read_write
+
+            def initialize
+              @read_only = 1
+              @write_only = 2
+              @read_write = 3
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestAttrClass) if defined?(TestAttrClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts attr_reader as METHOD scope' do
+        class_scope = extractor.extract(TestAttrClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('read_only')
+      end
+
+      it 'extracts attr_writer as METHOD scope' do
+        class_scope = extractor.extract(TestAttrClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('write_only=')
+      end
+
+      it 'extracts attr_accessor as both reader and writer METHOD scopes' do
+        class_scope = extractor.extract(TestAttrClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('read_write')
+        expect(method_names).to include('read_write=')
+      end
+    end
+
+    context 'with prepended modules' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestPrependModule
+            def prepended_method; end
+          end
+
+          class TestPrependedClass
+            prepend TestPrependModule
+
+            def original_method; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestPrependedClass) if defined?(TestPrependedClass)
+        Object.send(:remove_const, :TestPrependModule) if defined?(TestPrependModule)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'captures prepended modules in language_specifics' do
+        class_scope = extractor.extract(TestPrependedClass).scopes.first
+
+        expect(class_scope.language_specifics[:prepended_modules]).to include('TestPrependModule')
+      end
+    end
+
+    context 'with all parameter types' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestAllParamsClass
+            def method_with_all_params(required, optional = nil, *rest, keyword:, optional_kw: 'default', **keyrest, &blk)
+              # Method with every Ruby parameter type
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestAllParamsClass) if defined?(TestAllParamsClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts required, optional, rest, keyword, and keyrest parameters' do
+        class_scope = extractor.extract(TestAllParamsClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'method_with_all_params' }
+
+        param_names = method_scope.symbols.map(&:name)
+
+        expect(param_names).not_to include('self')
+        expect(param_names).to include('required')
+        expect(param_names).to include('optional')
+        expect(param_names).to include('rest')
+        expect(param_names).to include('keyword')
+        expect(param_names).to include('optional_kw')
+        expect(param_names).to include('keyrest')
+      end
+
+      it 'skips block parameters' do
+        class_scope = extractor.extract(TestAllParamsClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'method_with_all_params' }
+
+        param_names = method_scope.symbols.map(&:name)
+
+        expect(param_names).not_to include('blk')
+      end
+
+      it 'all extracted parameters are ARG symbol type' do
+        class_scope = extractor.extract(TestAllParamsClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'method_with_all_params' }
+
+        method_scope.symbols.each do |sym|
+          expect(sym.symbol_type).to eq('ARG')
+        end
+      end
+    end
+
+    context 'with exception handling (begin/rescue/ensure equivalent)' do
+      # Ported from Java SymbolExtractionTransformerTest: symbolExtraction03 (try-catch-finally)
+      # Ruby doesn't expose local variable scoping from bytecode, but we verify
+      # that methods containing exception handling constructs are still extracted.
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestExceptionClass
+            def method_with_rescue(input)
+              result = nil
+              begin
+                result = Integer(input)
+              rescue ArgumentError => e
+                result = -1
+              rescue TypeError
+                result = -2
+              ensure
+                @last_input = input
+              end
+              result
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestExceptionClass) if defined?(TestExceptionClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts method containing begin/rescue/ensure' do
+        class_scope = extractor.extract(TestExceptionClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'method_with_rescue' }
+
+        expect(method_scope).not_to be_nil
+        expect(method_scope.scope_type).to eq('METHOD')
+      end
+
+      it 'extracts parameters from method with exception handling' do
+        class_scope = extractor.extract(TestExceptionClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'method_with_rescue' }
+
+        param_names = method_scope.symbols.map(&:name)
+        expect(param_names).to include('input')
+      end
+    end
+
+    context 'with define_method (metaprogramming)' do
+      # Ported from Java: tests dynamically defined methods. Java tests bytecode
+      # for dynamic proxies; Ruby equivalent is define_method.
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestDefineMethodClass
+            define_method(:dynamic_method) do |arg1, arg2|
+              arg1 + arg2
+            end
+
+            def regular_method; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestDefineMethodClass) if defined?(TestDefineMethodClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts dynamically defined methods' do
+        class_scope = extractor.extract(TestDefineMethodClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('dynamic_method')
+        expect(method_names).to include('regular_method')
+      end
+
+      it 'extracts parameters from define_method' do
+        class_scope = extractor.extract(TestDefineMethodClass).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'dynamic_method' }
+
+        param_names = method_scope.symbols.map(&:name)
+        expect(param_names).to include('arg1')
+        expect(param_names).to include('arg2')
+      end
+    end
+
+    context 'with Struct class' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          TestStructClass = Struct.new(:name, :age) do
+            def greeting
+              "Hello, \#{name}"
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestStructClass) if defined?(TestStructClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts Struct-based class' do
+        scope = extractor.extract(TestStructClass)
+
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.name).to eq(scope.source_file)
+      end
+
+      it 'extracts user-defined methods on Struct' do
+        class_scope = extractor.extract(TestStructClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('greeting')
+      end
+    end
+
+    # === Ruby-specific metaprogramming edge cases ===
+    # Tests for patterns unique to Ruby: class_eval, eval, define_method variants,
+    # OpenStruct, and refinements. These complement the Java-ported tests above.
+
+    context 'with class_eval adding methods' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestClassEvalTarget
+            def original_method; end
+          end
+
+          TestClassEvalTarget.class_eval do
+            def eval_added_method(x, y); x + y; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestClassEvalTarget) if defined?(TestClassEvalTarget)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts methods added via class_eval' do
+        class_scope = extractor.extract(TestClassEvalTarget).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('original_method')
+        expect(method_names).to include('eval_added_method')
+      end
+
+      it 'extracts parameters from class_eval methods' do
+        class_scope = extractor.extract(TestClassEvalTarget).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'eval_added_method' }
+
+        param_names = method_scope.symbols.map(&:name)
+        expect(param_names).to include('x', 'y')
+      end
+    end
+
+    context 'with eval-defined class' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          eval("class TestEvalDefinedClass; def eval_method; end; end")
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestEvalDefinedClass) if defined?(TestEvalDefinedClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'returns nil for class defined via eval (source_location is "(eval)")' do
+        # eval-defined methods have source_location ["(eval)", N] which is
+        # correctly filtered by user_code_path? (includes '(eval)' check)
+        scope = extractor.extract(TestEvalDefinedClass)
+        expect(scope).to be_nil
+      end
+    end
+
+    context 'with define_method using a lambda' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestDefineMethodLambda
+            handler = ->(a, b) { a * b }
+            define_method(:from_lambda, handler)
+
+            def regular; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestDefineMethodLambda) if defined?(TestDefineMethodLambda)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts method defined from lambda' do
+        class_scope = extractor.extract(TestDefineMethodLambda).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('from_lambda')
+        expect(method_names).to include('regular')
+      end
+
+      it 'extracts lambda parameters' do
+        class_scope = extractor.extract(TestDefineMethodLambda).scopes.first
+        method_scope = class_scope.scopes.find { |s| s.name == 'from_lambda' }
+
+        param_names = method_scope.symbols.map(&:name)
+        expect(param_names).to include('a', 'b')
+      end
+    end
+
+    context 'with OpenStruct subclass' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          require 'ostruct'
+          class TestOpenStructChild < OpenStruct
+            def custom_method; "custom"; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestOpenStructChild) if defined?(TestOpenStructChild)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts user-defined methods on OpenStruct subclass' do
+        scope = extractor.extract(TestOpenStructChild)
+
+        expect(scope).not_to be_nil
+        class_scope = scope.scopes.first
+        method_names = class_scope.scopes.map(&:name)
+        expect(method_names).to include('custom_method')
+      end
+
+      it 'includes OpenStruct as superclass in language_specifics' do
+        class_scope = extractor.extract(TestOpenStructChild).scopes.first
+        expect(class_scope.language_specifics[:super_classes]).to include('OpenStruct')
+      end
+    end
+
+    context 'with refinements' do
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          module TestRefinementModule
+            refine String do
+              def shout; upcase + "!"; end
+            end
+
+            def self.helper_method; "helper"; end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestRefinementModule) if defined?(TestRefinementModule)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts the refinement module itself (has a singleton method)' do
+        file_scope = extractor.extract(TestRefinementModule)
+        expect(file_scope).not_to be_nil
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestRefinementModule')
+      end
+
+      it 'does not add refined methods to the target class' do
+        # String.instance_methods(false) never includes refinement methods —
+        # they are only visible within `using` scope. So String extraction
+        # (which is filtered as stdlib anyway) would not show `shout`.
+        # This test documents the behavior for awareness.
+        expect(String.instance_methods(false)).not_to include(:shout)
+      end
+    end
+
+    context 'with filtering excluded packages/code' do
+      # Ported from Java SymbolExtractionTransformerTest: symbolExtraction15 (filtering)
+      # and SymDBEnablementTest: noIncludesFilterOutDatadogClass
+
+      it 'returns nil for Datadog internal classes' do
+        expect(extractor.extract(Datadog::SymbolDatabase::Extractor)).to be_nil
+        expect(extractor.extract(Datadog::SymbolDatabase::Scope)).to be_nil
+        expect(extractor.extract(Datadog::SymbolDatabase::Component)).to be_nil
+      end
+
+      it 'returns nil for Ruby stdlib classes' do
+        expect(extractor.extract(File)).to be_nil
+        expect(extractor.extract(Dir)).to be_nil
+        expect(extractor.extract(IO)).to be_nil
+      end
+
+      it 'returns nil for gem classes' do
+        expect(extractor.extract(RSpec)).to be_nil
+        expect(extractor.extract(RSpec::Core::Example)).to be_nil
+      end
+    end
+
+    context 'with class containing blocks and lambdas' do
+      # Ported from Java SymbolExtractionTransformerTest: symbolExtraction06 (lambdas)
+      # Ruby doesn't extract block/lambda scopes, but the enclosing methods should still work.
+      before do
+        @filename = create_user_code_file(<<~RUBY)
+          class TestBlockClass
+            MY_LAMBDA = ->(x) { x * 2 }
+            MY_PROC = Proc.new { |y| y + 1 }
+
+            def method_with_block
+              [1, 2, 3].each do |item|
+                puts item
+              end
+            end
+
+            def method_with_lambda
+              doubler = ->(n) { n * 2 }
+              doubler.call(5)
+            end
+          end
+        RUBY
+        load @filename
+      end
+
+      after do
+        Object.send(:remove_const, :TestBlockClass) if defined?(TestBlockClass)
+        cleanup_user_code_file(@filename)
+      end
+
+      it 'extracts methods that contain blocks' do
+        class_scope = extractor.extract(TestBlockClass).scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('method_with_block')
+        expect(method_names).to include('method_with_lambda')
+      end
+
+      it 'extracts lambda constants as STATIC_FIELD symbols' do
+        class_scope = extractor.extract(TestBlockClass).scopes.first
+        constant_names = class_scope.symbols.map(&:name)
+
+        expect(constant_names).to include('MY_LAMBDA')
+        expect(constant_names).to include('MY_PROC')
+      end
+    end
+
+    context 'with duplicate class through re-load' do
+      # Ported from Java SymDBEnablementTest: noDuplicateSymbolExtraction
+      # Tests that the same class is not extracted twice when loaded from different paths.
+      it 'produces consistent extraction for the same class' do
+        filename = create_user_code_file(<<~RUBY)
+          class TestDuplicateClass
+            def some_method; end
+          end
+        RUBY
+        load filename
+
+        scope1 = extractor.extract(TestDuplicateClass)
+        scope2 = extractor.extract(TestDuplicateClass)
+
+        # Same class should produce identical extractions
+        expect(scope1.to_json).to eq(scope2.to_json)
+
+        Object.send(:remove_const, :TestDuplicateClass)
+        cleanup_user_code_file(filename)
+      end
+    end
+  end
+
+  describe '.user_code_module?' do
+    it 'returns false for Datadog namespace' do
+      expect(extractor.send(:user_code_module?, Datadog::SymbolDatabase::Extractor)).to be false
+    end
+
+    it 'returns false for anonymous modules' do
+      expect(extractor.send(:user_code_module?, Module.new)).to be false
+    end
+
+    it 'returns false for C-implemented Ruby internals (ThreadGroup, Thread::Backtrace, RubyVM)' do
+      # These classes have no Ruby-defined methods (source_location is nil for all),
+      # so find_source_file falls back to const_source_location, which returns ["<main>", 0]
+      # for their nested constants — a pseudo-path that is not an absolute path.
+      # See: Pitfall 25, tmp/reproduce_threadgroup_leak.rb
+      expect(extractor.send(:user_code_module?, ThreadGroup)).to be false
+      expect(extractor.send(:user_code_module?, Thread::Backtrace)).to be false
+      expect(extractor.send(:user_code_module?, RubyVM)).to be false
+    end
+
+    it 'returns true for user code class' do
+      user_file = create_user_code_file(<<~RUBY)
+        class TestUserCodeModuleCheck
+          def a_method; end
+        end
+      RUBY
+      load user_file
+
+      expect(extractor.send(:user_code_module?, TestUserCodeModuleCheck)).to be true
+
+      Object.send(:remove_const, :TestUserCodeModuleCheck)
+      cleanup_user_code_file(user_file)
+    end
+
+    it 'returns true for class with mixed gem and user methods' do
+      user_file = create_user_code_file(<<~RUBY)
+        class TestMixedSourceModule
+          def user_method; end
+        end
+      RUBY
+      load user_file
+
+      gem_path = '/fake/gems/activerecord-7.0/lib/autosave.rb'
+      gem_method = instance_double(Method, source_location: [gem_path, 1])
+      user_method = TestMixedSourceModule.instance_method(:user_method)
+
+      allow(TestMixedSourceModule).to receive(:instance_methods).with(false).and_return([:gem_method, :user_method])
+      allow(TestMixedSourceModule).to receive(:instance_method).with(:gem_method).and_return(gem_method)
+      allow(TestMixedSourceModule).to receive(:instance_method).with(:user_method).and_return(user_method)
+
+      expect(extractor.send(:user_code_module?, TestMixedSourceModule)).to be true
+
+      Object.send(:remove_const, :TestMixedSourceModule)
+      cleanup_user_code_file(user_file)
+    end
+
+    it 'returns false for class with only gem methods' do
+      gem_path = '/fake/gems/activerecord-7.0/lib/autosave.rb'
+      mod = Class.new
+      allow(mod).to receive(:name).and_return('SomeGemClass')
+
+      gem_method = instance_double(Method, source_location: [gem_path, 1])
+      allow(mod).to receive(:instance_methods).with(false).and_return([:gem_method])
+      allow(mod).to receive(:instance_method).with(:gem_method).and_return(gem_method)
+      allow(mod).to receive(:singleton_methods).with(false).and_return([])
+
+      expect(extractor.send(:user_code_module?, mod)).to be false
+    end
+
+    it 'returns false for stdlib class monkey-patched by Datadog instrumentation' do
+      # Simulates Net::HTTP when dd-trace-rb instruments it:
+      # - Most methods point to /usr/lib/ruby/3.2.0/net/http.rb (stdlib)
+      # - The patched `request` method points to lib/datadog/tracing/contrib/http/instrumentation.rb
+      # Without the /lib/datadog/ exclusion, find_source_file would return the Datadog path
+      # as "user code", causing Net::HTTP to be extracted.
+      mod = Class.new
+      allow(mod).to receive(:name).and_return('Net::HTTP')
+
+      stdlib_method = instance_double(Method, source_location: ['/usr/lib/ruby/3.2.0/net/http.rb', 100])
+      datadog_method = instance_double(Method, source_location: ['/app/lib/datadog/tracing/contrib/http/instrumentation.rb', 26])
+
+      allow(mod).to receive(:instance_methods).with(false).and_return([:request, :get])
+      allow(mod).to receive(:instance_method).with(:request).and_return(datadog_method)
+      allow(mod).to receive(:instance_method).with(:get).and_return(stdlib_method)
+      allow(mod).to receive(:singleton_methods).with(false).and_return([])
+
+      expect(extractor.send(:user_code_module?, mod)).to be false
+    end
+  end
+
+  describe '.user_code_path?' do
+    it 'returns false for gem paths' do
+      expect(extractor.send(:user_code_path?, '/path/to/gems/rspec/lib/rspec.rb')).to be false
+    end
+
+    it 'returns false for ruby stdlib paths' do
+      expect(extractor.send(:user_code_path?, '/usr/lib/ruby/3.2/pathname.rb')).to be false
+    end
+
+    it 'returns false for internal paths' do
+      expect(extractor.send(:user_code_path?, '<internal:array>')).to be false
+    end
+
+    it 'returns false for pseudo-paths from C-level interpreter init' do
+      # "<main>" line 0 is Ruby's sentinel for constants assigned during C startup
+      # (before any .rb file runs). Affects ThreadGroup::Default, Thread::Backtrace::Location,
+      # RubyVM::InstructionSequence, etc. See: Pitfall 25, tmp/reproduce_threadgroup_leak.rb
+      expect(extractor.send(:user_code_path?, '<main>')).to be false
+      expect(extractor.send(:user_code_path?, 'ruby')).to be false
+    end
+
+    it 'returns false for eval paths' do
+      expect(extractor.send(:user_code_path?, '(eval):1')).to be false
+    end
+
+    it 'returns false for spec paths' do
+      expect(extractor.send(:user_code_path?, '/project/spec/my_spec.rb')).to be false
+    end
+
+    it 'returns false for Datadog library paths (monkey-patched methods)' do
+      # When dd-trace-rb instruments stdlib classes like Net::HTTP, the patched method
+      # source points to lib/datadog/tracing/contrib/. Without this exclusion,
+      # Net::HTTP would be incorrectly classified as user code.
+      expect(extractor.send(:user_code_path?,
+        '/home/user/.gem/ruby/3.2.0/gems/datadog-2.0.0/lib/datadog/tracing/contrib/http/instrumentation.rb')).to be false
+      expect(extractor.send(:user_code_path?,
+        '/real.home/user/dtr/lib/datadog/tracing/contrib/http/instrumentation.rb')).to be false
+      expect(extractor.send(:user_code_path?,
+        '/app/vendor/bundle/lib/datadog/core/pin.rb')).to be false
+    end
+
+    it 'returns true for user code paths' do
+      expect(extractor.send(:user_code_path?, '/app/lib/my_class.rb')).to be true
+      expect(extractor.send(:user_code_path?, '/home/user/project/file.rb')).to be true
+      expect(extractor.send(:user_code_path?, File.join(@test_dir, 'test.rb'))).to be true
+    end
+  end
+
+  describe '.find_source_file' do
+    before do
+      @filename = create_user_code_file(<<~RUBY)
+        class TestClassForSourceFile
+          def test_method
+          end
+        end
+      RUBY
+      load @filename
+    end
+
+    after do
+      Object.send(:remove_const, :TestClassForSourceFile) if defined?(TestClassForSourceFile)
+      cleanup_user_code_file(@filename)
+    end
+
+    it 'finds source file from instance methods' do
+      source_file = extractor.send(:find_source_file, TestClassForSourceFile)
+      expect(source_file).to eq(@filename)
+    end
+
+    it 'returns nil for modules without methods' do
+      empty_mod = Module.new
+
+      source_file = extractor.send(:find_source_file, empty_mod)
+      expect(source_file).to be_nil
+    end
+
+    it 'prefers user code path over gem path' do
+      # Simulate ActiveRecord model: first method points to gem, second to user code
+      user_file = create_user_code_file(<<~RUBY)
+        class TestClassWithMixedSources
+          def user_method; end
+        end
+      RUBY
+      load user_file
+
+      gem_path = '/fake/gems/activerecord-7.0/lib/active_record/autosave.rb'
+
+      # Stub instance_methods to return gem method first, user method second
+      allow(TestClassWithMixedSources).to receive(:instance_methods).with(false).and_return([:gem_method, :user_method])
+
+      gem_method = instance_double(Method, source_location: [gem_path, 10])
+      user_method = TestClassWithMixedSources.instance_method(:user_method)
+
+      allow(TestClassWithMixedSources).to receive(:instance_method).with(:gem_method).and_return(gem_method)
+      allow(TestClassWithMixedSources).to receive(:instance_method).with(:user_method).and_return(user_method)
+
+      source_file = extractor.send(:find_source_file, TestClassWithMixedSources)
+      expect(source_file).to eq(user_file)
+
+      Object.send(:remove_const, :TestClassWithMixedSources)
+      cleanup_user_code_file(user_file)
+    end
+
+    it 'falls back to stdlib path when only Datadog instrumentation and stdlib paths exist' do
+      # Simulates Net::HTTP: the Datadog instrumentation path is not user code,
+      # so find_source_file should fall back to the stdlib path.
+      stdlib_path = '/usr/lib/ruby/3.2.0/net/http.rb'
+      datadog_path = '/app/lib/datadog/tracing/contrib/http/instrumentation.rb'
+      mod = Module.new
+
+      datadog_method = instance_double(Method, source_location: [datadog_path, 26])
+      stdlib_method = instance_double(Method, source_location: [stdlib_path, 100])
+
+      allow(mod).to receive(:instance_methods).with(false).and_return([:request, :get])
+      allow(mod).to receive(:instance_method).with(:request).and_return(datadog_method)
+      allow(mod).to receive(:instance_method).with(:get).and_return(stdlib_method)
+
+      source_file = extractor.send(:find_source_file, mod)
+      expect(source_file).to eq(datadog_path)  # Falls back to first non-nil path
+    end
+
+    it 'falls back to gem path when no user code path exists' do
+      gem_path = '/fake/gems/activerecord-7.0/lib/active_record/autosave.rb'
+      mod = Module.new
+
+      gem_method = instance_double(Method, source_location: [gem_path, 10])
+      allow(mod).to receive(:instance_methods).with(false).and_return([:gem_method])
+      allow(mod).to receive(:instance_method).with(:gem_method).and_return(gem_method)
+
+      source_file = extractor.send(:find_source_file, mod)
+      expect(source_file).to eq(gem_path)
+    end
+  end
+
+  describe 'class/module defined across multiple files (reopening)' do
+    # Case 12 & 13 from SYMBOL_EXTRACTION_CASES.md
+    # Ruby allows reopening a class or module in multiple files. All methods from all
+    # files should appear in the extracted scope, not just those from one file.
+
+    context 'class reopened across two files' do
+      before do
+        @file1 = create_user_code_file(<<~RUBY)
+          class TestReopenedClass
+            def method_from_file1
+              'file1'
+            end
+          end
+        RUBY
+
+        @file2 = create_user_code_file(<<~RUBY)
+          class TestReopenedClass
+            def method_from_file2
+              'file2'
+            end
+          end
+        RUBY
+
+        load @file1
+        load @file2
+      end
+
+      after do
+        Object.send(:remove_const, :TestReopenedClass) if defined?(TestReopenedClass)
+        cleanup_user_code_file(@file1)
+        cleanup_user_code_file(@file2)
+      end
+
+      it 'includes methods from both files in the extracted scope' do
+        scope = extractor.extract(TestReopenedClass)
+
+        expect(scope).not_to be_nil
+        class_scope = scope.scopes.first
+        method_names = class_scope.scopes.map(&:name)
+
+        expect(method_names).to include('method_from_file1')
+        expect(method_names).to include('method_from_file2')
+      end
+    end
+
+    context 'module reopened across two files' do
+      before do
+        @file1 = create_user_code_file(<<~RUBY)
+          module TestReopenedModule
+            def self.method_from_file1
+              'file1'
+            end
+          end
+        RUBY
+
+        @file2 = create_user_code_file(<<~RUBY)
+          module TestReopenedModule
+            def self.method_from_file2
+              'file2'
+            end
+          end
+        RUBY
+
+        load @file1
+        load @file2
+      end
+
+      after do
+        Object.send(:remove_const, :TestReopenedModule) if defined?(TestReopenedModule)
+        cleanup_user_code_file(@file1)
+        cleanup_user_code_file(@file2)
+      end
+
+      it 'extracts the MODULE scope (methods from either file satisfy source discovery)' do
+        # Module methods are not extracted as child METHOD scopes — they are used only
+        # for source location discovery. The test verifies the module is found at all,
+        # meaning find_source_file can locate user code from at least one of the files.
+        file_scope = extractor.extract(TestReopenedModule)
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestReopenedModule')
+        expect(file_scope.source_file).to eq(@file1).or(eq(@file2))
+      end
+    end
+  end
+
+  describe 'module inside class' do
+    # Case 7 from SYMBOL_EXTRACTION_CASES.md
+    # A module defined as a constant of a class (e.g. class Foo; module Bar; end; end)
+    # should be extractable as a standalone root scope via its fully-qualified name.
+
+    before do
+      @filename = create_user_code_file(<<~RUBY)
+        class TestOuterClass
+          def outer_method
+            'outer'
+          end
+
+          module TestInnerModule
+            def self.inner_method
+              'inner'
+            end
+          end
+        end
+      RUBY
+      load @filename
+    end
+
+    after do
+      TestOuterClass.send(:remove_const, :TestInnerModule) if defined?(TestOuterClass::TestInnerModule)
+      Object.send(:remove_const, :TestOuterClass) if defined?(TestOuterClass)
+      cleanup_user_code_file(@filename)
+    end
+
+    it 'extracts the inner module as a standalone root FILE scope' do
+      file_scope = extractor.extract(TestOuterClass::TestInnerModule)
+
+      expect(file_scope).not_to be_nil
+      expect(file_scope.scope_type).to eq('FILE')
+      module_scope = file_scope.scopes.first
+      expect(module_scope.scope_type).to eq('MODULE')
+      expect(module_scope.name).to eq('TestOuterClass::TestInnerModule')
+    end
+
+    it 'extracts the outer class independently' do
+      scope = extractor.extract(TestOuterClass)
+
+      expect(scope).not_to be_nil
+      class_scope = scope.scopes.first
+      expect(class_scope.scope_type).to eq('CLASS')
+      method_names = class_scope.scopes.map(&:name)
+      expect(method_names).to include('outer_method')
+    end
+  end
+
+  # ── extract_all tests ──────────────────────────────────────────────
+  # These test the production path: two-pass extraction with FQN-based nesting
+  # and per-file method grouping.
+
+  describe '.extract_all' do
+    around do |example|
+      Dir.mktmpdir('symbol_db_extract_all_test') do |dir|
+        @test_dir = dir
+        example.run
+      end
+    end
+
+    def create_test_file(filename, content)
+      path = File.join(@test_dir, filename)
+      File.write(path, content)
+      File.realpath(path)
+    end
+
+    # Find the FILE scope containing a child with the given name.
+    # ObjectSpace may contain stale modules from previous examples (not yet GC'd),
+    # so matching by file path is unreliable. Match by content instead.
+    def find_file_scope(scopes, child_name)
+      scopes.find do |s|
+        s.scope_type == 'FILE' && s.scopes.any? { |c| c.name == child_name }
+      end
+    end
+
+    # Force GC before extract_all to clean up stale modules from previous examples.
+    # Without this, ObjectSpace may contain modules that were remove_const'd but
+    # not yet garbage collected, causing extract_all to see phantom entries.
+    def extract_all_clean
+      GC.start
+      extractor.extract_all
+    end
+
+    context 'simple class in one file' do
+      before do
+        @file = create_test_file('user.rb', <<~RUBY)
+          class ExtractAllSimpleClass
+            def remember; end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllSimpleClass) if defined?(ExtractAllSimpleClass)
+      end
+
+      it 'produces FILE → CLASS → METHOD hierarchy' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSimpleClass')
+
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        expect(file_scope.language_specifics[:file_hash]).to match(/\A[0-9a-f]{40}\z/)
+
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllSimpleClass' }
+        expect(class_scope).not_to be_nil
+        expect(class_scope.scope_type).to eq('CLASS')
+
+        method_scope = class_scope.scopes.find { |s| s.name == 'remember' }
+        expect(method_scope).not_to be_nil
+        expect(method_scope.scope_type).to eq('METHOD')
+      end
+
+      it 'includes injectable lines on instance METHOD scopes' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSimpleClass')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllSimpleClass' }
+        method_scope = class_scope.scopes.find { |s| s.name == 'remember' }
+
+        expect(method_scope.injectible_lines?).to eq(true).or eq(false)
+        if method_scope.injectible_lines?
+          expect(method_scope.injectible_lines).to be_an(Array)
+          expect(method_scope.injectible_lines).not_to be_empty
+          method_scope.injectible_lines.each do |range|
+            expect(range[:start]).to be <= range[:end]
+          end
+        end
+        expect(method_scope.end_line).to be >= method_scope.start_line
+      end
+    end
+
+    context 'end_line correctness via extract_all' do
+      before do
+        @file = create_test_file('multiline.rb', <<~RUBY)
+          class ExtractAllMultiline
+            def lengthy(a, b)
+              x = a + b
+              y = x * 2
+              z = y - 1
+              z
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllMultiline) if defined?(ExtractAllMultiline)
+      end
+
+      it 'sets end_line from trace_points max, not start_line' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllMultiline')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllMultiline' }
+        method_scope = class_scope.scopes.find { |s| s.name == 'lengthy' }
+
+        expect(method_scope.end_line).to be > method_scope.start_line
+      end
+    end
+
+    # ── Injectable lines unit tests ──────────────────────────────────────
+
+    describe 'build_injectable_ranges' do
+      it 'compresses consecutive lines into ranges' do
+        ranges = extractor.send(:build_injectable_ranges, [4, 5, 6, 8, 10, 11])
+        expect(ranges).to eq([{start: 4, end: 6}, {start: 8, end: 8}, {start: 10, end: 11}])
+      end
+
+      it 'returns a single range for all-consecutive input' do
+        ranges = extractor.send(:build_injectable_ranges, [1, 2, 3, 4, 5])
+        expect(ranges).to eq([{start: 1, end: 5}])
+      end
+
+      it 'returns individual ranges for non-consecutive input' do
+        ranges = extractor.send(:build_injectable_ranges, [1, 3, 5, 7])
+        expect(ranges).to eq([{start: 1, end: 1}, {start: 3, end: 3}, {start: 5, end: 5}, {start: 7, end: 7}])
+      end
+
+      it 'returns a single-element range for one line' do
+        ranges = extractor.send(:build_injectable_ranges, [10])
+        expect(ranges).to eq([{start: 10, end: 10}])
+      end
+
+      it 'returns empty for empty input' do
+        ranges = extractor.send(:build_injectable_ranges, [])
+        expect(ranges).to eq([])
+      end
+    end
+
+    describe 'extract_injectable_lines' do
+      before do
+        @file = create_test_file('injectable_test.rb', <<~RUBY)
+          class ExtractAllInjectableTest
+            def multi_line(a, b)
+              x = a + b
+              y = x * 2
+              z = y - 1
+              z
+            end
+
+            def initialize
+              @value = 42
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllInjectableTest) if defined?(ExtractAllInjectableTest)
+      end
+
+      it 'returns nil for C-extension methods (iseq nil)' do
+        # String#length is a C method with no iseq
+        method = String.instance_method(:length)
+        ranges, end_line = extractor.send(:extract_injectable_lines, method, 1)
+        expect(ranges).to be_nil
+        expect(end_line).to eq(1)
+      end
+
+      it 'deduplicates line numbers before range compression' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllInjectableTest')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllInjectableTest' }
+        method_scope = class_scope.scopes.find { |s| s.name == 'multi_line' }
+
+        # Ranges should have no overlapping or duplicate entries
+        method_scope.injectible_lines.each_cons(2) do |a, b|
+          expect(a[:end]).to be < b[:start]
+        end
+      end
+
+      it 'includes initialize method first line as injectable' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllInjectableTest')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllInjectableTest' }
+        init_scope = class_scope.scopes.find { |s| s.name == 'initialize' }
+
+        expect(init_scope).not_to be_nil
+        expect(init_scope.injectible_lines?).to eq(true)
+        expect(init_scope.injectible_lines.first[:start]).to eq(init_scope.start_line).or be > init_scope.start_line
+      end
+    end
+
+    context 'nested module and class' do
+      before do
+        @file = create_test_file('nested.rb', <<~RUBY)
+          module ExtractAllOuter
+            def self.outer_func; end
+
+            class ExtractAllInner
+              def inner_method; end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllOuter) if defined?(ExtractAllOuter)
+      end
+
+      it 'nests via FQN split: FILE → MODULE(Outer) → CLASS(Inner)' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllOuter')
+        expect(file_scope).not_to be_nil
+
+        # Outer module at top level under FILE, using short name
+        outer = file_scope.scopes.find { |s| s.name == 'ExtractAllOuter' }
+        expect(outer).not_to be_nil
+        expect(outer.scope_type).to eq('MODULE')
+
+        # Inner class nested under outer, using short name (not FQN)
+        inner = outer.scopes.find { |s| s.name == 'ExtractAllInner' }
+        expect(inner).not_to be_nil
+        expect(inner.scope_type).to eq('CLASS')
+
+        # Inner class has its method
+        method_scope = inner.scopes.find { |s| s.name == 'inner_method' }
+        expect(method_scope).not_to be_nil
+      end
+    end
+
+    context 'deeply nested namespace (A::B::C)' do
+      before do
+        @file = create_test_file('deep.rb', <<~RUBY)
+          module ExtractAllDeepA
+            module ExtractAllDeepB
+              class ExtractAllDeepC
+                def deep_method; end
+              end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllDeepA) if defined?(ExtractAllDeepA)
+      end
+
+      it 'builds full nesting chain: FILE → MODULE(A) → MODULE(B) → CLASS(C)' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllDeepA')
+        expect(file_scope).not_to be_nil
+
+        mod_a = file_scope.scopes.find { |s| s.name == 'ExtractAllDeepA' }
+        expect(mod_a).not_to be_nil
+        expect(mod_a.scope_type).to eq('MODULE')
+
+        mod_b = mod_a.scopes.find { |s| s.name == 'ExtractAllDeepB' }
+        expect(mod_b).not_to be_nil
+        expect(mod_b.scope_type).to eq('MODULE')
+
+        cls_c = mod_b.scopes.find { |s| s.name == 'ExtractAllDeepC' }
+        expect(cls_c).not_to be_nil
+        expect(cls_c.scope_type).to eq('CLASS')
+
+        expect(cls_c.scopes.find { |s| s.name == 'deep_method' }).not_to be_nil
+      end
+    end
+
+    context 'class reopened across two files' do
+      before do
+        @file1 = create_test_file('reopen1.rb', <<~RUBY)
+          class ExtractAllReopened
+            def method_from_file1; end
+          end
+        RUBY
+        @file2 = create_test_file('reopen2.rb', <<~RUBY)
+          class ExtractAllReopened
+            def method_from_file2; end
+          end
+        RUBY
+        load @file1
+        load @file2
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllReopened) if defined?(ExtractAllReopened)
+      end
+
+      it 'produces two FILE scopes, each with only methods from that file' do
+        scopes = extract_all_clean
+
+        # Both FILE scopes contain ExtractAllReopened — distinguish by method content
+        reopened_files = scopes.select do |s|
+          s.scope_type == 'FILE' && s.scopes.any? { |c| c.name == 'ExtractAllReopened' }
+        end
+        expect(reopened_files.size).to eq(2)
+
+        file1_scope = reopened_files.find { |s| s.name.end_with?('reopen1.rb') }
+        file2_scope = reopened_files.find { |s| s.name.end_with?('reopen2.rb') }
+
+        expect(file1_scope).not_to be_nil
+        expect(file2_scope).not_to be_nil
+
+        cls1 = file1_scope.scopes.find { |s| s.name == 'ExtractAllReopened' }
+        cls2 = file2_scope.scopes.find { |s| s.name == 'ExtractAllReopened' }
+
+        expect(cls1).not_to be_nil
+        expect(cls2).not_to be_nil
+
+        methods1 = cls1.scopes.select { |s| s.scope_type == 'METHOD' }.map(&:name)
+        methods2 = cls2.scopes.select { |s| s.scope_type == 'METHOD' }.map(&:name)
+
+        expect(methods1).to include('method_from_file1')
+        expect(methods1).not_to include('method_from_file2')
+        expect(methods2).to include('method_from_file2')
+        expect(methods2).not_to include('method_from_file1')
+      end
+    end
+
+    context 'module with methods AND nested class in same file' do
+      before do
+        @file = create_test_file('mixed.rb', <<~RUBY)
+          module ExtractAllMixed
+            SOME_CONST = 42
+
+            def self.module_func; end
+            def instance_helper; end
+
+            class ExtractAllMixedChild
+              def child_method; end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllMixed) if defined?(ExtractAllMixed)
+      end
+
+      it 'places child class under parent module in the same FILE scope' do
+        scopes = extract_all_clean
+        file_scope = scopes.find { |s| s.source_file == @file }
+        expect(file_scope).not_to be_nil
+
+        mod = file_scope.scopes.find { |s| s.name == 'ExtractAllMixed' }
+        expect(mod).not_to be_nil
+        expect(mod.scope_type).to eq('MODULE')
+
+        child = mod.scopes.find { |s| s.name == 'ExtractAllMixedChild' }
+        expect(child).not_to be_nil
+        expect(child.scope_type).to eq('CLASS')
+
+        expect(child.scopes.find { |s| s.name == 'child_method' }).not_to be_nil
+      end
+
+      it 'extracts symbols (constants) on the module scope' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllMixed')
+        expect(file_scope).not_to be_nil
+        mod = file_scope.scopes.find { |s| s.name == 'ExtractAllMixed' }
+
+        const = mod.symbols.find { |s| s.name == 'SOME_CONST' }
+        expect(const).not_to be_nil
+        expect(const.symbol_type).to eq('STATIC_FIELD')
+      end
+    end
+
+    context 'compact notation (class Foo::Bar::Baz)' do
+      before do
+        # Pre-create namespace so const_get works
+        @file = create_test_file('compact.rb', <<~RUBY)
+          module ExtractAllCompactNs
+            module ExtractAllCompactInner
+              class ExtractAllCompactLeaf
+                def compact_method; end
+              end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllCompactNs) if defined?(ExtractAllCompactNs)
+      end
+
+      it 'reconstructs nesting from FQN even for compact notation' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllCompactNs')
+        expect(file_scope).not_to be_nil
+
+        ns = file_scope.scopes.find { |s| s.name == 'ExtractAllCompactNs' }
+        expect(ns).not_to be_nil
+        expect(ns.scope_type).to eq('MODULE')
+
+        inner = ns.scopes.find { |s| s.name == 'ExtractAllCompactInner' }
+        expect(inner).not_to be_nil
+
+        leaf = inner.scopes.find { |s| s.name == 'ExtractAllCompactLeaf' }
+        expect(leaf).not_to be_nil
+        expect(leaf.scope_type).to eq('CLASS')
+      end
+    end
+
+    context 'class inside class' do
+      before do
+        @file = create_test_file('class_in_class.rb', <<~RUBY)
+          class ExtractAllOuterClass
+            def outer_method; end
+
+            class ExtractAllInnerClass
+              def inner_method; end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllOuterClass) if defined?(ExtractAllOuterClass)
+      end
+
+      it 'nests CLASS inside CLASS: FILE → CLASS(Outer) → CLASS(Inner)' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllOuterClass')
+        expect(file_scope).not_to be_nil
+
+        outer = file_scope.scopes.find { |s| s.name == 'ExtractAllOuterClass' }
+        expect(outer).not_to be_nil
+        expect(outer.scope_type).to eq('CLASS')
+
+        inner = outer.scopes.find { |s| s.name == 'ExtractAllInnerClass' }
+        expect(inner).not_to be_nil
+        expect(inner.scope_type).to eq('CLASS')
+      end
+    end
+
+    context 'module inside class' do
+      before do
+        @file = create_test_file('mod_in_class.rb', <<~RUBY)
+          class ExtractAllHostClass
+            def host_method; end
+
+            module ExtractAllInnerMod
+              def self.inner_func; end
+            end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllHostClass) if defined?(ExtractAllHostClass)
+      end
+
+      it 'nests MODULE inside CLASS: FILE → CLASS(Host) → MODULE(Inner)' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllHostClass')
+        expect(file_scope).not_to be_nil
+
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllHostClass' }
+        expect(host).not_to be_nil
+        expect(host.scope_type).to eq('CLASS')
+
+        inner = host.scopes.find { |s| s.name == 'ExtractAllInnerMod' }
+        expect(inner).not_to be_nil
+        expect(inner.scope_type).to eq('MODULE')
+      end
+    end
+
+    context 'file_hash on FILE scope' do
+      before do
+        @file = create_test_file('filehash.rb', <<~RUBY)
+          class ExtractAllFileHashTest
+            def some_method; end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllFileHashTest) if defined?(ExtractAllFileHashTest)
+      end
+
+      it 'puts file_hash on FILE scope, not on inner scopes' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllFileHashTest')
+        expect(file_scope).not_to be_nil
+
+        # file_hash on FILE
+        expect(file_scope.language_specifics[:file_hash]).to match(/\A[0-9a-f]{40}\z/)
+
+        # NOT on inner CLASS
+        class_scope = file_scope.scopes.first
+        expect(class_scope.language_specifics).not_to have_key(:file_hash)
+      end
+    end
+
+    context 'method parameters and visibility' do
+      before do
+        @file = create_test_file('params.rb', <<~RUBY)
+          class ExtractAllParamsClass
+            def public_method(arg1, arg2); end
+
+            private
+
+            def private_method(secret); end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllParamsClass) if defined?(ExtractAllParamsClass)
+      end
+
+      it 'extracts method parameters and visibility' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllParamsClass')
+        cls = file_scope.scopes.find { |s| s.name == 'ExtractAllParamsClass' }
+
+        pub = cls.scopes.find { |s| s.name == 'public_method' }
+        expect(pub.language_specifics[:visibility]).to eq('public')
+        param_names = pub.symbols.map(&:name)
+        expect(param_names).to include('arg1', 'arg2')
+        expect(param_names).not_to include('self')
+
+        priv = cls.scopes.find { |s| s.name == 'private_method' }
+        expect(priv.language_specifics[:visibility]).to eq('private')
+      end
+    end
+
+    context 'class language_specifics (superclass, included modules)' do
+      before do
+        @file = create_test_file('lang_specifics.rb', <<~RUBY)
+          module ExtractAllMixin
+            def mixin_method; end
+          end
+
+          class ExtractAllBaseLS
+            def base_method; end
+          end
+
+          class ExtractAllDerivedLS < ExtractAllBaseLS
+            include ExtractAllMixin
+            def derived_method; end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllDerivedLS) if defined?(ExtractAllDerivedLS)
+        Object.send(:remove_const, :ExtractAllBaseLS) if defined?(ExtractAllBaseLS)
+        Object.send(:remove_const, :ExtractAllMixin) if defined?(ExtractAllMixin)
+      end
+
+      it 'includes super_classes and included_modules on CLASS scope' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllDerivedLS')
+        derived = file_scope.scopes.find { |s| s.name == 'ExtractAllDerivedLS' }
+
+        expect(derived).not_to be_nil
+        expect(derived.language_specifics[:super_classes]).to include('ExtractAllBaseLS')
+        expect(derived.language_specifics[:included_modules]).to include('ExtractAllMixin')
+      end
+    end
+  end
+end

--- a/spec/datadog/symbol_database/file_hash_spec.rb
+++ b/spec/datadog/symbol_database/file_hash_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/file_hash'
+require 'tempfile'
+
+RSpec.describe Datadog::SymbolDatabase::FileHash do
+  let(:logger) { instance_double(Logger, debug: nil) }
+
+  describe '.compute' do
+    it 'returns nil for nil path' do
+      expect(described_class.compute(nil, logger: logger)).to be_nil
+    end
+
+    it 'returns nil for non-existent file' do
+      expect(described_class.compute('/path/that/does/not/exist.rb', logger: logger)).to be_nil
+    end
+
+    it 'computes hash for empty file' do
+      Tempfile.create(['test', '.rb']) do |f|
+        f.close
+
+        hash = described_class.compute(f.path, logger: logger)
+
+        expect(hash).to be_a(String)
+        expect(hash.length).to eq(40)  # SHA-1 hex is 40 chars
+        # Empty file: "blob 0\0" -> known hash
+        expect(hash).to eq('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+      end
+    end
+
+    it 'computes hash for file with content' do
+      Tempfile.create(['test', '.rb']) do |f|
+        f.write("puts 'hello'\n")
+        f.close
+
+        hash = described_class.compute(f.path, logger: logger)
+
+        expect(hash).to be_a(String)
+        expect(hash.length).to eq(40)
+        expect(hash).to match(/^[0-9a-f]{40}$/)
+      end
+    end
+
+    it 'produces identical hash to git hash-object (validates Git blob algorithm compatibility)' do
+      Tempfile.create(['test', '.rb']) do |f|
+        content = "# frozen_string_literal: true\n\nclass MyClass\n  def my_method\n    42\n  end\nend\n"
+        f.write(content)
+        f.close
+
+        our_hash = described_class.compute(f.path, logger: logger)
+
+        git_hash = `git hash-object "#{f.path}"`.strip
+
+        expect(our_hash).to eq(git_hash)
+      end
+    end
+
+    it 'handles different file sizes' do
+      # Small file
+      Tempfile.create(['small', '.rb']) do |f|
+        f.write('x')
+        f.close
+        small_hash = described_class.compute(f.path, logger: logger)
+        expect(small_hash).to be_a(String)
+      end
+
+      # Larger file
+      Tempfile.create(['large', '.rb']) do |f|
+        f.write('x' * 10000)
+        f.close
+        large_hash = described_class.compute(f.path, logger: logger)
+        expect(large_hash).to be_a(String)
+      end
+    end
+
+    it 'handles binary mode reading' do
+      Tempfile.create(['test', '.rb']) do |f|
+        f.write("before\0after")
+        f.close
+
+        hash = described_class.compute(f.path, logger: logger)
+
+        expect(hash).to be_a(String)
+        expect(hash.length).to eq(40)
+      end
+    end
+
+    it 'returns nil and logs on read error' do
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:read).and_raise(Errno::EACCES, "Permission denied")
+
+      expect(logger).to receive(:debug) { |&block| expect(block.call).to match(/file hash failed/i) }
+
+      hash = described_class.compute('/fake/unreadable/file.rb', logger: logger)
+
+      expect(hash).to be_nil
+    end
+
+    it 'handles UTF-8 content' do
+      Tempfile.create(['test', '.rb']) do |f|
+        f.write("# Encoding: UTF-8\nclass Café\nend\n")
+        f.close
+
+        hash = described_class.compute(f.path, logger: logger)
+
+        expect(hash).to be_a(String)
+        expect(hash.length).to eq(40)
+      end
+    end
+
+    it 'handles files with different line endings' do
+      Tempfile.create(['unix', '.rb']) do |f|
+        f.write("line1\nline2\n")
+        f.close
+        unix_hash = described_class.compute(f.path, logger: logger)
+        expect(unix_hash).to be_a(String)
+      end
+
+      Tempfile.create(['windows', '.rb']) do |f|
+        f.write("line1\r\nline2\r\n")
+        f.close
+        windows_hash = described_class.compute(f.path, logger: logger)
+        expect(windows_hash).to be_a(String)
+      end
+
+      # Different line endings should produce different hashes
+      # (This is expected - Git treats them as different content)
+    end
+  end
+end

--- a/spec/datadog/symbol_database/scope_context_spec.rb
+++ b/spec/datadog/symbol_database/scope_context_spec.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/logger'
+require 'datadog/symbol_database/scope_context'
+require 'datadog/symbol_database/scope'
+
+RSpec.describe Datadog::SymbolDatabase::ScopeContext do
+  let(:uploader) { instance_double(Datadog::SymbolDatabase::Uploader) }
+  let(:raw_logger) { instance_double(Logger, debug: nil) }
+  let(:settings) do
+    s = double('settings')
+    symdb = double('symbol_database', internal: double('internal', trace_logging: false))
+    allow(s).to receive(:symbol_database).and_return(symdb)
+    s
+  end
+  let(:logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
+  let(:test_scope) { Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'TestClass') }
+
+  subject(:context) { described_class.new(uploader, logger: logger) }
+
+  after do
+    # Cleanup any running timers
+    context.reset
+  end
+
+  describe '#initialize' do
+    it 'creates context with empty scopes' do
+      expect(context.size).to eq(0)
+      expect(context.scopes_pending?).to be false
+    end
+  end
+
+  describe '#add_scope' do
+    it 'adds scope to batch' do
+      context.add_scope(test_scope)
+
+      expect(context.size).to eq(1)
+      expect(context.scopes_pending?).to be true
+    end
+
+    it 'increments file count' do
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      # File count tracked (implementation detail, testing via behavior)
+      expect(context.size).to eq(2)
+    end
+
+    context 'when batch size limit reached' do
+      it 'triggers immediate upload' do
+        expect(uploader).to receive(:upload_scopes) do |scopes|
+          expect(scopes.size).to eq(400)
+        end
+
+        # Add 400 scopes
+        400.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        expect(context.size).to eq(0)  # Batch cleared after upload
+      end
+
+      it 'continues batching after upload' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add 401 scopes
+        401.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        expect(context.size).to eq(1)  # 401st scope in new batch
+      end
+    end
+
+    context 'with inactivity timer' do
+      it 'would trigger upload after inactivity (timer disabled in tests)' do
+        allow(uploader).to receive(:upload_scopes)
+
+        test_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+        test_context.add_scope(test_scope)
+        expect(test_context.size).to eq(1)
+
+        # Manually trigger what timer would do
+        test_context.flush
+
+        expect(test_context.size).to eq(0)
+      end
+
+      it 'timer gets reset on scope additions (verified by integration tests)' do
+        allow(uploader).to receive(:upload_scopes)
+
+        test_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+        test_context.add_scope(test_scope)
+        test_context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Class2'))
+
+        # Without timer, scopes stay in batch
+        expect(test_context.size).to eq(2)
+
+        # Manual flush works
+        test_context.flush
+        expect(test_context.size).to eq(0)
+      end
+    end
+
+    context 'with deduplication' do
+      it 'skips already uploaded modules' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add same scope twice
+        context.add_scope(test_scope)
+        context.add_scope(test_scope)
+
+        expect(context.size).to eq(1)  # Only added once
+      end
+
+      it 'tracks uploaded modules across batches' do
+        allow(uploader).to receive(:upload_scopes)
+
+        context.add_scope(test_scope)
+        context.flush  # Upload first batch
+
+        # Try to add same scope again
+        context.add_scope(test_scope)
+
+        expect(context.size).to eq(0)  # Not added (already uploaded)
+      end
+    end
+
+    context 'with file limit' do
+      it 'stops accepting scopes after MAX_FILES limit' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add MAX_FILES scopes
+        described_class::MAX_FILES.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        # Try to add one more
+        extra_scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'ExtraClass')
+        expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/file limit.*reached/i) }
+
+        context.add_scope(extra_scope)
+
+        # Should not be in batch
+        expect(context.size).to be < described_class::MAX_FILES
+      end
+    end
+  end
+
+  describe '#flush' do
+    it 'uploads current batch immediately' do
+      expect(uploader).to receive(:upload_scopes) do |scopes|
+        expect(scopes.size).to eq(2)
+      end
+
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      context.flush
+
+      expect(context.size).to eq(0)
+    end
+
+    it 'does nothing if batch is empty' do
+      expect(uploader).not_to receive(:upload_scopes)
+
+      context.flush
+    end
+  end
+
+  describe '#shutdown' do
+    it 'uploads remaining scopes' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      context.shutdown
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(2)
+    end
+
+    it 'kills timer thread' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.shutdown
+
+      # Shutdown uploads and kills timer
+      expect(context.size).to eq(0)
+    end
+
+    it 'clears scopes after shutdown' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.shutdown
+
+      expect(context.size).to eq(0)
+    end
+  end
+
+  describe '#reset' do
+    it 'clears all state' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.reset
+
+      expect(context.size).to eq(0)
+      expect(context.scopes_pending?).to be false
+    end
+
+    it 'kills timer' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.reset
+
+      # Reset clears scopes and kills timer
+      expect(context.size).to eq(0)
+    end
+  end
+
+  describe '#pending?' do
+    it 'returns false when no scopes' do
+      expect(context.scopes_pending?).to be false
+    end
+
+    it 'returns true when scopes exist' do
+      context.add_scope(test_scope)
+      expect(context.scopes_pending?).to be true
+    end
+  end
+
+  describe '#size' do
+    it 'returns 0 when empty' do
+      expect(context.size).to eq(0)
+    end
+
+    it 'returns count of scopes' do
+      context.add_scope(test_scope)
+      expect(context.size).to eq(1)
+
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+      expect(context.size).to eq(2)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'handles concurrent scope additions' do
+      allow(uploader).to receive(:upload_scopes)
+
+      # Use timer_enabled: false so the test validates mutex-protected concurrent
+      # additions without timer interference (timer could flush mid-test, making
+      # the final size non-deterministic).
+      timer_off_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+      threads = 10.times.map do |i|
+        Thread.new do
+          10.times do |j|
+            scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Thread#{i}Class#{j}")
+            timer_off_context.add_scope(scope)
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      # All 100 unique scopes should be present (no losses from races)
+      expect(timer_off_context.size).to eq(100)
+    end
+  end
+
+  # === Tests ported from Java SymbolSinkTest ===
+
+  describe 'multi-scope batching (ported from Java SymbolSinkTest.testMultiScopeFlush)' do
+    it 'batches multiple scopes into a single upload call' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      5.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}"))
+      end
+
+      context.flush
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(5)
+      names = uploaded_scopes.map(&:name)
+      expect(names).to include('Class0', 'Class1', 'Class2', 'Class3', 'Class4')
+    end
+  end
+
+  describe 'implicit flush at capacity (ported from Java SymbolSinkTest.testQueueFull)' do
+    it 'uploads automatically at MAX_SCOPES and continues batching remaining' do
+      upload_calls = []
+      allow(uploader).to receive(:upload_scopes) { |scopes| upload_calls << scopes.dup }
+
+      # Add exactly MAX_SCOPES scopes to trigger implicit flush
+      described_class::MAX_SCOPES.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Batch1Class#{i}"))
+      end
+
+      # Should have flushed the first batch
+      expect(upload_calls.size).to eq(1)
+      expect(upload_calls[0].size).to eq(described_class::MAX_SCOPES)
+
+      # Add one more scope (should be in new batch)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'ExtraClass'))
+      expect(context.size).to eq(1)
+
+      # Flush the remaining
+      context.flush
+      expect(upload_calls.size).to eq(2)
+      expect(upload_calls[1].size).to eq(1)
+      expect(upload_calls[1][0].name).to eq('ExtraClass')
+    end
+  end
+
+  describe 'upload on shutdown with pending scopes (ported from Java SymbolSinkTest)' do
+    it 'flushes all pending scopes on shutdown' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      3.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "ShutdownClass#{i}"))
+      end
+
+      context.shutdown
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(3)
+    end
+  end
+
+  describe 'deduplication across multiple flushes (ported from Java SymDBEnablementTest.noDuplicateSymbolExtraction)' do
+    it 'does not re-upload the same scope after flush and re-add' do
+      upload_calls = []
+      allow(uploader).to receive(:upload_scopes) { |scopes| upload_calls << scopes.dup }
+
+      scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'UniqueClass')
+
+      context.add_scope(scope)
+      context.flush
+      expect(upload_calls.size).to eq(1)
+      expect(upload_calls[0].size).to eq(1)
+
+      # Try to add the same scope again
+      context.add_scope(scope)
+      context.flush
+
+      # Should not have triggered a second upload (empty batch)
+      expect(upload_calls.size).to eq(1)
+    end
+  end
+end

--- a/spec/datadog/symbol_database/scope_spec.rb
+++ b/spec/datadog/symbol_database/scope_spec.rb
@@ -230,7 +230,6 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'my_method',
-        has_injectible_lines: true,
         injectible_lines: [{start: 10, end: 12}, {start: 15, end: 15}],
       )
 
@@ -240,12 +239,10 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash[:injectible_lines]).to eq([{start: 10, end: 12}, {start: 15, end: 15}])
     end
 
-    it 'includes has_injectible_lines: false on METHOD scope without ranges' do
+    it 'includes injectible_lines?: false on METHOD scope without ranges' do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'native_method',
-        has_injectible_lines: false,
-        injectible_lines: nil,
       )
 
       hash = scope.to_h


### PR DESCRIPTION
**What does this PR do?**

Adds the core data models and extraction pipeline for the symbol database feature:

- `Extractor` — walks Ruby ISeqs to extract class/module/method metadata from loaded code
- `Scope` — data model representing class, module, and method scopes
- `ScopeContext` — aggregation and batching layer for extracted scopes
- `FileHash` — Git-compatible SHA-1 blob hashing for commit inference
- `Logger` — logging wrapper for symbol database components

These components are self-contained: no dependency on core/configuration, transport, or remote config. They are the pure data model and extraction logic that the rest of the symbol database feature builds on.

**Motivation:**

Extracted from #5431 to enable focused review of the extraction logic — the core novelty of the symbol database feature — independent of the transport and configuration plumbing.

**Change log entry**

None.

**Additional Notes:**

~4,100 lines of new code with comprehensive specs (~3,150 lines of specs). The `Extractor` is the heaviest component — it handles Ruby version differences (2.5–4.0), JRuby compatibility, edge cases like reopened classes across files, and attr_* method extraction.

**How to test the change?**

Specs run under `test:main`:

```bash
bundle exec rspec spec/datadog/symbol_database/
```