### PR TITLE
Reproduce flaky: backfill iseq tp.enable failure

### DIFF
--- a/spec/datadog/di/ext/backfill_integration_spec.rb
+++ b/spec/datadog/di/ext/backfill_integration_spec.rb
@@ -110,6 +110,34 @@ RSpec.describe "CodeTracker backfill integration" do
       expect(BackfillIntegrationTestClass.new.test_method).to eq(42)
     end
 
+    context "when whole-file iseq tp.enable fails" do
+      # Simulates the rare CI condition where the backfilled whole-file
+      # iseq's child references become stale (ArgumentError from
+      # tp.enable). The instrumenter should fall back to a per-method
+      # iseq that directly contains the target line.
+      it "falls back to per-method iseq and installs the probe" do
+        # Replace the whole-file iseq in the registry with a dummy iseq
+        # that does NOT cover line 22. This forces tp.enable to raise
+        # ArgumentError, triggering the per-method iseq fallback.
+        code_tracker = Datadog::DI.code_tracker
+        dummy_iseq = RubyVM::InstructionSequence.compile("nil", "dummy.rb")
+
+        # Find the real path used in the registry
+        real_result = code_tracker.iseqs_for_path_suffix("backfill_integration_test_class.rb")
+        expect(real_result).not_to be_nil
+        real_path = real_result[0]
+
+        # Inject the dummy iseq into the whole-file registry
+        code_tracker.send(:registry)[real_path] = dummy_iseq
+
+        expect(diagnostics_transport).to receive(:send_diagnostics)
+        probe_manager.add_probe(probe)
+        component.probe_notifier_worker.flush
+
+        expect(probe_manager.probe_repository.installed_probes.length).to eq(1)
+      end
+    end
+
     context "with snapshot capture" do
       let(:probe) do
         Datadog::DI::Probe.new(


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/di/ext/backfill_integration_spec.rb`. Forces the `ArgumentError: can not enable any hooks` condition to validate the hypothesis in CI. Expected result: the new test fails deterministically.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [Ruby 3.2 / build & test (standard) [4]](https://github.com/DataDog/dd-trace-rb/actions/runs/25003344720/job/73219356150) on PR #5560.

**Root cause:** Ruby 3.2.9 backported `rb_iseq_alloc_with_dummy_path` ([Backport #11036](https://github.com/ruby/ruby/commit/2a4469ea590e6719eb30e8b7aea7e147e3b82f75)) which creates dummy profiler iseqs during `require`/`load`. These have `type :top`, `first_lineno == 0`, the same `absolute_path` as the real iseq, but `iseq_size == 0` (no bytecode). When `backfill_registry` stores one instead of the real iseq, `tp.enable` raises `ArgumentError` because `iseq_iterate_children` finds no child iseqs to traverse.

**Reproducer technique:**

After `activate_tracking!` populates the registry with the real whole-file iseq, the test overwrites the registry entry with `RubyVM::InstructionSequence.compile("nil", "dummy.rb")` — an iseq that has no events at line 22. This forces `tp.enable(target: iseq, target_line: 22)` to raise `ArgumentError: can not enable any hooks`.

This bypasses `backfill_registry` (injects into the registry directly) because the reproducer branch does not include the fix. In the real failure, the dummy iseq enters the registry via `backfill_registry` because there is no `trace_points.empty?` filter.

**Related PRs:**
- Fix: #5645
- Validation: #5646

**Change log entry**

None.

**How to test the change?**

CI should show the new test failing deterministically with `ArgumentError: can not enable any hooks`.