### PR TITLE
Sanitize time in junit exports

### DIFF
--- a/spec/support/deterministic_junit_formatter.rb
+++ b/spec/support/deterministic_junit_formatter.rb
@@ -23,6 +23,8 @@ class DeterministicJunitFormatter < RspecJunitFormatter
     [/\b[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i, '<UUID>'],
     # ISO 8601 timestamp: "2026-04-02 14:19:20.830733764 +0000" → <timestamp>
     [/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[\d. +-]*/, '<timestamp>'],
+    # Time.now.to_i → <time>
+    [/\d{10}/, '<time>']
   ]
 
   private


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Replace any mutable coming from `Time.now.to_i` in junit exports

**Motivation:**

Leftover from #5653 

It fixes test names coming from this [test](https://github.com/DataDog/dd-trace-rb/blob/524bafda70447cab9356c74d54c2c3dbcb9f21c5/spec/datadog/core/telemetry/request_spec.rb#L16-L78).

Here is an example of the actual [output](https://app.datadoghq.com/ci/test/AwAAAZ3zFKJK84PVlwAAABhBWjN6RktKS0FBQ2NaYTh0TDFneGFGazQAAAAkZjE5ZGYzMTUtYjc5My00NzVjLTliYzktNGJkZjgwMjUwMDJkAACs5A?colorByAttr=service&currentTab=overview&env=ci&eventStack=AwAAAZ3zFKJK84PVlwAAABhBWjN6RktKS0FBQ2NaYTh0TDFneGFGazQAAAAkZjE5ZGYzMTUtYjc5My00NzVjLTliYzktNGJkZjgwMjUwMDJkAACs5A&index=citest&testId=AwAAAZ3zFKJK84PVlwAAABhBWjN6RktKS0FBQ2NaYTh0TDFneGFGazQAAAAkZjE5ZGYzMTUtYjc5My00NzVjLTliYzktNGJkZjgwMjUwMDJkAACs5A) :  `Datadog::Core::Telemetry::Request.build_payload <...lot of stuff...> :tracer_time=>(be between 1777899811 and 1777899811 (inclusive))}`

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
