### PR TITLE
Invert ExceptionMessageCop: prefer e.message over bare interpolation

### DIFF
--- a/.customcops.yml
+++ b/.customcops.yml
@@ -15,7 +15,7 @@ CustomCops/EnvUsageCop:
 # Custom cop to enforce consistent exception logging format
 CustomCops/ExceptionMessageCop:
   Enabled: true
-  Description: 'Enforces consistent exception logging format: use `e` instead of `e.message`, `e.class` instead of `e.class.name`'
+  Description: 'Enforces consistent exception logging format: use `e.message` instead of bare `#{e}` interpolation, `e.class` instead of `e.class.name`, and require `#{e.class}` alongside any exception interpolation'
   SafeAutoCorrect: false
   Include:
     - "lib/**/*"

--- a/lib/datadog/appsec/autoload.rb
+++ b/lib/datadog/appsec/autoload.rb
@@ -7,7 +7,7 @@ if %w[1 true].include?((Datadog::DATADOG_ENV['DD_APPSEC_ENABLED'] || '').downcas
   rescue => e
     Kernel.warn(
       '[datadog] AppSec failed to instrument. No security check will be performed. error: ' \
-      " #{e.class}: #{e}"
+      " #{e.class}: #{e.message}"
     )
   end
 end

--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -47,7 +47,7 @@ module Datadog
           security_engine = SecurityEngine::Engine.new(appsec_settings: settings.appsec, telemetry: telemetry)
           new(security_engine: security_engine)
         rescue => e
-          Datadog.logger.warn("AppSec is disabled: #{e.class}: #{e}; there may be additional logged errors above")
+          Datadog.logger.warn("AppSec is disabled: #{e.class}: #{e.message}; there may be additional logged errors above")
 
           # Not reporting to telemetry here because some of the rescued exceptions
           # have already been reported by the code that raised them

--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -25,7 +25,7 @@ module Datadog
             def query
               ::Rack::Utils.parse_query(request.query_string)
             rescue => e
-              Datadog.logger.debug { "AppSec: Failed to parse request query string: #{e.class}: #{e}" }
+              Datadog.logger.debug { "AppSec: Failed to parse request query string: #{e.class}: #{e.message}" }
               AppSec.telemetry.report(e, description: 'AppSec: Failed to parse request query string')
 
               {}

--- a/lib/datadog/appsec/contrib/rails/patcher.rb
+++ b/lib/datadog/appsec/contrib/rails/patcher.rb
@@ -138,7 +138,7 @@ module Datadog
               end
             rescue => e
               error_message = 'Failed to get application routes'
-              Datadog.logger.error("#{error_message}, #{e.class}: #{e}")
+              Datadog.logger.error("#{error_message}, #{e.class}: #{e.message}")
               AppSec.telemetry.report(e, description: error_message)
             end
           end
@@ -148,7 +148,7 @@ module Datadog
               Datadog::AppSec::Contrib::Rails::Patcher.report_routes_via_telemetry(::Rails.application.routes.routes)
             rescue => e
               error_message = 'Failed to get application routes'
-              Datadog.logger.error("#{error_message}, #{e.class}: #{e}")
+              Datadog.logger.error("#{error_message}, #{e.class}: #{e.message}")
               AppSec.telemetry.report(e, description: error_message)
             end
           end

--- a/lib/datadog/appsec/security_engine/runner.rb
+++ b/lib/datadog/appsec/security_engine/runner.rb
@@ -79,7 +79,7 @@ module Datadog
         def try_run(persistent_data, ephemeral_data, timeout)
           waf_context.run(persistent_data, ephemeral_data, timeout)
         rescue WAF::LibDDWAFError => e
-          Datadog.logger.debug { "#{@debug_tag} execution error: #{e.class}: #{e} backtrace: #{e.backtrace&.first(3)}" }
+          Datadog.logger.debug { "#{@debug_tag} execution error: #{e.class}: #{e.message} backtrace: #{e.backtrace&.first(3)}" }
           AppSec.telemetry.report(e, description: 'libddwaf-rb internal low-level error')
 
           WAF::Result.new(

--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -18,7 +18,7 @@ module Datadog
         require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"
         nil
       rescue LoadError => e
-        "#{e.class}: #{e}"
+        "#{e.class}: #{e.message}"
       end
   end
 

--- a/lib/datadog/core/configuration.rb
+++ b/lib/datadog/core/configuration.rb
@@ -238,7 +238,7 @@ module Datadog
           yield write_components
         rescue ThreadError => e
           logger_without_components.error(
-            "Detected deadlock during datadog initialization: #{e.class}: #{e}. " \
+            "Detected deadlock during datadog initialization: #{e.class}: #{e.message}. " \
             'Please report this at https://github.com/datadog/dd-trace-rb/blob/master/CONTRIBUTING.md#found-a-bug' \
             "\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
           )

--- a/lib/datadog/core/configuration/components.rb
+++ b/lib/datadog/core/configuration/components.rb
@@ -98,7 +98,7 @@ module Datadog
               agent_info: agent_info
             )
           rescue => e
-            logger.warn("Failed to initialize Data Streams Monitoring: #{e.class}: #{e}")
+            logger.warn("Failed to initialize Data Streams Monitoring: #{e.class}: #{e.message}")
             nil
           end
         end

--- a/lib/datadog/core/contrib/rails/utils.rb
+++ b/lib/datadog/core/contrib/rails/utils.rb
@@ -14,7 +14,7 @@ module Datadog
             end
             application_name&.underscore
           rescue => e
-            Datadog.logger.debug("Failed to extract Rails application name: #{e.class}: #{e}")
+            Datadog.logger.debug("Failed to extract Rails application name: #{e.class}: #{e.message}")
             nil
           end
 

--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -55,7 +55,7 @@ module Datadog
             # Unhandled exception report triggering means that the application is already in a bad state
             # We don't want to swallow non-StandardError exceptions here; we would rather just let the
             # application crash
-            Datadog.logger.debug { "Crashtracker failed to report unhandled exception: #{e.class}: #{e}" }
+            Datadog.logger.debug { "Crashtracker failed to report unhandled exception: #{e.class}: #{e.message}" }
           end
         end
 
@@ -130,7 +130,7 @@ module Datadog
           self.class._native_stop
           logger.debug('Crash tracking stopped successfully')
         rescue => e
-          logger.error("Failed to stop crash tracking: #{e.class}: #{e}")
+          logger.error("Failed to stop crash tracking: #{e.class}: #{e.message}")
         end
 
         private
@@ -149,7 +149,7 @@ module Datadog
           )
           logger.debug("Crash tracking action: #{action} successful")
         rescue => e
-          logger.error("Failed to #{action} crash tracking: #{e.class}: #{e}")
+          logger.error("Failed to #{action} crash tracking: #{e.class}: #{e.message}")
         end
       end
     end

--- a/lib/datadog/core/diagnostics/environment_logger.rb
+++ b/lib/datadog/core/diagnostics/environment_logger.rb
@@ -53,7 +53,7 @@ module Datadog
           end
         rescue => e
           logger.warn(
-            "Failed to collect core environment information: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Failed to collect core environment information: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
         end
       end

--- a/lib/datadog/core/environment/container.rb
+++ b/lib/datadog/core/environment/container.rb
@@ -108,7 +108,7 @@ module Datadog
             end
           rescue => e
             Datadog.logger.debug(
-              "Error while checking cgroup namespace. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+              "Error while checking cgroup namespace. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
             )
             false
           end
@@ -172,7 +172,7 @@ module Datadog
           @entry = Entry.new # Empty entry if no valid cgroup entry is found
         rescue => e
           Datadog.logger.debug(
-            "Error while reading container entry. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Error while reading container entry. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
           @entry = Entry.new unless defined?(@entry)
           @entry

--- a/lib/datadog/core/feature_flags.rb
+++ b/lib/datadog/core/feature_flags.rb
@@ -37,7 +37,7 @@ module Datadog
           #       moved into C extension
           @value = json?(value) ? JSON.parse(value) : value
         rescue JSON::ParserError => e
-          raise Error, "Failed to parse JSON value: #{e.class}: #{e}"
+          raise Error, "Failed to parse JSON value: #{e.class}: #{e.message}"
         end
 
         # Check if the resolution resulted in an error

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -101,7 +101,7 @@ module Datadog
           statsd.count(stat, value, metric_options(options))
         rescue => e
           logger.error(
-            "Failed to send count stat. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Failed to send count stat. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           telemetry.report(e, description: 'Failed to send count stat')
         end
@@ -115,7 +115,7 @@ module Datadog
           statsd.distribution(stat, value, metric_options(options))
         rescue => e
           logger.error(
-            "Failed to send distribution stat. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Failed to send distribution stat. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           telemetry.report(e, description: 'Failed to send distribution stat')
         end
@@ -128,7 +128,7 @@ module Datadog
           statsd.increment(stat, metric_options(options))
         rescue => e
           logger.error(
-            "Failed to send increment stat. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Failed to send increment stat. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           telemetry.report(e, description: 'Failed to send increment stat')
         end
@@ -142,7 +142,7 @@ module Datadog
           statsd.gauge(stat, value, metric_options(options))
         rescue => e
           logger.error(
-            "Failed to send gauge stat. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Failed to send gauge stat. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           telemetry.report(e, description: 'Failed to send gauge stat')
         end
@@ -162,7 +162,7 @@ module Datadog
           rescue => e
             # TODO: Likely to be redundant, since `distribution` handles its own errors.
             logger.error(
-              "Failed to send time stat. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+              "Failed to send time stat. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
             )
             telemetry.report(e, description: 'Failed to send time stat')
           end

--- a/lib/datadog/core/remote/client.rb
+++ b/lib/datadog/core/remote/client.rb
@@ -57,7 +57,7 @@ module Datadog
 
             contents = Configuration::ContentList.parse(response.target_files)
           rescue Remote::Configuration::Path::ParseError => e
-            raise SyncError, "#{e.class}: #{e}"
+            raise SyncError, "#{e.class}: #{e.message}"
           end
 
           # To make sure steep does not complain

--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -45,7 +45,7 @@ module Datadog
             rescue Client::SyncError => e
               # Transient errors due to network or agent. Logged the error but not via telemetry
               logger.error do
-                "remote worker client sync error: #{e.class}: #{e} location: #{Array(e.backtrace).first}. skipping sync"
+                "remote worker client sync error: #{e.class}: #{e.message} location: #{Array(e.backtrace).first}. skipping sync"
               end
             rescue => e
               # In case of unexpected errors, reset the negotiation object
@@ -55,7 +55,7 @@ module Datadog
 
               # Transient errors due to network or agent. Logged the error but not via telemetry
               logger.error do
-                "remote worker error: #{e.class}: #{e} location: #{Array(e.backtrace).first}. " \
+                "remote worker error: #{e.class}: #{e.message} location: #{Array(e.backtrace).first}. " \
                 'resetting client state'
               end
 

--- a/lib/datadog/core/runtime/metrics.rb
+++ b/lib/datadog/core/runtime/metrics.rb
@@ -100,7 +100,7 @@ module Datadog
         def try_flush
           yield
         rescue => e
-          Datadog.logger.warn("Error while sending runtime metric. Cause: #{e.class}: #{e}")
+          Datadog.logger.warn("Error while sending runtime metric. Cause: #{e.class}: #{e.message}")
         end
 
         def default_metric_options

--- a/lib/datadog/core/telemetry/emitter.rb
+++ b/lib/datadog/core/telemetry/emitter.rb
@@ -39,7 +39,7 @@ module Datadog
           res
         rescue => e
           logger.debug {
-            "Unable to send telemetry request for event `#{event.respond_to?(:type) ? event.type : event.to_s}`: #{e.class}: #{e}"
+            "Unable to send telemetry request for event `#{event.respond_to?(:type) ? event.type : event.to_s}`: #{e.class}: #{e.message}"
           }
           Core::Transport::InternalErrorResponse.new(e)
         end

--- a/lib/datadog/core/utils.rb
+++ b/lib/datadog/core/utils.rb
@@ -63,7 +63,7 @@ module Datadog
           str.encode(::Encoding::UTF_8)
         end
       rescue => e
-        Datadog.logger.debug("Error encoding string in UTF-8: #{e.class}: #{e}")
+        Datadog.logger.debug("Error encoding string in UTF-8: #{e.class}: #{e.message}")
 
         placeholder
       end

--- a/lib/datadog/core/workers/async.rb
+++ b/lib/datadog/core/workers/async.rb
@@ -168,7 +168,7 @@ module Datadog
             rescue Exception => e
               @error = e
               Datadog.logger.debug(
-                "Worker thread error. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+                "Worker thread error. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
               )
               raise
 

--- a/lib/datadog/data_streams/pathway_context.rb
+++ b/lib/datadog/data_streams/pathway_context.rb
@@ -46,7 +46,7 @@ module Datadog
           decode(binary_data)
         rescue ArgumentError => e
           # Invalid base64 encoding - may indicate version mismatch or corruption
-          Datadog.logger.debug { "Failed to decode DSM pathway context: #{e.class}: #{e}" }
+          Datadog.logger.debug { "Failed to decode DSM pathway context: #{e.class}: #{e.message}" }
           nil
         end
       end

--- a/lib/datadog/data_streams/processor.rb
+++ b/lib/datadog/data_streams/processor.rb
@@ -329,7 +329,7 @@ module Datadog
         # Send to agent outside mutex to avoid blocking customer code if agent is slow/hung.
         send_stats_to_agent(payload)
       rescue => e
-        @logger.debug("Failed to flush DSM stats to agent: #{e.class}: #{e}")
+        @logger.debug("Failed to flush DSM stats to agent: #{e.class}: #{e.message}")
       end
 
       def get_current_pathway

--- a/lib/datadog/di/base.rb
+++ b/lib/datadog/di/base.rb
@@ -52,12 +52,12 @@ module Datadog
           Datadog::DI.activate_tracking!
         rescue => exc
           if defined?(Datadog.logger)
-            Datadog.logger.warn { "di: Failed to activate code tracking for DI: #{exc.class}: #{exc}" }
+            Datadog.logger.warn { "di: Failed to activate code tracking for DI: #{exc.class}: #{exc.message}" }
           else
             # We do not have Datadog logger potentially because DI code tracker is
             # being loaded early in application boot process and the rest of datadog
             # wasn't loaded yet. Output to standard error.
-            warn("datadog: di: Failed to activate code tracking for DI: #{exc.class}: #{exc}")
+            warn("datadog: di: Failed to activate code tracking for DI: #{exc.class}: #{exc.message}")
           end
         end
       end

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -124,7 +124,7 @@ module Datadog
         # Backfill is best-effort — if it fails, line probes on
         # pre-loaded code won't work but everything else is unaffected.
         if component = DI.current_component
-          component.logger.debug { "di: backfill_registry failed: #{exc.class}: #{exc}" }
+          component.logger.debug { "di: backfill_registry failed: #{exc.class}: #{exc.message}" }
           component.telemetry&.report(exc, description: "backfill_registry failed")
         end
         nil
@@ -197,7 +197,7 @@ module Datadog
             # but we will have DI.current_component (set to nil).
             if component = DI.current_component
               raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
-              component.logger.debug { "di: unhandled exception in script_compiled trace point: #{exc.class}: #{exc}" }
+              component.logger.debug { "di: unhandled exception in script_compiled trace point: #{exc.class}: #{exc.message}" }
               component.telemetry&.report(exc, description: "Unhandled exception in script_compiled trace point")
               # TODO test this path
             else

--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -122,7 +122,7 @@ module Datadog
           payload = probe_notification_builder.build_errored(probe, exc)
           probe_notifier_worker.add_status(payload)
         rescue => nested_exc
-          logger.debug { "di: failed to build error notification: #{nested_exc.class}: #{nested_exc}" }
+          logger.debug { "di: failed to build error notification: #{nested_exc.class}: #{nested_exc.message}" }
           telemetry&.report(nested_exc, description: 'Error building probe error notification')
           raise
         end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -155,7 +155,7 @@ module Datadog
                     rescue => nested_exc
                       raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                      instrumenter.logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc}" }
+                      instrumenter.logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc.message}" }
                       instrumenter.telemetry&.report(nested_exc, description: "Error in probe condition evaluation failed callback")
                     end
                   else
@@ -163,7 +163,7 @@ module Datadog
 
                     raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                    instrumenter.logger.debug { "di: error evaluating condition without context (tracer bug?): #{exc.class}: #{exc}" }
+                    instrumenter.logger.debug { "di: error evaluating condition without context (tracer bug?): #{exc.class}: #{exc.message}" }
                     instrumenter.telemetry&.report(exc, description: "Error evaluating condition without context")
                     # If execution gets here, there is probably a bug in the tracer.
                   end
@@ -250,7 +250,7 @@ module Datadog
               rescue => di_exc
                 raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                instrumenter.logger.debug { "di: unhandled exception in method probe: #{di_exc.class}: #{di_exc}" }
+                instrumenter.logger.debug { "di: unhandled exception in method probe: #{di_exc.class}: #{di_exc.message}" }
                 instrumenter.telemetry&.report(di_exc, description: "Unhandled exception in method probe")
               end
 
@@ -545,7 +545,7 @@ module Datadog
               rescue => nested_exc
                 raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc}" }
+                logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc.message}" }
                 telemetry&.report(nested_exc, description: "Error in probe condition evaluation failed callback")
               end
 
@@ -555,7 +555,7 @@ module Datadog
 
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-              logger.debug { "di: error evaluating condition without context (tracer bug?): #{exc.class}: #{exc}" }
+              logger.debug { "di: error evaluating condition without context (tracer bug?): #{exc.class}: #{exc.message}" }
               telemetry&.report(exc, description: "Error evaluating condition without context")
               # If execution gets here, there is probably a bug in the tracer.
             end
@@ -577,7 +577,7 @@ module Datadog
         check_and_disable_if_exceeded(probe, responder, di_start_time)
       rescue => exc
         raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-        logger.debug { "di: unhandled exception in line trace point: #{exc.class}: #{exc}" }
+        logger.debug { "di: unhandled exception in line trace point: #{exc.class}: #{exc.message}" }
         telemetry&.report(exc, description: "Unhandled exception in line trace point")
         # TODO test this path
       end
@@ -650,7 +650,7 @@ module Datadog
       def symbolize_class_name(cls_name)
         Object.const_get(cls_name)
       rescue NameError => exc
-        raise Error::DITargetNotDefined, "Class not defined: #{cls_name}: #{exc.class}: #{exc}"
+        raise Error::DITargetNotDefined, "Class not defined: #{cls_name}: #{exc.class}: #{exc.message}"
       end
     end
   end

--- a/lib/datadog/di/probe_builder.rb
+++ b/lib/datadog/di/probe_builder.rb
@@ -58,7 +58,7 @@ module Datadog
           condition: cond,
         )
       rescue KeyError => exc
-        raise ArgumentError, "Malformed remote configuration entry for probe: #{exc.class}: #{exc}: #{config}"
+        raise ArgumentError, "Malformed remote configuration entry for probe: #{exc.class}: #{exc.message}: #{config}"
       end
 
       def build_template_segments(segments)

--- a/lib/datadog/di/probe_file_loader.rb
+++ b/lib/datadog/di/probe_file_loader.rb
@@ -50,7 +50,7 @@ module Datadog
             rescue => exc
               raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-              component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI probe file loader: #{exc.class}: #{exc}" }
+              component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI probe file loader: #{exc.class}: #{exc.message}" }
               component.telemetry&.report(exc, description: "Unhandled exception adding probe in DI probe file loader")
 
               # TODO test this path
@@ -64,7 +64,7 @@ module Datadog
             raise
           end
 
-          component.logger.debug { "di: unhandled exception handling a probe in DI probe file loader: #{exc.class}: #{exc}" }
+          component.logger.debug { "di: unhandled exception handling a probe in DI probe file loader: #{exc.class}: #{exc.message}" }
           component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI probe file loader")
         end
       rescue

--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -30,7 +30,7 @@ module Datadog
           install_pending_method_probes(tp.self)
         rescue => exc
           raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-          logger.debug { "di: unhandled exception in definition trace point: #{exc.class}: #{exc}" }
+          logger.debug { "di: unhandled exception in definition trace point: #{exc.class}: #{exc.message}" }
           telemetry&.report(exc, description: "Unhandled exception in definition trace point")
           # TODO test this path
         end
@@ -133,13 +133,13 @@ module Datadog
         # In "propagate all exceptions" mode we will try to instrument again.
         raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-        logger.debug { "di: error processing probe configuration: #{exc.class}: #{exc}" }
+        logger.debug { "di: error processing probe configuration: #{exc.class}: #{exc.message}" }
         telemetry&.report(exc, description: "Error processing probe configuration")
 
         payload = probe_notification_builder.build_errored(probe, exc)
         probe_notifier_worker.add_status(payload, probe: probe)
 
-        probe_repository.add_failed(probe.id, "#{exc.class}: #{exc}")
+        probe_repository.add_failed(probe.id, "#{exc.class}: #{exc.message}")
 
         raise
       end
@@ -164,7 +164,7 @@ module Datadog
             raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
             # Silence all exceptions?
             # TODO should we propagate here and rescue upstream?
-            logger.debug { "di: error removing #{probe.type} probe at #{probe.location} (#{probe.id}): #{exc.class}: #{exc}" }
+            logger.debug { "di: error removing #{probe.type} probe at #{probe.location} (#{probe.id}): #{exc.class}: #{exc.message}" }
             telemetry&.report(exc, description: "Error removing probe")
           end
         end
@@ -193,13 +193,13 @@ module Datadog
                 rescue => exc
                   raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-                  logger.debug { "di: error installing #{probe.type} probe at #{probe.location} (#{probe.id}) after class is defined: #{exc.class}: #{exc}" }
+                  logger.debug { "di: error installing #{probe.type} probe at #{probe.location} (#{probe.id}) after class is defined: #{exc.class}: #{exc.message}" }
                   telemetry&.report(exc, description: "Error installing probe after class is defined")
 
                   payload = probe_notification_builder.build_errored(probe, exc)
                   probe_notifier_worker.add_status(payload, probe: probe)
 
-                  probe_repository.add_failed(probe.id, "#{exc.class}: #{exc}")
+                  probe_repository.add_failed(probe.id, "#{exc.class}: #{exc.message}")
                 end
               end
             end

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -368,7 +368,7 @@ module Datadog
           end
         rescue => exc
           evaluation_errors << {
-            message: "#{exc.class}: #{exc}",
+            message: "#{exc.class}: #{exc.message}",
             expr: segment.dsl_expr,
           }
           '[evaluation error]'

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -95,7 +95,7 @@ module Datadog
             rescue => exc
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-              logger.debug { "di: error in probe notifier worker: #{exc.class}: #{exc} (at #{exc.backtrace.first})" }
+              logger.debug { "di: error in probe notifier worker: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
               telemetry&.report(exc, description: "Error in probe notifier worker")
             end
             @lock.synchronize do
@@ -320,7 +320,7 @@ module Datadog
               end
             rescue => exc
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-              logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc} (at #{exc.backtrace.first})" }
+              logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
               telemetry&.report(exc, description: "Error sending #{event_type}")
             end
           end

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -88,11 +88,11 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc.message}")
           rescue => exc
             raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-            component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI remote receiver: #{exc.class}: #{exc}" }
+            component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI remote receiver: #{exc.class}: #{exc.message}" }
             component.telemetry&.report(exc, description: "Unhandled exception adding probe in DI remote receiver")
 
             # TODO test this path
@@ -106,7 +106,7 @@ module Datadog
             # content as errored but with a somewhat different exception
             # message.
             # TODO assert content state (errored for this example)
-            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
+            content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc.message}")
           end
 
           # Important: even if processing fails for this probe config,
@@ -117,11 +117,11 @@ module Datadog
         rescue => exc
           raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-          component.logger.debug { "di: unhandled exception handling a probe in DI remote receiver: #{exc.class}: #{exc}" }
+          component.logger.debug { "di: unhandled exception handling a probe in DI remote receiver: #{exc.class}: #{exc.message}" }
           component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI remote receiver")
 
           # TODO assert content state (errored for this example)
-          content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc}")
+          content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc.message}")
         end
 
         # This method does not mark +previous_content+ as succeeded or errored,
@@ -136,7 +136,7 @@ module Datadog
         rescue => exc
           raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-          component.logger.debug { "di: unhandled exception removing probes in DI remote receiver: #{exc.class}: #{exc}" }
+          component.logger.debug { "di: unhandled exception removing probes in DI remote receiver: #{exc.class}: #{exc.message}" }
           component.telemetry&.report(exc, description: "Unhandled exception removing probes in DI remote receiver")
         end
 

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -186,7 +186,7 @@ module Datadog
                 # surface errors so they can fix their serializers) or they may be defined
                 # internally by dd-trace-rb (in which case we need to fix them). We use
                 # WARN level to surface these errors in either case.
-                Datadog.logger.warn("DI: Custom serializer condition failed: #{e.class}: #{e}")
+                Datadog.logger.warn("DI: Custom serializer condition failed: #{e.class}: #{e.message}")
                 telemetry&.report(e, description: "Custom serializer condition failed")
                 next
               end

--- a/lib/datadog/di/transport/input.rb
+++ b/lib/datadog/di/transport/input.rb
@@ -81,14 +81,14 @@ module Datadog
               # Serialization failed for this snapshot - report via callback
               # This catches JSON::GeneratorError, Encoding errors, TypeError, etc.
               probe_id = snapshot.dig(:debugger, :snapshot, :probe, :id)
-              logger.debug { "di: JSON encoding failed for snapshot (probe #{probe_id}): #{exc.class}: #{exc}" }
+              logger.debug { "di: JSON encoding failed for snapshot (probe #{probe_id}): #{exc.class}: #{exc.message}" }
               telemetry&.report(exc, description: "JSON encoding failed for snapshot")
 
               if probe_id
                 begin
                   on_serialization_error.call(probe_id, exc)
                 rescue => callback_exc
-                  logger.debug { "di: error in serialization error callback for probe #{probe_id}: #{callback_exc.class}: #{callback_exc}" }
+                  logger.debug { "di: error in serialization error callback for probe #{probe_id}: #{callback_exc.class}: #{callback_exc.message}" }
                   telemetry&.report(callback_exc, description: "Error in serialization error callback")
                 end
               end
@@ -110,7 +110,7 @@ module Datadog
               begin
                 send_input_chunk(chunked_payload, serialized_tags)
               rescue => exc
-                logger.debug { "di: failed to send snapshot chunk: #{exc.class}: #{exc} (at #{exc.backtrace.first})" }
+                logger.debug { "di: failed to send snapshot chunk: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
                 telemetry&.report(exc, description: "Error sending snapshot chunk")
               end
             end

--- a/lib/datadog/kit/enable_core_dumps.rb
+++ b/lib/datadog/kit/enable_core_dumps.rb
@@ -30,7 +30,7 @@ module Datadog
           Process.setrlimit(:CORE, maximum_size)
         rescue => e
           Kernel.warn(
-            "[datadog] Failed to enable core dumps. Cause: #{e.class}: #{e} " \
+            "[datadog] Failed to enable core dumps. Cause: #{e.class}: #{e.message} " \
             "Location: #{Array(e.backtrace).first}"
           )
           return

--- a/lib/datadog/open_feature/evaluation_engine.rb
+++ b/lib/datadog/open_feature/evaluation_engine.rb
@@ -42,7 +42,7 @@ module Datadog
         @telemetry.report(e, description: 'OpenFeature: Failed to fetch flag value')
 
         ResolutionDetails.build_error(
-          value: default_value, error_code: Ext::GENERAL, error_message: "#{e.class}: #{e}"
+          value: default_value, error_code: Ext::GENERAL, error_message: "#{e.class}: #{e.message}"
         )
       end
 
@@ -60,10 +60,10 @@ module Datadog
       rescue => e
         message = 'OpenFeature: Failed to reconfigure, reverting to the previous configuration'
 
-        @logger.error("#{message}, #{e.class}: #{e}")
+        @logger.error("#{message}, #{e.class}: #{e.message}")
         @telemetry.report(e, description: "#{message} (#{e.class})")
 
-        raise ReconfigurationError, "#{e.class}: #{e}"
+        raise ReconfigurationError, "#{e.class}: #{e.message}"
       end
     end
   end

--- a/lib/datadog/open_feature/exposures/reporter.rb
+++ b/lib/datadog/open_feature/exposures/reporter.rb
@@ -29,7 +29,7 @@ module Datadog
           event = Event.build(result, flag_key: flag_key, context: context)
           @worker.enqueue(event)
         rescue => e
-          @logger.debug { "OpenFeature: Failed to report resolution details: #{e.class}: #{e}" }
+          @logger.debug { "OpenFeature: Failed to report resolution details: #{e.class}: #{e.message}" }
           @telemetry.report(e, description: 'OpenFeature: Failed to report resolution details')
 
           false

--- a/lib/datadog/open_feature/exposures/worker.rb
+++ b/lib/datadog/open_feature/exposures/worker.rb
@@ -105,7 +105,7 @@ module Datadog
 
           response
         rescue => e
-          @logger.debug { "OpenFeature: Failed to flush resolution details events: #{e.class}: #{e}" }
+          @logger.debug { "OpenFeature: Failed to flush resolution details events: #{e.class}: #{e.message}" }
           @telemetry.report(e, description: 'OpenFeature: Failed to flush resolution details events')
 
           nil

--- a/lib/datadog/open_feature/metrics/flag_eval_metrics.rb
+++ b/lib/datadog/open_feature/metrics/flag_eval_metrics.rb
@@ -61,7 +61,7 @@ module Datadog
           )
           counter.add(1, attributes: attributes)
         rescue => e
-          @logger.debug { "OpenFeature: Failed to record evaluation metric: #{e.class}: #{e}" }
+          @logger.debug { "OpenFeature: Failed to record evaluation metric: #{e.class}: #{e.message}" }
           @telemetry.report(e, description: 'OpenFeature: Failed to record evaluation metric')
         end
 
@@ -84,7 +84,7 @@ module Datadog
             )
           end
         rescue => e
-          @logger.debug { "OpenFeature: Failed to create metrics counter: #{e.class}: #{e}" }
+          @logger.debug { "OpenFeature: Failed to create metrics counter: #{e.class}: #{e.message}" }
           nil
         end
 
@@ -102,7 +102,7 @@ module Datadog
           meter_provider = ::OpenTelemetry.meter_provider
           sdk_meter_provider?(meter_provider) ? meter_provider : nil
         rescue LoadError => e
-          @logger.debug { "OpenFeature: Failed to initialize OTel metrics: #{e.class}: #{e}" }
+          @logger.debug { "OpenFeature: Failed to initialize OTel metrics: #{e.class}: #{e.message}" }
           nil
         end
 

--- a/lib/datadog/open_feature/provider.rb
+++ b/lib/datadog/open_feature/provider.rb
@@ -130,7 +130,7 @@ module Datadog
         ::OpenFeature::SDK::Provider::ResolutionDetails.new(
           value: default_value,
           error_code: Ext::GENERAL,
-          error_message: "#{e.class}: #{e}",
+          error_message: "#{e.class}: #{e.message}",
           reason: Ext::ERROR
         )
       end

--- a/lib/datadog/open_feature/remote.rb
+++ b/lib/datadog/open_feature/remote.rb
@@ -41,7 +41,7 @@ module Datadog
                   engine.reconfigure!(read_content(content))
                   content.applied
                 rescue EvaluationEngine::ReconfigurationError => e
-                  content.errored("Error applying OpenFeature configuration: #{e.class}: #{e}")
+                  content.errored("Error applying OpenFeature configuration: #{e.class}: #{e.message}")
                 end
               when :delete
                 # NOTE: For now, we treat deletion as clearing the configuration

--- a/lib/datadog/open_feature/transport.rb
+++ b/lib/datadog/open_feature/transport.rb
@@ -55,7 +55,7 @@ module Datadog
             @api.call(env)
           end
         rescue => e
-          message = "Internal error during request. Cause: #{e.class}: #{e} " \
+          message = "Internal error during request. Cause: #{e.class}: #{e.message} " \
                     "Location: #{Array(e.backtrace).first}"
           @logger.debug(message)
 

--- a/lib/datadog/opentelemetry/metrics.rb
+++ b/lib/datadog/opentelemetry/metrics.rb
@@ -11,7 +11,7 @@ module Datadog
         new(components).configure_metrics_sdk
         true
       rescue => exc
-        components.logger.error("Failed to initialize OpenTelemetry metrics: #{exc.class}: #{exc}: #{exc.backtrace.join("\n")}")
+        components.logger.error("Failed to initialize OpenTelemetry metrics: #{exc.class}: #{exc.message}: #{exc.backtrace.join("\n")}")
         false
       end
 
@@ -67,7 +67,7 @@ module Datadog
 
         configure_otlp_exporter(provider)
       rescue => e
-        @logger.warn("Failed to configure OTLP metrics exporter:  #{e.class}: #{e}")
+        @logger.warn("Failed to configure OTLP metrics exporter:  #{e.class}: #{e.message}")
       end
 
       def default_metrics_endpoint
@@ -101,7 +101,7 @@ module Datadog
         )
         provider.add_metric_reader(reader)
       rescue LoadError => e
-        @logger.warn("Could not load OTLP metrics exporter:  #{e.class}: #{e}")
+        @logger.warn("Could not load OTLP metrics exporter:  #{e.class}: #{e.message}")
       end
 
       # Returns metrics config value if explicitly set, otherwise falls back to exporter config or computed default value.

--- a/lib/datadog/opentelemetry/sdk/configurator.rb
+++ b/lib/datadog/opentelemetry/sdk/configurator.rb
@@ -37,7 +37,7 @@ module Datadog
           begin
             require 'opentelemetry-metrics-sdk'
           rescue LoadError => exc
-            components.logger.warn("Failed to load OpenTelemetry metrics gems: #{exc.class}: #{exc}")
+            components.logger.warn("Failed to load OpenTelemetry metrics gems: #{exc.class}: #{exc.message}")
             return super
           end
 

--- a/lib/datadog/opentelemetry/sdk/metrics_exporter.rb
+++ b/lib/datadog/opentelemetry/sdk/metrics_exporter.rb
@@ -19,7 +19,7 @@ module Datadog
           telemetry&.inc(TELEMETRY_NAMESPACE, metric_name, 1, tags: TELEMETRY_TAGS)
           result
         rescue => e
-          Datadog.logger.error("Failed to export OpenTelemetry Metrics:  #{e.class}: #{e}")
+          Datadog.logger.error("Failed to export OpenTelemetry Metrics:  #{e.class}: #{e.message}")
           telemetry&.inc(TELEMETRY_NAMESPACE, METRIC_EXPORT_FAILURES, 1, tags: TELEMETRY_TAGS)
           raise
         end

--- a/lib/datadog/profiling/collectors/code_provenance.rb
+++ b/lib/datadog/profiling/collectors/code_provenance.rb
@@ -146,7 +146,7 @@ module Datadog
         rescue Exception => e # rubocop:disable Lint/RescueException
           Datadog.logger.debug(
             "CodeProvenance#bundler_bin_path failed. " \
-            "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
           nil
         end

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -115,7 +115,7 @@ module Datadog
               operation_name = self.class._native_failure_exception_during_operation(self).inspect
               Datadog.logger.warn(
                 "CpuAndWallTimeWorker thread error. " \
-                "Operation: #{operation_name} Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+                "Operation: #{operation_name} Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
               )
               on_failure_proc&.call
               Datadog::Core::Telemetry::Logger.report(e, description: "CpuAndWallTimeWorker thread error: #{operation_name}")

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -44,7 +44,7 @@ module Datadog
               @failure_exception = e
               Datadog.logger.warn(
                 "IdleSamplingHelper thread error. " \
-                "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+                "Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
               )
               Datadog::Core::Telemetry::Logger.report(e, description: "IdleSamplingHelper thread error")
             end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -92,7 +92,7 @@ module Datadog
         [profiler, {profiling_enabled: true}]
       rescue Exception => e # rubocop:disable Lint/RescueException
         logger.warn do
-          "Failed to initialize profiling: #{e.class}: #{e} " \
+          "Failed to initialize profiling: #{e.class}: #{e.message} " \
           "Location: #{Array(e.backtrace).first}"
         end
         Datadog::Core::Telemetry::Logger.report(e, description: "Failed to initialize profiling")
@@ -376,7 +376,7 @@ module Datadog
         rescue StandardError, LoadError => e
           logger.warn(
             "Failed to probe `mysql2` gem information. " \
-            "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
 
           true

--- a/lib/datadog/profiling/load_native_extension.rb
+++ b/lib/datadog/profiling/load_native_extension.rb
@@ -5,5 +5,5 @@ begin
 rescue LoadError => e
   raise LoadError,
     "Failed to load the profiling native extension. To fix this, please remove and then reinstall datadog " \
-    "(Details: #{e.class}: #{e})"
+    "(Details: #{e.class}: #{e.message})"
 end

--- a/lib/datadog/profiling/scheduler.rb
+++ b/lib/datadog/profiling/scheduler.rb
@@ -65,7 +65,7 @@ module Datadog
       rescue Exception => e # rubocop:disable Lint/RescueException
         Datadog.logger.warn(
           "Profiling::Scheduler thread error. " \
-          "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+          "Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
         )
         on_failure_proc&.call
         Datadog::Core::Telemetry::Logger.report(e, description: "Profiling::Scheduler thread error")
@@ -136,7 +136,7 @@ module Datadog
           transport.export(flush)
         rescue => e
           Datadog.logger.warn(
-            "Unable to report profile. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Unable to report profile. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
           Datadog::Core::Telemetry::Logger.report(e, description: "Unable to report profile")
         end

--- a/lib/datadog/profiling/tasks/exec.rb
+++ b/lib/datadog/profiling/tasks/exec.rb
@@ -43,10 +43,10 @@ module Datadog
         def exec_with_error_handling(args)
           Kernel.exec(*args)
         rescue Errno::ENOENT => e
-          Kernel.warn "ddprofrb exec failed: #{e.class}: #{e} (command was '#{args.join(" ")}')"
+          Kernel.warn "ddprofrb exec failed: #{e.class}: #{e.message} (command was '#{args.join(" ")}')"
           Kernel.exit 127
         rescue Errno::EACCES, Errno::ENOEXEC => e
-          Kernel.warn "ddprofrb exec failed: #{e.class}: #{e} (command was '#{args.join(" ")}')"
+          Kernel.warn "ddprofrb exec failed: #{e.class}: #{e.message} (command was '#{args.join(" ")}')"
           Kernel.exit 126
         end
       end

--- a/lib/datadog/profiling/tasks/setup.rb
+++ b/lib/datadog/profiling/tasks/setup.rb
@@ -16,7 +16,7 @@ module Datadog
             setup_at_fork_hooks
           rescue StandardError, ScriptError => e
             Datadog.logger.warn do
-              "Profiler extensions unavailable. Cause: #{e.class}: #{e} " \
+              "Profiler extensions unavailable. Cause: #{e.class}: #{e.message} " \
               "Location: #{Array(e.backtrace).first}"
             end
             Datadog::Core::Telemetry::Logger.report(e, description: "Profiler extensions unavailable")
@@ -31,7 +31,7 @@ module Datadog
             Profiling.start_if_enabled
           rescue => e
             Datadog.logger.warn do
-              "Error during post-fork hooks. Cause: #{e.class}: #{e} " \
+              "Error during post-fork hooks. Cause: #{e.class}: #{e.message} " \
               "Location: #{Array(e.backtrace).first}"
             end
             Datadog::Core::Telemetry::Logger.report(e, description: "Error during post-fork hooks")

--- a/lib/datadog/single_step_instrument.rb
+++ b/lib/datadog/single_step_instrument.rb
@@ -17,5 +17,5 @@ begin
   require_relative 'auto_instrument'
   Datadog::SingleStepInstrument.const_set(:LOADED, true)
 rescue StandardError, LoadError => e
-  warn "Single step instrumentation failed: #{e.class}: #{e}\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
+  warn "Single step instrumentation failed: #{e.class}: #{e.message}\n\tSource:\n\t#{Array(e.backtrace).join("\n\t")}"
 end

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -116,7 +116,7 @@ module Datadog
 
         wrap_in_file_scope(source_file, [inner_scope])
       rescue => e
-        @logger.debug { "symdb: failed to extract #{mod_name || '<unknown>'}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to extract #{mod_name || '<unknown>'}: #{e.class}: #{e.message}" }
         @telemetry&.inc('tracers', 'symbol_database.extract_error', 1)
         nil
       end
@@ -138,7 +138,7 @@ module Datadog
         file_trees = build_file_trees(entries)
         convert_trees_to_scopes(file_trees)
       rescue => e
-        @logger.debug { "symdb: error in extract_all: #{e.class}: #{e}" }
+        @logger.debug { "symdb: error in extract_all: #{e.class}: #{e.message}" }
         @telemetry&.inc('tracers', 'symbol_database.extract_all_error', 1)
         []
       end
@@ -153,7 +153,7 @@ module Datadog
       def safe_mod_name(mod)
         Module.instance_method(:name).bind(mod).call
       rescue => e
-        @logger.debug { "symdb: safe_mod_name failed: #{e.class}: #{e}" }
+        @logger.debug { "symdb: safe_mod_name failed: #{e.class}: #{e.message}" }
         nil
       end
 
@@ -281,7 +281,7 @@ module Datadog
             location = begin
               namespace.const_source_location(const_name)
             rescue => e
-              @logger.debug { "symdb: const_source_location(#{const_name}) failed: #{e.class}: #{e}" }
+              @logger.debug { "symdb: const_source_location(#{const_name}) failed: #{e.class}: #{e.message}" }
               nil
             end
 
@@ -297,7 +297,7 @@ module Datadog
             location = begin
               mod.const_source_location(child_const_name)
             rescue => e
-              @logger.debug { "symdb: const_source_location(#{child_const_name}) failed: #{e.class}: #{e}" }
+              @logger.debug { "symdb: const_source_location(#{child_const_name}) failed: #{e.class}: #{e.message}" }
               nil
             end
             next unless location && !location.empty?
@@ -313,7 +313,7 @@ module Datadog
 
         fallback
       rescue => e
-        @logger.debug { "symdb: error finding source file for #{safe_mod_name(mod) || '<unknown>'}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: error finding source file for #{safe_mod_name(mod) || '<unknown>'}: #{e.class}: #{e.message}" }
         nil
       end
 
@@ -399,7 +399,7 @@ module Datadog
 
         [starts.min, ends.max]
       rescue => e
-        @logger.debug { "symdb: error calculating line range for #{klass.name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: error calculating line range for #{klass.name}: #{e.class}: #{e.message}" }
         [UNKNOWN_MIN_LINE, UNKNOWN_MAX_LINE]
       end
 
@@ -442,7 +442,7 @@ module Datadog
 
         specifics
       rescue => e
-        @logger.debug { "symdb: error building language specifics for #{klass.name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: error building language specifics for #{klass.name}: #{e.class}: #{e.message}" }
         {}
       end
 
@@ -465,7 +465,7 @@ module Datadog
 
         scopes
       rescue => e
-        @logger.debug { "symdb: failed to extract methods from #{klass.name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to extract methods from #{klass.name}: #{e.class}: #{e.message}" }
         []
       end
 
@@ -500,7 +500,7 @@ module Datadog
           symbols: extract_method_parameters(method)
         )
       rescue => e
-        @logger.debug { "symdb: failed to extract method #{klass.name}##{method_name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to extract method #{klass.name}##{method_name}: #{e.class}: #{e.message}" }
         nil
       end
 
@@ -578,7 +578,7 @@ module Datadog
         method_name = begin
           method.name.to_s
         rescue => e
-          @logger.debug { "symdb: method.name failed: #{e.class}: #{e}" }
+          @logger.debug { "symdb: method.name failed: #{e.class}: #{e.message}" }
           'unknown'
         end
         params = method.parameters
@@ -600,7 +600,7 @@ module Datadog
           )
         end
       rescue => e
-        @logger.debug { "symdb: failed to extract parameters from #{method_name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to extract parameters from #{method_name}: #{e.class}: #{e.message}" }
         []
       end
 
@@ -629,7 +629,7 @@ module Datadog
 
           entries[mod_name] = {mod: mod, methods_by_file: methods_by_file}
         rescue => e
-          @logger.debug { "symdb: error collecting #{mod_name || '<unknown>'}: #{e.class}: #{e}" }
+          @logger.debug { "symdb: error collecting #{mod_name || '<unknown>'}: #{e.class}: #{e.message}" }
         end
 
         entries
@@ -655,12 +655,12 @@ module Datadog
 
           result[loc[0]] << {name: method_name, method: method, type: :instance}
         rescue => e
-          @logger.debug { "symdb: error grouping method #{method_name}: #{e.class}: #{e}" }
+          @logger.debug { "symdb: error grouping method #{method_name}: #{e.class}: #{e.message}" }
         end
 
         result
       rescue => e
-        @logger.debug { "symdb: error grouping methods: #{e.class}: #{e}" }
+        @logger.debug { "symdb: error grouping methods: #{e.class}: #{e.message}" }
         {}
       end
 
@@ -688,7 +688,7 @@ module Datadog
             place_in_tree(root, parts, entry[:mod], mod_name, methods, file_path)
           end
         rescue => e
-          @logger.debug { "symdb: error building tree for #{mod_name}: #{e.class}: #{e}" }
+          @logger.debug { "symdb: error building tree for #{mod_name}: #{e.class}: #{e.message}" }
         end
 
         file_trees
@@ -744,7 +744,7 @@ module Datadog
         const = Object.const_get(fqn)
         const.is_a?(Class) ? 'CLASS' : 'MODULE'
       rescue => e
-        @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e}, defaulting to MODULE" }
+        @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e.message}, defaulting to MODULE" }
         'MODULE'
       end
 
@@ -841,7 +841,7 @@ module Datadog
         )
       rescue => e
         klass_name = klass ? (safe_mod_name(klass) || '<unknown>') : '<unknown>'
-        @logger.debug { "symdb: failed to build method scope #{klass_name}##{method_name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to build method scope #{klass_name}##{method_name}: #{e.class}: #{e.message}" }
         nil
       end
 
@@ -882,15 +882,15 @@ module Datadog
           # Lint/ShadowedException disabled: NameError/NoMethodError do descend from
           # StandardError, but Ruby's rescue-clause-order semantics ensure the bare rescue
           # below only catches exceptions not matched here.
-          @logger.debug { "symdb: skipping module constant #{const_name}: #{e.class}: #{e}" }
+          @logger.debug { "symdb: skipping module constant #{const_name}: #{e.class}: #{e.message}" }
         rescue => e
-          @logger.debug { "symdb: unexpected error reading module constant #{const_name}: #{e.class}: #{e}" }
+          @logger.debug { "symdb: unexpected error reading module constant #{const_name}: #{e.class}: #{e.message}" }
         end
 
         symbols
       rescue => e
         mod_name = safe_mod_name(mod) || '<unknown>'
-        @logger.debug { "symdb: failed to extract symbols from #{mod_name}: #{e.class}: #{e}" }
+        @logger.debug { "symdb: failed to extract symbols from #{mod_name}: #{e.class}: #{e.message}" }
         []
       end
     end

--- a/lib/datadog/symbol_database/file_hash.rb
+++ b/lib/datadog/symbol_database/file_hash.rb
@@ -38,7 +38,7 @@ module Datadog
         # to match against Git objects, not using SHA-1 for authentication/integrity.
         Digest::SHA1.hexdigest(git_blob)  # nosemgrep: ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
       rescue => e
-        logger.debug { "symdb: file hash failed for #{file_path}: #{e.class}: #{e}" }
+        logger.debug { "symdb: file hash failed for #{file_path}: #{e.class}: #{e.message}" }
         nil
       end
     end

--- a/lib/datadog/tracing/buffer.rb
+++ b/lib/datadog/tracing/buffer.rb
@@ -56,7 +56,7 @@ module Datadog
         @buffer_spans += trace.length
       rescue => e
         Datadog.logger.debug(
-          "Failed to measure queue accept. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+          "Failed to measure queue accept. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
         )
       end
 
@@ -66,7 +66,7 @@ module Datadog
         @buffer_spans -= trace.length
       rescue => e
         Datadog.logger.debug(
-          "Failed to measure queue drop. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+          "Failed to measure queue drop. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
         )
       end
 
@@ -91,7 +91,7 @@ module Datadog
         @buffer_spans = 0
       rescue => e
         Datadog.logger.debug(
-          "Failed to measure queue. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+          "Failed to measure queue. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
         )
       end
     end

--- a/lib/datadog/tracing/configuration/settings.rb
+++ b/lib/datadog/tracing/configuration/settings.rb
@@ -430,7 +430,7 @@ module Datadog
                       rescue => e
                         # `File#read` errors have clear and actionable messages, no need to add extra exception info.
                         Datadog.logger.warn(
-                          "Cannot read span sampling rules file `#{rules_file}`: #{e.class}: #{e}." \
+                          "Cannot read span sampling rules file `#{rules_file}`: #{e.class}: #{e.message}." \
                           'No span sampling rules will be applied.'
                         )
                         nil

--- a/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb
@@ -43,7 +43,7 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_CONTROLLER)
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -88,7 +88,7 @@ module Datadog
                 span.finish
               end
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/action_view/events/render_template.rb
+++ b/lib/datadog/tracing/contrib/action_view/events/render_template.rb
@@ -47,7 +47,7 @@ module Datadog
 
               record_exception(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/discard.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/discard.rb
@@ -40,7 +40,7 @@ module Datadog
               set_common_tags(span, payload)
               span.set_tag(Ext::TAG_JOB_ERROR, payload[:error])
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/enqueue.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/enqueue.rb
@@ -39,7 +39,7 @@ module Datadog
 
               set_common_tags(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/enqueue_at.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/enqueue_at.rb
@@ -39,7 +39,7 @@ module Datadog
 
               set_common_tags(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/enqueue_retry.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/enqueue_retry.rb
@@ -41,7 +41,7 @@ module Datadog
               span.set_tag(Ext::TAG_JOB_ERROR, payload[:error])
               span.set_tag(Ext::TAG_JOB_RETRY_WAIT, payload[:wait])
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/perform.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/perform.rb
@@ -39,7 +39,7 @@ module Datadog
 
               set_common_tags(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_job/events/retry_stopped.rb
+++ b/lib/datadog/tracing/contrib/active_job/events/retry_stopped.rb
@@ -40,7 +40,7 @@ module Datadog
               set_common_tags(span, payload)
               span.set_tag(Ext::TAG_JOB_ERROR, payload[:error])
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_model_serializers/events/render.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/events/render.rb
@@ -35,7 +35,7 @@ module Datadog
 
               set_common_tags(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_model_serializers/events/serialize.rb
+++ b/lib/datadog/tracing/contrib/active_model_serializers/events/serialize.rb
@@ -37,7 +37,7 @@ module Datadog
 
               set_common_tags(span, payload)
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
           end
         end

--- a/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/instantiation.rb
@@ -49,7 +49,7 @@ module Datadog
               span.set_tag(Ext::TAG_INSTANTIATION_CLASS_NAME, payload.fetch(:class_name))
               span.set_tag(Ext::TAG_INSTANTIATION_RECORD_COUNT, payload.fetch(:record_count))
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
           end

--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -69,7 +69,7 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_HOST, config[:host]) if config[:host]
               span.set_tag(Tracing::Metadata::Ext::NET::TAG_TARGET_PORT, config[:port]) if config[:port]
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
           end

--- a/lib/datadog/tracing/contrib/active_record/utils.rb
+++ b/lib/datadog/tracing/contrib/active_record/utils.rb
@@ -77,7 +77,7 @@ module Datadog
               # in case.
               Datadog.logger.debug(
                 "connection_id #{connection_id} does not represent a valid object. " \
-                        "Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+                        "Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
               )
             end
           else

--- a/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
+++ b/lib/datadog/tracing/contrib/active_support/cache/events/cache.rb
@@ -94,7 +94,7 @@ module Datadog
                   set_cache_key(span, key, mapping[:multi_key])
                 end
               rescue => e
-                Datadog.logger.error("#{e.class}: #{e}")
+                Datadog.logger.error("#{e.class}: #{e.message}")
                 Datadog::Core::Telemetry::Logger.report(e)
               end
 

--- a/lib/datadog/tracing/contrib/active_support/notifications/subscription.rb
+++ b/lib/datadog/tracing/contrib/active_support/notifications/subscription.rb
@@ -125,7 +125,7 @@ module Datadog
                 @block&.call(span, name, id, payload)
               rescue => e
                 Datadog.logger.debug(
-                  "ActiveSupport::Notifications handler for '#{name}' failed: #{e.class}: #{e}"
+                  "ActiveSupport::Notifications handler for '#{name}' failed: #{e.class}: #{e.message}"
                 )
               end
             end
@@ -147,7 +147,7 @@ module Datadog
                   callback.call(event, key, *args)
                 rescue => e
                   Datadog.logger.debug(
-                    "ActiveSupport::Notifications '#{key}' callback for '#{event}' failed: #{e.class}: #{e}"
+                    "ActiveSupport::Notifications '#{key}' callback for '#{event}' failed: #{e.class}: #{e.message}"
                   )
                 end
               end

--- a/lib/datadog/tracing/contrib/aws/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/aws/instrumentation.rb
@@ -90,7 +90,7 @@ module Datadog
 
             Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
           rescue => e
-            Datadog.logger.error("#{e.class}: #{e}")
+            Datadog.logger.error("#{e.class}: #{e.message}")
             Datadog::Core::Telemetry::Logger.report(e)
           end
           # rubocop:enable Metrics/MethodLength

--- a/lib/datadog/tracing/contrib/component.rb
+++ b/lib/datadog/tracing/contrib/component.rb
@@ -20,7 +20,7 @@ module Datadog
             @registry.each do |name, callback|
               callback.call(config)
             rescue => e
-              Datadog.logger.warn("Error configuring integration #{name}: #{e.class}: #{e}")
+              Datadog.logger.warn("Error configuring integration #{name}: #{e.class}: #{e.message}")
             end
           end
 

--- a/lib/datadog/tracing/contrib/dalli/quantize.rb
+++ b/lib/datadog/tracing/contrib/dalli/quantize.rb
@@ -16,7 +16,7 @@ module Datadog
             command = Core::Utils.utf8_encode(command, binary: true, placeholder: placeholder)
             Core::Utils.truncate(command, Ext::QUANTIZE_MAX_CMD_LENGTH)
           rescue => e
-            Datadog.logger.debug("Error sanitizing Dalli operation: #{e.class}: #{e}")
+            Datadog.logger.debug("Error sanitizing Dalli operation: #{e.class}: #{e.message}")
             placeholder
           end
         end

--- a/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/elasticsearch/patcher.rb
@@ -98,7 +98,7 @@ module Datadog
                 Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
               rescue => e
                 # TODO: Refactor the code to streamline the execution without ensure
-                Datadog.logger.error("#{e.class}: #{e}")
+                Datadog.logger.error("#{e.class}: #{e.message}")
                 Datadog::Core::Telemetry::Logger.report(e)
               ensure
                 # the call is still executed

--- a/lib/datadog/tracing/contrib/excon/middleware.rb
+++ b/lib/datadog/tracing/contrib/excon/middleware.rb
@@ -40,7 +40,7 @@ module Datadog
                 span
               end
             rescue => e
-              Datadog.logger.debug { "#{e.class}: #{e}" }
+              Datadog.logger.debug { "#{e.class}: #{e.message}" }
             end
 
             @stack.request_call(datum)
@@ -180,7 +180,7 @@ module Datadog
               end
             end
           rescue => e
-            Datadog.logger.debug { "#{e.class}: #{e}" }
+            Datadog.logger.debug { "#{e.class}: #{e.message}" }
           end
 
           def propagate!(trace, span, datum)

--- a/lib/datadog/tracing/contrib/faraday/middleware.rb
+++ b/lib/datadog/tracing/contrib/faraday/middleware.rb
@@ -83,7 +83,7 @@ module Datadog
 
             Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
           rescue => e
-            Datadog.logger.error("#{e.class}: #{e}")
+            Datadog.logger.error("#{e.class}: #{e.message}")
             Datadog::Core::Telemetry::Logger.report(e)
           end
           # rubocop:enable Metrics/AbcSize
@@ -98,7 +98,7 @@ module Datadog
               Datadog.configuration.tracing.header_tags.response_tags(env[:response_headers])
             )
           rescue => e
-            Datadog.logger.error("#{e.class}: #{e}")
+            Datadog.logger.error("#{e.class}: #{e.message}")
             Datadog::Core::Telemetry::Logger.report(e)
           end
           # rubocop:enable Metrics/AbcSize

--- a/lib/datadog/tracing/contrib/grape/endpoint.rb
+++ b/lib/datadog/tracing/contrib/grape/endpoint.rb
@@ -77,7 +77,7 @@ module Datadog
 
               Thread.current[KEY_RUN] = true
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -121,7 +121,7 @@ module Datadog
                 span.finish(finish)
               end
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -165,7 +165,7 @@ module Datadog
 
               Thread.current[KEY_RENDER] = true
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -190,7 +190,7 @@ module Datadog
                 span.finish(finish)
               end
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -229,7 +229,7 @@ module Datadog
                 span.finish(finish)
               end
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/client.rb
@@ -90,7 +90,7 @@ module Datadog
               end
               Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue => e
-              Datadog.logger.debug("GRPC client trace failed: #{e.class}: #{e}")
+              Datadog.logger.debug("GRPC client trace failed: #{e.class}: #{e.message}")
             end
 
             def find_deadline(call)
@@ -112,7 +112,7 @@ module Datadog
 
               Core::Utils.extract_host_port(peer_address)
             rescue => e
-              Datadog.logger.debug { "Could not parse host:port from #{call}: #{e.class}: #{e}" }
+              Datadog.logger.debug { "Could not parse host:port from #{call}: #{e.class}: #{e.message}" }
               nil
             end
           end

--- a/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
+++ b/lib/datadog/tracing/contrib/grpc/datadog_interceptor/server.rb
@@ -54,7 +54,7 @@ module Datadog
               Tracing.continue_trace!(GRPC.extract(metadata))
             rescue => e
               Datadog.logger.debug(
-                "unable to propagate GRPC metadata to context: #{e.class}: #{e}"
+                "unable to propagate GRPC metadata to context: #{e.class}: #{e.message}"
               )
             end
 
@@ -86,7 +86,7 @@ module Datadog
               # Measure service stats
               Contrib::Analytics.set_measured(span)
             rescue => e
-              Datadog.logger.debug("GRPC server trace failed: #{e.class}: #{e}")
+              Datadog.logger.debug("GRPC server trace failed: #{e.class}: #{e.message}")
             end
           end
         end

--- a/lib/datadog/tracing/contrib/http/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/http/instrumentation.rb
@@ -93,7 +93,7 @@ module Datadog
 
               Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue => e
-              Datadog.logger.error("error preparing span from http request: #{e.class}: #{e}")
+              Datadog.logger.error("error preparing span from http request: #{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 
@@ -108,7 +108,7 @@ module Datadog
                 Datadog.configuration.tracing.header_tags.response_tags(response)
               )
             rescue => e
-              Datadog.logger.error("error preparing span from http response: #{e.class}: #{e}")
+              Datadog.logger.error("error preparing span from http response: #{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httpclient/instrumentation.rb
@@ -42,7 +42,7 @@ module Datadog
                   annotate_span_with_request!(span, req, request_options)
                 rescue => e
                   Datadog.logger.error(
-                    "error preparing span for httpclient request: #{e.class}: #{e}, Source: #{e.backtrace}"
+                    "error preparing span for httpclient request: #{e.class}: #{e.message}, Source: #{e.backtrace}"
                   )
                   Datadog::Core::Telemetry::Logger.report(e)
                 ensure
@@ -110,7 +110,7 @@ module Datadog
               )
             rescue => e
               Datadog.logger.error(
-                "error preparing span from httpclient response: #{e.class}: #{e}, Source: #{e.backtrace}"
+                "error preparing span from httpclient response: #{e.class}: #{e.message}, Source: #{e.backtrace}"
               )
               Datadog::Core::Telemetry::Logger.report(e)
             end

--- a/lib/datadog/tracing/contrib/httprb/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/httprb/instrumentation.rb
@@ -41,7 +41,7 @@ module Datadog
                   # Add additional request specific tags to the span.
                   annotate_span_with_request!(span, req, request_options)
                 rescue => e
-                  logger.error("error preparing span for http.rb request: #{e.class}: #{e}, Source: #{e.backtrace}")
+                  logger.error("error preparing span for http.rb request: #{e.class}: #{e.message}, Source: #{e.backtrace}")
                   Datadog::Core::Telemetry::Logger.report(e)
                 ensure
                   res = super(req, options)
@@ -117,7 +117,7 @@ module Datadog
                 Datadog.configuration.tracing.header_tags.response_tags(response.headers)
               )
             rescue => e
-              logger.error("error preparing span from http.rb response: #{e.class}: #{e}, Source: #{e.backtrace}")
+              logger.error("error preparing span from http.rb response: #{e.class}: #{e.message}, Source: #{e.backtrace}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/kafka/instrumentation/consumer.rb
+++ b/lib/datadog/tracing/contrib/kafka/instrumentation/consumer.rb
@@ -27,7 +27,7 @@ module Datadog
                       auto_instrumentation: true
                     ) { |key| headers[key] }
                   rescue => e
-                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e}")
+                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e.message}")
                   end
 
                   yield(message) if block
@@ -49,7 +49,7 @@ module Datadog
                       auto_instrumentation: true
                     )
                   rescue => e
-                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e}")
+                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e.message}")
                   end
 
                   yield(batch) if block

--- a/lib/datadog/tracing/contrib/kafka/instrumentation/producer.rb
+++ b/lib/datadog/tracing/contrib/kafka/instrumentation/producer.rb
@@ -30,7 +30,7 @@ module Datadog
                       end
                     end
                   rescue => e
-                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e}")
+                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e.message}")
                   end
                 end
 
@@ -51,7 +51,7 @@ module Datadog
                       end
                     end
                   rescue => e
-                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e}")
+                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e.message}")
                   end
                 end
 

--- a/lib/datadog/tracing/contrib/karafka/patcher.rb
+++ b/lib/datadog/tracing/contrib/karafka/patcher.rb
@@ -49,7 +49,7 @@ module Datadog
                       auto_instrumentation: true
                     ) { |key| headers[key] }
                   rescue => e
-                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e}")
+                    Datadog.logger.debug("Error setting DSM checkpoint: #{e.class}: #{e.message}")
                   end
                 end
 

--- a/lib/datadog/tracing/contrib/mongodb/subscribers.rb
+++ b/lib/datadog/tracing/contrib/mongodb/subscribers.rb
@@ -73,7 +73,7 @@ module Datadog
             # set the resource with the quantized query
             span.resource = serialized_query
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'started' event: #{e.class}: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'started' event: #{e.class}: #{e.message}")
           end
           # rubocop:enable Metrics/AbcSize
 
@@ -85,7 +85,7 @@ module Datadog
             # the framework itself, so we set only the error and the message
             span.set_error(event)
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'failed' event: #{e.class}: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'failed' event: #{e.class}: #{e.message}")
           ensure
             # whatever happens, the Span must be removed from the local storage and
             # it must be finished to prevent any leak
@@ -101,7 +101,7 @@ module Datadog
             rows = event.reply.fetch('n', nil)
             span.set_tag(Ext::TAG_ROWS, rows) unless rows.nil?
           rescue => e
-            Datadog.logger.debug("error when handling MongoDB 'succeeded' event: #{e.class}: #{e}")
+            Datadog.logger.debug("error when handling MongoDB 'succeeded' event: #{e.class}: #{e.message}")
           ensure
             # whatever happens, the Span must be removed from the local storage and
             # it must be finished to prevent any leak

--- a/lib/datadog/tracing/contrib/opensearch/patcher.rb
+++ b/lib/datadog/tracing/contrib/opensearch/patcher.rb
@@ -84,7 +84,7 @@ module Datadog
                 span.resource = "#{method} #{quantized_url}"
                 Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
               rescue => e
-                Datadog.logger.error("#{e.class}: #{e}")
+                Datadog.logger.error("#{e.class}: #{e.message}")
                 Datadog::Core::Telemetry::Logger.report(e)
                 # TODO: Refactor the code to streamline the execution without ensure
               ensure

--- a/lib/datadog/tracing/contrib/presto/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/presto/instrumentation.rb
@@ -28,7 +28,7 @@ module Datadog
                     span.type = Tracing::Metadata::Ext::SQL::TYPE
                     span.set_tag(Ext::TAG_QUERY_ASYNC, false)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e.message}")
                   end
 
                   super(query)
@@ -46,7 +46,7 @@ module Datadog
                     span.type = Tracing::Metadata::Ext::SQL::TYPE
                     span.set_tag(Ext::TAG_QUERY_ASYNC, !blk.nil?)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e.message}")
                   end
 
                   super(query, &blk)
@@ -65,7 +65,7 @@ module Datadog
                     # ^ not an SQL type span, since there's no SQL query
                     span.set_tag(Ext::TAG_QUERY_ID, query_id)
                   rescue => e
-                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e}")
+                    Datadog.logger.debug("error preparing span for presto: #{e.class}: #{e.message}")
                   end
 
                   super(query_id)

--- a/lib/datadog/tracing/contrib/rack/patcher.rb
+++ b/lib/datadog/tracing/contrib/rack/patcher.rb
@@ -41,7 +41,7 @@ module Datadog
             # context of middleware patching outside a Rails server process (eg. a
             # process that doesn't serve HTTP requests but has Rails environment
             # loaded such as a Resque master process)
-            Datadog.logger.debug("Error patching middleware stack: #{e.class}: #{e}")
+            Datadog.logger.debug("Error patching middleware stack: #{e.class}: #{e.message}")
           end
 
           def retain_middleware_name(middleware)

--- a/lib/datadog/tracing/contrib/rack/request_queue.rb
+++ b/lib/datadog/tracing/contrib/rack/request_queue.rb
@@ -39,7 +39,7 @@ module Datadog
           rescue => e
             # in case of an Exception we don't create a
             # `request.queuing` span
-            Datadog.logger.debug("[rack] unable to parse request queue headers: #{e.class}: #{e}")
+            Datadog.logger.debug("[rack] unable to parse request queue headers: #{e.class}: #{e.message}")
             nil
           end
         end

--- a/lib/datadog/tracing/contrib/rails/log_injection.rb
+++ b/lib/datadog/tracing/contrib/rails/log_injection.rb
@@ -18,7 +18,7 @@ module Datadog
             app_config.log_tags << proc { Tracing.log_correlation if Datadog.configuration.tracing.log_injection }
           rescue => e
             Datadog.logger.warn(
-              "Unable to add Datadog Trace context to ActiveSupport::TaggedLogging: #{e.class}: #{e}"
+              "Unable to add Datadog Trace context to ActiveSupport::TaggedLogging: #{e.class}: #{e.message}"
             )
             false
           end

--- a/lib/datadog/tracing/contrib/rails/runner.rb
+++ b/lib/datadog/tracing/contrib/rails/runner.rb
@@ -86,7 +86,7 @@ module Datadog
                 # Reads one more byte than the limit to allow us to check if the source exceeds the limit.
                 source = File.read(file, MAX_TAG_VALUE_SIZE + 1)
               rescue => e
-                Datadog.logger.debug { "Failed to read file '#{file}' for Rails runner: #{e.class}: #{e}" }
+                Datadog.logger.debug { "Failed to read file '#{file}' for Rails runner: #{e.class}: #{e.message}" }
               end
 
               Tracing.trace(

--- a/lib/datadog/tracing/contrib/rake/instrumentation.rb
+++ b/lib/datadog/tracing/contrib/rake/instrumentation.rb
@@ -66,7 +66,7 @@ module Datadog
               span.set_tag(Ext::TAG_TASK_ARG_NAMES, arg_names)
               span.set_tag(Ext::TAG_INVOKE_ARGS, quantize_args(args)) unless args.nil?
             rescue => e
-              Datadog.logger.debug { "Error while tracing Rake invoke: #{e.class}: #{e}" }
+              Datadog.logger.debug { "Error while tracing Rake invoke: #{e.class}: #{e.message}" }
             end
 
             def annotate_execute!(span, args)
@@ -75,7 +75,7 @@ module Datadog
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_EXECUTE)
               span.set_tag(Ext::TAG_EXECUTE_ARGS, quantize_args(args.to_hash)) unless args.nil?
             rescue => e
-              Datadog.logger.debug { "Error while tracing Rake execute: #{e.class}: #{e}" }
+              Datadog.logger.debug { "Error while tracing Rake execute: #{e.class}: #{e.message}" }
             end
 
             def quantize_args(args)

--- a/lib/datadog/tracing/contrib/redis/quantize.rb
+++ b/lib/datadog/tracing/contrib/redis/quantize.rb
@@ -34,7 +34,7 @@ module Datadog
             str = Core::Utils.utf8_encode(arg, binary: true, placeholder: PLACEHOLDER)
             Core::Utils.truncate(str, VALUE_MAX_LEN, TOO_LONG_MARK)
           rescue => e
-            Datadog.logger.debug("non formattable Redis arg #{str}: #{e.class}: #{e}")
+            Datadog.logger.debug("non formattable Redis arg #{str}: #{e.class}: #{e.message}")
             PLACEHOLDER
           end
 

--- a/lib/datadog/tracing/contrib/redis/tags.rb
+++ b/lib/datadog/tracing/contrib/redis/tags.rb
@@ -47,7 +47,7 @@ module Datadog
 
               Contrib::SpanAttributeSchema.set_peer_service!(span, Ext::PEER_SERVICE_SOURCES)
             rescue => e
-              Datadog.logger.error("#{e.class}: #{e}")
+              Datadog.logger.error("#{e.class}: #{e.message}")
               Datadog::Core::Telemetry::Logger.report(e)
             end
 

--- a/lib/datadog/tracing/contrib/sidekiq/utils.rb
+++ b/lib/datadog/tracing/contrib/sidekiq/utils.rb
@@ -25,7 +25,7 @@ module Datadog
               job['class'].to_s
             end
           rescue => e
-            Datadog.logger.debug { "Error retrieving Sidekiq job class name (jid:#{job["jid"]}): #{e.class}: #{e}" }
+            Datadog.logger.debug { "Error retrieving Sidekiq job class name (jid:#{job["jid"]}): #{e.class}: #{e.message}" }
 
             job['class'].to_s
           end

--- a/lib/datadog/tracing/contrib/stripe/request.rb
+++ b/lib/datadog/tracing/contrib/stripe/request.rb
@@ -55,7 +55,7 @@ module Datadog
             span.set_tag(Ext::TAG_REQUEST_PATH, event.path)
             span.set_tag(Ext::TAG_REQUEST_NUM_RETRIES, event.num_retries.to_s)
           rescue => e
-            Datadog.logger.debug { "#{e.class}: #{e}" }
+            Datadog.logger.debug { "#{e.class}: #{e.message}" }
           end
 
           def configuration

--- a/lib/datadog/tracing/diagnostics/environment_logger.rb
+++ b/lib/datadog/tracing/diagnostics/environment_logger.rb
@@ -25,7 +25,7 @@ module Datadog
           end
         rescue => e
           logger.warn(
-            "Failed to collect tracing environment information: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+            "Failed to collect tracing environment information: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
           )
         end
       end

--- a/lib/datadog/tracing/distributed/baggage.rb
+++ b/lib/datadog/tracing/distributed/baggage.rb
@@ -77,7 +77,7 @@ module Datadog
             # Record telemetry for successful injection
             record_telemetry_metric('context_header_style.injected', 1, {'header_style' => 'baggage'})
           rescue => e
-            ::Datadog.logger.warn("Failed to encode and inject baggage header: #{e.class}: #{e}")
+            ::Datadog.logger.warn("Failed to encode and inject baggage header: #{e.class}: #{e.message}")
           end
         end
 

--- a/lib/datadog/tracing/distributed/datadog.rb
+++ b/lib/datadog/tracing/distributed/datadog.rb
@@ -140,7 +140,7 @@ module Datadog
         rescue => e
           set_tags_propagation_error(reason: 'encoding_error')
           ::Datadog.logger.warn(
-            "Failed to inject x-datadog-tags: #{e.class}: #{e} at #{Array(e.backtrace).first}"
+            "Failed to inject x-datadog-tags: #{e.class}: #{e.message} at #{Array(e.backtrace).first}"
           )
           nil
         end
@@ -167,7 +167,7 @@ module Datadog
         rescue => e
           set_tags_propagation_error(reason: 'decoding_error')
           ::Datadog.logger.warn(
-            "Failed to extract x-datadog-tags: #{e.class}: #{e} at #{Array(e.backtrace).first}"
+            "Failed to extract x-datadog-tags: #{e.class}: #{e.message} at #{Array(e.backtrace).first}"
           )
           nil
         end

--- a/lib/datadog/tracing/distributed/datadog_tags_codec.rb
+++ b/lib/datadog/tracing/distributed/datadog_tags_codec.rb
@@ -41,7 +41,7 @@ module Datadog
             "#{key}=#{value.strip}"
           end.join(',')
         rescue => e
-          raise EncodingError, "Error encoding tags `#{tags}`: `#{e.class}: #{e}`"
+          raise EncodingError, "Error encoding tags `#{tags}`: `#{e.class}: #{e.message}`"
         end
 
         # Deserializes a `x-datadog-tags`-formatted String into a {Hash<String,String>}.

--- a/lib/datadog/tracing/distributed/propagation.rb
+++ b/lib/datadog/tracing/distributed/propagation.rb
@@ -76,7 +76,7 @@ module Datadog
           rescue => e
             result = nil
             ::Datadog.logger.error(
-              "Error injecting distributed trace data. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+              "Error injecting distributed trace data. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
             )
             ::Datadog::Core::Telemetry::Logger.report(
               e,
@@ -139,7 +139,7 @@ module Datadog
           rescue => e
             # TODO: Not to report Telemetry logs for now
             ::Datadog.logger.error(
-              "Error extracting distributed trace data. Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+              "Error extracting distributed trace data. Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
             )
           end
           # Handle baggage after all other styles if present

--- a/lib/datadog/tracing/event.rb
+++ b/lib/datadog/tracing/event.rb
@@ -62,7 +62,7 @@ module Datadog
           block.call(*args)
         rescue => e
           Datadog.logger.debug do
-            "Error while handling '#{name}' event with '#{block}': #{e.class}: #{e} " \
+            "Error while handling '#{name}' event with '#{block}': #{e.class}: #{e.message} " \
             "at #{Array(e.backtrace).first}"
           end
         end

--- a/lib/datadog/tracing/metadata/tagging.rb
+++ b/lib/datadog/tracing/metadata/tagging.rb
@@ -52,7 +52,7 @@ module Datadog
             meta[Core::Utils.utf8_encode(key)] = Core::Utils.utf8_encode(value)
           end
         rescue => e
-          Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e.class}: #{e}")
+          Datadog.logger.debug("Unable to set the tag #{key}, ignoring it. Caused by: #{e.class}: #{e.message}")
         end
 
         # Sets tags from given hash, for each key in hash it sets the tag with that key
@@ -102,7 +102,7 @@ module Datadog
           # Encode strings in UTF-8 to facilitate downstream serialization
           metrics[Core::Utils.utf8_encode(key)] = value
         rescue => e
-          Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e.class}: #{e}")
+          Datadog.logger.debug("Unable to set the metric #{key}, ignoring it. Caused by: #{e.class}: #{e.message}")
         end
 
         # This method removes a metric for the given key. It acts like {#clear_tag}.

--- a/lib/datadog/tracing/pipeline.rb
+++ b/lib/datadog/tracing/pipeline.rb
@@ -51,7 +51,7 @@ module Datadog
         end
       rescue => e
         Datadog.logger.debug(
-          "trace dropped entirely due to `Pipeline.before_flush` error: #{e.class}: #{e}"
+          "trace dropped entirely due to `Pipeline.before_flush` error: #{e.class}: #{e.message}"
         )
 
         nil

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -43,7 +43,7 @@ module Datadog
 
           Datadog.send(:components).telemetry.client_configuration_change!(env_vars)
         rescue => e
-          content.errored("#{e.class}: #{e}: #{Array(e.backtrace).join("\n")}")
+          content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
         end
 
         def receivers(_telemetry)

--- a/lib/datadog/tracing/sampling/rule.rb
+++ b/lib/datadog/tracing/sampling/rule.rb
@@ -34,7 +34,7 @@ module Datadog
           @matcher.match?(trace)
         rescue => e
           Datadog.logger.error(
-            "Matcher failed. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Matcher failed. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           Datadog::Core::Telemetry::Logger.report(e, description: 'Matcher failed')
           nil

--- a/lib/datadog/tracing/sampling/rule_sampler.rb
+++ b/lib/datadog/tracing/sampling/rule_sampler.rb
@@ -85,7 +85,7 @@ module Datadog
           new(parsed_rules, rate_limit: rate_limit, default_sample_rate: default_sample_rate)
         rescue => e
           Datadog.logger.warn do
-            "Could not parse trace sampling rules '#{rules}': #{e.class}: #{e} at #{Array(e.backtrace).first}"
+            "Could not parse trace sampling rules '#{rules}': #{e.class}: #{e.message} at #{Array(e.backtrace).first}"
           end
 
           nil
@@ -133,7 +133,7 @@ module Datadog
           apply_rule!(trace, rule)
         rescue => e
           Datadog.logger.error(
-            "Rule sampling failed. Cause: #{e.class}: #{e} Source: #{Array(e.backtrace).first}"
+            "Rule sampling failed. Cause: #{e.class}: #{e.message} Source: #{Array(e.backtrace).first}"
           )
           Datadog::Core::Telemetry::Logger.report(e, description: 'Rule sampling failed')
 

--- a/lib/datadog/tracing/sampling/span/rule_parser.rb
+++ b/lib/datadog/tracing/sampling/span/rule_parser.rb
@@ -29,7 +29,7 @@ module Datadog
               rescue => e
                 Datadog.logger.warn(
                   "Error parsing Span Sampling Rules `#{rules.inspect}`: " \
-                  "#{e.class}: #{e} at #{Array(e.backtrace).first}"
+                  "#{e.class}: #{e.message} at #{Array(e.backtrace).first}"
                 )
                 return nil
               end
@@ -61,7 +61,7 @@ module Datadog
                 rescue => e
                   Datadog.logger.warn(
                     "Cannot parse Span Sampling Rule #{hash.inspect}: " \
-                    "#{e.class}: #{e} at #{Array(e.backtrace).first}"
+                    "#{e.class}: #{e.message} at #{Array(e.backtrace).first}"
                   )
                   return nil
                 end

--- a/lib/datadog/tracing/span_operation.rb
+++ b/lib/datadog/tracing/span_operation.rb
@@ -158,7 +158,7 @@ module Datadog
           begin
             start
           rescue => e
-            logger.debug { "Failed to start span: #{e.class}: #{e}" }
+            logger.debug { "Failed to start span: #{e.class}: #{e.message}" }
           ensure
             # We should yield to the provided block when possible, as this
             # block is application code that we don't want to hinder.
@@ -459,7 +459,7 @@ module Datadog
             rescue => e
               logger.debug do
                 "Custom on_error handler #{@handler} failed, using fallback behavior. \
-                  Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+                  Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
               end
 
               original&.call(op, error)
@@ -471,7 +471,7 @@ module Datadog
               @handler.call(*args)
             rescue => e
               logger.debug do
-                "Error in on_error handler '#{@handler}': #{e.class}: #{e} at #{Array(e.backtrace).first}"
+                "Error in on_error handler '#{@handler}': #{e.class}: #{e.message} at #{Array(e.backtrace).first}"
               end
             end
 

--- a/lib/datadog/tracing/trace_operation.rb
+++ b/lib/datadog/tracing/trace_operation.rb
@@ -181,7 +181,7 @@ module Datadog
 
         events.trace_resource_change.publish(self)
       rescue => e
-        logger.debug { "Error updating trace resource: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error updating trace resource: #{e.class}: #{e.message} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       def name
@@ -322,7 +322,7 @@ module Datadog
           id: id
         )
       rescue => e
-        logger.debug { "Failed to build new span: #{e.class}: #{e}" }
+        logger.debug { "Failed to build new span: #{e.class}: #{e.message}" }
 
         # Return dummy span
         SpanOperation.new(op_name, logger: logger)
@@ -543,7 +543,7 @@ module Datadog
         # Publish :span_before_start event
         events.span_before_start.publish(span_op, self)
       rescue => e
-        logger.debug { "Error starting span on trace: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error starting span on trace: #{e.class}: #{e.message} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       # For traces with automatic context management (auto_finish),
@@ -572,7 +572,7 @@ module Datadog
         # Publish :trace_finished event
         events.trace_finished.publish(self) if finished?
       rescue => e
-        logger.debug { "Error finishing span on trace: #{e.class}: #{e} Backtrace: #{e.backtrace.first(3)}" }
+        logger.debug { "Error finishing span on trace: #{e.class}: #{e.message} Backtrace: #{e.backtrace.first(3)}" }
       end
 
       # Track the root {SpanOperation} object from the current execution context.

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -153,7 +153,7 @@ module Datadog
             active_trace
           end
         rescue => e
-          logger.debug { "Failed to trace: #{e.class}: #{e}" }
+          logger.debug { "Failed to trace: #{e.class}: #{e.message}" }
 
           # Tracing failed: fallback and run code without tracing.
           return skip_trace(name, &block)
@@ -303,7 +303,7 @@ module Datadog
         @sampler.sample!(trace_op) if trace_op.sampling_priority.nil?
       rescue => e
         SAMPLE_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample trace: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample trace: #{e.class}: #{e.message} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -315,7 +315,7 @@ module Datadog
       rescue => e
         RECONSIDER_RESOURCE_SAMPLE_TRACE_LOG_ONLY_ONCE.run do
           logger.warn do
-            "Failed to reconsider trace sampling: #{e.class}: #{e} at #{Array(e.backtrace).first}"
+            "Failed to reconsider trace sampling: #{e.class}: #{e.message} at #{Array(e.backtrace).first}"
           end
         end
       end
@@ -563,7 +563,7 @@ module Datadog
         @span_sampler.sample!(trace_op, span)
       rescue => e
         SAMPLE_SPAN_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to sample span: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to sample span: #{e.class}: #{e.message} at #{Array(e.backtrace).first}" }
         end
       end
 
@@ -576,7 +576,7 @@ module Datadog
         write(trace) if trace && !trace.empty?
       rescue => e
         FLUSH_TRACE_LOG_ONLY_ONCE.run do
-          logger.warn { "Failed to flush trace: #{e.class}: #{e} at #{Array(e.backtrace).first}" }
+          logger.warn { "Failed to flush trace: #{e.class}: #{e.message} at #{Array(e.backtrace).first}" }
         end
       end
 

--- a/lib/datadog/tracing/transport/io/client.rb
+++ b/lib/datadog/tracing/transport/io/client.rb
@@ -44,7 +44,7 @@ module Datadog
             response
           rescue => e
             message =
-              "Internal error during IO transport request. Cause: #{e.class}: #{e} " \
+              "Internal error during IO transport request. Cause: #{e.class}: #{e.message} " \
                 "Location: #{Array(e.backtrace).first}"
 
             # Log error

--- a/lib/datadog/tracing/workers.rb
+++ b/lib/datadog/tracing/workers.rb
@@ -59,7 +59,7 @@ module Datadog
             # a fatal exception
             logger.warn(
               "Error during traces flush: dropped #{traces.length} items. " \
-              "Cause: #{e.class}: #{e} Location: #{Array(e.backtrace).first}"
+              "Cause: #{e.class}: #{e.message} Location: #{Array(e.backtrace).first}"
             )
           end
         end

--- a/rubocop/custom_cops/README.md
+++ b/rubocop/custom_cops/README.md
@@ -149,7 +149,9 @@ The `CustomCops::ExceptionMessageCop` enforces consistent exception logging form
 
 ### Purpose
 
-`Exception#to_s` and `Exception#message` have different contracts in Ruby. Subclasses can override them independently, and `to_s` is the method Ruby calls during string interpolation (`"#{e}"`). Using `e.message` directly can produce different output than `#{e}` when a subclass overrides one without the other. The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by detecting `e.message`, `e.class.name`, and bare `#{e}` without `#{e.class}` inside rescue blocks.
+`Exception#to_s` and `Exception#message` have different contracts in Ruby. `Exception#to_s` reads the message ivar directly and returns the class name when it's nil. `Exception#message` calls `to_s` by default — but exception subclasses commonly override `message` to compute a string from instance variables (Bundler, Rails ActionView/ActiveSupport, RubyGems, and several classes inside this gem do this). When `message` is overridden without a matching `to_s` override, `e.to_s` (and therefore `"#{e}"`) returns just the class name, while `e.message` returns the actual error string.
+
+The codebase convention is `"#{e.class}: #{e.message}"`. This cop enforces it by detecting `e.class.name` and bare `#{e}` interpolations inside rescue blocks, and by requiring `#{e.class}` alongside any exception interpolation.
 
 ### Examples
 
@@ -157,27 +159,29 @@ The `CustomCops::ExceptionMessageCop` enforces consistent exception logging form
 
 ```ruby
 rescue => e
-  log("#{e.class.name}: #{e.message}")
-  log("#{e.class.name} #{e.message}")
-  log("error: #{e.message}")
-  log("error: #{e}")           # missing class name
+  log("#{e.class.name}: #{e.message}")  # e.class.name should be e.class
+  log("#{e.class}: #{e}")               # bare #{e} should be #{e.message}
+  log("error: #{e.message}")            # missing class name
+  log("error: #{e}")                    # both: bare e and missing class
 ```
 
 #### Good
 
 ```ruby
 rescue => e
-  log("#{e.class}: #{e}")
+  log("#{e.class}: #{e.message}")
 ```
 
 ### Auto-correction
 
 The cop auto-corrects within string interpolation only:
 
-- `#{e.message}` → `#{e}`
+- `#{e}` → `#{e.message}`
 - `#{e.class.name}` → `#{e.class}`
 
-Outside interpolation (e.g., `log(e.message)`), the cop flags the offense but does not auto-correct, since the replacement may change semantics.
+The missing-`#{e.class}` rule is not auto-corrected — it requires a human to choose where the class name belongs in the surrounding text.
+
+Outside interpolation (e.g., `log(e.class.name)`), the cop flags the offense but does not auto-correct, since the replacement may change semantics.
 
 ### Testing
 

--- a/rubocop/custom_cops/exception_message_cop.rb
+++ b/rubocop/custom_cops/exception_message_cop.rb
@@ -4,50 +4,49 @@ module CustomCops
   # Custom cop that enforces consistent exception logging format.
   #
   # `Exception#to_s` and `Exception#message` have different contracts in Ruby.
-  # Subclasses can override them independently, and `to_s` is the method Ruby
-  # calls during string interpolation (`"#{e}"`). Using `e.message` directly
-  # can produce different output than `#{e}` when a subclass overrides one
-  # without the other.
+  # `Exception#to_s` reads the message ivar directly and returns the class name
+  # when it's nil. `Exception#message` calls `to_s` by default — but exception
+  # subclasses commonly override `message` to compute a string from instance
+  # variables (Bundler, Rails ActionView/ActiveSupport, RubyGems, and several
+  # classes inside this gem do this). When `message` is overridden without a
+  # matching `to_s` override, `e.to_s` (and therefore `"#{e}"`) returns just
+  # the class name, while `e.message` returns the actual error string.
   #
-  # The codebase convention is `"#{e.class}: #{e}"`. This cop enforces it by
-  # detecting `e.message` and `e.class.name` inside rescue blocks.
-  #
-  # @safety
-  #   This cop's autocorrection is unsafe because `e.message` and `e.to_s`
-  #   can differ if a custom exception overrides `to_s` without overriding
-  #   `message`, or vice versa. The convention prefers `to_s` (via interpolation).
+  # The codebase convention is `"#{e.class}: #{e.message}"`. This cop enforces
+  # it by detecting bare `"#{e}"` interpolations and `e.class.name` inside
+  # rescue blocks.
   #
   # @example
   #   # bad
   #   rescue => e
   #     log("#{e.class.name}: #{e.message}")
-  #     log("#{e.class.name} #{e.message}")
-  #     log("error: #{e.message}")
-  #     log("error: #{e}")           # missing class name
+  #     log("#{e.class}: #{e}")            # bare e -- loses overridden message
+  #     log("error: #{e}")                 # also missing class name
   #
   #   # good
   #   rescue => e
-  #     log("#{e.class}: #{e}")
+  #     log("#{e.class}: #{e.message}")
   class ExceptionMessageCop < RuboCop::Cop::Base
     extend RuboCop::Cop::AutoCorrector
 
     # rubocop:disable Lint/InterpolationCheck
-    MSG_MESSAGE = 'Use the exception directly instead of `.message`. ' \
-                  '`to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.'
+    MSG_BARE_EXCEPTION = 'Use `e.message` instead of bare `#{e}` interpolation. ' \
+                         '`#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.'
 
     MSG_CLASS_NAME = 'Use `.class` instead of `.class.name`. ' \
                      '`Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.'
 
     MSG_MISSING_CLASS = 'Include `#{e.class}` when interpolating an exception. ' \
-                        'The convention is `"#{e.class}: #{e}"`.'
+                        'The convention is `"#{e.class}: #{e.message}"`.'
     # rubocop:enable Lint/InterpolationCheck
 
-    # Detect bare `#{e}` without `#{e.class}` in the same string
+    # Detect bare `#{e}` (use-message offense) and missing `#{e.class}` in the same string
     def on_dstr(node)
       return unless inside_rescue?(node)
 
-      rescue_vars_in_string = []
-      has_class_call = {}
+      bare_exception_lvars = []
+      message_call_nodes = []
+      class_call_vars = {}
 
       node.children.each do |child|
         next unless child.begin_type?
@@ -56,53 +55,65 @@ module CustomCops
         next unless expr
 
         if expr.lvar_type? && rescue_variable?(expr)
-          rescue_vars_in_string << expr
+          bare_exception_lvars << expr
+        elsif exception_message_call?(expr) && rescue_variable?(expr.receiver)
+          message_call_nodes << expr
         elsif class_reference?(expr)
           var_node = class_reference_variable(expr)
-          has_class_call[var_node.children.first] = true if var_node
+          class_call_vars[var_node.children.first] = true if var_node
         end
       end
 
-      rescue_vars_in_string.each do |var_node|
-        var_name = var_node.children.first
-        next if has_class_call[var_name]
+      bare_exception_lvars.each do |var_node|
+        add_offense(var_node, message: MSG_BARE_EXCEPTION) do |corrector|
+          corrector.replace(var_node, "#{var_node.source}.message")
+        end
+      end
 
-        add_offense(var_node, message: MSG_MISSING_CLASS)
+      # Missing-class check: any exception interpolation (bare or .message) in
+      # this string requires a matching `#{e.class}` somewhere in the string.
+      # Report once per offending variable name; the offense lands on the bare
+      # lvar (when present) or the full `e.message` send (when only that form
+      # appears) so the highlight covers the offending interpolation.
+      reported_names = {}
+      candidates = bare_exception_lvars + message_call_nodes
+      candidates.each do |target|
+        var_name =
+          if target.lvar_type?
+            target.children.first
+          else
+            target.receiver.children.first
+          end
+        next if class_call_vars[var_name]
+        next if reported_names[var_name]
+
+        reported_names[var_name] = true
+        add_offense(target, message: MSG_MISSING_CLASS)
       end
     end
 
-    # Detect `e.message` and `e.class.name` where `e` is a rescue variable
+    # Detect `e.class.name` where `e` is a rescue variable
     # @!method on_send
     def on_send(node)
       return unless inside_rescue?(node)
+      return unless exception_class_name_call?(node)
 
-      if exception_message_call?(node)
-        variable = node.receiver
-        return unless rescue_variable?(variable)
+      class_call = node.receiver
+      variable = class_call.receiver
+      return unless rescue_variable?(variable)
 
-        add_offense(node, message: MSG_MESSAGE) do |corrector|
-          if inside_interpolation?(node)
-            corrector.replace(node, variable.source)
-          end
-        end
-      elsif exception_class_name_call?(node)
-        class_call = node.receiver
-        variable = class_call.receiver
-        return unless rescue_variable?(variable)
-
-        add_offense(node, message: MSG_CLASS_NAME) do |corrector|
-          if inside_interpolation?(node)
-            corrector.replace(node, class_call.source)
-          end
+      add_offense(node, message: MSG_CLASS_NAME) do |corrector|
+        if inside_interpolation?(node)
+          corrector.replace(node, class_call.source)
         end
       end
     end
 
     private
 
-    # Check if this is `e.message`
+    # Check if this is `e.message` (no args) on a local variable
     def exception_message_call?(node)
-      node.send_type? &&
+      node&.send_type? &&
         node.method_name == :message &&
         node.arguments.empty? &&
         node.receiver&.lvar_type?
@@ -121,7 +132,7 @@ module CustomCops
 
     # Check if a variable node is bound by a rescue clause
     def rescue_variable?(node)
-      return false unless node.lvar_type?
+      return false unless node&.lvar_type?
 
       var_name = node.children.first
       rescue_node = find_rescue_ancestor(node)
@@ -216,7 +227,7 @@ module CustomCops
       parent = node.parent
       return false unless parent
 
-      # Direct interpolation: #{e.message}
+      # Direct interpolation: #{e.class.name}
       if parent.begin_type? && parent.parent&.dstr_type?
         return true
       end

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -9,14 +9,14 @@ require 'rubocop/custom_cops/exception_message_cop'
 RSpec.describe CustomCops::ExceptionMessageCop do
   subject(:cop) { described_class.new }
 
-  describe 'e.message detection' do
-    it 'registers an offense for e.message in string interpolation and auto-corrects' do
+  describe 'bare exception interpolation' do
+    it 'registers an offense for bare #{e} in interpolation and auto-corrects to .message' do
       expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("#{e.message}")
-                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+          log("#{e.class}: #{e}")
+                             ^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
         end
       RUBY
 
@@ -24,18 +24,18 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("#{e}")
+          log("#{e.class}: #{e.message}")
         end
       RUBY
     end
 
-    it 'registers an offense for e.message in a longer interpolated string and auto-corrects' do
+    it 'registers an offense for bare #{e} in a longer interpolated string and auto-corrects' do
       expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("error: #{e.class}: #{e.message}")
-                                    ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+          log("#{e.class} happened: #{e}")
+                                      ^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
         end
       RUBY
 
@@ -43,37 +43,35 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("error: #{e.class}: #{e}")
+          log("#{e.class} happened: #{e.message}")
         end
       RUBY
-    end
-
-    it 'registers an offense for e.message outside interpolation but does not auto-correct' do
-      expect_offense(<<~'RUBY')
-        begin
-          something
-        rescue => e
-          log(e.message)
-              ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
-        end
-      RUBY
-
-      expect_no_corrections
     end
 
     it 'does not register an offense outside a rescue block' do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~'RUBY')
         e = SomeObject.new
-        log(e.message)
+        log("#{e}")
       RUBY
     end
 
-    it 'does not register an offense for message with arguments' do
+    it 'does not register an offense for `e.message` (the preferred form)' do
+      expect_no_offenses(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          log("#{e.class}: #{e.message}")
+        end
+      RUBY
+    end
+
+    it 'does not flag bare `e` outside string interpolation' do
+      # `raise e`, `log(e)`, etc. are valid uses of the rescue variable.
       expect_no_offenses(<<~RUBY)
         begin
           something
         rescue => e
-          log(e.message(:detailed))
+          raise e
         end
       RUBY
     end
@@ -85,7 +83,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("#{e.class.name}: #{e}")
+          log("#{e.class.name}: #{e.message}")
                  ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
@@ -94,7 +92,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("#{e.class}: #{e}")
+          log("#{e.class}: #{e.message}")
         end
       RUBY
     end
@@ -121,13 +119,13 @@ RSpec.describe CustomCops::ExceptionMessageCop do
   end
 
   describe 'combined patterns' do
-    it 'registers offenses for both e.class.name and e.message in one string' do
+    it 'registers offenses for both e.class.name and bare e and auto-corrects both' do
       expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
-          log("#{e.class.name} #{e.message}")
-                                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+          log("#{e.class.name} #{e}")
+                                 ^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
                  ^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
@@ -136,7 +134,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("#{e.class} #{e}")
+          log("#{e.class} #{e.message}")
         end
       RUBY
     end
@@ -156,7 +154,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          errors.each { |e| log("#{e.message}") }
+          errors.each { |e| log("#{e}") }
         end
       RUBY
     end
@@ -166,7 +164,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          pairs.each { |(k, e)| log("#{e.message}") }
+          pairs.each { |(k, e)| log("#{e}") }
         end
       RUBY
     end
@@ -176,7 +174,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          errors.each { |e| log("error: #{e}") }
+          errors.each { |e| log("error: #{e.message}") }
         end
       RUBY
     end
@@ -187,7 +185,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
           something
         rescue => e
           define_method(:helper) do |e|
-            log("#{e.message}")
+            log("#{e}")
           end
         end
       RUBY
@@ -199,8 +197,8 @@ RSpec.describe CustomCops::ExceptionMessageCop do
           something
         rescue => e
           errors.each { |e| log(e) }
-          log("#{e.message}")
-                 ^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+          log("#{e.class}: #{e}")
+                             ^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
         end
       RUBY
     end
@@ -212,8 +210,8 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => err
-          log("#{err.message}")
-                 ^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use the exception directly instead of `.message`. `to_s` and `message` have different contracts; `#{e}` calls `to_s`, which is the convention.
+          log("#{err.class}: #{err}")
+                               ^^^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
         end
       RUBY
 
@@ -221,7 +219,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => err
-          log("#{err}")
+          log("#{err.class}: #{err.message}")
         end
       RUBY
     end
@@ -231,7 +229,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => err
-          log("#{err.class.name}")
+          log("#{err.class.name}: #{err.message}")
                  ^^^^^^^^^^^^^^ CustomCops/ExceptionMessageCop: Use `.class` instead of `.class.name`. `Class#to_s` already returns the name; the extra `.name` call is redundant in interpolation.
         end
       RUBY
@@ -240,56 +238,67 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => err
-          log("#{err.class}")
+          log("#{err.class}: #{err.message}")
         end
       RUBY
     end
   end
 
   describe 'missing class detection' do
-    it 'registers an offense for bare exception without class in interpolation' do
+    it 'flags bare `#{e}` first; the missing-class offense surfaces on a second pass after autocorrect' do
+      # RuboCop deduplicates offenses on the same node, so the first pass shows
+      # only the bare-exception offense. After autocorrect to `e.message`, a
+      # subsequent pass flags the still-missing class — verified in the next test.
       expect_offense(<<~'RUBY')
         begin
           something
         rescue => e
           log("error: #{e}")
-                        ^ CustomCops/ExceptionMessageCop: Include `#{e.class}` when interpolating an exception. The convention is `"#{e.class}: #{e}"`.
+                        ^ CustomCops/ExceptionMessageCop: Use `e.message` instead of bare `#{e}` interpolation. `#{e}` calls `to_s`, which bypasses `message` overrides on subclasses.
+        end
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        begin
+          something
+        rescue => e
+          log("error: #{e.message}")
         end
       RUBY
     end
 
-    it 'registers an offense for bare exception with different variable name' do
+    it 'registers a missing-class offense for `#{e.message}` without class' do
       expect_offense(<<~'RUBY')
         begin
           something
-        rescue => err
-          log("error: #{err}")
-                        ^^^ CustomCops/ExceptionMessageCop: Include `#{e.class}` when interpolating an exception. The convention is `"#{e.class}: #{e}"`.
+        rescue => e
+          log("error: #{e.message}")
+                        ^^^^^^^^^ CustomCops/ExceptionMessageCop: Include `#{e.class}` when interpolating an exception. The convention is `"#{e.class}: #{e.message}"`.
         end
       RUBY
     end
 
-    it 'does not register an offense when class is present in the same string' do
+    it 'does not register a missing-class offense when class is present in the same string' do
       expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
-          log("#{e.class}: #{e}")
+          log("#{e.class}: #{e.message}")
         end
       RUBY
     end
 
-    it 'does not register an offense when class is present elsewhere in the same string' do
+    it 'does not register a missing-class offense when class is present elsewhere in the same string' do
       expect_no_offenses(<<~'RUBY')
         begin
           something
         rescue => e
-          log("#{e.class} happened: #{e}")
+          log("#{e.class} happened: #{e.message}")
         end
       RUBY
     end
 
-    it 'does not register an offense outside a rescue block' do
+    it 'does not register a missing-class offense outside a rescue block' do
       expect_no_offenses(<<~'RUBY')
         e = SomeObject.new
         log("error: #{e}")
@@ -303,7 +312,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
         begin
           something
         rescue => e
-          log("#{e.class}: #{e}")
+          log("#{e.class}: #{e.message}")
         end
       RUBY
     end

--- a/spec/rubocop/exception_message_cop_spec.rb
+++ b/spec/rubocop/exception_message_cop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
   subject(:cop) { described_class.new }
 
   describe 'bare exception interpolation' do
-    it 'registers an offense for bare #{e} in interpolation and auto-corrects to .message' do
+    it 'registers an offense for bare #{e} in interpolation and auto-corrects to .message' do # rubocop:disable Lint/InterpolationCheck
       expect_offense(<<~'RUBY')
         begin
           something
@@ -29,7 +29,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
       RUBY
     end
 
-    it 'registers an offense for bare #{e} in a longer interpolated string and auto-corrects' do
+    it 'registers an offense for bare #{e} in a longer interpolated string and auto-corrects' do # rubocop:disable Lint/InterpolationCheck
       expect_offense(<<~'RUBY')
         begin
           something
@@ -245,7 +245,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
   end
 
   describe 'missing class detection' do
-    it 'flags bare `#{e}` first; the missing-class offense surfaces on a second pass after autocorrect' do
+    it 'flags bare `#{e}` first; the missing-class offense surfaces on a second pass after autocorrect' do # rubocop:disable Lint/InterpolationCheck
       # RuboCop deduplicates offenses on the same node, so the first pass shows
       # only the bare-exception offense. After autocorrect to `e.message`, a
       # subsequent pass flags the still-missing class — verified in the next test.
@@ -267,7 +267,7 @@ RSpec.describe CustomCops::ExceptionMessageCop do
       RUBY
     end
 
-    it 'registers a missing-class offense for `#{e.message}` without class' do
+    it 'registers a missing-class offense for `#{e.message}` without class' do # rubocop:disable Lint/InterpolationCheck
       expect_offense(<<~'RUBY')
         begin
           something


### PR DESCRIPTION
**What does this PR do?**

Inverts [`CustomCops::ExceptionMessageCop`](rubocop/custom_cops/exception_message_cop.rb) so it enforces `e.message` over bare `#{e}` interpolation, and applies the autocorrect across `lib/**/*` (90 files). The previous direction (`e.message` → `e`) shipped in [#5582](https://github.com/DataDog/dd-trace-rb/pull/5582).

The cop now:
- flags bare `#{e}` in rescue-block interpolation, autocorrects to `#{e.message}`
- keeps flagging `e.class.name` → `e.class`
- requires `#{e.class}` alongside any exception interpolation (bare or `.message`); not autocorrected since placement is contextual

**Motivation:**

[@eregon flagged](https://github.com/DataDog/dd-trace-rb/pull/5582#pullrequestreview-4220684767) that `e.to_s` and `e.message` have asymmetric semantics in CRuby:

- `Exception#to_s` reads `@mesg` directly via `rb_attr_get` ([`error.c:1574-1581`](https://github.com/ruby/ruby/blob/master/error.c)) — does not call `message`.
- `Exception#message` calls `self.to_s` ([`error.c:1754-1758`](https://github.com/ruby/ruby/blob/master/error.c)).

So overriding `message` is invisible to `to_s` and string interpolation, but overriding `to_s` is visible to `message`. Verified empirically on Ruby 3.2.3.

**Implication:** `e.message` is correct for every override pattern:
- override `message` only → `message` returns the override; `to_s` returns just the class name (or the `@mesg` ivar if `super(msg)` was called)
- override `to_s` only → both return the override, since `Exception#message` is implemented as `rb_funcallv(exc, idTo_s, 0, 0)` ([CRuby `error.c`](https://docs.ruby-lang.org/en/master/Exception.html#method-i-message); [same in TruffleRuby](https://github.com/truffleruby/truffleruby/blob/db85920d7dc78a66e302da8a3a141e410c8df9fb/src/main/ruby/truffleruby/core/exception.rb#L45-L53))
- override both → each accessor returns its respective override

In all three cases, `e.message` is at least as correct as `e.to_s`.

A survey of popular Ruby libraries shows override-`message` is the dominant idiom:

| Repo | classes overriding `message` | classes overriding `to_s` |
|---|---|---|
| [Bundler](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/errors.rb) | 11 (`PermissionError` family, `ChecksumMismatchError`, etc. — set ivars in `initialize`, no `super(msg)`) | 1 ([`DSLError`](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/dsl.rb)) |
| Rails | 3 substantive ([`WrongEncodingError`](https://github.com/rails/rails/blob/main/actionview/lib/action_view/template/error.rb), [`InvalidContentError`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/encrypted_configuration.rb), `SyntaxErrorInTemplate`) | 0 |
| RubyGems | 2 ([`RuntimeRequirementNotMetError`](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/exceptions.rb), [`MissingSpecError`](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/errors.rb) — decorate via super) | 3 ([`FetchError`](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/remote_fetcher.rb) decoration) |
| dd-trace-rb itself | 8 ([`builder.rb`](lib/datadog/core/transport/http/builder.rb), [`transport.rb`](lib/datadog/core/transport/transport.rb), [`span_operation.rb`](lib/datadog/tracing/span_operation.rb)) | 1 ([`AIGuardAbortError`](lib/datadog/ai_guard.rb)) |

For each of these `message`-override classes, `e.to_s` returns just the class name. Confirmed standalone for Bundler's `PermissionError`: `e.message` returns the advisory string, `e.to_s` returns `"PermissionError"`. Under the previous cop, `"#{e.class}: #{e}"` on one of dd-trace-rb's own [`UnknownApiError`](lib/datadog/core/transport/http/builder.rb) renders the class name twice and drops the message.

The lone counterexample is [Stripe's `StripeError`](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/errors.rb), which uses `attr_reader :message` and decorates `to_s` with HTTP status — there `to_s` is strictly richer. Mongo's [`Notable#to_s`](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/error/notable.rb) decoration is symmetric (both accessors return the decorated form because `Exception#message` calls `to_s`), so it doesn't argue for either direction.

Ruby's own [exceptions doc](https://github.com/ruby/ruby/blob/master/doc/language/exceptions.md) treats `Exception#message` as the canonical accessor: *"This method returns the message as defined: `Exception#message`."*

**Change log entry**

None.

**Additional Notes:**

- Rebases cleanly on master ([#5582](https://github.com/DataDog/dd-trace-rb/pull/5582) is the immediate predecessor).
- Codebase apply is in a separate commit so the policy change can be reviewed independently of the mechanical edits.
- Two existing inline disables continue to apply: [`action_pack/instrumentation.rb`](lib/datadog/tracing/contrib/action_pack/action_controller/instrumentation.rb) intentionally uses `e.class.name` for the Rails `payload[:exception]` array convention; the disable still scopes correctly under the inverted cop.

**How to test the change?**

```bash
bundle exec rake spec:custom_cop
```

23 examples cover: bare-`e` autocorrect, `e.class.name` autocorrect, missing-class detection on both bare and `.message` forms, variable shadowing (block params, destructured params, `def` boundaries), and rescue-variable name variants.
