### PR TITLE
Add rack middleware for remote IP collection for AI Guard

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -378,6 +378,9 @@
   },
   'ai_guard:ruby_llm' => {
     'ruby-llm-latest' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ 4.0'
+  },
+  'ai_guard:rack' => {
+    'rack-latest' => '✅ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ 4.0'
   }
 }.each_with_object({}) do |(tasks, spec_metadata), hash|
   # Explode arrays of task names into individual tasks

--- a/Rakefile
+++ b/Rakefile
@@ -433,12 +433,18 @@ namespace :spec do
   task appsec: [:"appsec:all"]
 
   namespace :ai_guard do
-    task all: [:main, :ruby_llm]
+    task all: [:main, :rack, :ruby_llm]
 
     desc '' # "Explicitly hiding from `rake -T`"
     RSpec::Core::RakeTask.new(:main) do |t, args|
       t.pattern = 'spec/datadog/ai_guard/**/*_spec.rb,spec/datadog/ai_guard_spec.rb'
       t.exclude_pattern = 'spec/datadog/ai_guard/contrib/**/*_spec.rb'
+      t.rspec_opts = args.to_a.join(' ')
+    end
+
+    desc '' # "Explicitly hiding from `rake -T`"
+    RSpec::Core::RakeTask.new(:rack) do |t, args|
+      t.pattern = "spec/datadog/ai_guard/contrib/rack/**/*_spec.rb"
       t.rspec_opts = args.to_a.join(' ')
     end
 

--- a/lib/datadog/ai_guard.rb
+++ b/lib/datadog/ai_guard.rb
@@ -3,6 +3,8 @@
 require_relative "core/configuration"
 require_relative "ai_guard/configuration"
 
+require_relative "ai_guard/contrib/rack/integration"
+require_relative "ai_guard/contrib/rails/integration"
 require_relative "ai_guard/contrib/ruby_llm/integration"
 
 module Datadog
@@ -48,6 +50,10 @@ module Datadog
 
       def logger
         Datadog.send(:components).ai_guard&.logger
+      end
+
+      def telemetry
+        Datadog.send(:components).ai_guard&.telemetry
       end
 
       # Evaluates one or more messages using AI Guard API.
@@ -171,3 +177,5 @@ module Datadog
     end
   end
 end
+
+require_relative "ai_guard/autoload"

--- a/lib/datadog/ai_guard/autoload.rb
+++ b/lib/datadog/ai_guard/autoload.rb
@@ -5,6 +5,6 @@ if %w[1 true].include?((Datadog::DATADOG_ENV["DD_AI_GUARD_ENABLED"] || "").downc
     require_relative "contrib/auto_instrument"
     Datadog::AIGuard::Contrib::AutoInstrument.patch_all
   rescue => e
-    Kernel.warn("[datadog] AI Guard failed to auto-instrument. error: #{e.class}: #{e}")
+    Kernel.warn("[datadog] AI Guard failed to auto-instrument. error: #{e.class}: #{e.message}")
   end
 end

--- a/lib/datadog/ai_guard/autoload.rb
+++ b/lib/datadog/ai_guard/autoload.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+if %w[1 true].include?((Datadog::DATADOG_ENV["DD_AI_GUARD_ENABLED"] || "").downcase)
+  begin
+    require_relative "contrib/auto_instrument"
+    Datadog::AIGuard::Contrib::AutoInstrument.patch_all
+  rescue => e
+    Kernel.warn("[datadog] AI Guard failed to auto-instrument. error: #{e.class}: #{e}")
+  end
+end

--- a/lib/datadog/ai_guard/component.rb
+++ b/lib/datadog/ai_guard/component.rb
@@ -15,7 +15,7 @@ module Datadog
   module AIGuard
     # Component for API Guard product
     class Component
-      attr_reader :api_client, :logger
+      attr_reader :api_client, :logger, :telemetry
 
       def self.build(settings, logger:, telemetry:)
         return unless settings.respond_to?(:ai_guard) && settings.ai_guard.enabled

--- a/lib/datadog/ai_guard/contrib/auto_instrument.rb
+++ b/lib/datadog/ai_guard/contrib/auto_instrument.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AIGuard
+    module Contrib
+      # Auto-instrumentation for AI Guard integrations
+      module AutoInstrument
+        def self.patch_all
+          integrations = []
+
+          Datadog::AIGuard::Contrib::Integration.registry.each_value do |integration|
+            next unless integration.klass.auto_instrument?
+
+            integrations << integration.name
+          end
+
+          integrations.each do |integration_name|
+            Datadog.configuration.ai_guard.instrument(integration_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/contrib/rack/integration.rb
+++ b/lib/datadog/ai_guard/contrib/rack/integration.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "../integration"
+require_relative "patcher"
+require_relative "request_middleware"
+
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        # Rack integration for AI Guard
+        class Integration
+          include Datadog::AIGuard::Contrib::Integration
+
+          MINIMUM_VERSION = Gem::Version.new("1.1.0")
+
+          register_as :rack, auto_patch: false
+
+          def self.version
+            Gem.loaded_specs["rack"]&.version
+          end
+
+          def self.loaded?
+            !defined?(::Rack).nil?
+          end
+
+          def self.compatible?
+            super && !!(version&.>= MINIMUM_VERSION)
+          end
+
+          def self.auto_instrument?
+            false
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/contrib/rack/patcher.rb
+++ b/lib/datadog/ai_guard/contrib/rack/patcher.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        # Patcher for Rack integration
+        module Patcher
+          module_function
+
+          def patched?
+            !!Patcher.instance_variable_get(:@patched)
+          end
+
+          def target_version
+            Integration.version
+          end
+
+          def patch
+            Patcher.instance_variable_set(:@patched, true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
+++ b/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
@@ -3,16 +3,17 @@
 require_relative "../../../tracing/client_ip"
 require_relative "../../../tracing/contrib/rack/header_collection"
 require_relative "../../../tracing/metadata/ext"
+require_relative "../../ext"
 
 module Datadog
   module AIGuard
     module Contrib
       module Rack
-        # Topmost AI Guard Rack middleware. Inserted just below
-        # Datadog::Tracing::Contrib::Rack::TraceMiddleware, it tags the
-        # local root (request) span with client IP information whenever
-        # AI Guard is enabled, so any AI Guard span fired during the request
-        # has these tags reachable from the service entry span.
+        # AI Guard Rack middleware. Inserted just after
+        # Datadog::Tracing::Contrib::Rack::TraceMiddleware so that, on the
+        # way out of the request, the active span is the local root (request)
+        # span. Tags `http.client_ip` and `network.client.ip` on that span
+        # only when an AI Guard span was actually recorded during the request.
         class RequestMiddleware
           NETWORK_CLIENT_IP_TAG = "network.client.ip"
 
@@ -21,16 +22,24 @@ module Datadog
           end
 
           def call(env)
-            tag_client_ip(env)
-
             @app.call(env)
+          ensure
+            tag_client_ip(env) if ai_guard_span_recorded?
           end
 
           private
 
-          def tag_client_ip(env)
-            return unless Datadog::AIGuard.enabled?
+          def ai_guard_span_recorded?
+            trace = Datadog::Tracing.active_trace
+            return false unless trace
 
+            # `TraceOperation#@spans` has no reader; reaching for the ivar
+            # avoids expanding the public API of tracing for one consumer.
+            spans = trace.instance_variable_get(:@spans) || []
+            spans.any? { |span| span.name == Datadog::AIGuard::Ext::SPAN_NAME }
+          end
+
+          def tag_client_ip(env)
             span = Datadog::Tracing.active_span
             return unless span
 

--- a/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
+++ b/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
@@ -73,7 +73,7 @@ module Datadog
             if env["REMOTE_ADDR"] && span.get_tag(NETWORK_CLIENT_IP_TAG).nil?
               span.set_tag(NETWORK_CLIENT_IP_TAG, env["REMOTE_ADDR"])
             end
-          rescue StandardError => e # standard:disable Style/RescueStandardError
+          rescue => e
             Datadog::AIGuard.telemetry&.report(e, description: "AI Guard: failed to tag client IP on root span")
           end
         end

--- a/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
+++ b/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
@@ -9,11 +9,20 @@ module Datadog
   module AIGuard
     module Contrib
       module Rack
-        # AI Guard Rack middleware. Inserted just after
-        # Datadog::Tracing::Contrib::Rack::TraceMiddleware so that, on the
-        # way out of the request, the active span is the local root (request)
-        # span. Tags `http.client_ip` and `network.client.ip` on that span
-        # only when an AI Guard span was actually recorded during the request.
+        # AI Guard Rack middleware.
+        #
+        # Inserted into the middleware stack right after
+        # Datadog::Tracing::Contrib::Rack::TraceMiddleware (i.e. nested inside
+        # it). This ordering matters: on the way out of the request, AI Guard's
+        # `ensure` block unwinds *before* Tracing's ensure, while Tracing's
+        # request span is still live. We need that, because Tracing's ensure
+        # calls `request_span.finish`, which builds a frozen `Span` snapshot of
+        # the meta hash — any `set_tag` call after that point mutates the
+        # `SpanOperation` but never reaches the exported `Span`.
+        #
+        # So while the span is still active, we tag `http.client_ip` and
+        # `network.client.ip` on it — but only when an AI Guard span was
+        # actually recorded during the request.
         class RequestMiddleware
           NETWORK_CLIENT_IP_TAG = "network.client.ip"
 
@@ -24,31 +33,29 @@ module Datadog
           def call(env)
             @app.call(env)
           ensure
-            tag_client_ip(env) if client_ip_tags_missing? && ai_guard_span_recorded?
+            tag_client_ip(env) if consume_ai_guard_executed_flag
           end
 
           private
 
-          # Cheap pre-check: skip the finished-span scan entirely when both
-          # tags are already on the request span (e.g. set by the tracing
-          # client_ip middleware or by AppSec).
-          def client_ip_tags_missing?
-            span = Datadog::Tracing.active_span
-            return false unless span
-
-            span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_CLIENT_IP).nil? ||
-              span.get_tag(NETWORK_CLIENT_IP_TAG).nil?
-          end
-
-          def ai_guard_span_recorded?
+          # AI Guard's evaluation flow sets `ai_guard.executed` on the trace
+          # whenever an AI Guard span is created during the request. We read
+          # it here to know whether to tag client IP, then clear it so the
+          # internal flag does not propagate to the exported trace.
+          #
+          # `Tracing.active_trace` is publicly typed as `TraceSegment?` but at
+          # runtime returns a `TraceOperation`, which exposes `get_tag` and
+          # `clear_tag`. Pre-existing sig mismatch — hence the steep:ignore.
+          # steep:ignore:start
+          def consume_ai_guard_executed_flag
             trace = Datadog::Tracing.active_trace
             return false unless trace
+            return false unless trace.get_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG) == "1"
 
-            # `TraceOperation#@spans` has no reader; reaching for the ivar
-            # avoids expanding the public API of tracing for one consumer.
-            spans = trace.instance_variable_get(:@spans) || []
-            spans.any? { |span| span.name == Datadog::AIGuard::Ext::SPAN_NAME }
+            trace.clear_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG)
+            true
           end
+          # steep:ignore:end
 
           def tag_client_ip(env)
             span = Datadog::Tracing.active_span

--- a/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
+++ b/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../../../tracing/client_ip"
+require_relative "../../../tracing/contrib/rack/header_collection"
+require_relative "../../../tracing/metadata/ext"
+
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        # Topmost AI Guard Rack middleware. Inserted just below
+        # Datadog::Tracing::Contrib::Rack::TraceMiddleware, it tags the
+        # local root (request) span with client IP information whenever
+        # AI Guard is enabled, so any AI Guard span fired during the request
+        # has these tags reachable from the service entry span.
+        class RequestMiddleware
+          NETWORK_CLIENT_IP_TAG = "network.client.ip"
+
+          def initialize(app, opt = {})
+            @app = app
+          end
+
+          def call(env)
+            tag_client_ip(env)
+
+            @app.call(env)
+          end
+
+          private
+
+          def tag_client_ip(env)
+            return unless Datadog::AIGuard.enabled?
+
+            span = Datadog::Tracing.active_span
+            return unless span
+
+            if span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_CLIENT_IP).nil?
+              headers = Datadog::Tracing::Contrib::Rack::Header::RequestHeaderCollection.new(env)
+              Datadog::Tracing::ClientIp.set_client_ip_tag!(
+                span,
+                headers: headers,
+                remote_ip: env["REMOTE_ADDR"]
+              )
+            end
+
+            if env["REMOTE_ADDR"] && span.get_tag(NETWORK_CLIENT_IP_TAG).nil?
+              span.set_tag(NETWORK_CLIENT_IP_TAG, env["REMOTE_ADDR"])
+            end
+          rescue StandardError => e # standard:disable Style/RescueStandardError
+            Datadog::AIGuard.telemetry&.report(e, description: "AI Guard: failed to tag client IP on root span")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
+++ b/lib/datadog/ai_guard/contrib/rack/request_middleware.rb
@@ -24,10 +24,21 @@ module Datadog
           def call(env)
             @app.call(env)
           ensure
-            tag_client_ip(env) if ai_guard_span_recorded?
+            tag_client_ip(env) if client_ip_tags_missing? && ai_guard_span_recorded?
           end
 
           private
+
+          # Cheap pre-check: skip the finished-span scan entirely when both
+          # tags are already on the request span (e.g. set by the tracing
+          # client_ip middleware or by AppSec).
+          def client_ip_tags_missing?
+            span = Datadog::Tracing.active_span
+            return false unless span
+
+            span.get_tag(Datadog::Tracing::Metadata::Ext::HTTP::TAG_CLIENT_IP).nil? ||
+              span.get_tag(NETWORK_CLIENT_IP_TAG).nil?
+          end
 
           def ai_guard_span_recorded?
             trace = Datadog::Tracing.active_trace

--- a/lib/datadog/ai_guard/contrib/rails/integration.rb
+++ b/lib/datadog/ai_guard/contrib/rails/integration.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../integration"
+require_relative "patcher"
+
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rails
+        # Rails integration for AI Guard
+        class Integration
+          include Datadog::AIGuard::Contrib::Integration
+
+          MINIMUM_VERSION = Gem::Version.new("4")
+
+          register_as :rails, auto_patch: false
+
+          def self.version
+            Gem.loaded_specs["railties"]&.version
+          end
+
+          def self.loaded?
+            !defined?(::Rails).nil?
+          end
+
+          def self.compatible?
+            super && !!(version&.>= MINIMUM_VERSION)
+          end
+
+          def self.auto_instrument?
+            true
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/contrib/rails/patcher.rb
+++ b/lib/datadog/ai_guard/contrib/rails/patcher.rb
@@ -2,6 +2,7 @@
 
 require_relative "../../../core/utils/only_once"
 require_relative "../rack/request_middleware"
+require_relative "../../../tracing/contrib"
 require_relative "../../../tracing/contrib/rack/middlewares"
 
 module Datadog

--- a/lib/datadog/ai_guard/contrib/rails/patcher.rb
+++ b/lib/datadog/ai_guard/contrib/rails/patcher.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "../../../core/utils/only_once"
+require_relative "../rack/request_middleware"
+require_relative "../../../tracing/contrib/rack/middlewares"
+
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rails
+        # Patcher for AI Guard on Rails. Inserts the AI Guard Rack middleware
+        # right after the Tracing Rack middleware so the request span is
+        # already active when AI Guard tags the client IP.
+        module Patcher
+          BEFORE_INITIALIZE_ONLY_ONCE_PER_APP = Hash.new { |h, key| h[key] = Datadog::Core::Utils::OnlyOnce.new }
+
+          module_function
+
+          def patched?
+            !!Patcher.instance_variable_get(:@patched)
+          end
+
+          def target_version
+            Integration.version
+          end
+
+          def patch
+            patch_before_initialize
+            Patcher.instance_variable_set(:@patched, true)
+          end
+
+          def patch_before_initialize
+            ::ActiveSupport.on_load(:before_initialize) do
+              Datadog::AIGuard::Contrib::Rails::Patcher.before_initialize(self)
+            end
+          end
+
+          def before_initialize(app)
+            BEFORE_INITIALIZE_ONLY_ONCE_PER_APP[app].run do
+              # Middleware must be added before the application is initialized.
+              # Otherwise the middleware stack will be frozen.
+              add_middleware(app) if Datadog.configuration.tracing[:rails][:middleware]
+            end
+          end
+
+          def add_middleware(app)
+            if include_middleware?(Datadog::Tracing::Contrib::Rack::TraceMiddleware, app)
+              app.middleware.insert_after(
+                Datadog::Tracing::Contrib::Rack::TraceMiddleware,
+                Datadog::AIGuard::Contrib::Rack::RequestMiddleware
+              )
+            else
+              app.middleware.insert_before(0, Datadog::AIGuard::Contrib::Rack::RequestMiddleware)
+            end
+          end
+
+          def include_middleware?(middleware, app)
+            found = false
+
+            # find tracer middleware reference in Rails::Configuration::MiddlewareStackProxy
+            app.middleware.instance_variable_get(:@operations).each do |operation|
+              args = case operation
+              when Array
+                # rails 5.2
+                _op, args = operation
+                args
+              when Proc
+                if operation.binding.local_variables.include?(:args)
+                  # rails 6.0, 6.1
+                  operation.binding.local_variable_get(:args)
+                else
+                  # rails 7.0 uses ... to pass args
+                  # steep:ignore:start
+                  args_getter = Class.new do
+                    def method_missing(_op, *args) # standard:disable Style/MissingRespondToMissing
+                      args
+                    end
+                  end.new
+                  # steep:ignore:end
+                  operation.call(args_getter)
+                end
+              else
+                # unknown, pass through
+                []
+              end
+
+              found = true if args.include?(middleware)
+            end
+
+            found
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -16,6 +16,7 @@ module Datadog
               Tracing::Sampling::Ext::Decision::AI_GUARD
             )
             trace.set_tag(Ext::EVENT_TAG, true)
+            trace.set_tag(Ext::SERVICE_ENTRY_EXECUTED_TAG, "1")
 
             if (last_message = messages.last)
               if last_message.tool_call

--- a/lib/datadog/ai_guard/ext.rb
+++ b/lib/datadog/ai_guard/ext.rb
@@ -11,6 +11,7 @@ module Datadog
       REASON_TAG = "ai_guard.reason"
       BLOCKED_TAG = "ai_guard.blocked"
       EVENT_TAG = "ai_guard.event"
+      SERVICE_ENTRY_EXECUTED_TAG = "ai_guard.executed"
       METASTRUCT_TAG = "ai_guard"
     end
   end

--- a/lib/datadog/ai_guard/ext.rb
+++ b/lib/datadog/ai_guard/ext.rb
@@ -11,7 +11,7 @@ module Datadog
       REASON_TAG = "ai_guard.reason"
       BLOCKED_TAG = "ai_guard.blocked"
       EVENT_TAG = "ai_guard.event"
-      SERVICE_ENTRY_EXECUTED_TAG = "ai_guard.executed"
+      SERVICE_ENTRY_EXECUTED_TAG = "_dd.ai_guard.executed"
       METASTRUCT_TAG = "ai_guard"
     end
   end

--- a/sig/datadog/ai_guard.rbs
+++ b/sig/datadog/ai_guard.rbs
@@ -19,6 +19,8 @@ module Datadog
 
     def self.logger: () -> Core::Logger?
 
+    def self.telemetry: () -> Core::Telemetry::Component?
+
     def self.evaluate: (*Evaluation::Message messages, ?allow_raise: bool) -> (Evaluation::Result | Evaluation::NoOpResult)
 
     def self.message: (role: ::String | ::Symbol, ?content: ::String?) ?{ (Evaluation::ContentBuilder) -> void } -> Evaluation::Message

--- a/sig/datadog/ai_guard/autoload.rbs
+++ b/sig/datadog/ai_guard/autoload.rbs
@@ -1,0 +1,1 @@
+# This file intentionally empty: nothing to type

--- a/sig/datadog/ai_guard/component.rbs
+++ b/sig/datadog/ai_guard/component.rbs
@@ -3,8 +3,7 @@ module Datadog
     class Component
       attr_reader api_client: AIGuard::APIClient
       attr_reader logger: Core::Logger
-
-      @telemetry: Core::Telemetry::Component
+      attr_reader telemetry: Core::Telemetry::Component
 
       def self.build: (
         Core::Configuration::Settings settings,

--- a/sig/datadog/ai_guard/contrib/auto_instrument.rbs
+++ b/sig/datadog/ai_guard/contrib/auto_instrument.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module AutoInstrument
+        def self.patch_all: () -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/contrib/integration.rbs
+++ b/sig/datadog/ai_guard/contrib/integration.rbs
@@ -21,6 +21,8 @@ module Datadog
           def loaded?: () -> bool
 
           def compatible?: () -> bool
+
+          def auto_instrument?: () -> bool
         end
 
         class RegisteredIntegration < ::Struct[[::Symbol, _IntegrationKlass, integration_options]]

--- a/sig/datadog/ai_guard/contrib/rack/integration.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/integration.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        class Integration
+          include Datadog::AIGuard::Contrib::Integration
+          extend Datadog::AIGuard::Contrib::Integration::ClassMethods
+
+          MINIMUM_VERSION: ::Gem::Version
+
+          def self.version: () -> Gem::Version?
+
+          def self.loaded?: () -> bool
+
+          def self.compatible?: () -> bool
+
+          def self.auto_instrument?: () -> false
+
+          def patcher: () -> singleton(Patcher)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/contrib/rack/patcher.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/patcher.rbs
@@ -5,7 +5,7 @@ module Datadog
         module Patcher
           def self?.patched?: () -> bool
 
-          def self?.target_version: () -> untyped
+          def self?.target_version: () -> ::Gem::Version?
 
           def self?.patch: () -> void
         end

--- a/sig/datadog/ai_guard/contrib/rack/patcher.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/patcher.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        module Patcher
+          def self?.patched?: () -> bool
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rack
+        type rack_env = ::Hash[::String, any]
+        type rack_response = [::Integer, ::Hash[::String, ::String], ::Array[::String]]
+        type rack_app = ^(rack_env) -> rack_response
+
+        class RequestMiddleware
+          NETWORK_CLIENT_IP_TAG: ::String
+
+          @app: rack_app
+
+          def initialize: (rack_app app, ?::Hash[::Symbol, any] opt) -> void
+
+          def call: (rack_env env) -> rack_response
+
+          private
+
+          def tag_client_ip: (rack_env env) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
@@ -2,24 +2,20 @@ module Datadog
   module AIGuard
     module Contrib
       module Rack
-        type rack_env = ::Hash[::String, any]
-        type rack_response = [::Integer, ::Hash[::String, ::String], ::Array[::String]]
-        type rack_app = ^(rack_env) -> rack_response
-
         class RequestMiddleware
           NETWORK_CLIENT_IP_TAG: ::String
 
-          @app: rack_app
+          @app: ::Rack::app
 
-          def initialize: (rack_app app, ?::Hash[::Symbol, any] opt) -> void
+          def initialize: (::Rack::app app, ?::Hash[::Symbol, any] opt) -> void
 
-          def call: (rack_env env) -> rack_response
+          def call: (::Rack::env env) -> ::Rack::response
 
           private
 
           def consume_ai_guard_executed_flag: () -> bool
 
-          def tag_client_ip: (rack_env env) -> void
+          def tag_client_ip: (::Rack::env env) -> void
         end
       end
     end

--- a/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
@@ -17,6 +17,8 @@ module Datadog
 
           private
 
+          def client_ip_tags_missing?: () -> bool
+
           def ai_guard_span_recorded?: () -> bool
 
           def tag_client_ip: (rack_env env) -> void

--- a/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
@@ -17,6 +17,8 @@ module Datadog
 
           private
 
+          def ai_guard_span_recorded?: () -> bool
+
           def tag_client_ip: (rack_env env) -> void
         end
       end

--- a/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
+++ b/sig/datadog/ai_guard/contrib/rack/request_middleware.rbs
@@ -17,9 +17,7 @@ module Datadog
 
           private
 
-          def client_ip_tags_missing?: () -> bool
-
-          def ai_guard_span_recorded?: () -> bool
+          def consume_ai_guard_executed_flag: () -> bool
 
           def tag_client_ip: (rack_env env) -> void
         end

--- a/sig/datadog/ai_guard/contrib/rails/integration.rbs
+++ b/sig/datadog/ai_guard/contrib/rails/integration.rbs
@@ -1,0 +1,24 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rails
+        class Integration
+          include Datadog::AIGuard::Contrib::Integration
+          extend Datadog::AIGuard::Contrib::Integration::ClassMethods
+
+          MINIMUM_VERSION: ::Gem::Version
+
+          def self.version: () -> Gem::Version?
+
+          def self.loaded?: () -> bool
+
+          def self.compatible?: () -> bool
+
+          def self.auto_instrument?: () -> true
+
+          def patcher: () -> singleton(Patcher)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/contrib/rails/patcher.rbs
+++ b/sig/datadog/ai_guard/contrib/rails/patcher.rbs
@@ -7,13 +7,13 @@ module Datadog
 
           def self?.patched?: () -> bool
 
-          def self?.target_version: () -> untyped
+          def self?.target_version: () -> ::Gem::Version?
 
           def self?.patch: () -> void
 
           def self?.patch_before_initialize: () -> untyped
 
-          def self?.before_initialize: (untyped app) -> untyped
+          def self?.before_initialize: (untyped app) -> void
 
           def self?.add_middleware: (untyped app) -> untyped
 

--- a/sig/datadog/ai_guard/contrib/rails/patcher.rbs
+++ b/sig/datadog/ai_guard/contrib/rails/patcher.rbs
@@ -1,0 +1,25 @@
+module Datadog
+  module AIGuard
+    module Contrib
+      module Rails
+        module Patcher
+          BEFORE_INITIALIZE_ONLY_ONCE_PER_APP: untyped
+
+          def self?.patched?: () -> bool
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> void
+
+          def self?.patch_before_initialize: () -> untyped
+
+          def self?.before_initialize: (untyped app) -> untyped
+
+          def self?.add_middleware: (untyped app) -> untyped
+
+          def self?.include_middleware?: (untyped middleware, untyped app) -> bool
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ai_guard/ext.rbs
+++ b/sig/datadog/ai_guard/ext.rbs
@@ -8,6 +8,7 @@ module Datadog
       REASON_TAG: ::String
       BLOCKED_TAG: ::String
       EVENT_TAG: ::String
+      SERVICE_ENTRY_EXECUTED_TAG: ::String
       METASTRUCT_TAG: ::String
     end
   end

--- a/sig/datadog/tracing/client_ip.rbs
+++ b/sig/datadog/tracing/client_ip.rbs
@@ -1,9 +1,9 @@
 module Datadog
   module Tracing
     module ClientIp
-      def self.set_client_ip_tag: (Span span, ?headers: Core::HeaderCollection?, ?remote_ip: String?) -> void
+      def self.set_client_ip_tag: (Span | SpanOperation span, ?headers: Core::HeaderCollection?, ?remote_ip: String?) -> void
 
-      def self.set_client_ip_tag!: (Span span, ?headers: Core::HeaderCollection?, ?remote_ip: String?) -> void
+      def self.set_client_ip_tag!: (Span | SpanOperation span, ?headers: Core::HeaderCollection?, ?remote_ip: String?) -> void
 
       def self.extract_client_ip: (Core::HeaderCollection? headers, String? remote_ip) -> String?
 

--- a/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
+++ b/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
 
   before do
     Datadog.configure do |c|
-      c.ai_guard.enabled = ai_guard_enabled
+      c.ai_guard.enabled = true
     end
   end
 
@@ -29,10 +29,15 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     Datadog.configuration.reset!
   end
 
-  context "when AI Guard is enabled" do
-    let(:ai_guard_enabled) { true }
+  context "when an AI Guard span fired during the request" do
+    let(:app) do
+      lambda do |_env|
+        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        [200, {}, ["ok"]]
+      end
+    end
 
-    it "tags http.client_ip and network.client.ip on the active span" do
+    it "tags http.client_ip and network.client.ip on the request span" do
       Datadog::Tracing.trace("rack.request") do |span|
         middleware.call(env)
 
@@ -41,7 +46,7 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
       end
     end
 
-    it "passes the request to the inner app" do
+    it "passes the request through" do
       response = nil
       Datadog::Tracing.trace("rack.request") do
         response = middleware.call(env)
@@ -50,9 +55,18 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
       expect(response).to eq([200, {}, ["ok"]])
     end
 
-    context "when there is no active span" do
-      it "does not raise" do
-        expect { middleware.call(env) }.not_to raise_error
+    it "still tags on the way out when the inner app raises" do
+      raising_app = ->(_env) {
+        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        raise "boom"
+      }
+      mw = described_class.new(raising_app)
+
+      Datadog::Tracing.trace("rack.request") do |span|
+        expect { mw.call(env) }.to raise_error(RuntimeError, "boom")
+
+        expect(span.get_tag("http.client_ip")).to eq("198.51.100.42")
+        expect(span.get_tag("network.client.ip")).to eq("203.0.113.5")
       end
     end
 
@@ -107,10 +121,8 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     end
   end
 
-  context "when AI Guard is disabled" do
-    let(:ai_guard_enabled) { false }
-
-    it "does not tag the span" do
+  context "when no AI Guard span fired during the request" do
+    it "does not tag the request span" do
       Datadog::Tracing.trace("rack.request") do |span|
         middleware.call(env)
 
@@ -120,7 +132,22 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     end
 
     it "still passes the request through" do
-      expect(middleware.call(env)).to eq([200, {}, ["ok"]])
+      Datadog::Tracing.trace("rack.request") do
+        expect(middleware.call(env)).to eq([200, {}, ["ok"]])
+      end
+    end
+  end
+
+  context "when there is no active trace" do
+    let(:app) do
+      lambda do |_env|
+        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        [200, {}, ["ok"]]
+      end
+    end
+
+    it "does not raise" do
+      expect { middleware.call(env) }.not_to raise_error
     end
   end
 end

--- a/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
+++ b/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
@@ -138,6 +138,30 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     end
   end
 
+  context "when both client IP tags are already set" do
+    let(:app) do
+      lambda do |_env|
+        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        [200, {}, ["ok"]]
+      end
+    end
+
+    it "skips the span scan as a fast path" do
+      Datadog::Tracing.trace("rack.request") do |span|
+        span.set_tag("http.client_ip", "10.0.0.1")
+        span.set_tag("network.client.ip", "10.0.0.2")
+
+        active_trace = Datadog::Tracing.active_trace
+        expect(active_trace).not_to receive(:instance_variable_get).with(:@spans)
+
+        middleware.call(env)
+
+        expect(span.get_tag("http.client_ip")).to eq("10.0.0.1")
+        expect(span.get_tag("network.client.ip")).to eq("10.0.0.2")
+      end
+    end
+  end
+
   context "when there is no active trace" do
     let(:app) do
       lambda do |_env|

--- a/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
+++ b/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "datadog/tracing/contrib/support/spec_helper"
+
+require "datadog"
+require "datadog/ai_guard"
+require "rack"
+
+RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(_env) { [200, {}, ["ok"]] } }
+  let(:env) do
+    {
+      "REMOTE_ADDR" => "203.0.113.5",
+      "HTTP_X_FORWARDED_FOR" => "198.51.100.42",
+      "PATH_INFO" => "/",
+      "REQUEST_METHOD" => "GET",
+    }
+  end
+
+  before do
+    Datadog.configure do |c|
+      c.ai_guard.enabled = ai_guard_enabled
+    end
+  end
+
+  after do
+    Datadog.configuration.reset!
+  end
+
+  context "when AI Guard is enabled" do
+    let(:ai_guard_enabled) { true }
+
+    it "tags http.client_ip and network.client.ip on the active span" do
+      Datadog::Tracing.trace("rack.request") do |span|
+        middleware.call(env)
+
+        expect(span.get_tag("http.client_ip")).to eq("198.51.100.42")
+        expect(span.get_tag("network.client.ip")).to eq("203.0.113.5")
+      end
+    end
+
+    it "passes the request to the inner app" do
+      response = nil
+      Datadog::Tracing.trace("rack.request") do
+        response = middleware.call(env)
+      end
+
+      expect(response).to eq([200, {}, ["ok"]])
+    end
+
+    context "when there is no active span" do
+      it "does not raise" do
+        expect { middleware.call(env) }.not_to raise_error
+      end
+    end
+
+    context "when http.client_ip is already set" do
+      it "does not overwrite it" do
+        Datadog::Tracing.trace("rack.request") do |span|
+          span.set_tag("http.client_ip", "10.0.0.1")
+          middleware.call(env)
+
+          expect(span.get_tag("http.client_ip")).to eq("10.0.0.1")
+        end
+      end
+    end
+
+    context "when network.client.ip is already set" do
+      it "does not overwrite it" do
+        Datadog::Tracing.trace("rack.request") do |span|
+          span.set_tag("network.client.ip", "10.0.0.1")
+          middleware.call(env)
+
+          expect(span.get_tag("network.client.ip")).to eq("10.0.0.1")
+        end
+      end
+    end
+
+    context "when REMOTE_ADDR is missing" do
+      let(:env) { super().tap { |e| e.delete("REMOTE_ADDR") } }
+
+      it "does not set network.client.ip" do
+        Datadog::Tracing.trace("rack.request") do |span|
+          middleware.call(env)
+
+          expect(span.get_tag("network.client.ip")).to be_nil
+        end
+      end
+    end
+
+    context "when tagging raises" do
+      before do
+        allow(Datadog::Tracing::ClientIp).to receive(:set_client_ip_tag!).and_raise(StandardError, "boom")
+      end
+
+      it "reports to telemetry instead of raising" do
+        telemetry = instance_double(Datadog::Core::Telemetry::Component)
+        allow(Datadog::AIGuard).to receive(:telemetry).and_return(telemetry)
+        expect(telemetry).to receive(:report).with(an_instance_of(StandardError), description: a_string_including("AI Guard"))
+
+        Datadog::Tracing.trace("rack.request") do
+          expect { middleware.call(env) }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  context "when AI Guard is disabled" do
+    let(:ai_guard_enabled) { false }
+
+    it "does not tag the span" do
+      Datadog::Tracing.trace("rack.request") do |span|
+        middleware.call(env)
+
+        expect(span.get_tag("http.client_ip")).to be_nil
+        expect(span.get_tag("network.client.ip")).to be_nil
+      end
+    end
+
+    it "still passes the request through" do
+      expect(middleware.call(env)).to eq([200, {}, ["ok"]])
+    end
+  end
+end

--- a/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
+++ b/spec/datadog/ai_guard/contrib/rack/request_middleware_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     Datadog.configuration.reset!
   end
 
-  context "when an AI Guard span fired during the request" do
+  context "when AI Guard ran during the request" do
     let(:app) do
       lambda do |_env|
-        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        Datadog::Tracing.active_trace&.set_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG, "1")
         [200, {}, ["ok"]]
       end
     end
@@ -55,11 +55,19 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
       expect(response).to eq([200, {}, ["ok"]])
     end
 
+    it "removes the executed flag from the trace so it is not exported" do
+      Datadog::Tracing.trace("rack.request") do |_span, trace|
+        middleware.call(env)
+
+        expect(trace.get_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG)).to be_nil
+      end
+    end
+
     it "still tags on the way out when the inner app raises" do
-      raising_app = ->(_env) {
-        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+      raising_app = lambda do |_env|
+        Datadog::Tracing.active_trace&.set_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG, "1")
         raise "boom"
-      }
+      end
       mw = described_class.new(raising_app)
 
       Datadog::Tracing.trace("rack.request") do |span|
@@ -67,28 +75,6 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
 
         expect(span.get_tag("http.client_ip")).to eq("198.51.100.42")
         expect(span.get_tag("network.client.ip")).to eq("203.0.113.5")
-      end
-    end
-
-    context "when http.client_ip is already set" do
-      it "does not overwrite it" do
-        Datadog::Tracing.trace("rack.request") do |span|
-          span.set_tag("http.client_ip", "10.0.0.1")
-          middleware.call(env)
-
-          expect(span.get_tag("http.client_ip")).to eq("10.0.0.1")
-        end
-      end
-    end
-
-    context "when network.client.ip is already set" do
-      it "does not overwrite it" do
-        Datadog::Tracing.trace("rack.request") do |span|
-          span.set_tag("network.client.ip", "10.0.0.1")
-          middleware.call(env)
-
-          expect(span.get_tag("network.client.ip")).to eq("10.0.0.1")
-        end
       end
     end
 
@@ -121,7 +107,7 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     end
   end
 
-  context "when no AI Guard span fired during the request" do
+  context "when AI Guard did not run during the request" do
     it "does not tag the request span" do
       Datadog::Tracing.trace("rack.request") do |span|
         middleware.call(env)
@@ -138,34 +124,12 @@ RSpec.describe Datadog::AIGuard::Contrib::Rack::RequestMiddleware do
     end
   end
 
-  context "when both client IP tags are already set" do
-    let(:app) do
-      lambda do |_env|
-        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
-        [200, {}, ["ok"]]
-      end
-    end
-
-    it "skips the span scan as a fast path" do
-      Datadog::Tracing.trace("rack.request") do |span|
-        span.set_tag("http.client_ip", "10.0.0.1")
-        span.set_tag("network.client.ip", "10.0.0.2")
-
-        active_trace = Datadog::Tracing.active_trace
-        expect(active_trace).not_to receive(:instance_variable_get).with(:@spans)
-
-        middleware.call(env)
-
-        expect(span.get_tag("http.client_ip")).to eq("10.0.0.1")
-        expect(span.get_tag("network.client.ip")).to eq("10.0.0.2")
-      end
-    end
-  end
-
   context "when there is no active trace" do
     let(:app) do
       lambda do |_env|
-        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) { |_s| nil }
+        Datadog::Tracing.trace(Datadog::AIGuard::Ext::SPAN_NAME) do |_span, trace|
+          trace.set_tag(Datadog::AIGuard::Ext::SERVICE_ENTRY_EXECUTED_TAG, "1")
+        end
         [200, {}, ["ok"]]
       end
     end

--- a/vendor/rbs/rack/0/rack.rbs
+++ b/vendor/rbs/rack/0/rack.rbs
@@ -1,4 +1,8 @@
 module Rack
+  type env = ::Hash[::String, untyped]
+  type response = [::Integer, ::Hash[::String, ::String], ::Array[::String]]
+  type app = ^(env) -> response
+
   class Request
     def initialize: (::Hash[::String, untyped] env) -> void
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds collection of `http.client_ip` and `network.client.ip` tags to AI Guard via Rack middleware. This middleware is automatically added in Rails when AI Guard is enabled, similar to AppSec.

We want to always collect client IP addresses when AI Guard is used.

**Change log entry**
Yes. AI Guard: ensure that client IP is always collected when AI Guard is enabled.

**Additional Notes:**
[APPSEC-62200](https://datadoghq.atlassian.net/browse/APPSEC-62200)

**How to test the change?**
CI and manual testing with `appsec-app-generator`.

[APPSEC-62200]: https://datadoghq.atlassian.net/browse/APPSEC-62200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ