### PR TITLE
Revert "Add Ruby 4.0 to GitLab install-dependencies matrix"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,8 @@ install-dependencies:
   parallel:
     matrix:
       # ADD NEW RUBIES HERE
-      - RUBY_VERSION: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+      # TODO: Ruby 4.0 - Not added here yet to avoid increasing SSI OCI image size and adding premature support for 4.0.
+      - RUBY_VERSION: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
         ARCH: ["amd64", "arm64"]
   stage: package
   needs:


### PR DESCRIPTION
Reverts DataDog/dd-trace-rb#5656

Apparently the 4.0 image does not exist: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/jobs/1652455162