### PR TITLE
Add Ruby 4.0 to GitLab install-dependencies matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,8 +121,7 @@ install-dependencies:
   parallel:
     matrix:
       # ADD NEW RUBIES HERE
-      # TODO: Ruby 4.0 - Not added here yet to avoid increasing SSI OCI image size and adding premature support for 4.0.
-      - RUBY_VERSION: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+      - RUBY_VERSION: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
         ARCH: ["amd64", "arm64"]
   stage: package
   needs:


### PR DESCRIPTION
**What does this PR do?**

Adds `"4.0"` to the `RUBY_VERSION` matrix for the `install-dependencies` job in `.gitlab-ci.yml`, and removes the TODO that gated it.

**Motivation:**

The `build-image` (line 49) and `promote-image` (line 85) matrices already list `"4.0"`. The `install-dependencies` job was the only matrix in this file still missing it, gated on:

```
# TODO: Ruby 4.0 - Not added here yet to avoid increasing SSI OCI image size and adding premature support for 4.0.
```

With Ruby 4.0 now an officially supported runtime (see PR #5655 documenting it in `Compatibility.md`), the "premature support" rationale no longer holds and the install-dependencies matrix should match the others.

**Change log entry**

None.

**Additional Notes:**

Companion to #5655 (docs side of Ruby 4.0 support).

**How to test the change?**

GitLab CI will run the `install-dependencies` job for `RUBY_VERSION=4.0` on both `amd64` and `arm64`. A green pipeline confirms the OCI image builds and resolves dependencies on Ruby 4.0.