### PR TITLE
Fix types for AppSec Devise singin tracking patch

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -53,8 +53,6 @@ target :datadog do
 
   # Excluded due to https://github.com/soutaro/steep/issues/1232
   ignore 'lib/datadog/appsec/configuration/settings.rb'
-  ignore 'lib/datadog/appsec/contrib/devise/patcher.rb'
-  ignore 'lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb'
   ignore 'lib/datadog/appsec/contrib/devise/tracking_middleware.rb'
   ignore 'lib/datadog/appsec/contrib/rack/gateway/request.rb'
   ignore 'lib/datadog/appsec/contrib/rack/patcher.rb'

--- a/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
+++ b/lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb
@@ -18,9 +18,10 @@ module Datadog
               return result unless AppSec.enabled?
               return result if @_datadog_appsec_skip_track_login_event
               return result unless Configuration.auto_user_instrumentation_enabled?
-              return result unless AppSec.active_context
 
               context = AppSec.active_context
+              return result unless context
+
               if context.trace.nil? || context.span.nil?
                 Datadog.logger.debug { 'AppSec: unable to track signin events, due to missing trace or span' }
                 return result

--- a/sig/datadog/appsec/contrib/devise/patcher.rbs
+++ b/sig/datadog/appsec/contrib/devise/patcher.rbs
@@ -3,15 +3,13 @@ module Datadog
     module Contrib
       module Devise
         module Patcher
-          def self?.patched?: () -> untyped
+          GUARD_ONCE_PER_APP: ::Hash[any, ::Datadog::Core::Utils::OnlyOnce]
 
-          def self?.target_version: () -> untyped
+          def self?.patched?: () -> bool?
 
-          def self?.patch: () -> untyped
+          def self?.target_version: () -> ::Gem::Version?
 
-          def self?.patch_authenticable_strategy: () -> untyped
-
-          def self?.patch_registration_controller: () -> untyped
+          def self?.patch: () -> bool
         end
       end
     end

--- a/sig/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rbs
+++ b/sig/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rbs
@@ -12,9 +12,9 @@ module Datadog
 
             private
 
-            def record_successful_signin: (::Datadog::AppSec::Context context, any resource) -> void
+            def record_successful_signin: (::Datadog::AppSec::Context context, untyped resource) -> void
 
-            def record_failed_signin: (::Datadog::AppSec::Context context, any resource) -> void
+            def record_failed_signin: (::Datadog::AppSec::Context context, untyped resource) -> void
           end
         end
       end

--- a/sig/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rbs
+++ b/sig/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rbs
@@ -4,7 +4,17 @@ module Datadog
       module Devise
         module Patches
           module SigninTrackingPatch
-            def validate: (untyped resource) { () -> untyped } -> untyped
+            @_datadog_appsec_skip_track_login_event: bool?
+
+            attr_accessor authentication_hash: ::Hash[::Symbol, any]
+
+            def validate: (any resource) ?{ () -> any } -> bool
+
+            private
+
+            def record_successful_signin: (::Datadog::AppSec::Context context, any resource) -> void
+
+            def record_failed_signin: (::Datadog::AppSec::Context context, any resource) -> void
           end
         end
       end

--- a/vendor/rbs/devise/0/devise.rbs
+++ b/vendor/rbs/devise/0/devise.rbs
@@ -1,4 +1,6 @@
 module Devise
+  STRATEGIES: ::Hash[::Symbol, ::Symbol]
+
   class Mapping
     def class_name: () -> ::String
 
@@ -6,4 +8,19 @@ module Devise
   end
 
   def self.mappings: () -> ::Hash[::Symbol, Mapping]
+
+  class RegistrationsController
+    def self.descendants: () -> ::Array[Class]
+  end
+
+  module Strategies
+    class Authenticatable
+      attr_accessor authentication_hash: ::Hash[::Symbol, any]
+
+      def validate: (any resource) ?{ () -> any } -> bool
+    end
+
+    class Rememberable < Authenticatable
+    end
+  end
 end

--- a/vendor/rbs/devise/0/devise.rbs
+++ b/vendor/rbs/devise/0/devise.rbs
@@ -15,7 +15,7 @@ module Devise
 
   module Strategies
     class Authenticatable
-      attr_accessor authentication_hash: ::Hash[::Symbol, any]
+      attr_accessor authentication_hash: ::Hash[::Symbol, untyped]
 
       def validate: (any resource) ?{ () -> any } -> bool
     end

--- a/vendor/rbs/warden/0/warden.rbs
+++ b/vendor/rbs/warden/0/warden.rbs
@@ -1,0 +1,4 @@
+module Warden
+  class Manager
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
This PR fixes types for `lib/datadog/appsec/contrib/devise/patcher.rb` and `lib/datadog/appsec/contrib/devise/patches/signin_tracking_patch.rb`.

**Motivation:**
We want to have proper type declarations for all AppSec files.

**Change log entry**
None.

**Additional Notes:**
APPSEC-60626

**How to test the change?**
CI