### PR TITLE
Validate fix: extract_all stays fast on Ruby 2.6 with instrumentation

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -612,6 +612,15 @@ module Datadog
         entries = {}
 
         ObjectSpace.each_object(Module) do |mod|
+          # Singleton classes (per-object metaclasses) are never user-code classes.
+          # They're not const-referenced, DI cannot instrument methods on a singular
+          # object instance, and on Ruby 2.6 specifically, Module#name on unnamed
+          # singleton classes with long ancestor chains (e.g. through monkey-patches
+          # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
+          # — measured ~20ms per call, which dominates extract_all on heavily-loaded
+          # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
+          next if mod.singleton_class?
+
           mod_name = safe_mod_name(mod)
           next unless mod_name
           next unless user_code_module?(mod)

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -135,9 +135,23 @@ module Datadog
       #
       # @return [Array<Scope>] Array of FILE scopes
       def extract_all
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        os_total = 0
+        ObjectSpace.each_object(Module) { os_total += 1 }
+        t_os = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         entries = collect_extractable_modules
+        t_collect = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         file_trees = build_file_trees(entries)
-        convert_trees_to_scopes(file_trees)
+        t_build = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        result = convert_trees_to_scopes(file_trees)
+        t_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        warn format(
+          "SYMDB-MEASURE total=%.3fs os_count_only=%.3fs(%d mods) collect=%.3fs(%d entries) build=%.3fs convert=%.3fs",
+          t_end - t0, t_os - t0, os_total,
+          t_collect - t_os, entries.size,
+          t_build - t_collect, t_end - t_build
+        )
+        result
       rescue => e
         @logger.debug { "symdb: error in extract_all: #{e.class}: #{e}" }
         []

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2236,5 +2236,44 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(derived.language_specifics[:included_modules]).to include('ExtractAllMixin')
       end
     end
+
+    context 'with singleton classes in ObjectSpace' do
+      before do
+        @file = create_test_file('singleton_skip.rb', <<~RUBY)
+          class ExtractAllSingletonHost
+            def host_method; end
+          end
+        RUBY
+        load @file
+        # Force singleton classes to materialize so ObjectSpace contains them.
+        # On Ruby 2.6, asking Module#name on these takes ~20ms each — extract_all
+        # must skip them to avoid O(singleton_count) wall-clock cost.
+        @objs = Array.new(10) { Object.new.tap { |o| o.singleton_class } }
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllSingletonHost) if defined?(ExtractAllSingletonHost)
+        @objs = nil
+        GC.start
+      end
+
+      it 'does not include singleton classes in extracted scopes' do
+        scopes = extract_all_clean
+        all_names = scopes.flat_map { |s| [s.name] + (s.scopes || []).map(&:name) }
+        # Singleton classes return nil from Module#name; if any were extracted they
+        # would appear with empty/nil names (or as anonymous CLASS scopes).
+        expect(all_names).not_to include(nil)
+        expect(all_names).not_to include('')
+      end
+
+      it 'still extracts the user-code class hosting the singleton objects' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSingletonHost')
+        expect(file_scope).not_to be_nil
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllSingletonHost' }
+        expect(host).not_to be_nil
+        expect(host.scopes.map(&:name)).to include('host_method')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix in #5679 reduces extract_all timing on Ruby 2.6, by layering the reproducer (#5678) timing instrumentation over the fix and observing CI logs.

**Do not merge** — this PR exists for CI validation only.

This branch is the merge of:
- #5678 (reproducer / SYMDB-MEASURE instrumentation)
- #5679 (singleton-class skip)

If CI logs show `SYMDB-MEASURE total<1s` on the Ruby 2.6 shard that runs spec:main core_old (where the unfixed branch shows total=40s+), the fix has the predicted effect. If the timing is still 30+ seconds, the fix is insufficient and #5679 needs revision.

**Companion PRs:**
- Reproducer: #5678
- Fix: #5679

**Change log entry**

None.

**How to test the change?**

CI runs Unit Tests on every Ruby version via the `tmp/validate-symdb-extraction-perf` branch alias. Look for `SYMDB-MEASURE` lines in any Ruby 2.6 standard shard log; expect total <1s. spec/datadog/symbol_database/remote_config_integration_spec.rb tests should pass on every Ruby version on every shard.

**CI run on this branch:** [Unit Tests #25375638273](https://github.com/DataDog/dd-trace-rb/actions/runs/25375638273)