### PR TITLE
Skip singleton classes in Extractor#collect_extractable_modules

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -77,6 +77,14 @@ module Datadog
       # :call excluded — method entry is handled by method probes, not line probes
       INJECTABLE_LINE_EVENTS = [:line, :return].freeze
 
+      # Cached unbound Module#singleton_class? — dispatched explicitly so user classes
+      # that define their own `singleton_class?` (e.g. with required arguments) cannot
+      # intercept the predicate and cause the module to be silently dropped from
+      # extract_all. Cached at load time because collect_extractable_modules iterates
+      # ObjectSpace.each_object(Module) over tens of thousands of modules.
+      MODULE_SINGLETON_CLASS_PRED = Module.instance_method(:singleton_class?)
+      private_constant :MODULE_SINGLETON_CLASS_PRED
+
       # @param logger [Logger] Logger instance (SymbolDatabase::Logger facade or compatible)
       # @param settings [Configuration::Settings] Tracer settings
       # @param telemetry [Telemetry, nil] Optional telemetry for metrics
@@ -619,7 +627,7 @@ module Datadog
           # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
           # — measured ~20ms per call, which dominates extract_all on heavily-loaded
           # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
-          next if mod.singleton_class?
+          next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
 
           mod_name = safe_mod_name(mod)
           next unless mod_name

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -612,6 +612,15 @@ module Datadog
         entries = {}
 
         ObjectSpace.each_object(Module) do |mod|
+          # Singleton classes (per-object metaclasses) are never user-code classes.
+          # They're not const-referenced, DI cannot instrument methods on a singular
+          # object instance, and on Ruby 2.6 specifically, Module#name on unnamed
+          # singleton classes with long ancestor chains (e.g. through monkey-patches
+          # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
+          # — measured ~20ms per call, which dominates extract_all on heavily-loaded
+          # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
+          next if mod.singleton_class?
+
           mod_name = safe_mod_name(mod)
           next unless mod_name
           next unless user_code_module?(mod)

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -5,6 +5,7 @@ module Datadog
       UNKNOWN_MAX_LINE: Integer
       EXCLUDED_COMMON_MODULES: Array[String]
       INJECTABLE_LINE_EVENTS: Array[::Symbol]
+      MODULE_SINGLETON_CLASS_PRED: UnboundMethod
 
       @logger: untyped
       @settings: untyped

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2289,5 +2289,41 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(host.scopes.map(&:name)).to include('host_method')
       end
     end
+
+    context 'with a class overriding singleton_class?' do
+      # Some libraries define class methods that shadow Module#singleton_class?
+      # (typically with required arguments). The singleton-class skip in
+      # collect_extractable_modules dispatches via the unbound Module#singleton_class?
+      # so user overrides cannot intercept the predicate. Without that dispatch,
+      # calling the user method without its required argument would raise and the
+      # class would be silently dropped by the per-module rescue.
+      before do
+        @file = create_test_file('singleton_class_pred_override.rb', <<~RUBY)
+          class ExtractAllSingletonPredOverride
+            def self.singleton_class?(required_kwarg:)
+              required_kwarg
+            end
+
+            def host_method; end
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        if defined?(ExtractAllSingletonPredOverride)
+          Object.send(:remove_const, :ExtractAllSingletonPredOverride)
+        end
+      end
+
+      it 'still extracts the class despite the overridden predicate' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSingletonPredOverride')
+        expect(file_scope).not_to be_nil
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllSingletonPredOverride' }
+        expect(host).not_to be_nil
+        expect(host.scopes.map(&:name)).to include('host_method')
+      end
+    end
   end
 end

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2250,5 +2250,44 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(derived.language_specifics[:included_modules]).to include('ExtractAllMixin')
       end
     end
+
+    context 'with singleton classes in ObjectSpace' do
+      before do
+        @file = create_test_file('singleton_skip.rb', <<~RUBY)
+          class ExtractAllSingletonHost
+            def host_method; end
+          end
+        RUBY
+        load @file
+        # Force singleton classes to materialize so ObjectSpace contains them.
+        # On Ruby 2.6, asking Module#name on these takes ~20ms each — extract_all
+        # must skip them to avoid O(singleton_count) wall-clock cost.
+        @objs = Array.new(10) { Object.new.tap { |o| o.singleton_class } }
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllSingletonHost) if defined?(ExtractAllSingletonHost)
+        @objs = nil
+        GC.start
+      end
+
+      it 'does not include singleton classes in extracted scopes' do
+        scopes = extract_all_clean
+        all_names = scopes.flat_map { |s| [s.name] + (s.scopes || []).map(&:name) }
+        # Singleton classes return nil from Module#name; if any were extracted they
+        # would appear with empty/nil names (or as anonymous CLASS scopes).
+        expect(all_names).not_to include(nil)
+        expect(all_names).not_to include('')
+      end
+
+      it 'still extracts the user-code class hosting the singleton objects' do
+        scopes = extract_all_clean
+        file_scope = find_file_scope(scopes, 'ExtractAllSingletonHost')
+        expect(file_scope).not_to be_nil
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllSingletonHost' }
+        expect(host).not_to be_nil
+        expect(host.scopes.map(&:name)).to include('host_method')
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Cherry-picks #5679 onto master. Skips singleton classes in `Extractor#collect_extractable_modules` so they are not enumerated for symbol extraction.

**Motivation:**

#5679 merged into `symbol-database-upload` (PR #5431) but not master. The fix addresses a Ruby 2.6 hot-spot where `Module#name` on unnamed singleton classes with long ancestor chains is O(ancestors), causing `extract_all` to spend ~110s per invocation in test processes with many materialized singleton classes. Singleton classes are never user code regardless of the perf concern — they have no name, no const reference, and DI cannot instrument methods defined on a singular instance — so skipping them is correct semantics across all Ruby versions.

**Change log entry**

None.

**Additional Notes:**

Straight cherry-pick of 4c88974 from #5679 — applies cleanly with no conflicts.

**How to test the change?**

`bundle exec rake test:symbol_database` covers the two new `extract_all` examples in `spec/datadog/symbol_database/extractor_spec.rb` that materialize singleton classes in ObjectSpace and assert (a) no singleton class appears in the extracted scope tree, (b) a co-resident user-code class is still extracted normally.