### PR TITLE
SymDB: Add ScopeBatcher for batching extracted scopes

### DIFF
--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -35,6 +35,10 @@ module Datadog
       # This prevents runaway memory usage in applications with very large
       # numbers of loaded classes (e.g., heavily modularized Rails apps).
       MAX_FILES = 10_000
+      # Seconds to wait for the timer thread to exit when joining during
+      # shutdown or reset. Bounded so a misbehaving thread cannot hang the
+      # caller indefinitely.
+      TIMER_JOIN_TIMEOUT = 5
 
       # Initialize batching context.
       # @param uploader [Uploader] Uploader instance for triggering uploads
@@ -158,7 +162,7 @@ module Datadog
 
         # Join the timer thread outside the mutex.
         # The thread checks @timer_stopped and exits when signaled.
-        thread_to_join&.join(5)  # 5-second timeout to avoid hanging
+        thread_to_join&.join(TIMER_JOIN_TIMEOUT)
 
         # Upload outside mutex
         perform_upload(scopes_to_upload) unless scopes_to_upload.nil? || scopes_to_upload.empty?
@@ -197,7 +201,7 @@ module Datadog
           @timer_thread = nil
         end
 
-        thread_to_join&.join(5)
+        thread_to_join&.join(TIMER_JOIN_TIMEOUT)
 
         # Allow timer to be restarted after reset
         @mutex.synchronize do

--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -38,11 +38,14 @@ module Datadog
 
       # Initialize batching context.
       # @param uploader [Uploader] Uploader instance for triggering uploads
+      # @param logger [Logger] Logger for diagnostics
+      # @param telemetry [Core::Telemetry::Component, nil] Telemetry for error reporting
       # @param on_upload [Proc, nil] Optional callback called after upload (for testing)
       # @param timer_enabled [Boolean] Enable async timer (default true, false for tests)
-      def initialize(uploader, logger:, on_upload: nil, timer_enabled: true)
+      def initialize(uploader, logger:, telemetry: nil, on_upload: nil, timer_enabled: true)
         @uploader = uploader
         @logger = logger
+        @telemetry = telemetry
         @on_upload = on_upload
         @timer_enabled = timer_enabled
         @scopes = []
@@ -68,6 +71,7 @@ module Datadog
       # @param scope [Scope] The scope to add
       # @return [void]
       def add_scope(scope)
+        # @type var scopes_to_upload: ::Array[Scope]?
         scopes_to_upload = nil
 
         @mutex.synchronize do
@@ -93,10 +97,8 @@ module Datadog
           # Check if batch size reached (AFTER adding)
           if @scopes.size >= MAX_SCOPES
             # Prepare for upload (clear within mutex)
-            # steep:ignore:start
             scopes_to_upload = @scopes.dup
             @scopes.clear
-            # steep:ignore:end
           end
 
           # Signal the timer thread to reset its inactivity deadline.
@@ -111,15 +113,16 @@ module Datadog
         perform_upload(scopes_to_upload) if scopes_to_upload
       rescue => e
         @logger.debug { "symdb: failed to add scope: #{e.class}: #{e.message}" }
+        @telemetry&.report(e, description: 'symdb: failed to add scope')
         # Don't propagate, continue operation
       end
 
       # Force upload of current batch immediately.
       # @return [void]
       def flush
+        # @type var scopes_to_upload: ::Array[Scope]?
         scopes_to_upload = nil
 
-        # steep:ignore:start
         @mutex.synchronize do
           return if @scopes.empty?
 
@@ -128,18 +131,25 @@ module Datadog
         end
 
         perform_upload(scopes_to_upload)
-        # steep:ignore:end
       end
 
       # Shutdown and upload remaining scopes.
       # @return [void]
       def shutdown
+        # @type var scopes_to_upload: ::Array[Scope]?
         scopes_to_upload = nil
+        # @type var thread_to_join: ::Thread?
+        thread_to_join = nil
 
-        # steep:ignore:start
         @mutex.synchronize do
           @timer_stopped = true
           @timer_cv.signal  # Wake the timer thread so it exits
+
+          # Capture the timer thread under the mutex so a concurrent add_scope
+          # cannot create a new thread that we'd accidentally orphan when we
+          # nil the field below.
+          thread_to_join = @timer_thread
+          @timer_thread = nil
 
           scopes_to_upload = @scopes.dup
           @scopes.clear
@@ -147,34 +157,10 @@ module Datadog
 
         # Join the timer thread outside the mutex.
         # The thread checks @timer_stopped and exits when signaled.
-        @timer_thread&.join(5)  # 5-second timeout to avoid hanging
-        @timer_thread = nil
+        thread_to_join&.join(5)  # 5-second timeout to avoid hanging
 
         # Upload outside mutex
-        perform_upload(scopes_to_upload) unless scopes_to_upload.empty?
-        # steep:ignore:end
-      end
-
-      # Reset state (for testing).
-      # @return [void]
-      # @api private
-      def reset
-        @mutex.synchronize do
-          @scopes.clear
-          @timer_stopped = true
-          @timer_cv.signal
-          @file_count = 0
-          @uploaded_modules.clear
-        end
-
-        @timer_thread&.join(5)
-        @timer_thread = nil
-
-        # Allow timer to be restarted after reset
-        @mutex.synchronize do
-          @timer_stopped = false
-          @timer_signaled = false
-        end
+        perform_upload(scopes_to_upload) unless scopes_to_upload.nil? || scopes_to_upload.empty?
       end
 
       # Check if scopes are pending upload.
@@ -190,6 +176,34 @@ module Datadog
       end
 
       private
+
+      # Reset state. Private so production code cannot accidentally invoke it;
+      # tests call via +send(:reset)+.
+      # @return [void]
+      def reset
+        # @type var thread_to_join: ::Thread?
+        thread_to_join = nil
+
+        @mutex.synchronize do
+          @scopes.clear
+          @timer_stopped = true
+          @timer_cv.signal
+          @file_count = 0
+          @uploaded_modules.clear
+
+          # Capture under the mutex (see shutdown for rationale).
+          thread_to_join = @timer_thread
+          @timer_thread = nil
+        end
+
+        thread_to_join&.join(5)
+
+        # Allow timer to be restarted after reset
+        @mutex.synchronize do
+          @timer_stopped = false
+          @timer_signaled = false
+        end
+      end
 
       # Start the timer thread if not already running.
       # Must be called from within @mutex.synchronize.
@@ -245,6 +259,7 @@ module Datadog
         end
       rescue => e
         @logger.debug { "symdb: timer thread error: #{e.class}: #{e.message}" }
+        @telemetry&.report(e, description: 'symdb: timer thread error')
       end
 
       # Perform upload via uploader.
@@ -257,6 +272,7 @@ module Datadog
         @on_upload&.call(scopes)  # Notify tests after upload
       rescue => e
         @logger.debug { "symdb: upload failed: #{e.class}: #{e.message}" }
+        @telemetry&.report(e, description: 'symdb: upload failed')
         # Don't propagate, uploader handles retries
       end
     end

--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Datadog
+  module SymbolDatabase
+    # Batches extracted scopes and triggers uploads at appropriate times.
+    #
+    # Implements two upload triggers:
+    # 1. Size-based: Immediate upload when 400 scopes collected (MAX_SCOPES)
+    # 2. Time-based: Upload after 1 second of inactivity (debounce timer, not periodic)
+    #
+    # Also provides:
+    # - Deduplication: Tracks uploaded module names to prevent re-uploads
+    # - File limiting: Stops after 10,000 files to prevent runaway extraction
+    # - Thread safety: Mutex-protected state for concurrent access
+    #
+    # Timer implementation: A single long-lived thread waits on a ConditionVariable
+    # with a timeout. Each add_scope signals the CV to reset the deadline. When the
+    # timeout expires without a signal, the timer fires and flushes the batch.
+    # This avoids creating/destroying a thread per add_scope call.
+    #
+    # Flow: Extractor → add_scope → (batch or timer) → Uploader
+    # Created by: Component (during initialization)
+    # Calls: Uploader.upload_scopes when batch full or timer fires
+    #
+    # @api private
+    class ScopeBatcher
+      # Maximum scopes per batch before triggering immediate upload.
+      # This matches the batch size used in Java and Python tracers to ensure
+      # consistent upload behavior across languages.
+      MAX_SCOPES = 400
+      INACTIVITY_TIMEOUT = 1.0  # seconds
+      # Maximum unique files to track before stopping extraction.
+      # This prevents runaway memory usage in applications with very large
+      # numbers of loaded classes (e.g., heavily modularized Rails apps).
+      MAX_FILES = 10_000
+
+      # Initialize batching context.
+      # @param uploader [Uploader] Uploader instance for triggering uploads
+      # @param on_upload [Proc, nil] Optional callback called after upload (for testing)
+      # @param timer_enabled [Boolean] Enable async timer (default true, false for tests)
+      def initialize(uploader, logger:, on_upload: nil, timer_enabled: true)
+        @uploader = uploader
+        @logger = logger
+        @on_upload = on_upload
+        @timer_enabled = timer_enabled
+        @scopes = []
+        @mutex = Mutex.new
+        @file_count = 0
+        @uploaded_modules = Set.new
+
+        # Timer state: single long-lived thread + ConditionVariable for debounce.
+        # @timer_signaled is set to true on each add_scope and cleared by the timer
+        # thread after waking. This flag is needed because ConditionVariable#wait
+        # does not distinguish signal vs timeout on Ruby < 3.2 (returns self in both
+        # cases). The flag gives a portable way to detect whether the wakeup was a
+        # signal (reset deadline) or a timeout (fire the timer).
+        @timer_cv = ConditionVariable.new
+        @timer_thread = nil
+        @timer_stopped = false
+        @timer_signaled = false
+      end
+
+      # Add a scope to the batch.
+      # Triggers immediate upload if batch reaches 400 scopes.
+      # Resets inactivity timer if batch not full.
+      # @param scope [Scope] The scope to add
+      # @return [void]
+      def add_scope(scope)
+        scopes_to_upload = nil
+
+        @mutex.synchronize do
+          # Check file limit
+          if @file_count >= MAX_FILES
+            @logger.debug { "symdb: file limit (#{MAX_FILES}) reached, ignoring scope: #{scope.name}" }
+            return
+          end
+
+          @file_count += 1
+
+          # Check if already uploaded
+          if @uploaded_modules.include?(scope.name)
+            @logger.trace { "symdb: skipping #{scope.name}: already uploaded" }
+            return
+          end
+
+          @uploaded_modules.add(scope.name)
+
+          # Add the scope
+          @scopes << scope
+
+          # Check if batch size reached (AFTER adding)
+          if @scopes.size >= MAX_SCOPES
+            # Prepare for upload (clear within mutex)
+            # steep:ignore:start
+            scopes_to_upload = @scopes.dup
+            @scopes.clear
+            # steep:ignore:end
+          end
+
+          # Signal the timer thread to reset its inactivity deadline.
+          # If batch was full, this is harmless — the timer will just
+          # re-check and find an empty batch if it fires.
+          ensure_timer_running
+          @timer_signaled = true
+          @timer_cv.signal
+        end
+
+        # Upload outside mutex (if batch was full)
+        perform_upload(scopes_to_upload) if scopes_to_upload
+      rescue => e
+        @logger.debug { "symdb: failed to add scope: #{e.class}: #{e.message}" }
+        # Don't propagate, continue operation
+      end
+
+      # Force upload of current batch immediately.
+      # @return [void]
+      def flush
+        scopes_to_upload = nil
+
+        # steep:ignore:start
+        @mutex.synchronize do
+          return if @scopes.empty?
+
+          scopes_to_upload = @scopes.dup
+          @scopes.clear
+        end
+
+        perform_upload(scopes_to_upload)
+        # steep:ignore:end
+      end
+
+      # Shutdown and upload remaining scopes.
+      # @return [void]
+      def shutdown
+        scopes_to_upload = nil
+
+        # steep:ignore:start
+        @mutex.synchronize do
+          @timer_stopped = true
+          @timer_cv.signal  # Wake the timer thread so it exits
+
+          scopes_to_upload = @scopes.dup
+          @scopes.clear
+        end
+
+        # Join the timer thread outside the mutex.
+        # The thread checks @timer_stopped and exits when signaled.
+        @timer_thread&.join(5)  # 5-second timeout to avoid hanging
+        @timer_thread = nil
+
+        # Upload outside mutex
+        perform_upload(scopes_to_upload) unless scopes_to_upload.empty?
+        # steep:ignore:end
+      end
+
+      # Reset state (for testing).
+      # @return [void]
+      # @api private
+      def reset
+        @mutex.synchronize do
+          @scopes.clear
+          @timer_stopped = true
+          @timer_cv.signal
+          @file_count = 0
+          @uploaded_modules.clear
+        end
+
+        @timer_thread&.join(5)
+        @timer_thread = nil
+
+        # Allow timer to be restarted after reset
+        @mutex.synchronize do
+          @timer_stopped = false
+          @timer_signaled = false
+        end
+      end
+
+      # Check if scopes are pending upload.
+      # @return [Boolean] true if scopes waiting in batch
+      def scopes_pending?
+        @mutex.synchronize { @scopes.any? }
+      end
+
+      # Get current batch size.
+      # @return [Integer] Number of scopes in current batch
+      def size
+        @mutex.synchronize { @scopes.size }
+      end
+
+      private
+
+      # Start the timer thread if not already running.
+      # Must be called from within @mutex.synchronize.
+      # @return [void]
+      def ensure_timer_running
+        return unless @timer_enabled
+        return if @timer_thread&.alive?
+
+        @timer_stopped = false
+        @timer_signaled = false
+
+        @timer_thread = Thread.new do
+          timer_loop
+        end
+      end
+
+      # Timer thread main loop. Waits on the ConditionVariable with a timeout.
+      # Each signal resets the deadline (debounce). When the wait times out
+      # (no signal within INACTIVITY_TIMEOUT), the batch is flushed.
+      #
+      # Uses @timer_signaled flag instead of ConditionVariable#wait return value
+      # because Ruby < 3.2 returns self for both signal and timeout (no way to
+      # distinguish). The flag is set by add_scope before signaling, and cleared
+      # by the timer thread after waking.
+      # @return [void]
+      def timer_loop
+        loop do
+          should_flush = false
+
+          @mutex.synchronize do
+            return if @timer_stopped
+
+            @timer_signaled = false
+            @timer_cv.wait(@mutex, INACTIVITY_TIMEOUT)
+
+            return if @timer_stopped
+
+            if @timer_signaled
+              # Woke up because add_scope signaled — loop back to re-wait with
+              # a fresh timeout. This implements the debounce: the timeout resets
+              # on every scope addition.
+              next # steep:ignore BreakTypeMismatch
+            end
+
+            # Timed out (no signal within INACTIVITY_TIMEOUT). If there are
+            # scopes pending, flush them. Otherwise, loop back and wait again.
+            should_flush = !@scopes.empty?
+          end
+
+          if should_flush
+            flush
+          end
+        end
+      rescue => e
+        @logger.debug { "symdb: timer thread error: #{e.class}: #{e.message}" }
+      end
+
+      # Perform upload via uploader.
+      # @param scopes [Array<Scope>] Scopes to upload
+      # @return [void]
+      def perform_upload(scopes)
+        return if scopes.nil? || scopes.empty?
+
+        @uploader.upload_scopes(scopes)
+        @on_upload&.call(scopes)  # Notify tests after upload
+      rescue => e
+        @logger.debug { "symdb: upload failed: #{e.class}: #{e.message}" }
+        # Don't propagate, uploader handles retries
+      end
+    end
+  end
+end

--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -75,21 +75,22 @@ module Datadog
         scopes_to_upload = nil
 
         @mutex.synchronize do
-          # Check file limit
+          # Check file limit (counts only unique accepted files; duplicates are
+          # filtered by the dedup check below and do not consume the budget).
           if @file_count >= MAX_FILES
             @logger.debug { "symdb: file limit (#{MAX_FILES}) reached, ignoring scope: #{scope.name}" }
             return
           end
 
-          @file_count += 1
-
-          # Check if already uploaded
+          # Check if already uploaded — duplicates do not count toward MAX_FILES
+          # so a re-extraction scenario does not exhaust the budget for unique scopes.
           if @uploaded_modules.include?(scope.name)
             @logger.trace { "symdb: skipping #{scope.name}: already uploaded" }
             return
           end
 
           @uploaded_modules.add(scope.name)
+          @file_count += 1
 
           # Add the scope
           @scopes << scope

--- a/sig/datadog/symbol_database/scope_batcher.rbs
+++ b/sig/datadog/symbol_database/scope_batcher.rbs
@@ -7,6 +7,8 @@ module Datadog
 
       MAX_FILES: ::Integer
 
+      TIMER_JOIN_TIMEOUT: ::Integer
+
       @uploader: Uploader
 
       @logger: Logger

--- a/sig/datadog/symbol_database/scope_batcher.rbs
+++ b/sig/datadog/symbol_database/scope_batcher.rbs
@@ -1,37 +1,39 @@
 module Datadog
   module SymbolDatabase
     class ScopeBatcher
-      MAX_SCOPES: Integer
+      MAX_SCOPES: ::Integer
 
-      INACTIVITY_TIMEOUT: Float
+      INACTIVITY_TIMEOUT: ::Float
 
-      MAX_FILES: Integer
+      MAX_FILES: ::Integer
 
       @uploader: Uploader
 
       @logger: Logger
 
-      @on_upload: Proc?
+      @telemetry: Datadog::Core::Telemetry::Component?
+
+      @on_upload: ::Proc?
 
       @timer_enabled: bool
 
-      @scopes: Array[Scope]
+      @scopes: ::Array[Scope]
 
-      @mutex: Mutex
+      @mutex: ::Thread::Mutex
 
-      @timer_cv: Thread::ConditionVariable
+      @timer_cv: ::Thread::ConditionVariable
 
-      @timer_thread: Thread?
+      @timer_thread: ::Thread?
 
       @timer_stopped: bool
 
       @timer_signaled: bool
 
-      @file_count: Integer
+      @file_count: ::Integer
 
-      @uploaded_modules: Set[String?]
+      @uploaded_modules: ::Set[::String?]
 
-      def initialize: (Uploader uploader, logger: Logger, ?on_upload: Proc?, ?timer_enabled: bool) -> void
+      def initialize: (Uploader uploader, logger: Logger, ?telemetry: Datadog::Core::Telemetry::Component?, ?on_upload: ::Proc?, ?timer_enabled: bool) -> void
 
       def add_scope: (Scope scope) -> void
 
@@ -39,15 +41,15 @@ module Datadog
 
       def shutdown: () -> void
 
-      def reset: () -> void
-
-      def perform_upload: (Array[Scope]? scopes) -> void
+      def perform_upload: (::Array[Scope]? scopes) -> void
 
       def scopes_pending?: () -> bool
 
-      def size: () -> Integer
+      def size: () -> ::Integer
 
       private
+
+      def reset: () -> void
 
       def ensure_timer_running: () -> void
 

--- a/sig/datadog/symbol_database/scope_batcher.rbs
+++ b/sig/datadog/symbol_database/scope_batcher.rbs
@@ -1,0 +1,57 @@
+module Datadog
+  module SymbolDatabase
+    class ScopeBatcher
+      MAX_SCOPES: Integer
+
+      INACTIVITY_TIMEOUT: Float
+
+      MAX_FILES: Integer
+
+      @uploader: Uploader
+
+      @logger: Logger
+
+      @on_upload: Proc?
+
+      @timer_enabled: bool
+
+      @scopes: Array[Scope]
+
+      @mutex: Mutex
+
+      @timer_cv: Thread::ConditionVariable
+
+      @timer_thread: Thread?
+
+      @timer_stopped: bool
+
+      @timer_signaled: bool
+
+      @file_count: Integer
+
+      @uploaded_modules: Set[String?]
+
+      def initialize: (Uploader uploader, logger: Logger, ?on_upload: Proc?, ?timer_enabled: bool) -> void
+
+      def add_scope: (Scope scope) -> void
+
+      def flush: () -> void
+
+      def shutdown: () -> void
+
+      def reset: () -> void
+
+      def perform_upload: (Array[Scope]? scopes) -> void
+
+      def scopes_pending?: () -> bool
+
+      def size: () -> Integer
+
+      private
+
+      def ensure_timer_running: () -> void
+
+      def timer_loop: () -> void
+    end
+  end
+end

--- a/spec/datadog/symbol_database/scope_batcher_spec.rb
+++ b/spec/datadog/symbol_database/scope_batcher_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
   subject(:context) { described_class.new(uploader, logger: logger) }
 
   after do
-    # Cleanup any running timers
-    context.reset
+    # Cleanup any running timers (reset is private)
+    context.send(:reset)
   end
 
   describe '#initialize' do
@@ -208,12 +208,12 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
     end
   end
 
-  describe '#reset' do
+  describe 'reset (private, test-only)' do
     it 'clears all state' do
       allow(uploader).to receive(:upload_scopes)
 
       context.add_scope(test_scope)
-      context.reset
+      context.send(:reset)
 
       expect(context.size).to eq(0)
       expect(context.scopes_pending?).to be false
@@ -223,7 +223,7 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
       allow(uploader).to receive(:upload_scopes)
 
       context.add_scope(test_scope)
-      context.reset
+      context.send(:reset)
 
       # Reset clears scopes and kills timer
       expect(context.size).to eq(0)
@@ -360,6 +360,75 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
 
       # Should not have triggered a second upload (empty batch)
       expect(upload_calls.size).to eq(1)
+    end
+  end
+
+  describe 'error handling' do
+    let(:telemetry) { instance_double('Datadog::Core::Telemetry::Component', report: nil) }
+
+    subject(:context) { described_class.new(uploader, logger: logger, telemetry: telemetry, timer_enabled: false) }
+
+    context 'when add_scope raises unexpectedly' do
+      it 'logs and reports telemetry without propagating' do
+        # Force the dedup Set lookup to raise — exercises the outer rescue in add_scope
+        broken_set = Set.new
+        def broken_set.include?(_)
+          raise StandardError, 'set blew up'
+        end
+        context.instance_variable_set(:@uploaded_modules, broken_set)
+
+        expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/failed to add scope.*StandardError.*set blew up/i) }
+        expect(telemetry).to receive(:report).with(an_instance_of(StandardError), description: 'symdb: failed to add scope')
+
+        expect { context.add_scope(test_scope) }.not_to raise_error
+      end
+    end
+
+    context 'when uploader raises during perform_upload' do
+      it 'logs and reports telemetry without propagating' do
+        allow(uploader).to receive(:upload_scopes).and_raise(StandardError, 'upload blew up')
+
+        expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/upload failed.*StandardError.*upload blew up/i) }
+        expect(telemetry).to receive(:report).with(an_instance_of(StandardError), description: 'symdb: upload failed')
+
+        context.add_scope(test_scope)
+        expect { context.flush }.not_to raise_error
+      end
+    end
+
+    context 'when timer thread raises unexpectedly' do
+      let(:timer_telemetry) { instance_double('Datadog::Core::Telemetry::Component', report: nil) }
+      let(:timer_logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
+
+      # Use a real timer for this test to exercise the rescue in timer_loop.
+      subject(:timer_context) { described_class.new(uploader, logger: timer_logger, telemetry: timer_telemetry) }
+
+      it 'logs and reports telemetry without crashing the process' do
+        # Stub @scopes.empty? to raise inside the timer loop's mutex section.
+        broken_scopes = []
+        def broken_scopes.empty?
+          raise StandardError, 'scope check blew up'
+        end
+
+        captured = Queue.new
+        allow(timer_telemetry).to receive(:report) do |error, description:|
+          captured.push([error.message, description])
+        end
+
+        timer_context.instance_variable_set(:@scopes, broken_scopes)
+        # Trigger the timer loop by sending a signal so the wait returns and the
+        # timed-out branch runs against the broken @scopes.
+        timer_context.instance_variable_get(:@mutex).synchronize do
+          timer_context.send(:ensure_timer_running)
+        end
+
+        # The timer waits 1s then probes @scopes.empty? — wait for the report.
+        message, description = Timeout.timeout(5) { captured.pop }
+        expect(message).to match(/scope check blew up/)
+        expect(description).to eq('symdb: timer thread error')
+
+        timer_context.shutdown
+      end
     end
   end
 end

--- a/spec/datadog/symbol_database/scope_batcher_spec.rb
+++ b/spec/datadog/symbol_database/scope_batcher_spec.rb
@@ -150,6 +150,23 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
         # Should not be in batch
         expect(context.size).to be < described_class::MAX_FILES
       end
+
+      it 'does not count duplicates toward the file limit' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Offer the same scope MAX_FILES + 1 times. The dedup check should drop
+        # all duplicate offerings so they do not consume the file budget.
+        (described_class::MAX_FILES + 1).times do
+          context.add_scope(test_scope)
+        end
+
+        # The unique file budget has barely been touched — only one accepted file.
+        # A subsequent unique scope must still be accepted (not dropped at the limit).
+        next_unique = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'AfterDuplicates')
+        context.add_scope(next_unique)
+
+        expect(context.size).to eq(2)  # original test_scope + next_unique
+      end
     end
   end
 

--- a/spec/datadog/symbol_database/scope_batcher_spec.rb
+++ b/spec/datadog/symbol_database/scope_batcher_spec.rb
@@ -50,11 +50,10 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
     context 'when batch size limit reached' do
       it 'triggers immediate upload' do
         expect(uploader).to receive(:upload_scopes) do |scopes|
-          expect(scopes.size).to eq(400)
+          expect(scopes.size).to eq(described_class::MAX_SCOPES)
         end
 
-        # Add 400 scopes
-        400.times do |i|
+        described_class::MAX_SCOPES.times do |i|
           scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
           context.add_scope(scope)
         end
@@ -63,15 +62,19 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
       end
 
       it 'continues batching after upload' do
-        allow(uploader).to receive(:upload_scopes)
+        upload_calls = []
+        allow(uploader).to receive(:upload_scopes) { |scopes| upload_calls << scopes.dup }
 
-        # Add 401 scopes
-        401.times do |i|
+        # Add MAX_SCOPES + 1 scopes — the first MAX_SCOPES trigger an upload,
+        # the extra scope sits in the next batch.
+        (described_class::MAX_SCOPES + 1).times do |i|
           scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
           context.add_scope(scope)
         end
 
-        expect(context.size).to eq(1)  # 401st scope in new batch
+        expect(upload_calls.size).to eq(1)
+        expect(upload_calls.first.size).to eq(described_class::MAX_SCOPES)
+        expect(context.size).to eq(1)  # MAX_SCOPES + 1th scope in new batch
       end
     end
 

--- a/spec/datadog/symbol_database/scope_batcher_spec.rb
+++ b/spec/datadog/symbol_database/scope_batcher_spec.rb
@@ -1,0 +1,365 @@
+# frozen_string_literal: true
+
+require 'datadog/symbol_database/logger'
+require 'datadog/symbol_database/scope_batcher'
+require 'datadog/symbol_database/scope'
+require 'datadog/symbol_database/uploader'
+
+RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
+  let(:uploader) { instance_double(Datadog::SymbolDatabase::Uploader) }
+  let(:raw_logger) { instance_double(Logger, debug: nil) }
+  let(:settings) do
+    s = double('settings')
+    symdb = double('symbol_database', internal: double('internal', trace_logging: false))
+    allow(s).to receive(:symbol_database).and_return(symdb)
+    s
+  end
+  let(:logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
+  let(:test_scope) { Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'TestClass') }
+
+  subject(:context) { described_class.new(uploader, logger: logger) }
+
+  after do
+    # Cleanup any running timers
+    context.reset
+  end
+
+  describe '#initialize' do
+    it 'creates context with empty scopes' do
+      expect(context.size).to eq(0)
+      expect(context.scopes_pending?).to be false
+    end
+  end
+
+  describe '#add_scope' do
+    it 'adds scope to batch' do
+      context.add_scope(test_scope)
+
+      expect(context.size).to eq(1)
+      expect(context.scopes_pending?).to be true
+    end
+
+    it 'increments file count' do
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      # File count tracked (implementation detail, testing via behavior)
+      expect(context.size).to eq(2)
+    end
+
+    context 'when batch size limit reached' do
+      it 'triggers immediate upload' do
+        expect(uploader).to receive(:upload_scopes) do |scopes|
+          expect(scopes.size).to eq(400)
+        end
+
+        # Add 400 scopes
+        400.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        expect(context.size).to eq(0)  # Batch cleared after upload
+      end
+
+      it 'continues batching after upload' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add 401 scopes
+        401.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        expect(context.size).to eq(1)  # 401st scope in new batch
+      end
+    end
+
+    context 'with inactivity timer' do
+      it 'would trigger upload after inactivity (timer disabled in tests)' do
+        allow(uploader).to receive(:upload_scopes)
+
+        test_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+        test_context.add_scope(test_scope)
+        expect(test_context.size).to eq(1)
+
+        # Manually trigger what timer would do
+        test_context.flush
+
+        expect(test_context.size).to eq(0)
+      end
+
+      it 'timer gets reset on scope additions (verified by integration tests)' do
+        allow(uploader).to receive(:upload_scopes)
+
+        test_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+        test_context.add_scope(test_scope)
+        test_context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Class2'))
+
+        # Without timer, scopes stay in batch
+        expect(test_context.size).to eq(2)
+
+        # Manual flush works
+        test_context.flush
+        expect(test_context.size).to eq(0)
+      end
+    end
+
+    context 'with deduplication' do
+      it 'skips already uploaded modules' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add same scope twice
+        context.add_scope(test_scope)
+        context.add_scope(test_scope)
+
+        expect(context.size).to eq(1)  # Only added once
+      end
+
+      it 'tracks uploaded modules across batches' do
+        allow(uploader).to receive(:upload_scopes)
+
+        context.add_scope(test_scope)
+        context.flush  # Upload first batch
+
+        # Try to add same scope again
+        context.add_scope(test_scope)
+
+        expect(context.size).to eq(0)  # Not added (already uploaded)
+      end
+    end
+
+    context 'with file limit' do
+      it 'stops accepting scopes after MAX_FILES limit' do
+        allow(uploader).to receive(:upload_scopes)
+
+        # Add MAX_FILES scopes
+        described_class::MAX_FILES.times do |i|
+          scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}")
+          context.add_scope(scope)
+        end
+
+        # Try to add one more
+        extra_scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'ExtraClass')
+        expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/file limit.*reached/i) }
+
+        context.add_scope(extra_scope)
+
+        # Should not be in batch
+        expect(context.size).to be < described_class::MAX_FILES
+      end
+    end
+  end
+
+  describe '#flush' do
+    it 'uploads current batch immediately' do
+      expect(uploader).to receive(:upload_scopes) do |scopes|
+        expect(scopes.size).to eq(2)
+      end
+
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      context.flush
+
+      expect(context.size).to eq(0)
+    end
+
+    it 'does nothing if batch is empty' do
+      expect(uploader).not_to receive(:upload_scopes)
+
+      context.flush
+    end
+  end
+
+  describe '#shutdown' do
+    it 'uploads remaining scopes' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      context.add_scope(test_scope)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+
+      context.shutdown
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(2)
+    end
+
+    it 'kills timer thread' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.shutdown
+
+      # Shutdown uploads and kills timer
+      expect(context.size).to eq(0)
+    end
+
+    it 'clears scopes after shutdown' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.shutdown
+
+      expect(context.size).to eq(0)
+    end
+  end
+
+  describe '#reset' do
+    it 'clears all state' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.reset
+
+      expect(context.size).to eq(0)
+      expect(context.scopes_pending?).to be false
+    end
+
+    it 'kills timer' do
+      allow(uploader).to receive(:upload_scopes)
+
+      context.add_scope(test_scope)
+      context.reset
+
+      # Reset clears scopes and kills timer
+      expect(context.size).to eq(0)
+    end
+  end
+
+  describe '#pending?' do
+    it 'returns false when no scopes' do
+      expect(context.scopes_pending?).to be false
+    end
+
+    it 'returns true when scopes exist' do
+      context.add_scope(test_scope)
+      expect(context.scopes_pending?).to be true
+    end
+  end
+
+  describe '#size' do
+    it 'returns 0 when empty' do
+      expect(context.size).to eq(0)
+    end
+
+    it 'returns count of scopes' do
+      context.add_scope(test_scope)
+      expect(context.size).to eq(1)
+
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'Other'))
+      expect(context.size).to eq(2)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'handles concurrent scope additions' do
+      allow(uploader).to receive(:upload_scopes)
+
+      # Use timer_enabled: false so the test validates mutex-protected concurrent
+      # additions without timer interference (timer could flush mid-test, making
+      # the final size non-deterministic).
+      timer_off_context = described_class.new(uploader, logger: logger, timer_enabled: false)
+
+      threads = 10.times.map do |i|
+        Thread.new do
+          10.times do |j|
+            scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Thread#{i}Class#{j}")
+            timer_off_context.add_scope(scope)
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      # All 100 unique scopes should be present (no losses from races)
+      expect(timer_off_context.size).to eq(100)
+    end
+  end
+
+  # === Tests ported from Java SymbolSinkTest ===
+
+  describe 'multi-scope batching (ported from Java SymbolSinkTest.testMultiScopeFlush)' do
+    it 'batches multiple scopes into a single upload call' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      5.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Class#{i}"))
+      end
+
+      context.flush
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(5)
+      names = uploaded_scopes.map(&:name)
+      expect(names).to include('Class0', 'Class1', 'Class2', 'Class3', 'Class4')
+    end
+  end
+
+  describe 'implicit flush at capacity (ported from Java SymbolSinkTest.testQueueFull)' do
+    it 'uploads automatically at MAX_SCOPES and continues batching remaining' do
+      upload_calls = []
+      allow(uploader).to receive(:upload_scopes) { |scopes| upload_calls << scopes.dup }
+
+      # Add exactly MAX_SCOPES scopes to trigger implicit flush
+      described_class::MAX_SCOPES.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "Batch1Class#{i}"))
+      end
+
+      # Should have flushed the first batch
+      expect(upload_calls.size).to eq(1)
+      expect(upload_calls[0].size).to eq(described_class::MAX_SCOPES)
+
+      # Add one more scope (should be in new batch)
+      context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'ExtraClass'))
+      expect(context.size).to eq(1)
+
+      # Flush the remaining
+      context.flush
+      expect(upload_calls.size).to eq(2)
+      expect(upload_calls[1].size).to eq(1)
+      expect(upload_calls[1][0].name).to eq('ExtraClass')
+    end
+  end
+
+  describe 'upload on shutdown with pending scopes (ported from Java SymbolSinkTest)' do
+    it 'flushes all pending scopes on shutdown' do
+      uploaded_scopes = nil
+      allow(uploader).to receive(:upload_scopes) { |scopes| uploaded_scopes = scopes }
+
+      3.times do |i|
+        context.add_scope(Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: "ShutdownClass#{i}"))
+      end
+
+      context.shutdown
+
+      expect(uploaded_scopes).not_to be_nil
+      expect(uploaded_scopes.size).to eq(3)
+    end
+  end
+
+  describe 'deduplication across multiple flushes (ported from Java SymDBEnablementTest.noDuplicateSymbolExtraction)' do
+    it 'does not re-upload the same scope after flush and re-add' do
+      upload_calls = []
+      allow(uploader).to receive(:upload_scopes) { |scopes| upload_calls << scopes.dup }
+
+      scope = Datadog::SymbolDatabase::Scope.new(scope_type: 'CLASS', name: 'UniqueClass')
+
+      context.add_scope(scope)
+      context.flush
+      expect(upload_calls.size).to eq(1)
+      expect(upload_calls[0].size).to eq(1)
+
+      # Try to add the same scope again
+      context.add_scope(scope)
+      context.flush
+
+      # Should not have triggered a second upload (empty batch)
+      expect(upload_calls.size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Adds `Datadog::SymbolDatabase::ScopeBatcher`, which batches Scope objects produced by the extractor and triggers the Uploader (#5670) at appropriate times.

Two upload triggers:
- Size-based: 400 scopes per batch (`MAX_SCOPES`, matches the Java/Python tracers)
- Time-based: 1 second of inactivity (debounce timer, not periodic)

Plus deduplication of already-uploaded module names, a 10,000-file limit to bound memory in heavily-modularized apps, and Mutex-protected state for concurrent `add_scope` calls.

The timer is implemented as a single long-lived thread waiting on a `ConditionVariable` with timeout. Each `add_scope` signals the CV to reset the deadline; when the timeout expires without a signal, the timer fires and flushes the batch. Avoids the thread-per-add_scope cost of the earlier design.

**Motivation:**

Extracted from #5431 (in-progress symbol database upload work). Splitting the batching logic into its own PR keeps the diff focused and reviewable. The Component class in #5431 wires ScopeBatcher between Extractor and Uploader; forward-references to ScopeBatcher already merged in `scope.rb`, `uploader.rb`, and `extractor.rb` become accurate with this PR.

**Change log entry**

None.

**Additional Notes:**

Companion / parent PR: #5431 (will rebase on top of this once merged).

**How to test the change?**

26 RSpec examples cover initialization, `add_scope` (size-trigger, deduplication, file-limit), `flush`, `reset`, `shutdown`, `pending?`, `size`, thread-safety under concurrent additions, multi-scope batching, and dedup across multiple flushes. Tests ported from Java's `SymbolSinkTest` are noted in their context descriptions.

```
bundle exec rspec spec/datadog/symbol_database/scope_batcher_spec.rb
```