### PR TITLE
SymDB: Rename injectible/injectable Ruby identifiers to targetable

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -71,11 +71,11 @@ module Datadog
       EXCLUDED_COMMON_MODULES = ['Kernel', 'PP::', 'JSON::', 'Enumerable', 'Comparable'].freeze
 
       # RubyVM::InstructionSequence#trace_points event types included when
-      # computing injectable lines on METHOD scopes.
+      # computing targetable lines on METHOD scopes.
       # :line — any line with executable bytecode (primary line probe target)
       # :return — last expression before method returns (DI instruments return events)
       # :call excluded — method entry is handled by method probes, not line probes
-      INJECTABLE_LINE_EVENTS = [:line, :return].freeze
+      TARGETABLE_LINE_EVENTS = [:line, :return].freeze
 
       # Cached unbound Module#singleton_class? — dispatched explicitly so user classes
       # that define their own `singleton_class?` (e.g. with required arguments) cannot
@@ -399,7 +399,7 @@ module Datadog
           location = method.source_location
           next unless location && location[0]
           starts << location[1]
-          _ranges, method_end = extract_injectable_lines(method, location[1])
+          _ranges, method_end = extract_targetable_lines(method, location[1])
           ends << method_end
         end
 
@@ -491,7 +491,7 @@ module Datadog
         source_file, line = location
         return nil unless user_code_path?(source_file)  # Skip gem/stdlib methods
 
-        injectable_lines, end_line = extract_injectable_lines(method, line)
+        targetable_lines, end_line = extract_targetable_lines(method, line)
 
         Scope.new(
           scope_type: 'METHOD',
@@ -499,7 +499,7 @@ module Datadog
           source_file: source_file,
           start_line: line,
           end_line: end_line,
-          injectible_lines: injectable_lines,
+          targetable_lines: targetable_lines,
           language_specifics: {
             visibility: method_visibility(klass, method_name),
             method_type: method_type.to_s,
@@ -526,29 +526,29 @@ module Datadog
         end
       end
 
-      # Extract injectable lines and end_line from a method's bytecode.
+      # Extract targetable lines and end_line from a method's bytecode.
       # Returns [ranges, end_line] where ranges is an array of {start:, end:} hashes
       # or nil if iseq is unavailable (C-extension methods).
       # @param method [Method, UnboundMethod] The method
       # @param start_line [Integer] Fallback end_line if iseq unavailable
       # @return [Array(Array<Hash>, Integer), Array(nil, Integer)]
-      def extract_injectable_lines(method, start_line)
+      def extract_targetable_lines(method, start_line)
         iseq = RubyVM::InstructionSequence.of(method) # steep:ignore
         unless iseq
-          @logger.debug { "symdb: no iseq for #{method.name} (C extension or native), skipping injectable lines" }
+          @logger.debug { "symdb: no iseq for #{method.name} (C extension or native), skipping targetable lines" }
           return [nil, start_line]
         end
 
         lines = iseq.trace_points
-          .select { |_, event| INJECTABLE_LINE_EVENTS.include?(event) }
+          .select { |_, event| TARGETABLE_LINE_EVENTS.include?(event) }
           .map(&:first)
           .uniq
           .sort
 
         end_line = lines.max || start_line
-        ranges = build_injectable_ranges(lines)
+        ranges = build_targetable_ranges(lines)
         result = ranges.empty? ? nil : ranges
-        @logger.debug { "symdb: #{method.name} injectable lines: #{result ? "#{ranges.size} range(s), lines #{lines.first}..#{lines.last}" : 'none (no matching events)'}" }
+        @logger.debug { "symdb: #{method.name} targetable lines: #{result ? "#{ranges.size} range(s), lines #{lines.first}..#{lines.last}" : 'none (no matching events)'}" }
         [result, end_line]
       end
 
@@ -556,7 +556,7 @@ module Datadog
       # [4, 5, 6, 8, 10, 11] => [{start: 4, end: 6}, {start: 8, end: 8}, {start: 10, end: 11}]
       # @param lines [Array<Integer>] Sorted, deduplicated line numbers
       # @return [Array<Hash>] Array of {start:, end:} range hashes
-      def build_injectable_ranges(lines)
+      def build_targetable_ranges(lines)
         return [] if lines.empty?
 
         ranges = []
@@ -840,7 +840,7 @@ module Datadog
 
         source_file, line = location
 
-        injectable_lines, end_line = extract_injectable_lines(method, line)
+        targetable_lines, end_line = extract_targetable_lines(method, line)
 
         Scope.new(
           scope_type: 'METHOD',
@@ -848,7 +848,7 @@ module Datadog
           source_file: source_file,
           start_line: line,
           end_line: end_line,
-          injectible_lines: injectable_lines,
+          targetable_lines: targetable_lines,
           language_specifics: {
             visibility: klass ? method_visibility(klass, method_name) : 'public', # steep:ignore
             method_type: 'instance',

--- a/lib/datadog/symbol_database/scope.rb
+++ b/lib/datadog/symbol_database/scope.rb
@@ -22,9 +22,11 @@ module Datadog
         # - nil: not computed (source unreadable, native/C-extension method)
         # - []: computed but no executable lines found (comments/whitespace only)
         # - non-empty: computed, contains executable line ranges
-        # nil and [] both serialize as injectible_lines?: false on METHOD
-        # scopes. Key is absent on non-METHOD scopes.
-        :injectible_lines,
+        # nil and [] both serialize as has_injectible_lines: false on METHOD
+        # scopes. Key is absent on non-METHOD scopes. The wire format key
+        # name keeps the historical spelling +injectible+ for backend
+        # compatibility; the Ruby identifier is +targetable_lines+.
+        :targetable_lines,
         :language_specifics, :symbols, :scopes
 
       # Initialize a new Scope
@@ -33,7 +35,7 @@ module Datadog
       # @param source_file [String, nil] Path to source file
       # @param start_line [Integer, nil] Starting line number (UNKNOWN_MIN_LINE for unknown)
       # @param end_line [Integer, nil] Ending line number (UNKNOWN_MAX_LINE for entire file)
-      # @param injectible_lines [Array<Hash>, nil] Ranges of executable lines [{start:, end:}]
+      # @param targetable_lines [Array<Hash>, nil] Ranges of executable lines [{start:, end:}]
       # @param language_specifics [Hash, nil] Ruby-specific metadata
       # @param symbols [Array<Symbol>, nil] Symbols defined in this scope
       # @param scopes [Array<Scope>, nil] Nested child scopes
@@ -43,7 +45,7 @@ module Datadog
         source_file: nil,
         start_line: nil,
         end_line: nil,
-        injectible_lines: nil,
+        targetable_lines: nil,
         language_specifics: nil,
         symbols: nil,
         scopes: nil
@@ -53,15 +55,15 @@ module Datadog
         @source_file = source_file
         @start_line = start_line
         @end_line = end_line
-        @injectible_lines = injectible_lines
+        @targetable_lines = targetable_lines
         @language_specifics = language_specifics || {}
         @symbols = symbols || []
         @scopes = scopes || []
       end
 
-      # @return [Boolean] true when injectible_lines is non-nil and non-empty
-      def injectible_lines?
-        !injectible_lines.nil? && !injectible_lines.empty?
+      # @return [Boolean] true when targetable_lines is non-nil and non-empty
+      def targetable_lines?
+        !targetable_lines.nil? && !targetable_lines.empty?
       end
 
       # Convert scope to Hash for JSON serialization.
@@ -79,11 +81,13 @@ module Datadog
           scopes: scopes.empty? ? nil : scopes.map(&:to_h),
         }
         h.compact!
-        # Injectable lines only on METHOD scopes (per spec — not on CLASS/MODULE/FILE).
+        # Targetable lines only on METHOD scopes (per spec — not on CLASS/MODULE/FILE).
         # Always emit has_injectible_lines (even when false) on METHOD scopes.
+        # Wire format keeps the historical spelling +injectible+; Ruby identifier
+        # is +targetable_lines+.
         if scope_type == 'METHOD'
-          h[:has_injectible_lines] = injectible_lines? # steep:ignore ArgumentTypeMismatch
-          h[:injectible_lines] = injectible_lines if injectible_lines && !injectible_lines.empty?
+          h[:has_injectible_lines] = targetable_lines? # steep:ignore ArgumentTypeMismatch
+          h[:injectible_lines] = targetable_lines if targetable_lines && !targetable_lines.empty?
         end
         h
       end

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -4,7 +4,7 @@ module Datadog
       UNKNOWN_MIN_LINE: Integer
       UNKNOWN_MAX_LINE: Integer
       EXCLUDED_COMMON_MODULES: Array[String]
-      INJECTABLE_LINE_EVENTS: Array[::Symbol]
+      TARGETABLE_LINE_EVENTS: Array[::Symbol]
       MODULE_SINGLETON_CLASS_PRED: UnboundMethod
 
       @logger: untyped
@@ -43,9 +43,9 @@ module Datadog
 
       def method_visibility: (Class klass, ::Symbol method_name) -> String
 
-      def extract_injectable_lines: (Method | UnboundMethod method, Integer start_line) -> [Array[Hash[::Symbol, Integer]]?, Integer]
+      def extract_targetable_lines: (Method | UnboundMethod method, Integer start_line) -> [Array[Hash[::Symbol, Integer]]?, Integer]
 
-      def build_injectable_ranges: (Array[Integer] lines) -> Array[Hash[::Symbol, Integer]]
+      def build_targetable_ranges: (Array[Integer] lines) -> Array[Hash[::Symbol, Integer]]
 
       def extract_method_parameters: (UnboundMethod method) -> Array[Symbol]
 

--- a/sig/datadog/symbol_database/scope.rbs
+++ b/sig/datadog/symbol_database/scope.rbs
@@ -11,7 +11,7 @@ module Datadog
 
       @end_line: Integer?
 
-      @injectible_lines: Array[Hash[::Symbol, Integer]]?
+      @targetable_lines: Array[Hash[::Symbol, Integer]]?
 
       @language_specifics: Hash[::Symbol, untyped]
 
@@ -25,7 +25,7 @@ module Datadog
         ?source_file: String?,
         ?start_line: Integer?,
         ?end_line: Integer?,
-        ?injectible_lines: Array[Hash[::Symbol, Integer]]?,
+        ?targetable_lines: Array[Hash[::Symbol, Integer]]?,
         ?language_specifics: Hash[::Symbol, untyped]?,
         ?symbols: Array[Datadog::SymbolDatabase::Symbol]?,
         ?scopes: Array[Scope]?
@@ -41,9 +41,9 @@ module Datadog
 
       attr_reader end_line: Integer?
 
-      def injectible_lines?: () -> bool
+      def targetable_lines?: () -> bool
 
-      attr_reader injectible_lines: Array[Hash[::Symbol, Integer]]?
+      attr_reader targetable_lines: Array[Hash[::Symbol, Integer]]?
 
       attr_reader language_specifics: Hash[::Symbol, untyped]
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -224,13 +224,13 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(arg2.symbol_type).to eq('ARG')
       end
 
-      it 'includes injectable lines on instance METHOD scopes via extract() path' do
+      it 'includes targetable lines on instance METHOD scopes via extract() path' do
         class_scope = extractor.extract(TestUserClass).scopes.first
         method_scope = class_scope.scopes.find { |s| s.name == 'public_method' }
 
-        expect(method_scope.injectible_lines?).to eq(true)
-        expect(method_scope.injectible_lines).to be_an(Array)
-        expect(method_scope.injectible_lines).not_to be_empty
+        expect(method_scope.targetable_lines?).to eq(true)
+        expect(method_scope.targetable_lines).to be_an(Array)
+        expect(method_scope.targetable_lines).not_to be_empty
         expect(method_scope.end_line).to be >= method_scope.start_line
       end
     end
@@ -1712,17 +1712,17 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(method_scope.scope_type).to eq('METHOD')
       end
 
-      it 'includes injectable lines on instance METHOD scopes' do
+      it 'includes targetable lines on instance METHOD scopes' do
         scopes = extract_all_clean
         file_scope = find_file_scope(scopes, 'ExtractAllSimpleClass')
         class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllSimpleClass' }
         method_scope = class_scope.scopes.find { |s| s.name == 'remember' }
 
-        expect(method_scope.injectible_lines?).to eq(true).or eq(false)
-        if method_scope.injectible_lines?
-          expect(method_scope.injectible_lines).to be_an(Array)
-          expect(method_scope.injectible_lines).not_to be_empty
-          method_scope.injectible_lines.each do |range|
+        expect(method_scope.targetable_lines?).to eq(true).or eq(false)
+        if method_scope.targetable_lines?
+          expect(method_scope.targetable_lines).to be_an(Array)
+          expect(method_scope.targetable_lines).not_to be_empty
+          method_scope.targetable_lines.each do |range|
             expect(range[:start]).to be <= range[:end]
           end
         end
@@ -1790,36 +1790,36 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
     # ── Injectable lines unit tests ──────────────────────────────────────
 
-    describe 'build_injectable_ranges' do
+    describe 'build_targetable_ranges' do
       it 'compresses consecutive lines into ranges' do
-        ranges = extractor.send(:build_injectable_ranges, [4, 5, 6, 8, 10, 11])
+        ranges = extractor.send(:build_targetable_ranges, [4, 5, 6, 8, 10, 11])
         expect(ranges).to eq([{start: 4, end: 6}, {start: 8, end: 8}, {start: 10, end: 11}])
       end
 
       it 'returns a single range for all-consecutive input' do
-        ranges = extractor.send(:build_injectable_ranges, [1, 2, 3, 4, 5])
+        ranges = extractor.send(:build_targetable_ranges, [1, 2, 3, 4, 5])
         expect(ranges).to eq([{start: 1, end: 5}])
       end
 
       it 'returns individual ranges for non-consecutive input' do
-        ranges = extractor.send(:build_injectable_ranges, [1, 3, 5, 7])
+        ranges = extractor.send(:build_targetable_ranges, [1, 3, 5, 7])
         expect(ranges).to eq([{start: 1, end: 1}, {start: 3, end: 3}, {start: 5, end: 5}, {start: 7, end: 7}])
       end
 
       it 'returns a single-element range for one line' do
-        ranges = extractor.send(:build_injectable_ranges, [10])
+        ranges = extractor.send(:build_targetable_ranges, [10])
         expect(ranges).to eq([{start: 10, end: 10}])
       end
 
       it 'returns empty for empty input' do
-        ranges = extractor.send(:build_injectable_ranges, [])
+        ranges = extractor.send(:build_targetable_ranges, [])
         expect(ranges).to eq([])
       end
     end
 
-    describe 'extract_injectable_lines' do
+    describe 'extract_targetable_lines' do
       before do
-        @file = create_test_file('injectable_test.rb', <<~RUBY)
+        @file = create_test_file('targetable_test.rb', <<~RUBY)
           class ExtractAllInjectableTest
             def multi_line(a, b)
               x = a + b
@@ -1843,7 +1843,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       it 'returns nil for C-extension methods (iseq nil)' do
         # String#length is a C method with no iseq
         method = String.instance_method(:length)
-        ranges, end_line = extractor.send(:extract_injectable_lines, method, 1)
+        ranges, end_line = extractor.send(:extract_targetable_lines, method, 1)
         expect(ranges).to be_nil
         expect(end_line).to eq(1)
       end
@@ -1855,20 +1855,20 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         method_scope = class_scope.scopes.find { |s| s.name == 'multi_line' }
 
         # Ranges should have no overlapping or duplicate entries
-        method_scope.injectible_lines.each_cons(2) do |a, b|
+        method_scope.targetable_lines.each_cons(2) do |a, b|
           expect(a[:end]).to be < b[:start]
         end
       end
 
-      it 'includes initialize method first line as injectable' do
+      it 'includes initialize method first line as targetable' do
         scopes = extract_all_clean
         file_scope = find_file_scope(scopes, 'ExtractAllInjectableTest')
         class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllInjectableTest' }
         init_scope = class_scope.scopes.find { |s| s.name == 'initialize' }
 
         expect(init_scope).not_to be_nil
-        expect(init_scope.injectible_lines?).to eq(true)
-        expect(init_scope.injectible_lines.first[:start]).to eq(init_scope.start_line).or be > init_scope.start_line
+        expect(init_scope.targetable_lines?).to eq(true)
+        expect(init_scope.targetable_lines.first[:start]).to eq(init_scope.start_line).or be > init_scope.start_line
       end
     end
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -1788,7 +1788,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
     end
 
-    # ── Injectable lines unit tests ──────────────────────────────────────
+    # ── Targetable lines unit tests ──────────────────────────────────────
 
     describe 'build_targetable_ranges' do
       it 'compresses consecutive lines into ranges' do
@@ -1820,7 +1820,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     describe 'extract_targetable_lines' do
       before do
         @file = create_test_file('targetable_test.rb', <<~RUBY)
-          class ExtractAllInjectableTest
+          class ExtractAllTargetableTest
             def multi_line(a, b)
               x = a + b
               y = x * 2
@@ -1837,7 +1837,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
 
       after do
-        Object.send(:remove_const, :ExtractAllInjectableTest) if defined?(ExtractAllInjectableTest)
+        Object.send(:remove_const, :ExtractAllTargetableTest) if defined?(ExtractAllTargetableTest)
       end
 
       it 'returns nil for C-extension methods (iseq nil)' do
@@ -1850,8 +1850,8 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
       it 'deduplicates line numbers before range compression' do
         scopes = extract_all_clean
-        file_scope = find_file_scope(scopes, 'ExtractAllInjectableTest')
-        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllInjectableTest' }
+        file_scope = find_file_scope(scopes, 'ExtractAllTargetableTest')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllTargetableTest' }
         method_scope = class_scope.scopes.find { |s| s.name == 'multi_line' }
 
         # Ranges should have no overlapping or duplicate entries
@@ -1862,8 +1862,8 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
       it 'includes initialize method first line as targetable' do
         scopes = extract_all_clean
-        file_scope = find_file_scope(scopes, 'ExtractAllInjectableTest')
-        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllInjectableTest' }
+        file_scope = find_file_scope(scopes, 'ExtractAllTargetableTest')
+        class_scope = file_scope.scopes.find { |s| s.name == 'ExtractAllTargetableTest' }
         init_scope = class_scope.scopes.find { |s| s.name == 'initialize' }
 
         expect(init_scope).not_to be_nil

--- a/spec/datadog/symbol_database/scope_spec.rb
+++ b/spec/datadog/symbol_database/scope_spec.rb
@@ -50,24 +50,24 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
     end
   end
 
-  describe '#injectible_lines?' do
-    it 'returns false when injectible_lines is nil' do
+  describe '#targetable_lines?' do
+    it 'returns false when targetable_lines is nil' do
       scope = described_class.new(scope_type: 'METHOD', name: 'foo')
-      expect(scope.injectible_lines?).to eq(false)
+      expect(scope.targetable_lines?).to eq(false)
     end
 
-    it 'returns false when injectible_lines is empty' do
-      scope = described_class.new(scope_type: 'METHOD', name: 'foo', injectible_lines: [])
-      expect(scope.injectible_lines?).to eq(false)
+    it 'returns false when targetable_lines is empty' do
+      scope = described_class.new(scope_type: 'METHOD', name: 'foo', targetable_lines: [])
+      expect(scope.targetable_lines?).to eq(false)
     end
 
-    it 'returns true when injectible_lines has ranges' do
+    it 'returns true when targetable_lines has ranges' do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'foo',
-        injectible_lines: [{start: 5, end: 7}],
+        targetable_lines: [{start: 5, end: 7}],
       )
-      expect(scope.injectible_lines?).to eq(true)
+      expect(scope.targetable_lines?).to eq(true)
     end
   end
 
@@ -247,11 +247,11 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash[:scopes].first[:scopes].first[:scopes].first[:scope_type]).to eq('METHOD')
     end
 
-    it 'includes injectable lines fields on METHOD scope with ranges' do
+    it 'includes targetable lines fields on METHOD scope with ranges' do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'my_method',
-        injectible_lines: [{start: 10, end: 12}, {start: 15, end: 15}],
+        targetable_lines: [{start: 10, end: 12}, {start: 15, end: 15}],
       )
 
       hash = scope.to_h
@@ -260,7 +260,7 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash[:injectible_lines]).to eq([{start: 10, end: 12}, {start: 15, end: 15}])
     end
 
-    it 'includes injectible_lines?: false on METHOD scope without ranges' do
+    it 'includes has_injectible_lines: false on METHOD scope without ranges' do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'native_method',
@@ -272,7 +272,7 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash).not_to have_key(:injectible_lines)
     end
 
-    it 'excludes injectable lines fields from CLASS scope' do
+    it 'excludes targetable lines fields from CLASS scope' do
       scope = described_class.new(
         scope_type: 'CLASS',
         name: 'MyClass',
@@ -284,7 +284,7 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash).not_to have_key(:injectible_lines)
     end
 
-    it 'excludes injectable lines fields from MODULE scope' do
+    it 'excludes targetable lines fields from MODULE scope' do
       scope = described_class.new(
         scope_type: 'MODULE',
         name: 'MyModule',
@@ -296,7 +296,7 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash).not_to have_key(:injectible_lines)
     end
 
-    it 'excludes injectable lines fields from FILE scope' do
+    it 'excludes targetable lines fields from FILE scope' do
       scope = described_class.new(
         scope_type: 'FILE',
         name: '/app/test.rb',

--- a/spec/datadog/symbol_database/service_version_spec.rb
+++ b/spec/datadog/symbol_database/service_version_spec.rb
@@ -2,6 +2,7 @@
 
 require 'datadog/symbol_database/service_version'
 require 'datadog/symbol_database/scope'
+require 'datadog/symbol_database/symbol'
 
 RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
   describe '#initialize' do

--- a/spec/datadog/symbol_database/service_version_spec.rb
+++ b/spec/datadog/symbol_database/service_version_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
         source_file: '/app/models/user.rb',
         start_line: 5,
         end_line: 7,
-        injectible_lines: [{start: 6, end: 7}],
+        targetable_lines: [{start: 6, end: 7}],
         language_specifics: {visibility: 'public', method_type: 'instance'},
         symbols: [
           Datadog::SymbolDatabase::Symbol.new(symbol_type: 'ARG', name: 'token', line: 5),


### PR DESCRIPTION
**What does this PR do?**

Renames the internal Ruby identifiers across SymbolDatabase from `injectible` / `injectable` to `targetable`. The change is internal-only — the wire format hash keys (`:has_injectible_lines`, `:injectible_lines`) are intentionally preserved in `Scope#to_h` for backend compatibility.

Renamed:
- `Scope#injectible_lines` (attr) → `#targetable_lines`
- `Scope#injectible_lines?` → `#targetable_lines?`
- `Scope.new(injectible_lines:)` keyword arg → `(targetable_lines:)`
- `Extractor::INJECTABLE_LINE_EVENTS` constant → `TARGETABLE_LINE_EVENTS`
- `Extractor#extract_injectable_lines` → `#extract_targetable_lines`
- `Extractor#build_injectable_ranges` → `#build_targetable_ranges`
- Local variables and comments using `"injectable lines"` / `"injectible_lines"` text

Preserved (wire format / backend contract):
- `:has_injectible_lines` hash key in `Scope#to_h` output
- `:injectible_lines` hash key in `Scope#to_h` output
- All test assertions checking those keys

**Motivation:**

Extracted from #5431 (in-progress symbol database upload work). Keeping the rename atomic and reviewable in isolation lets the broader work in #5431 continue without bundling unrelated identifier renames into a large PR.

**Change log entry**

None.

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/scope_spec.rb \
  spec/datadog/symbol_database/extractor_spec.rb \
  spec/datadog/symbol_database/service_version_spec.rb
```

Verification on this branch:
- 164 examples, 0 failures
- `bundle exec steep check lib/datadog/symbol_database/scope.rb lib/datadog/symbol_database/extractor.rb` — No type error detected
- `bundle exec rake standard` — clean