### PR TITLE
Add a metric for total wait time on GVL

### DIFF
--- a/benchmarks/profiling_http_transport.rb
+++ b/benchmarks/profiling_http_transport.rb
@@ -60,6 +60,7 @@ class ProfilerHttpTransportBenchmark
       tags_as_array: [],
       internal_metadata: {no_signals_workaround_enabled: false},
       info_json: JSON.generate({profiler: {benchmarking: true}}),
+      metrics_data: nil,
     }
 
     # This was added as a workaround to allow https://github.com/DataDog/dd-trace-rb/pull/5072 to be merged

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1,4 +1,5 @@
 #include <ruby.h>
+#include <stdatomic.h>
 
 #include "datadog_ruby_common.h"
 #include "collectors_thread_context.h"
@@ -113,6 +114,10 @@ static ID otel_fiber_context_storage_id; // id of :@opentelemetry_context in Rub
 // In production this should not be a problem: there should only be one profiler, which is the last one created,
 // and that'll be the one that last wrote this setting.
 static uint32_t global_waiting_for_gvl_threshold_ns = MILLIS_AS_NS(10);
+
+// Accumulates total wall-time (ns) spent by all threads waiting for the GVL.
+// Updated atomically from on_gvl_running (which runs outside the GVL).
+static atomic_uint_fast64_t global_gvl_wait_time_ns_total = 0;
 
 typedef enum { OTEL_CONTEXT_ENABLED_FALSE, OTEL_CONTEXT_ENABLED_ONLY, OTEL_CONTEXT_ENABLED_BOTH } otel_context_enabled;
 typedef enum { OTEL_CONTEXT_SOURCE_UNKNOWN, OTEL_CONTEXT_SOURCE_FIBER_IVAR, OTEL_CONTEXT_SOURCE_FIBER_LOCAL } otel_context_source;
@@ -268,6 +273,7 @@ static void trace_identifiers_for(
 );
 static bool should_collect_resource(VALUE root_span);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
+static VALUE _native_gvl_wait_time_ns_and_reset(DDTRACE_UNUSED VALUE self);
 static VALUE thread_list(thread_context_collector_state *state);
 static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE sample_weight, VALUE new_object);
 static VALUE _native_new_empty_thread(VALUE self);
@@ -328,6 +334,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
   rb_define_singleton_method(collectors_thread_context_class, "_native_initialize", _native_initialize, -1);
   rb_define_singleton_method(collectors_thread_context_class, "_native_inspect", _native_inspect, 1);
   rb_define_singleton_method(collectors_thread_context_class, "_native_reset_after_fork", _native_reset_after_fork, 1);
+  rb_define_singleton_method(collectors_thread_context_class, "_native_gvl_wait_time_ns_and_reset", _native_gvl_wait_time_ns_and_reset, 0);
   rb_define_singleton_method(testing_module, "_native_sample", _native_sample, 3);
   rb_define_singleton_method(testing_module, "_native_sample_allocation", _native_sample_allocation, 3);
   rb_define_singleton_method(testing_module, "_native_on_gc_start", _native_on_gc_start, 1);
@@ -1468,6 +1475,10 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector
   return Qtrue;
 }
 
+static VALUE _native_gvl_wait_time_ns_and_reset(DDTRACE_UNUSED VALUE self) {
+  return ULL2NUM(thread_context_collector_gvl_wait_time_ns_and_reset());
+}
+
 static VALUE thread_list(thread_context_collector_state *state) {
   VALUE result = state->thread_list_buffer;
   rb_ary_clear(result);
@@ -1931,6 +1942,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     long waiting_for_gvl_duration_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - gvl_waiting_at;
 
+    if (waiting_for_gvl_duration_ns > 0) {
+      atomic_fetch_add(&global_gvl_wait_time_ns_total, waiting_for_gvl_duration_ns);
+    }
+
     bool should_sample = waiting_for_gvl_duration_ns >= waiting_for_gvl_threshold_ns;
 
     if (should_sample) {
@@ -2186,6 +2201,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     return Qtrue;
   }
 
+  uint64_t thread_context_collector_gvl_wait_time_ns_and_reset(void) {
+    return atomic_exchange(&global_gvl_wait_time_ns_total, 0);
+  }
+
 #else
   static bool handle_gvl_waiting(
     DDTRACE_UNUSED thread_context_collector_state *state,
@@ -2195,6 +2214,8 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     DDTRACE_UNUSED sampling_buffer* sampling_buffer,
     DDTRACE_UNUSED long current_cpu_time_ns
   ) { return false; }
+
+  uint64_t thread_context_collector_gvl_wait_time_ns_and_reset(void) { return 0; }
 #endif // NO_GVL_INSTRUMENTATION
 
 #define MAX_SAFE_LOOKUP_SIZE 16

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -18,6 +18,7 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 __attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);
+uint64_t thread_context_collector_gvl_wait_time_ns_and_reset(void);
 
 
 #ifndef NO_GVL_INSTRUMENTATION

--- a/ext/datadog_profiling_native_extension/http_transport.c
+++ b/ext/datadog_profiling_native_extension/http_transport.c
@@ -204,6 +204,7 @@ static VALUE _native_do_export(
   VALUE internal_metadata_json = rb_funcall(flush, rb_intern("internal_metadata_json"), 0);
   VALUE info_json = rb_funcall(flush, rb_intern("info_json"), 0);
   VALUE process_tags = rb_funcall(flush, rb_intern("process_tags"), 0);
+  VALUE metrics_data = rb_funcall(flush, rb_intern("metrics_data"), 0);
 
   enforce_encoded_profile_instance(encoded_profile);
   ENFORCE_TYPE(code_provenance_file_name, T_STRING);
@@ -216,14 +217,25 @@ static VALUE _native_do_export(
   bool have_code_provenance = !NIL_P(code_provenance_data);
   if (have_code_provenance) ENFORCE_TYPE(code_provenance_data, T_STRING);
 
-  int to_compress_length = have_code_provenance ? 1 : 0;
+  // Metrics data may be nil if there are no metrics to report
+  bool have_metrics = !NIL_P(metrics_data);
+  if (have_metrics) ENFORCE_TYPE(metrics_data, T_STRING);
+
+  int to_compress_length = (have_code_provenance ? 1 : 0) + (have_metrics ? 1 : 0);
   ddog_prof_Exporter_File to_compress[to_compress_length];
   ddog_prof_Exporter_Slice_File files_to_compress_and_export = {.ptr = to_compress, .len = to_compress_length};
 
+  int file_index = 0;
   if (have_code_provenance) {
-    to_compress[0] = (ddog_prof_Exporter_File) {
+    to_compress[file_index++] = (ddog_prof_Exporter_File) {
       .name = char_slice_from_ruby_string(code_provenance_file_name),
       .file = byte_slice_from_ruby_string(code_provenance_data),
+    };
+  }
+  if (have_metrics) {
+    to_compress[file_index++] = (ddog_prof_Exporter_File) {
+      .name = DDOG_CHARSLICE_C("metrics.json"),
+      .file = byte_slice_from_ruby_string(metrics_data),
     };
   }
 

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -163,8 +163,6 @@ static const uint8_t all_value_types_positions[] =
 typedef struct {
   // How many individual samples were recorded into this slot (un-weighted)
   uint64_t recorded_samples;
-  // Total wall-time (ns) of samples recorded while waiting for the GVL
-  uint64_t gvl_wait_time_ns;
 } stats_slot;
 
 typedef struct {
@@ -651,9 +649,6 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   );
 
   active_slot.data->stats.recorded_samples++;
-  if (labels.is_gvl_waiting_state) {
-    active_slot.data->stats.gvl_wait_time_ns += values.wall_time_ns;
-  }
 
   sampler_unlock_active_profile(active_slot);
 
@@ -1021,7 +1016,6 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
     ID2SYM(rb_intern("serialization_time_ns")), /* => */ LONG2NUM(serialization_time_ns),
     ID2SYM(rb_intern("heap_iteration_prep_time_ns")), /* => */ LONG2NUM(heap_iteration_prep_time_ns),
     ID2SYM(rb_intern("heap_profile_build_time_ns")), /* => */ LONG2NUM(heap_profile_build_time_ns),
-    ID2SYM(rb_intern("gvl_wait_time_ns")), /* => */ ULL2NUM(slot->stats.gvl_wait_time_ns),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -163,6 +163,8 @@ static const uint8_t all_value_types_positions[] =
 typedef struct {
   // How many individual samples were recorded into this slot (un-weighted)
   uint64_t recorded_samples;
+  // Total wall-time (ns) of samples recorded while waiting for the GVL
+  uint64_t gvl_wait_time_ns;
 } stats_slot;
 
 typedef struct {
@@ -649,6 +651,9 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   );
 
   active_slot.data->stats.recorded_samples++;
+  if (labels.is_gvl_waiting_state) {
+    active_slot.data->stats.gvl_wait_time_ns += values.wall_time_ns;
+  }
 
   sampler_unlock_active_profile(active_slot);
 
@@ -1016,6 +1021,7 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
     ID2SYM(rb_intern("serialization_time_ns")), /* => */ LONG2NUM(serialization_time_ns),
     ID2SYM(rb_intern("heap_iteration_prep_time_ns")), /* => */ LONG2NUM(heap_iteration_prep_time_ns),
     ID2SYM(rb_intern("heap_profile_build_time_ns")), /* => */ LONG2NUM(heap_profile_build_time_ns),
+    ID2SYM(rb_intern("gvl_wait_time_ns")), /* => */ ULL2NUM(slot->stats.gvl_wait_time_ns),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
   return stats_as_hash;

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -108,7 +108,7 @@ module Datadog
             }
           ),
           info_json: info_json,
-          metrics_data: build_metrics_json(profile_stats),
+          metrics_data: build_metrics_json,
         )
       end
 
@@ -130,10 +130,10 @@ module Datadog
         (finish - start) < minimum_duration_seconds
       end
 
-      #: (::Hash[::Symbol, untyped]?) -> ::String?
-      def build_metrics_json(profile_stats)
-        gvl_wait_time_ns = profile_stats&.dig(:gvl_wait_time_ns)
-        return nil if gvl_wait_time_ns.nil? || gvl_wait_time_ns == 0
+      #: () -> ::String?
+      def build_metrics_json
+        gvl_wait_time_ns = Datadog::Profiling::Collectors::ThreadContext._native_gvl_wait_time_ns_and_reset
+        return nil if gvl_wait_time_ns == 0
 
         JSON.generate([["ruby_global_lock_wait_time_total", gvl_wait_time_ns]])
       end

--- a/lib/datadog/profiling/exporter.rb
+++ b/lib/datadog/profiling/exporter.rb
@@ -108,6 +108,7 @@ module Datadog
             }
           ),
           info_json: info_json,
+          metrics_data: build_metrics_json(profile_stats),
         )
       end
 
@@ -127,6 +128,14 @@ module Datadog
       #: (::Time, ::Time) -> bool
       def duration_below_threshold?(start, finish)
         (finish - start) < minimum_duration_seconds
+      end
+
+      #: (::Hash[::Symbol, untyped]?) -> ::String?
+      def build_metrics_json(profile_stats)
+        gvl_wait_time_ns = profile_stats&.dig(:gvl_wait_time_ns)
+        return nil if gvl_wait_time_ns.nil? || gvl_wait_time_ns == 0
+
+        JSON.generate([["ruby_global_lock_wait_time_total", gvl_wait_time_ns]])
       end
     end
   end

--- a/lib/datadog/profiling/flush.rb
+++ b/lib/datadog/profiling/flush.rb
@@ -15,6 +15,7 @@ module Datadog
       attr_reader :process_tags #: ::String
       attr_reader :internal_metadata_json #: ::String
       attr_reader :info_json #: ::String
+      attr_reader :metrics_data #: ::String?
 
       # @rbs start: ::Time
       # @rbs finish: ::Time
@@ -25,6 +26,7 @@ module Datadog
       # @rbs process_tags: ::String
       # @rbs internal_metadata: ::Hash[::Symbol, ::String | bool | ::Numeric]
       # @rbs info_json: ::String
+      # @rbs metrics_data: ::String?
       # @rbs return: void
       def initialize(
         start:,
@@ -35,7 +37,8 @@ module Datadog
         tags_as_array:,
         process_tags:,
         internal_metadata:,
-        info_json:
+        info_json:,
+        metrics_data:
       )
         @start = start
         @finish = finish
@@ -46,6 +49,7 @@ module Datadog
         @process_tags = process_tags
         @internal_metadata_json = JSON.generate(internal_metadata)
         @info_json = info_json
+        @metrics_data = metrics_data
       end
     end
   end

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -95,8 +95,11 @@ RSpec.describe Datadog::Profiling::Exporter do
       end
     end
 
-    context "when profile_stats includes gvl_wait_time_ns" do
-      let(:profile_stats) { {stat1: 1, gvl_wait_time_ns: 50_000_000} }
+    context "when there is accumulated GVL wait time" do
+      before do
+        allow(Datadog::Profiling::Collectors::ThreadContext)
+          .to receive(:_native_gvl_wait_time_ns_and_reset).and_return(50_000_000)
+      end
 
       it "returns a flush with metrics_data containing the GVL wait time" do
         parsed = JSON.parse(flush.metrics_data)
@@ -104,16 +107,11 @@ RSpec.describe Datadog::Profiling::Exporter do
       end
     end
 
-    context "when profile_stats has gvl_wait_time_ns of 0" do
-      let(:profile_stats) { {stat1: 1, gvl_wait_time_ns: 0} }
-
-      it "returns a flush with nil metrics_data" do
-        expect(flush.metrics_data).to be nil
+    context "when there is no accumulated GVL wait time" do
+      before do
+        allow(Datadog::Profiling::Collectors::ThreadContext)
+          .to receive(:_native_gvl_wait_time_ns_and_reset).and_return(0)
       end
-    end
-
-    context "when profile_stats does not include gvl_wait_time_ns" do
-      let(:profile_stats) { {stat1: 1} }
 
       it "returns a flush with nil metrics_data" do
         expect(flush.metrics_data).to be nil

--- a/spec/datadog/profiling/exporter_spec.rb
+++ b/spec/datadog/profiling/exporter_spec.rb
@@ -95,6 +95,31 @@ RSpec.describe Datadog::Profiling::Exporter do
       end
     end
 
+    context "when profile_stats includes gvl_wait_time_ns" do
+      let(:profile_stats) { {stat1: 1, gvl_wait_time_ns: 50_000_000} }
+
+      it "returns a flush with metrics_data containing the GVL wait time" do
+        parsed = JSON.parse(flush.metrics_data)
+        expect(parsed).to eq([["ruby_global_lock_wait_time_total", 50_000_000]])
+      end
+    end
+
+    context "when profile_stats has gvl_wait_time_ns of 0" do
+      let(:profile_stats) { {stat1: 1, gvl_wait_time_ns: 0} }
+
+      it "returns a flush with nil metrics_data" do
+        expect(flush.metrics_data).to be nil
+      end
+    end
+
+    context "when profile_stats does not include gvl_wait_time_ns" do
+      let(:profile_stats) { {stat1: 1} }
+
+      it "returns a flush with nil metrics_data" do
+        expect(flush.metrics_data).to be nil
+      end
+    end
+
     context "when duration of profile is below 1s" do
       let(:finish) { start + 0.99 }
 

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Datadog::Profiling::Flush do
       )
     end
 
-    let(:metrics_data) { '[["ruby_gvl_wait_time", 50000000]]' }
+    let(:metrics_data) { '[["ruby_global_lock_wait_time_total", 50000000]]' }
 
     subject(:flush) do
       described_class.new(

--- a/spec/datadog/profiling/flush_spec.rb
+++ b/spec/datadog/profiling/flush_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Datadog::Profiling::Flush do
       )
     end
 
+    let(:metrics_data) { '[["ruby_gvl_wait_time", 50000000]]' }
+
     subject(:flush) do
       described_class.new(
         start: start,
@@ -35,6 +37,7 @@ RSpec.describe Datadog::Profiling::Flush do
         process_tags: process_tags,
         internal_metadata: internal_metadata,
         info_json: info_json,
+        metrics_data: metrics_data,
       )
     end
 
@@ -48,7 +51,8 @@ RSpec.describe Datadog::Profiling::Flush do
         tags_as_array: tags_as_array,
         process_tags: process_tags,
         internal_metadata_json: '{"no_signals_workaround_enabled":false}',
-        info_json: info_json
+        info_json: info_json,
+        metrics_data: metrics_data,
       )
     end
   end

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
     end
 
     context "when metrics data is available" do
-      let(:metrics_data) { '[["ruby_gvl_wait_time", 50000000]]' }
+      let(:metrics_data) { '[["ruby_global_lock_wait_time_total", 50000000]]' }
 
       it "includes the metrics.json file in the payload" do
         success = http_transport.export(flush)

--- a/spec/datadog/profiling/http_transport_spec.rb
+++ b/spec/datadog/profiling/http_transport_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
       process_tags: process_tags,
       internal_metadata: {no_signals_workaround_enabled: true},
       info_json: info_json,
+      metrics_data: metrics_data,
     )
   end
   let(:serialize_result) { Datadog::Profiling::StackRecorder.for_testing.serialize }
@@ -71,6 +72,7 @@ RSpec.describe Datadog::Profiling::HttpTransport do
   let(:pprof_file_name) { "profile.pprof" }
   let(:code_provenance_file_name) { "the_code_provenance_file_name.json" }
   let(:code_provenance_data) { "the_code_provenance_data" }
+  let(:metrics_data) { nil }
   let(:tags_as_array) { [%w[tag_a value_a], %w[tag_b value_b]] }
   let(:process_tags) { '' }
   let(:info_json) do
@@ -427,6 +429,38 @@ RSpec.describe Datadog::Profiling::HttpTransport do
         expect(event_data).to match(expected_data_in_payload.merge("attachments" => [pprof_file_name]))
 
         expect(body[code_provenance_file_name]).to be nil
+      end
+    end
+
+    context "when metrics data is available" do
+      let(:metrics_data) { '[["ruby_gvl_wait_time", 50000000]]' }
+
+      it "includes the metrics.json file in the payload" do
+        success = http_transport.export(flush)
+
+        expect(success).to be true
+
+        boundary = request["content-type"][%r{^multipart/form-data; boundary=(.+)}, 1]
+        body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
+        event_data = JSON.parse(body.fetch("event"))
+
+        expect(event_data["attachments"]).to include("metrics.json")
+        expect(Zstd.decompress(body.fetch("metrics.json"))).to eq metrics_data
+      end
+    end
+
+    context "when metrics data is not available" do
+      let(:metrics_data) { nil }
+
+      it "does not include metrics.json in the payload" do
+        success = http_transport.export(flush)
+
+        expect(success).to be true
+
+        boundary = request["content-type"][%r{^multipart/form-data; boundary=(.+)}, 1]
+        body = WEBrick::HTTPUtils.parse_form_data(StringIO.new(request.body), boundary)
+
+        expect(body["metrics.json"]).to be nil
       end
     end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Record the total time spent waiting for the GVL as a metric.
See https://github.com/DataDog/dd-trace-rb/issues/3433.
Alternative to #5569 to see how Claude Code compares to Cursor.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Added metric for total time spent waiting for the GVL.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->
I used Claude Code.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
