### PR TITLE
Add parsing limits to tracestate and traceparent

### DIFF
--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -414,7 +414,13 @@ module Datadog
             # We parse 1 byte over the limit to detect if the last member
             # is a partial member (toss) or ends exactly at the limit (keep).
             remove_last_member = tracestate.byteslice(TRACESTATE_MAX_SIZE_LIMIT, 1) != ','
-            tracestate = tracestate.byteslice(0, TRACESTATE_MAX_SIZE_LIMIT)
+
+            # To ensure we don't have a trailing partial UTF-8 codepoint, we keep one extra byte
+            # and safely remove it with `#chop`.
+            # `#chop` walks back the string until it finds a valid character boundary and deletes
+            # from there.
+            tracestate = tracestate.byteslice(0, TRACESTATE_MAX_SIZE_LIMIT + 1) #: String
+            tracestate = tracestate.chop
           end
 
           vendors = tracestate.split(',', TRACESTATE_MAX_LIST_MEMBERS + 1)

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -149,9 +149,9 @@ module Datadog
         # @see https://www.w3.org/TR/trace-context/#tracestate-header
         def build_tracestate(digest)
           tracestate = +'dd='
-          tracestate << last_dd_parent_id(digest)
-          tracestate << "s:#{digest.trace_sampling_priority};" if digest.trace_sampling_priority
-          tracestate << "o:#{serialize_origin(digest.trace_origin)};" if digest.trace_origin
+          append_dd(tracestate, last_dd_parent_id(digest))
+          append_dd(tracestate, "s:#{digest.trace_sampling_priority};") if digest.trace_sampling_priority
+          append_dd(tracestate, "o:#{serialize_origin(digest.trace_origin)};") if digest.trace_origin
 
           # Replacing this by safe navigation seems to have a different behaviour on Rubies <= 3.0.
           # It cause a LocalJumpError in the CI.
@@ -159,43 +159,48 @@ module Datadog
             digest.trace_distributed_tags.each do |name, value|
               tag = "t.#{serialize_tag_key(name)}:#{serialize_tag_value(value)};"
 
-              # If tracestate size limit is exceed, drop the remaining data.
-              # String#bytesize is used because only ASCII characters are allowed.
-              #
-              # We add 1 to the limit because of the trailing comma, which will be removed before returning.
-              break if tracestate.bytesize + tag.bytesize > (TRACESTATE_VALUE_SIZE_LIMIT + 1)
-
-              tracestate << tag
+              # If tracestate size limit is exceeded, drop the remaining data.
+              break unless append_dd(tracestate, tag)
             end
           end
 
-          tracestate << digest.trace_state_unknown_fields if digest.trace_state_unknown_fields
+          append_dd(tracestate, digest.trace_state_unknown_fields) if digest.trace_state_unknown_fields
+          vendors = split_tracestate(digest.trace_state)
 
           # Is there any Datadog-specific information to propagate.
           # Check for > 3 size because the empty prefix `dd=` has 3 characters.
-          if tracestate.size > 3
+          if tracestate.bytesize > 3
             # Propagate upstream tracestate with `dd=...` appended to the list
             tracestate.chop! # Removes trailing `;` from Datadog trace state string.
 
-            if digest.trace_state
-              trace_state = digest.trace_state.strip
-
-              # Delete existing `dd=` tracestate fields, if present.
-              vendors = split_tracestate(trace_state)
-              vendors.reject! { |v| v.start_with?('dd=') }
-            end
-
             if vendors && !vendors.empty?
+              # Delete existing `dd=` tracestate fields, if present.
+              vendors.reject! { |v| v.start_with?('dd=') }
+
               # Ensure the list has at most 31 elements, as we need to prepend Datadog's
               # entry and the limit is 32 elements total.
-              vendors = vendors[0..30]
-              "#{tracestate},#{vendors.join(",")}"
-            else
-              tracestate.to_s
+              vendors.first(TRACESTATE_MAX_LIST_MEMBERS - 1).each do |vendor|
+                break if tracestate.bytesize + vendor.bytesize + 1 > TRACESTATE_MAX_SIZE_LIMIT
+
+                tracestate << ',' << vendor
+              end
             end
-          else
-            digest.trace_state # Propagate upstream tracestate with no Datadog changes
+
+            tracestate.to_s
+          elsif vendors && !vendors.empty?
+            vendors.join(',')
           end
+        end
+
+        # Appends a Datadog tracestate field when it fits.
+        def append_dd(tracestate, field)
+          return true if field.empty?
+
+          # We add 1 to the limit because of the trailing semicolon, which will be removed before returning.
+          return false if tracestate.bytesize + field.bytesize > (TRACESTATE_VALUE_SIZE_LIMIT + 1)
+
+          tracestate << field
+          true
         end
 
         def last_dd_parent_id(digest)
@@ -281,18 +286,20 @@ module Datadog
 
         def parse_traceparent_string(traceparent)
           return unless traceparent
+          return if traceparent.bytesize > TRACEPARENT_MAX_SIZE_LIMIT
 
-          version, trace_id, parent_id, trace_flags, extra = traceparent.strip.split('-')
+          traceparent = traceparent.strip
 
-          return if version.size != 2 || version[0] < '0' || version[0] > 'f' || version[1] < '0' || version[1] > 'f'
+          version, trace_id, parent_id, trace_flags, extra = traceparent.split('-', 5)
+
+          return unless version && trace_id && parent_id && trace_flags
+          return if version.size != 2 || trace_id.size != 32 || parent_id.size != 16 || trace_flags.size != 2
+          return if version[0] < '0' || version[0] > 'f' || version[1] < '0' || version[1] > 'f'
 
           return if version == INVALID_VERSION
 
           # Extra fields are not allowed in version 00, but we have to be lenient for future versions.
           return if version == SPEC_VERSION && extra
-
-          # Invalid field sizes
-          return if trace_id.size != 32 || parent_id.size != 16 || trace_flags.size != 2
 
           [Integer(trace_id, 16), Integer(parent_id, 16), Integer(trace_flags, 16)]
         rescue ArgumentError # Conversion to integer failed
@@ -306,9 +313,10 @@ module Datadog
         # @return [Array<String,Integer,String,String,Hash>] returns 4 values:
         # tracestate, sampling_priority, ts_parent_id, origin, tags.
         def extract_tracestate(tracestate)
-          return unless tracestate
-
           vendors = split_tracestate(tracestate)
+          return unless vendors && !vendors.empty?
+
+          tracestate = vendors.join(',')
 
           # Find Datadog's `dd=` tracestate field.
           idx = vendors.index { |v| v.start_with?('dd=') }
@@ -396,9 +404,37 @@ module Datadog
           end
         end
 
+        # We MUST NOT propagate partial members, but we SHOULD try
+        # to parse as much of the tracestate as possible.
         def split_tracestate(tracestate)
-          tracestate.split(/[ \t]*+,[ \t]*+/)[0..31]
+          return unless tracestate
+
+          remove_last_member = false
+          if tracestate.bytesize > TRACESTATE_MAX_SIZE_LIMIT
+            # We parse 1 byte over the limit to detect if the last member
+            # is a partial member (toss) or ends exactly at the limit (keep).
+            remove_last_member = tracestate.byteslice(TRACESTATE_MAX_SIZE_LIMIT, 1) != ','
+            tracestate = tracestate.byteslice(0, TRACESTATE_MAX_SIZE_LIMIT)
+          end
+
+          vendors = tracestate.split(',', TRACESTATE_MAX_LIST_MEMBERS + 1)
+          if vendors.length > TRACESTATE_MAX_LIST_MEMBERS || remove_last_member
+            vendors.pop
+          end
+
+          vendors.each(&:strip!)
+          vendors.pop while vendors.last == ''
+          vendors
         end
+
+        TRACEPARENT_MAX_SIZE_LIMIT = 512
+        private_constant :TRACEPARENT_MAX_SIZE_LIMIT
+
+        TRACESTATE_MAX_SIZE_LIMIT = 512
+        private_constant :TRACESTATE_MAX_SIZE_LIMIT
+
+        TRACESTATE_MAX_LIST_MEMBERS = 32
+        private_constant :TRACESTATE_MAX_LIST_MEMBERS
 
         # Version 0xFF is invalid as per spec
         # @see https://www.w3.org/TR/trace-context/#version

--- a/sig/datadog/tracing/distributed/baggage.rbs
+++ b/sig/datadog/tracing/distributed/baggage.rbs
@@ -2,6 +2,8 @@ module Datadog
   module Tracing
     module Distributed
       class Baggage
+        type baggage = ::Hash[::String, ::String]
+
         BAGGAGE_KEY : "baggage"
         DD_TRACE_BAGGAGE_MAX_ITEMS : 64
         DD_TRACE_BAGGAGE_MAX_BYTES : 8192
@@ -17,18 +19,18 @@ module Datadog
 
         def inject!: (untyped digest, untyped data) -> (nil | untyped)
 
-        def extract: (untyped data) -> (nil | untyped)
+        def extract: (untyped data) -> TraceDigest?
 
 
         private
 
-        def encode_item: (String item, String safe_characters) -> string
+        def encode_item: (::String item, ::String safe_characters) -> ::String
 
-        def parse_baggage_header: (String baggage_header) -> Hash[String, String]
+        def parse_baggage_header: (::String baggage_header) -> baggage
 
-        def build_baggage_tags: (Hash[String, String] baggage) -> Hash[String, String]
+        def build_baggage_tags: (baggage baggage) -> baggage
 
-        def record_telemetry_metric: (String metric_name, Integer value, Hash[String, String] tags) -> void
+        def record_telemetry_metric: (::String metric_name, ::Integer value, baggage tags) -> void
         end
     end
   end

--- a/sig/datadog/tracing/distributed/trace_context.rbs
+++ b/sig/datadog/tracing/distributed/trace_context.rbs
@@ -21,6 +21,7 @@ module Datadog
         def build_traceparent_string: (untyped trace_id, untyped parent_id, untyped trace_flags) -> ::String
         def build_trace_flags: (untyped digest) -> untyped
         def build_tracestate: (untyped digest) -> untyped
+        def append_dd: (untyped tracestate, untyped field) -> bool
         def serialize_origin: (untyped value) -> untyped
         def serialize_tag_key: (untyped name) -> untyped
         def serialize_tag_value: (untyped value) -> untyped
@@ -37,6 +38,9 @@ module Datadog
         def parse_priority_sampling: (untyped sampled, untyped sampling_priority) -> untyped
 
         def split_tracestate: (untyped tracestate) -> untyped
+        TRACEPARENT_MAX_SIZE_LIMIT: 512
+        TRACESTATE_MAX_SIZE_LIMIT: 512
+        TRACESTATE_MAX_LIST_MEMBERS: 32
         INVALID_VERSION: "ff"
         DEFAULT_TRACE_FLAGS: 0
         TRACE_FLAGS_SAMPLED: 1

--- a/sig/datadog/tracing/distributed/trace_context.rbs
+++ b/sig/datadog/tracing/distributed/trace_context.rbs
@@ -2,6 +2,12 @@ module Datadog
   module Tracing
     module Distributed
       class TraceContext
+        type tags = ::Hash[::String, ::String]
+        type traceparent_fields = [::Integer, ::Integer, ::Integer]
+        type extracted_traceparent = [::Integer, ::Integer, ::Integer, ::Integer]
+        type extracted_datadog_fields = [::String?, ::Integer?, ::String?, tags?, ::String?]
+        type extracted_tracestate = [::String, ::Integer?, ::String?, ::String?, tags?, ::String?]
+
         TRACEPARENT_KEY: "traceparent"
 
         TRACESTATE_KEY: "tracestate"
@@ -17,27 +23,28 @@ module Datadog
         private
         module Refine
         end
-        def build_traceparent: (untyped digest) -> untyped
-        def build_traceparent_string: (untyped trace_id, untyped parent_id, untyped trace_flags) -> ::String
-        def build_trace_flags: (untyped digest) -> untyped
-        def build_tracestate: (untyped digest) -> untyped
-        def append_dd: (untyped tracestate, untyped field) -> bool
-        def serialize_origin: (untyped value) -> untyped
-        def serialize_tag_key: (untyped name) -> untyped
-        def serialize_tag_value: (untyped value) -> untyped
+        def build_traceparent: (TraceDigest digest) -> ::String
+        def build_traceparent_string: (::Integer trace_id, ::Integer parent_id, ::Integer trace_flags) -> ::String
+        def build_trace_flags: (TraceDigest digest) -> ::Integer
+        def build_tracestate: (TraceDigest digest) -> ::String?
+        def append_dd: (::String tracestate, ::String field) -> bool
+        def last_dd_parent_id: (TraceDigest digest) -> ::String
+        def serialize_origin: (::String value) -> ::String
+        def serialize_tag_key: (::String name) -> ::String
+        def serialize_tag_value: (::String value) -> ::String
 
-        def extract_traceparent: (untyped traceparent) -> (nil | ::Array[untyped])
+        def extract_traceparent: (::String? traceparent) -> extracted_traceparent?
 
-        def parse_traceparent_string: (untyped traceparent) -> untyped
+        def parse_traceparent_string: (::String? traceparent) -> traceparent_fields?
 
-        def parse_sampled_flag: (untyped trace_flags) -> untyped
-        def extract_tracestate: (untyped tracestate) -> (nil | untyped | ::Array[untyped])
+        def parse_sampled_flag: (::Integer trace_flags) -> ::Integer
+        def extract_tracestate: (::String? tracestate) -> (::String | extracted_tracestate)?
 
-        def extract_datadog_fields: (untyped dd_tracestate) -> ::Array[untyped]
-        def deserialize_tag_value: (untyped value) -> untyped
-        def parse_priority_sampling: (untyped sampled, untyped sampling_priority) -> untyped
+        def extract_datadog_fields: (::String dd_tracestate) -> extracted_datadog_fields
+        def deserialize_tag_value: (::String value) -> ::String
+        def parse_priority_sampling: (::Integer sampled, ::Integer? sampling_priority) { (::String | :drop decision) -> void } -> ::Integer
 
-        def split_tracestate: (untyped tracestate) -> untyped
+        def split_tracestate: (::String? tracestate) -> ::Array[::String]?
         TRACEPARENT_MAX_SIZE_LIMIT: 512
         TRACESTATE_MAX_SIZE_LIMIT: 512
         TRACESTATE_MAX_LIST_MEMBERS: 32
@@ -46,6 +53,7 @@ module Datadog
         TRACE_FLAGS_SAMPLED: 1
         TRACESTATE_VALUE_SIZE_LIMIT: 256
         INVALID_ORIGIN_CHARS: ::Regexp
+        REMAP_ORIGIN_CHARS: ::Regexp
         INVALID_TAG_KEY_CHARS: ::Regexp
         INVALID_TAG_VALUE_CHARS: ::Regexp
       end

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -600,6 +600,19 @@ RSpec.shared_examples 'Trace Context distributed format' do
         it { expect(digest.trace_state).to eq('v=1') }
       end
 
+      context 'with a trailing tracestate member truncated inside a multibyte character' do
+        let(:complete_member) { 'v=1' }
+        let(:partial_key) { 'w=' }
+        let(:partial_value) do
+          'a' * (512 - complete_member.bytesize - 1 - partial_key.bytesize - 1) + '🍀' # A 4-leaf clover, 4-byte character
+        end
+        let(:tracestate) { "#{complete_member},#{partial_key}#{partial_value}" }
+
+        it 'extracts complete members before the partial multibyte tail' do
+          expect(digest.trace_state).to eq(complete_member)
+        end
+      end
+
       context 'trailing whitespace' do
         let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-00 ' }
 

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -302,11 +302,34 @@ RSpec.shared_examples 'Trace Context distributed format' do
             end
           end
 
+          context 'and an oversized upstream tracestate' do
+            let(:upstream_tracestate) { Array.new(100) { |i| "other#{i}=vendor#{i}" }.join(',') }
+
+            it 'truncates whole values to the tracestate limit' do
+              expect(tracestate).to start_with('dd=o:origin,')
+              expect(tracestate.bytesize).to be <= 512
+              expect(tracestate.split(',').all? { |member| member.include?('=') }).to be true
+            end
+          end
+
           context 'and unknown `dd=` tracestate values' do
             let(:options) { super().merge(trace_origin: 'origin', trace_state_unknown_fields: 'future=field;') }
 
             it 'joins known and unknown `dd=` fields' do
               expect(tracestate).to eq('dd=o:origin;future=field,other=vendor')
+            end
+          end
+
+          context 'and oversized unknown `dd=` tracestate values' do
+            let(:options) do
+              super().merge(
+                trace_origin: 'origin',
+                trace_state_unknown_fields: "future=field;large:#{'x' * 300};small:ok;"
+              )
+            end
+
+            it 'drops unknown fields when they exceed the Datadog value limit' do
+              expect(tracestate).to eq('dd=o:origin,other=vendor')
             end
           end
         end
@@ -365,6 +388,11 @@ RSpec.shared_examples 'Trace Context distributed format' do
 
       context 'more fields than expected' do
         let(:traceparent) { '00-00000000000000000000000000c0ffee-0000000000000bee-01-FFFFF' }
+        it { is_expected.to be_nil }
+      end
+
+      context 'prohibitively large future version' do
+        let(:traceparent) { '01-00000000000000000000000000c0ffee-0000000000000bee-01-' + ('x' * 512) }
         it { is_expected.to be_nil }
       end
     end
@@ -520,6 +548,56 @@ RSpec.shared_examples 'Trace Context distributed format' do
         it { expect(digest.span_id).to eq(0xBEE) }
         it { expect(digest.trace_state).to eq('v1=1,v2=2') }
         it { expect(digest.trace_origin).to eq('origin') }
+      end
+
+      context 'with oversized tracestate vendors' do
+        let(:tracestate) { Array.new(100) { |i| "v#{i}=#{'a' * 8}" }.join(',') }
+
+        it 'truncates whole values to the tracestate limit' do
+          expect(digest.trace_state.bytesize).to be <= 512
+          expect(digest.trace_state.split(',').length).to be <= 32
+          expect(digest.trace_state.split(',').all? { |member| member.include?('=') }).to be true
+        end
+      end
+
+      context 'with more than 32 tracestate vendors' do
+        let(:tracestate) { Array.new(33) { |i| "v#{i}=1" }.join(',') }
+
+        it 'keeps only the first 32 values' do
+          expect(digest.trace_state).to eq(Array.new(32) { |i| "v#{i}=1" }.join(','))
+        end
+      end
+
+      context 'with an oversized tracestate value' do
+        let(:tracestate) { 'v=' + ('a' * 600) }
+
+        it { expect(digest.trace_state).to be_nil }
+      end
+
+      context 'with a tracestate value at the size limit' do
+        let(:tracestate) { 'v=' + ('a' * 510) }
+
+        it { expect(digest.trace_state).to eq(tracestate) }
+      end
+
+      context 'with a tracestate delimiter one byte after the size limit' do
+        let(:member) { 'v=' + ('a' * 510) }
+        let(:tracestate) { "#{member},other=value" }
+
+        it { expect(digest.trace_state).to eq(member) }
+      end
+
+      context 'with ambiguous whitespace one byte after the size limit' do
+        let(:member) { 'v=' + ('a' * 510) }
+        let(:tracestate) { "#{member} ,other=value" }
+
+        it { expect(digest.trace_state).to be_nil }
+      end
+
+      context 'with an oversized tracestate tail' do
+        let(:tracestate) { 'v=1,' + ('a' * 600) }
+
+        it { expect(digest.trace_state).to eq('v=1') }
       end
 
       context 'trailing whitespace' do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

Ensure when parsing the [W3C Trace Context](https://www.w3.org/TR/trace-context/) propagation headers `traceparent` and `tracestate`, ensure they respect our processing limits:
* `traceparent`: 512 bytes
* `tracestate`: 512 bytes
* `tracestate` members: 32 entries

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Add parsing limits to `tracestate` and `traceparent` propagation headers and remove whitespace around  list members.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
`bundle exec rspec spec/datadog/tracing/distributed/trace_context_spec.rb`
