### PR TITLE
Add deterministic junit formatter

### DIFF
--- a/.rspec-local.example
+++ b/.rspec-local.example
@@ -1,5 +1,6 @@
 <% require 'digest' %>
 --require spec_helper
+--require ./spec/support/deterministic_junit_formatter
 --format documentation
---format RspecJunitFormatter
+--format DeterministicJunitFormatter
 --out <%= "tmp/rspec/" + Digest::MD5.hexdigest(ENV['BUNDLE_GEMFILE'] + ARGV.join) + ".xml" %>

--- a/spec/support/deterministic_junit_formatter.rb
+++ b/spec/support/deterministic_junit_formatter.rb
@@ -1,0 +1,37 @@
+# JUnit formatter that replaces non-deterministic runtime values in test names
+# (memory addresses, UUIDs, timestamps) with stable placeholders.
+#
+# Only affects JUnit XML output — example.metadata is never mutated,
+# so other formatters (progress, documentation, etc.) see the original names.
+#
+# Usage in .rspec or via RSPEC_OPTS:
+#   --require ./spec/support/deterministic_junit_formatter
+#   --format DeterministicJunitFormatter
+#   --out junit.xml
+
+require 'rspec_junit_formatter'
+
+class DeterministicJunitFormatter < RspecJunitFormatter
+  RSpec::Core::Formatters.register self, :start, :stop, :dump_summary
+
+  SANITIZATIONS = [
+    # Object with memory address: #<Foo::Bar:0x00007f... attrs> → #<Foo::Bar:0xXXXX>
+    [/#<([A-Z][a-zA-Z_:]*):0x[0-9a-f]{6,}[^>]*>/, '#<\1:0xXXXX>'],
+    # Proc or lambda: #<Proc:0x00007f... /path:line (lambda)> → #<Proc:0xXXXX>
+    [/#<Proc:0x[0-9a-f]{6,}[^>]*>/, '#<Proc:0xXXXX>'],
+    # UUID v4: 550e8400-e29b-41d4-a716-446655440000 → <UUID>
+    [/\b[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i, '<UUID>'],
+    # ISO 8601 timestamp: "2026-04-02 14:19:20.830733764 +0000" → <timestamp>
+    [/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[\d. +-]*/, '<timestamp>'],
+  ]
+
+  private
+
+  def description_for(notification)
+    sanitize(super)
+  end
+
+  def sanitize(str)
+    SANITIZATIONS.reduce(str) { |s, (pattern, replacement)| s.gsub(pattern, replacement) }
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Introduces a `DeterministicJunitFormatter` that sanitizes non-deterministic runtime values in JUnit XML test names, and wires it into the CI RSpec configuration.

**Motivation:**

Unnamed `it` blocks whose matchers reference live objects (e.g. `it { is_expected.to eq(obj) }`) produce auto-generated test names containing memory addresses (`#<Foo:0x00007f…>`), UUIDs, or timestamps. These names change on every run, breaking JUnit XML diffing and flakiness tracking in CI.

Rather than requiring every such test to be fixed upfront, this PR applies a sanitization layer at the JUnit output stage so CI reports are immediately stable.

**Change log entry**

None.

**Additional Notes:**

`DeterministicJunitFormatter` subclasses `RspecJunitFormatter` and overrides only `description_for`, replacing non-deterministic patterns with stable placeholders:

- `#<ClassName:0x…>` → `#<ClassName:0xXXXX>`
- `#<Proc:0x…>` → `#<Proc:0xXXXX>`
- UUID v4 → `<UUID>`
- ISO 8601 timestamp → `<timestamp>`

Anyone can add new rules while `example.metadata` is never mutated, so `--format documentation` and all other formatters continue to see the original test names. Only the JUnit XML output is affected.
