### PR TITLE
[APMS-19371] Initialize `@cache` in CachingResolver as a `st_table`

### DIFF
--- a/lib/datadog/tracing/contrib/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/configuration/resolver.rb
@@ -95,20 +95,22 @@ module Datadog
             super(*args)
 
             @cache_limit = cache_limit
-            @cache = {}
-            @cache_mutex = Mutex.new
+            # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.2 (see https://bugs.ruby-lang.org/issues/21170)
+            # We initialize the hash with 10 dummy entries + clear it to force Ruby to use an
+            # "st_table" representation for the Hash, not an "ar_table" (since Ruby will not
+            # shrink a Hash using an "st_table" back to an "ar_table")
+            @cache = Hash[*1..20]
+            @cache.clear
           end
 
           # (see Resolver#resolve)
           def resolve(value)
-            @cache_mutex.synchronize do
-              @cache.fetch(value) do
-                if @cache.size >= @cache_limit
-                  @cache.shift # Remove the oldest entry if cache is full
-                end
-
-                @cache[value] = super
+            @cache.fetch(value) do
+              if @cache.size >= @cache_limit
+                @cache.shift # Remove the oldest entry if cache is full
               end
+
+              @cache[value] = super
             end
           end
 
@@ -120,9 +122,7 @@ module Datadog
 
           # Clears the internal cache.
           def reset_cache
-            @cache_mutex.synchronize do
-              @cache.clear
-            end
+            @cache.clear
           end
         end
       end

--- a/lib/datadog/tracing/contrib/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/configuration/resolver.rb
@@ -96,18 +96,19 @@ module Datadog
 
             @cache_limit = cache_limit
             @cache = {}
+            @cache_mutex = Mutex.new
           end
 
           # (see Resolver#resolve)
           def resolve(value)
-            if @cache.key?(value)
-              @cache[value]
-            else
-              if @cache.size >= @cache_limit
-                @cache.shift # Remove the oldest entry if cache is full
-              end
+            @cache_mutex.synchronize do
+              @cache.fetch(value) do
+                if @cache.size >= @cache_limit
+                  @cache.shift # Remove the oldest entry if cache is full
+                end
 
-              @cache[value] = super
+                @cache[value] = super
+              end
             end
           end
 
@@ -119,7 +120,9 @@ module Datadog
 
           # Clears the internal cache.
           def reset_cache
-            @cache.clear
+            @cache_mutex.synchronize do
+              @cache.clear
+            end
           end
         end
       end

--- a/lib/datadog/tracing/contrib/configuration/resolver.rb
+++ b/lib/datadog/tracing/contrib/configuration/resolver.rb
@@ -95,7 +95,7 @@ module Datadog
             super(*args)
 
             @cache_limit = cache_limit
-            # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.2 (see https://bugs.ruby-lang.org/issues/21170)
+            # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.3 (see https://bugs.ruby-lang.org/issues/21170)
             # We initialize the hash with 10 dummy entries + clear it to force Ruby to use an
             # "st_table" representation for the Hash, not an "ar_table" (since Ruby will not
             # shrink a Hash using an "st_table" back to an "ar_table")

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::CachingResolver do
     end
   end
 
-  # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.2 (see https://bugs.ruby-lang.org/issues/21170)
+  # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.3 (see https://bugs.ruby-lang.org/issues/21170)
   context 'with a cache key with a #hash of -1 and a cache promotion to st_table' do
     let(:cache_limit) { 200 }
     let(:resolver_class) do

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -166,59 +166,5 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::CachingResolver do
         expect { resolver.resolve('second_key') }.to(change { resolver.invocations }.by(1)) # Removes `third_key` from cache
       end
     end
-
-    context 'when a concurrent eviction happens during a hash key lookup' do
-      let(:cache_limit) { 1 }
-      let(:value) { :cached_value }
-      let(:key) { cached_key }
-      let(:cached_key) { comparable_value_class.new }
-      let(:lookup_key) { comparable_value_class.new(lookup_started, continue_lookup) }
-      let(:lookup_started) { Queue.new }
-      let(:continue_lookup) { Queue.new }
-
-      let(:comparable_value_class) do
-        Class.new do
-          def initialize(lookup_started = nil, continue_lookup = nil)
-            @lookup_started = lookup_started
-            @continue_lookup = continue_lookup
-          end
-
-          # Ruby Hash keys use #hash to select a bucket; returning the same
-          # Integer forces Hash#key? to compare keys with #eql?.
-          def hash
-            1
-          end
-
-          def eql?(_other)
-            if @lookup_started
-              # Pause while Hash#key? is comparing the lookup key, so another
-              # thread can try to evict the cache entry at the same time.
-              @lookup_started << true
-              @continue_lookup.pop
-              @lookup_started = nil
-            end
-
-            true
-          end
-        end
-      end
-
-      it 'returns the cached value' do
-        resolver.resolve(cached_key)
-
-        # The lookup key is equivalent to the cached key and should return the
-        # cached value even if a concurrent resolve attempts to evict the entry.
-        lookup_thread = Thread.new { resolver.resolve(lookup_key) }
-        lookup_started.pop
-
-        evicting_thread = Thread.new { resolver.resolve(:evicting_key) }
-        continue_lookup << true
-
-        lookup_result = lookup_thread.value
-        evicting_thread.join
-
-        expect(lookup_result).to eq(:cached_value)
-      end
-    end
   end
 end

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -167,4 +167,39 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::CachingResolver do
       end
     end
   end
+
+  # Workaround for Ruby VM < 3.2.8, < 3.3.8 and < 3.4.2 (see https://bugs.ruby-lang.org/issues/21170)
+  context 'with a cache key with a #hash of -1 and a cache promotion to st_table' do
+    let(:cache_limit) { 200 }
+    let(:resolver_class) do
+      Class.new(Datadog::Tracing::Contrib::Configuration::Resolver) do
+        prepend Datadog::Tracing::Contrib::Configuration::CachingResolver
+        attr_reader :cache
+
+        def resolve(input)
+          input.hash
+        end
+      end
+    end
+
+    subject(:cache) do
+      key_class = Class.new do
+        attr_reader :hash
+
+        def initialize(hash_value)
+          @hash = hash_value
+        end
+      end
+
+      # 9 elements guarantees that the @cache hash does not fit in a
+      # ar_table in both 32 and 64-bit MRI builds.
+      0.downto(-8).each { |hash_value| resolver.resolve(key_class.new(hash_value)) }
+
+      resolver.cache
+    end
+
+    it 'does not corrupt the cache' do
+      expect(cache.keys.size).to eq(cache.size)
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
+++ b/spec/datadog/tracing/contrib/configuration/resolver_spec.rb
@@ -166,5 +166,59 @@ RSpec.describe Datadog::Tracing::Contrib::Configuration::CachingResolver do
         expect { resolver.resolve('second_key') }.to(change { resolver.invocations }.by(1)) # Removes `third_key` from cache
       end
     end
+
+    context 'when a concurrent eviction happens during a hash key lookup' do
+      let(:cache_limit) { 1 }
+      let(:value) { :cached_value }
+      let(:key) { cached_key }
+      let(:cached_key) { comparable_value_class.new }
+      let(:lookup_key) { comparable_value_class.new(lookup_started, continue_lookup) }
+      let(:lookup_started) { Queue.new }
+      let(:continue_lookup) { Queue.new }
+
+      let(:comparable_value_class) do
+        Class.new do
+          def initialize(lookup_started = nil, continue_lookup = nil)
+            @lookup_started = lookup_started
+            @continue_lookup = continue_lookup
+          end
+
+          # Ruby Hash keys use #hash to select a bucket; returning the same
+          # Integer forces Hash#key? to compare keys with #eql?.
+          def hash
+            1
+          end
+
+          def eql?(_other)
+            if @lookup_started
+              # Pause while Hash#key? is comparing the lookup key, so another
+              # thread can try to evict the cache entry at the same time.
+              @lookup_started << true
+              @continue_lookup.pop
+              @lookup_started = nil
+            end
+
+            true
+          end
+        end
+      end
+
+      it 'returns the cached value' do
+        resolver.resolve(cached_key)
+
+        # The lookup key is equivalent to the cached key and should return the
+        # cached value even if a concurrent resolve attempts to evict the entry.
+        lookup_thread = Thread.new { resolver.resolve(lookup_key) }
+        lookup_started.pop
+
+        evicting_thread = Thread.new { resolver.resolve(:evicting_key) }
+        continue_lookup << true
+
+        lookup_result = lookup_thread.value
+        evicting_thread.join
+
+        expect(lookup_result).to eq(:cached_value)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR force initialize `@cache` in CachingResolver as a `st_table`.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Support ticket APMS-19371. Thanks to @ivoanjo , the issue was narrowed to a [Ruby bug](https://bugs.ruby-lang.org/issues/21170), that is now fixed, but still present in older rubies. Initializing `@cache` as a `st_stable` is a workaround to prevent the corruption of the hash table.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Minimal repro app (segfault before the fix, goes through 1000000 loops without segfaulting after)
```ruby
require_relative 'lib/datadog/tracing/contrib/configuration/resolver'

max_iterations = Integer(ARGV.fetch(0, '1000000'))

class BadHash < Hash
  attr_reader :hash

  def initialize(hash_value)
    @hash = hash_value
    self[:x] = 1
  end
end

Resolver = Class.new(Datadog::Tracing::Contrib::Configuration::Resolver) do
  prepend Datadog::Tracing::Contrib::Configuration::CachingResolver
end

max_iterations.times do
  resolver = Resolver.new

  0.downto(-16) do |hash_value|
    resolver.add(BadHash.new(hash_value), hash_value)
  end

  0.downto(-16) do |hash_value|
    resolver.resolve(BadHash.new(hash_value))
  end

  17.times do |hash_value|
    resolver.resolve(BadHash.new(hash_value))
  end

  resolver.resolve(BadHash.new(-1))
end

warn "completed #{max_iterations} iterations without crashing"
```

Run it with :
```sh
docker run --rm \
  -v "$PWD:/app" \
  -w /app \
  ruby:3.4.2 \
  ruby caching_resolver_cache_segfault_repro.rb
```

<!-- Unsure? Have a question? Request a review! -->
