### PR TITLE
Reproduce: extract_all is slow on Ruby 2.6

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -135,9 +135,23 @@ module Datadog
       #
       # @return [Array<Scope>] Array of FILE scopes
       def extract_all
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        os_total = 0
+        ObjectSpace.each_object(Module) { os_total += 1 }
+        t_os = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         entries = collect_extractable_modules
+        t_collect = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         file_trees = build_file_trees(entries)
-        convert_trees_to_scopes(file_trees)
+        t_build = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        result = convert_trees_to_scopes(file_trees)
+        t_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        warn format(
+          "SYMDB-MEASURE total=%.3fs os_count_only=%.3fs(%d mods) collect=%.3fs(%d entries) build=%.3fs convert=%.3fs",
+          t_end - t0, t_os - t0, os_total,
+          t_collect - t_os, entries.size,
+          t_build - t_collect, t_end - t_build
+        )
+        result
       rescue => e
         @logger.debug { "symdb: error in extract_all: #{e.class}: #{e}" }
         []


### PR DESCRIPTION
**What does this PR do?**

Adds timing instrumentation (`SYMDB-MEASURE` STDERR prints) to `Extractor#extract_all` so CI logs reveal how long the function actually takes per Ruby version, with a per-phase breakdown (ObjectSpace count, collect, build, convert).

**Do not merge** — this PR exists to measure, not to fix.

**Motivation:**

PR #5431's flaky failure on Ruby 2.6 [1] core_old ([job](https://github.com/DataDog/dd-trace-rb/actions/runs/25326353038/job/74248400964)) was originally hypothesized as "ObjectSpace size after thousands of tests." That hypothesis was wrong. This PR's instrumentation in CI shows what is actually happening.

**Expected CI signal** (from earlier run on this same instrumentation [tmp/measure-symdb-extraction](https://github.com/DataDog/dd-trace-rb/actions/runs/25349025568)):

| Ruby | total | os_count | collect | mods |
|------|-------|----------|---------|------|
| 2.6  | **40.7s** | 28ms | **40.7s** | 30K |
| 2.7  | 0.33s | 27ms | 0.31s | 30K |
| 3.0  | 0.40s | 27ms | 0.37s | 30K |
| 3.1  | 0.44s | 36ms | 0.41s | 30K |
| 3.2  | 0.40s | 33ms | 0.37s | 30K |
| 3.3  | 0.33s | 14ms | 0.32s | 30K |

`os_count_only` (just iterating ObjectSpace.each_object(Module) with no per-module work) is identical across versions — so the cost is in the per-module work, not the iteration. On Ruby 2.6 specifically, `Module#name` on unnamed singleton classes with long ancestor chains (Datadog's `AtForkMonkeyPatch::KernelMonkeyPatch` prepended into Kernel + FFI fork tracking) is O(ancestors). ~5,600 such singletons × ~20ms each = ~112s.

**Companion PRs:**
- Fix: #5679
- Validation: #5680

**Change log entry**

None.

**How to test the change?**

CI logs will print `SYMDB-MEASURE total=...s` after every `extract_all` invocation. On Ruby 2.6 [shard running spec:main core_old] expect total to be 30+ seconds and the integration tests in remote_config_integration_spec.rb to fail naturally (their wait_for_idle(timeout: 5) is shorter than that). On Ruby 2.7+ same shard, expect total <1s and tests to pass.

**CI run on this branch:** [Unit Tests #25375638921](https://github.com/DataDog/dd-trace-rb/actions/runs/25375638921)