### PR TITLE
Skip flaky backfill integration tests

### DIFF
--- a/spec/datadog/di/ext/backfill_integration_spec.rb
+++ b/spec/datadog/di/ext/backfill_integration_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe "CodeTracker backfill integration" do
     end
 
     it "backfills the iseq and allows the probe to be installed" do
+      skip "temporarily skipped due to flakiness in ci"
       expect(diagnostics_transport).to receive(:send_diagnostics)
       probe_manager.add_probe(probe)
       component.probe_notifier_worker.flush
@@ -102,6 +103,7 @@ RSpec.describe "CodeTracker backfill integration" do
     end
 
     it "fires the probe when the target line executes" do
+      skip "temporarily skipped due to flakiness in ci"
       expect(diagnostics_transport).to receive(:send_diagnostics)
       probe_manager.add_probe(probe)
       component.probe_notifier_worker.flush
@@ -120,6 +122,7 @@ RSpec.describe "CodeTracker backfill integration" do
       end
 
       it "captures local variables from the backfilled iseq" do
+        skip "temporarily skipped due to flakiness in ci"
         expect(diagnostics_transport).to receive(:send_diagnostics)
         probe_manager.add_probe(probe)
 


### PR DESCRIPTION
**What does this PR do?**

Temporarily skips 3 flaky backfill integration specs in `spec/datadog/di/ext/backfill_integration_spec.rb`:
- "backfills the iseq and allows the probe to be installed"
- "fires the probe when the target line executes"
- "captures local variables from the backfilled iseq"

**Motivation:**

These tests are flaky in CI ([example failure](https://github.com/DataDog/dd-trace-rb/actions/runs/25003344720/job/73219356150?pr=5560)). Skipping them to unblock CI while the root cause is investigated.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

CI should pass with these tests skipped.