### PR TITLE
Tolerate invalid UTF-8 and malformed percent-encoding in baggage headers

### DIFF
--- a/lib/datadog/tracing/distributed/baggage.rb
+++ b/lib/datadog/tracing/distributed/baggage.rb
@@ -136,6 +136,15 @@ module Datadog
         # @param baggage_header [String] The W3C Baggage header string to parse
         # @return [Hash<String, String>] A hash of decoded baggage items
         def parse_baggage_header(baggage_header)
+          # Reject inputs that would cause String operations below to raise.
+          # `valid_encoding?` is true for ASCII-8BIT regardless of byte values, so
+          # the typical Rack path is unaffected; only UTF-8-tagged-but-actually-invalid
+          # input (e.g. headers re-encoded upstream) is short-circuited here.
+          unless baggage_header.valid_encoding?
+            record_telemetry_metric('context_header_style.malformed', 1, {'header_style' => 'baggage'})
+            return {}
+          end
+
           baggage = {}
           baggages = baggage_header.split(',')
           baggages.each do |key_value|
@@ -147,8 +156,17 @@ module Datadog
               return {}
             end
 
-            key = URI.decode_www_form_component(key.strip)
-            value = URI.decode_www_form_component(value.strip)
+            begin
+              key = URI.decode_www_form_component(key.strip)
+              value = URI.decode_www_form_component(value.strip)
+            rescue ArgumentError
+              # `URI.decode_www_form_component` raises on malformed percent encoding
+              # (e.g. `%XX`, lone `%`). Treat as malformed rather than letting it
+              # propagate to `Propagation#extract`'s caller.
+              record_telemetry_metric('context_header_style.malformed', 1, {'header_style' => 'baggage'})
+              return {}
+            end
+
             if key.empty? || value.empty?
               # Record telemetry for malformed header
               record_telemetry_metric('context_header_style.malformed', 1, {'header_style' => 'baggage'})

--- a/spec/datadog/tracing/distributed/baggage_spec.rb
+++ b/spec/datadog/tracing/distributed/baggage_spec.rb
@@ -404,6 +404,67 @@ RSpec.describe Datadog::Tracing::Distributed::Baggage do
           expect(result.baggage).to eq({})
         end
       end
+
+      context 'with invalid UTF-8 bytes in the header' do
+        # `String#split` and `String#strip` raise `ArgumentError: invalid byte
+        # sequence in UTF-8` when the receiver is UTF-8-tagged but contains an
+        # invalid byte sequence. That exception escapes `Propagation#extract`
+        # because the baggage propagator runs outside its rescue block, despite
+        # the `extract` docstring's "never raises" promise.
+        let(:data) { {'baggage' => (+"key=value\xC0\xC0").force_encoding('UTF-8')} }
+
+        it 'returns empty baggage and records malformed telemetry, never raises' do
+          expect(telemetry).to receive(:inc).with(
+            'instrumentation_telemetry_data.tracers',
+            'context_header_style.malformed',
+            1,
+            tags: {'header_style' => 'baggage'}
+          )
+
+          result = nil
+          expect { result = propagation.extract(data) }.not_to raise_error
+          expect(result.baggage).to eq({})
+        end
+      end
+
+      context 'with malformed percent-encoding in a value' do
+        # `URI.decode_www_form_component` raises `ArgumentError: invalid
+        # %-encoding (%XX)` on malformed percent sequences. Same escape route
+        # as the invalid-UTF-8 case above.
+        let(:data) { {'baggage' => 'key=%XX'} }
+
+        it 'returns empty baggage and records malformed telemetry, never raises' do
+          expect(telemetry).to receive(:inc).with(
+            'instrumentation_telemetry_data.tracers',
+            'context_header_style.malformed',
+            1,
+            tags: {'header_style' => 'baggage'}
+          )
+
+          result = nil
+          expect { result = propagation.extract(data) }.not_to raise_error
+          expect(result.baggage).to eq({})
+        end
+      end
+
+      context 'with ASCII-8BIT-encoded header (typical Rack input)' do
+        # Rack delivers HTTP header values as ASCII-8BIT (binary). Every byte
+        # sequence is "valid" in that encoding, so `valid_encoding?` is true
+        # and parsing proceeds normally.
+        let(:data) { {'baggage' => (+'key=value').force_encoding('ASCII-8BIT')} }
+
+        it 'parses normally' do
+          expect(telemetry).to receive(:inc).with(
+            'instrumentation_telemetry_data.tracers',
+            'context_header_style.extracted',
+            1,
+            tags: {'header_style' => 'baggage'}
+          )
+
+          result = propagation.extract(data)
+          expect(result.baggage).to eq('key' => 'value')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Makes `Datadog::Tracing::Distributed::Baggage#parse_baggage_header` treat two classes of malformed input as "malformed header → empty baggage" rather than raising `ArgumentError` into the caller:

1. `baggage_header.valid_encoding? == false` — UTF-8-tagged input containing invalid byte sequences. Affects `String#split`, `String#strip`, and `URI.decode_www_form_component`, all of which raise on invalid UTF-8.
2. Malformed percent encoding (e.g. `%XX`, lone `%`) — raises from `URI.decode_www_form_component`.

Both paths now record the existing `context_header_style.malformed` telemetry metric and return `{}`, matching the shape of every other malformed-header branch in this method.

**Motivation:**

This PR was opened in response to review feedback on #5672 (the baggage size/item limits PR), to make the recommendations easier to evaluate as a self-contained change. The findings surfaced during a focused review of how the parser interacts with non-ASCII and malformed input.

`Propagation#extract` documents that it never raises — it logs and returns. That contract holds for every other distributed-trace propagator because the loop in `Propagation#extract` is wrapped in `rescue => e`. Baggage is the exception: `propagate_baggage` is invoked outside that rescue (`lib/datadog/tracing/distributed/propagation.rb:146`), so any exception raised inside `Baggage#extract` propagates to whoever called `Propagation#extract` — typically a Rack middleware in customer code.

A baggage header containing either invalid UTF-8 bytes (when the upstream hands the propagator a UTF-8-tagged string) or \`%XX\` is enough to trigger this. Both raises are pre-existing in the parser; this PR closes them at their source.

The change is intentionally narrow:
- ASCII-8BIT input (Rack's default for HTTP headers) is unaffected: \`valid_encoding?\` is true for binary-encoded strings regardless of byte values.
- Valid UTF-8 input is unaffected.
- The existing malformed paths and telemetry are unchanged.

**Change log entry**

Yes. Stop raising on baggage headers containing invalid UTF-8 bytes or malformed percent-encoded sequences; treat them as malformed and return empty baggage.

**Additional Notes:**

Companion to #5672 — both touch \`parse_baggage_header\` but at different lines (size/item caps vs. encoding/decoding safety) and merge cleanly in either order.

**How to test the change?**

\`\`\`
bundle exec rspec spec/datadog/tracing/distributed/baggage_spec.rb
\`\`\`

Three new specs cover: invalid-UTF-8 input never raises, malformed percent-encoded input never raises, and ASCII-8BIT input continues to parse normally. Verified that the first two specs fail without the production change.