### PR TITLE
Document Ruby 4.0 support and remove obsolete Ruby 3.5 references

### DIFF
--- a/datadog.gemspec
+++ b/datadog.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |spec|
   # (and yes we have a test for it)
   spec.add_dependency 'libdatadog', '~> 30.0.0.1.0'
 
-  # Will no longer be a default gem on Ruby 3.5, see
+  # Will no longer be a default gem on Ruby 4.0, see
   # https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c and
   # https://stdgems.org/ .
   # We support all versions of this gem and don't particularly require any version restriction.

--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -7,10 +7,10 @@ The Ruby Datadog Trace library is open source. See the [dd-trace-rb][1] GitHub r
 
 ### Supported Ruby interpreters
 
-<!-- Ensure that all "# TODO: Ruby 3.5 - " comments are addressed before including 3.5 in our public support docs -->
 | Type  | Documentation              | Version   | Support type              | Gem version support |
 |-------|----------------------------|-----------|---------------------------|---------------------|
-| MRI   | https://www.ruby-lang.org/ | 3.4       | [latest](#support-latest) | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 4.0       | [latest](#support-latest) | Latest              |
+|       |                            | 3.4       | [latest](#support-latest) | Latest              |
 |       |                            | 3.3       | [latest](#support-latest) | Latest              |
 |       |                            | 3.2       | [latest](#support-latest) | Latest              |
 |       |                            | 3.1       | [latest](#support-latest) | Latest              |


### PR DESCRIPTION
**What does this PR do?**

Updates the public Ruby compatibility documentation and one in-code comment to reflect that Ruby 4.0 is supported and that Ruby 3.5 was never released.

- `docs/Compatibility.md`: adds an MRI 4.0 row to the supported-interpreters table, and removes the HTML gating comment that referenced `# TODO: Ruby 3.5 -` comments (no such comments exist anywhere in the repo).
- `datadog.gemspec`: updates the comment on the `logger` dependency to say "Ruby 4.0" instead of "Ruby 3.5" (the linked Ruby commit demoting `logger` from defaults applies to what shipped as 4.0).

**Motivation:**

`Matrixfile`, `docker-compose.yml`, and the GitHub Actions test matrix all already run on Ruby 4.0. The customer-facing support doc lagged behind. The gating comment ("address all `# TODO: Ruby 3.5 -` comments before publishing 3.5") referenced a phantom set — there are zero such comments in the codebase, and 3.5 was never released.

**Change log entry**

Yes. Document official support for Ruby 4.0.

**Additional Notes:**

Companion CI cleanup in #5656 (adds Ruby 4.0 to the `install-dependencies` matrix in `.gitlab-ci.yml`).

**How to test the change?**

Docs- and comment-only change; the rendered Compatibility table now lists MRI 4.0 alongside the existing rows.