### PR TITLE
[APPSEC-62718] Add block tag to rasp.rule.match telemetry metric

### DIFF
--- a/lib/datadog/appsec/metrics/telemetry.rb
+++ b/lib/datadog/appsec/metrics/telemetry.rb
@@ -5,6 +5,11 @@ module Datadog
     module Metrics
       # A class responsible for reporting WAF and RASP telemetry metrics.
       module Telemetry
+        ACTION_BLOCK = 'block_request'
+        ACTION_REDIRECT = 'redirect_request'
+        BLOCK_SUCCESS = 'success'
+        BLOCK_IRRELEVANT = 'irrelevant'
+
         module_function
 
         def report_rasp(type, result, phase: nil)
@@ -19,8 +24,15 @@ module Datadog
           namespace = Ext::TELEMETRY_METRICS_NAMESPACE
 
           AppSec.telemetry.inc(namespace, 'rasp.rule.eval', 1, tags: tags)
-          AppSec.telemetry.inc(namespace, 'rasp.rule.match', 1, tags: tags) if result.match?
           AppSec.telemetry.inc(namespace, 'rasp.timeout', 1, tags: tags) if result.timeout?
+
+          if result.match?
+            blocked = result.actions.key?(ACTION_BLOCK) || result.actions.key?(ACTION_REDIRECT)
+            # NOTE: Mutates tags to avoid an extra hash allocation. Keep this the last .inc call.
+            tags[:block] = blocked ? BLOCK_SUCCESS : BLOCK_IRRELEVANT
+
+            AppSec.telemetry.inc(namespace, 'rasp.rule.match', 1, tags: tags)
+          end
         end
       end
     end

--- a/sig/datadog/appsec/metrics/telemetry.rbs
+++ b/sig/datadog/appsec/metrics/telemetry.rbs
@@ -2,6 +2,11 @@ module Datadog
   module AppSec
     module Metrics
       module Telemetry
+        ACTION_BLOCK: ::String
+        ACTION_REDIRECT: ::String
+        BLOCK_SUCCESS: ::String
+        BLOCK_IRRELEVANT: ::String
+
         def self?.report_rasp: (Ext::rasp_rule_type type, SecurityEngine::result result, ?phase: ::String?) -> void
       end
     end

--- a/spec/datadog/appsec/metrics/telemetry_spec.rb
+++ b/spec/datadog/appsec/metrics/telemetry_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Datadog::AppSec::Metrics::Telemetry do
   let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
 
   describe '.report_rasp' do
-    context 'when reporting a match run result' do
+    context 'when result matches without blocking actions' do
       let(:run_result) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
           events: [], actions: {}, attributes: {}, keep: false, timeout: false, duration_ns: 0, duration_ext_ns: 0,
@@ -22,17 +22,53 @@ RSpec.describe Datadog::AppSec::Metrics::Telemetry do
         )
       end
 
-      it 'does not set WAF metrics on the span' do
+      it 'reports rasp.rule.match with irrelevant block tag' do
         expect(telemetry).to receive(:inc)
           .with('specsec', 'rasp.rule.eval', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
         expect(telemetry).to receive(:inc)
-          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
+          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99', block: 'irrelevant'})
 
         described_class.report_rasp('my-type', run_result)
       end
     end
 
-    context 'when reporting a match run result with timeout' do
+    context 'when result matches with block_request action' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [], actions: {'block_request' => {}}, attributes: {}, keep: false, timeout: false,
+          duration_ns: 0, duration_ext_ns: 0, input_truncated: false
+        )
+      end
+
+      it 'reports rasp.rule.match with success block tag' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99', block: 'success'})
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when result matches with redirect_request action' do
+      let(:run_result) do
+        Datadog::AppSec::SecurityEngine::Result::Match.new(
+          events: [], actions: {'redirect_request' => {}}, attributes: {}, keep: false, timeout: false,
+          duration_ns: 0, duration_ext_ns: 0, input_truncated: false
+        )
+      end
+
+      it 'reports rasp.rule.match with success block tag' do
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.eval', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
+        expect(telemetry).to receive(:inc)
+          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99', block: 'success'})
+
+        described_class.report_rasp('my-type', run_result)
+      end
+    end
+
+    context 'when result matches with timeout' do
       let(:run_result) do
         Datadog::AppSec::SecurityEngine::Result::Match.new(
           events: [], actions: {}, attributes: {}, keep: false, timeout: true, duration_ns: 0, duration_ext_ns: 0,
@@ -40,11 +76,11 @@ RSpec.describe Datadog::AppSec::Metrics::Telemetry do
         )
       end
 
-      it 'does not set WAF metrics on the span' do
+      it 'reports rasp.rule.match with block irrelevant and rasp.timeout' do
         expect(telemetry).to receive(:inc)
           .with('specsec', 'rasp.rule.eval', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
         expect(telemetry).to receive(:inc)
-          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
+          .with('specsec', 'rasp.rule.match', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99', block: 'irrelevant'})
         expect(telemetry).to receive(:inc)
           .with('specsec', 'rasp.timeout', 1, tags: {rule_type: 'my-type', waf_version: '1.42.99'})
 


### PR DESCRIPTION
**What does this PR do?**

Adds the `block` tag to the `appsec.rasp.rule.match` telemetry metric per RFC 471, indicating whether a RASP match resulted in blocking.

**Motivation:**

The K9 Ruby Ecosystems April 2026 site-up report flagged `block` as 100% N/A on `rasp.rule.match` (Tier 1 finding T1-2). Python and Go already emit this tag; Ruby and Java do not. Without it we cannot distinguish blocked vs monitored RASP matches fleet-wide.

APPSEC-62718

**Change log entry**

None.

**Additional Notes:**

Tag values follow RFC 471 and match Python/Go implementations:
- `success` — WAF actions contain `block_request` or `redirect_request`
- `irrelevant` — match without blocking (monitoring mode)

The `block` tag is only added to `rasp.rule.match`, not to `rasp.rule.eval` or `rasp.timeout`. Tags hash is mutated in-place to avoid an extra allocation — the match emission is intentionally last.

**How to test the change?**

`bundle exec rspec spec/datadog/appsec/metrics/telemetry_spec.rb`