### PR TITLE
Validate fix for flaky: symdb RC integration tests

### DIFF
--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
     # tests don't wait the production 5 seconds.
     Datadog::SymbolDatabase::Component.reset_uploaded_this_process_for_tests!
     stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0.05)
+
+    # Limit ObjectSpace.each_object(Module) to the test class hierarchy so
+    # extract_all completes in milliseconds rather than tens of seconds.
+    # Real extraction logic (find_source_file, build_file_trees, etc.) still
+    # runs against the test modules — only the iteration scope is constrained.
+    # Without this stub, full ObjectSpace iteration after thousands of prior
+    # tests in spec:main can exceed any reasonable wait_for_idle timeout
+    # (~30-40s observed in Ruby 2.6 [1] core_old shard CI).
+    test_modules = [RCIntegrationTestModule, RCIntegrationTestModule::RCIntegrationTestClass]
+    allow(ObjectSpace).to receive(:each_object).and_call_original
+    allow(ObjectSpace).to receive(:each_object).with(Module) do |&block|
+      test_modules.each(&block)
+    end
   end
 
   # Load test code in a temp dir (not /spec/) so it passes user_code_path? filter

--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
 
       GC.start
       component.start_upload
-      component.wait_for_idle(timeout: 5)
+      component.wait_for_idle(timeout: 30)
 
       # Transport should have been called with a multipart form
       expect(captured_forms).not_to be_empty
@@ -153,7 +153,7 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
 
       GC.start
       Datadog::SymbolDatabase::Remote.send(:process_change, component, change)
-      component.wait_for_idle(timeout: 5)
+      component.wait_for_idle(timeout: 30)
 
       expect(captured_forms).not_to be_empty
       expect(content).to have_received(:applied)
@@ -194,7 +194,7 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
 
       GC.start
       Datadog::SymbolDatabase::Remote.send(:process_change, component, insert_change)
-      component.wait_for_idle(timeout: 5)
+      component.wait_for_idle(timeout: 30)
       expect(captured_forms).not_to be_empty
 
       # Then delete
@@ -219,7 +219,7 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
 
       GC.start
       component.start_upload
-      component.wait_for_idle(timeout: 5)
+      component.wait_for_idle(timeout: 30)
       upload_count_after_first = captured_forms.size
 
       # Second call should be a no-op (uploaded_this_process? is true).

--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
     # tests don't wait the production 5 seconds.
     Datadog::SymbolDatabase::Component.reset_uploaded_this_process_for_tests!
     stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0.05)
+
+    # REPRODUCER: simulate slow extract_all (heavily-loaded ObjectSpace in CI)
+    # to exceed the wait_for_idle(timeout: 5) window. Mirrors the Ruby 2.6 [1]
+    # core_old shard failure mode where extraction takes >5s due to thousands
+    # of modules loaded after ~5000 prior tests in the same process.
+    allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all).and_wrap_original do |original|
+      sleep 6
+      original.call
+    end
   end
 
   # Load test code in a temp dir (not /spec/) so it passes user_code_path? filter


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the forced failure. This branch merges:
- Reproducer PR: #5667 (forces wait_for_idle timeout)
- Fix PR: #5669 (extends wait_for_idle to 30s)

If CI passes, the fix addresses the exact failure mode the reproducer forces. If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for validation only.

**Companion PRs:**
- Reproducer: #5667
- Fix: #5669

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the forced failure. CI fails = fix is insufficient. Locally on Ruby 3.2: 5 examples, 0 failures in 24.58 seconds (extraction includes the 6s reproducer sleep, then the fix's 30s window holds).

**Validation runs against Unit Tests workflow** (PRs target the PR #5431 branch, which the workflow does not trigger on; Unit Tests triggers on `tmp/*` branches):
- [Unit Tests on tmp/validate-flaky-symdb-rc-integration](https://github.com/DataDog/dd-trace-rb/actions/runs/25331068074) (rev 2)