### PR TITLE
Reproduce flaky: symdb RC integration tests

### DIFF
--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
     # tests don't wait the production 5 seconds.
     Datadog::SymbolDatabase::Component.reset_uploaded_this_process_for_tests!
     stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0.05)
+
+    # REPRODUCER: simulate slow extract_all (heavily-loaded ObjectSpace in CI)
+    # to exceed the wait_for_idle(timeout: 5) window. Mirrors the Ruby 2.6 [1]
+    # core_old shard failure mode where extraction takes >5s due to thousands
+    # of modules loaded after ~5000 prior tests in the same process.
+    allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all).and_wrap_original do |original|
+      sleep 6
+      original.call
+    end
   end
 
   # Load test code in a temp dir (not /spec/) so it passes user_code_path? filter


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky tests in `spec/datadog/symbol_database/remote_config_integration_spec.rb`. Wraps `Datadog::SymbolDatabase::Extractor#extract_all` with a 6s sleep to force the same timing condition that causes the failure in CI on Ruby 2.6 [1] (core_old shard).

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test job: [Ruby 2.6 / build & test (standard) [1] on PR #5431](https://github.com/DataDog/dd-trace-rb/actions/runs/25326353038/job/74248400964?pr=5431). The same tests passed on every other Ruby 2.6 shard and every other Ruby version on commit 47b7509374f4d58d569d6d6afc73757a24f1a4f3.

**Hypothesis:** `wait_for_idle(timeout: 5)` is too short when `Extractor#extract_all` iterates a heavily-loaded ObjectSpace in `spec:main core_old`. The scheduler thread is still mid-extraction when `wait_for_idle` times out, `captured_forms` is still empty, and the assertion fails.

**Reproducer technique:** the spec's `before` block now stubs `Extractor#extract_all` to `sleep 6` before calling the original. Locally on Ruby 3.2, this reproduces the exact same 3 failures observed in CI.

**Change log entry**

None.

**How to test the change?**

CI should show the same 3 tests failing in the Ruby 2.6 [1] core_old shard with the identical assertion message.

**Companion PRs:**
- Fix: #5669
- Validation: #5671

**Validation runs against Unit Tests workflow** (PRs target the PR #5431 branch, which the workflow does not trigger on; Unit Tests triggers on `tmp/*` branches):
- [Unit Tests on tmp/reproduce-flaky-symdb-rc-integration](https://github.com/DataDog/dd-trace-rb/actions/runs/25329385935)