### PR TITLE
Skip singleton classes in Extractor#collect_extractable_modules

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -612,6 +612,15 @@ module Datadog
         entries = {}
 
         ObjectSpace.each_object(Module) do |mod|
+          # Singleton classes (per-object metaclasses) are never user-code classes.
+          # They're not const-referenced, DI cannot instrument methods on a singular
+          # object instance, and on Ruby 2.6 specifically, Module#name on unnamed
+          # singleton classes with long ancestor chains (e.g. through monkey-patches
+          # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
+          # — measured ~20ms per call, which dominates extract_all on heavily-loaded
+          # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
+          next if mod.singleton_class?
+
           mod_name = safe_mod_name(mod)
           next unless mod_name
           next unless user_code_module?(mod)

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2236,5 +2236,44 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(derived.language_specifics[:included_modules]).to include('ExtractAllMixin')
       end
     end
+
+    context 'with singleton classes in ObjectSpace' do
+      before do
+        @file = create_test_file('singleton_skip.rb', <<~RUBY)
+          class ExtractAllSingletonHost
+            def host_method; end
+          end
+        RUBY
+        load @file
+        # Force singleton classes to materialize so ObjectSpace contains them.
+        # On Ruby 2.6, asking Module#name on these takes ~20ms each — extract_all
+        # must skip them to avoid O(singleton_count) wall-clock cost.
+        @objs = Array.new(10) { Object.new.tap { |o| o.singleton_class } }
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllSingletonHost) if defined?(ExtractAllSingletonHost)
+        @objs = nil
+        GC.start
+      end
+
+      it 'does not include singleton classes in extracted scopes' do
+        scopes = extract_all_clean
+        all_names = scopes.flat_map { |s| [s.name] + (s.scopes || []).map(&:name) }
+        # Singleton classes return nil from Module#name; if any were extracted they
+        # would appear with empty/nil names (or as anonymous CLASS scopes).
+        expect(all_names).not_to include(nil)
+        expect(all_names).not_to include('')
+      end
+
+      it 'still extracts the user-code class hosting the singleton objects' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSingletonHost')
+        expect(file_scope).not_to be_nil
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllSingletonHost' }
+        expect(host).not_to be_nil
+        expect(host.scopes.map(&:name)).to include('host_method')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Skips singleton classes (per-object metaclasses) when iterating `ObjectSpace.each_object(Module)` in `Extractor#collect_extractable_modules`. Adds two regression tests in `extractor_spec.rb`.

**Motivation:**

PR #5431's flaky CI failure on Ruby 2.6 [1] core_old ([job](https://github.com/DataDog/dd-trace-rb/actions/runs/25326353038/job/74248400964)) was caused by `Extractor#extract_all` taking 30+ seconds per call on Ruby 2.6 — exceeding the integration test's 5-second `wait_for_idle` budget.

**Root cause** (measured locally on Ruby 2.6 with full `spec:main` process state, instrumentation in #5678):

```
SYMDB-MEASURE total=131.568s os_count_only=0.023s(29811 mods) collect=131.544s
SYMDB-SAFEMODNAME-BUCKETS {"<100us"=>44581, "<10ms"=>360, "<100ms"=>5601}
SYMDB-SAFEMODNAME-SLOW 0.027s {ancestors_count=>29, singleton_class_of=>true,
  sample_ancestor=>"Module,Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch"}
SYMDB-SAFEMODNAME-SLOW 0.026s {ancestors_count=>10, singleton_class_of=>true,
  sample_ancestor=>"Module,Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch"}
SYMDB-SAFEMODNAME-SLOW 0.026s {ancestors_count=>9, singleton_class_of=>true,
  sample_ancestor=>"Datadog::Core::Utils::AtForkMonkeyPatch::KernelMonkeyPatch,FFI::LegacyForkTracking::KernelExtPrivate"}
```

~5,600 unnamed singleton classes × ~20ms per `Module#name` call = ~112s. On Ruby 2.6, `Module#name` on an unnamed singleton class walks something proportional to its ancestor chain, and these chains are long because dd-trace-rb prepends `AtForkMonkeyPatch::KernelMonkeyPatch` into `Kernel` (which every Object's singleton class inherits from), and FFI does the same for fork tracking. Ruby 2.7+ optimized this path, so other versions complete the same work in ~300ms.

**Fix:** skip singleton classes at the iteration boundary. They are never user-code classes regardless of the Ruby 2.6 perf concern: they have no const reference, return nil from `Module#name`, and DI cannot instrument methods bound to a singular object instance. Skipping is correct semantics on every Ruby version, and a no-op on 2.7+ where the slow path was already optimized away.

**Local verification on Ruby 2.6** (against spec:main process state): `extract_all` drops from ~110s to <1s. Spec verification: 283 examples, 0 failures across `spec/datadog/symbol_database/` on both Ruby 2.6 and Ruby 3.2.

**Companion PRs:**
- Reproducer (instrumentation, do not merge): #5678
- Validation: #5680

**Change log entry**

None.

**How to test the change?**

`extractor_spec.rb` adds `'.extract_all with singleton classes in ObjectSpace'` examples that materialize singleton classes in ObjectSpace and assert (a) no singleton class appears in extracted scopes, (b) a co-resident user-code class is still extracted normally. Run on Ruby 2.6 with `BUNDLE_GEMFILE=gemfiles/ruby_2.6_core_old.gemfile bundle exec rspec spec/datadog/symbol_database/`.

**CI run on this branch:** [Unit Tests #25375640163](https://github.com/DataDog/dd-trace-rb/actions/runs/25375640163)

**Validation results:**

| | extract_all on Ruby 2.6 spec:main | integration test outcome |
|---|---|---|
| Reproducer ([#5678](https://github.com/DataDog/dd-trace-rb/pull/5678), no fix) | 42-43s × 6 calls (~30K modules) | 3/5 fail — the original failure |
| Validation ([#5680](https://github.com/DataDog/dd-trace-rb/pull/5680), reproducer + this fix) | 1.5-2.0s × 3 calls (~30K modules) | all pass |

~28× speedup on Ruby 2.6 in the heavy spec:main process state, comfortably under the test's 5-second `wait_for_idle` budget. No standard-test failures across either CI run.

The `dd/junit` and `dd/coverage` failures on the validation/reproducer tmp/* runs are unrelated infrastructure failures — those checks fail because tmp/* branches don't have access to internal Datadog credentials.