### PR TITLE
Fix Ruby 2.5 shadowing warning in URL encoded parser

### DIFF
--- a/lib/datadog/appsec/utils/http/url_encoded.rb
+++ b/lib/datadog/appsec/utils/http/url_encoded.rb
@@ -30,8 +30,8 @@ module Datadog
               #
               # @type var key: ::String
               # @type var value: ::String
-              key, value = pair.split('=', 2).map! do |value|
-                CGI.unescape(value)
+              key, value = pair.split('=', 2).map! do |val|
+                CGI.unescape(val)
               end #: [::String, ::String]
 
               if (stored = memo[key])


### PR DESCRIPTION
**What does this PR do?**

Renames a block variable in `AppSec::Utils::HTTP::URLEncoded` to avoid shadowing the outer destructuring variable of the same name.

**Motivation:**

Ruby 2.5 emits a `warning: shadowing` diagnostic for the block parameter `value` at line 33, which causes `loading_spec` to fail because it asserts that loading products produces no output.

**Change log entry**

None.

**Additional Notes:**

One-line rename: `|value|` → `|val|`.

**How to test the change?**

```bash
ASDF_RUBY_VERSION=2.5.9 bundle exec rspec spec/loading_spec.rb --seed 20904
```