### PR TITLE
SymDB: Remove telemetry from Extractor

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -9,9 +9,9 @@ module Datadog
   module SymbolDatabase
     # Extracts symbol metadata from loaded Ruby modules and classes via introspection.
     #
-    # Instance created by Component with injected dependencies (logger, settings,
-    # telemetry). All methods are instance methods accessing @logger, @settings,
-    # @telemetry directly — no parameter threading needed.
+    # Instance created by Component with injected dependencies (logger, settings).
+    # All methods are instance methods accessing @logger, @settings directly —
+    # no parameter threading needed.
     #
     # Uses Ruby's reflection APIs (Module#constants, Class#instance_methods, Method#parameters)
     # to build hierarchical Scope structures representing code organization.
@@ -46,10 +46,9 @@ module Datadog
     #    for post-hoc diagnosis, return nil or empty array. One bad method/module
     #    doesn't kill the entire class extraction.
     #
-    # 3. **Top-level entry rescues** (`rescue => e` with logging + telemetry):
+    # 3. **Top-level entry rescues** (`rescue => e` with logging):
     #    extract() and extract_all() are the error boundaries. Any exception that
-    #    escapes layers 1-2 is caught here, logged, and tracked via telemetry.
-    #    These are the only rescue blocks that increment telemetry counters.
+    #    escapes layers 1-2 is caught here and logged.
     #
     # @api private
     class Extractor
@@ -87,11 +86,9 @@ module Datadog
 
       # @param logger [Logger] Logger instance (SymbolDatabase::Logger facade or compatible)
       # @param settings [Configuration::Settings] Tracer settings
-      # @param telemetry [Telemetry, nil] Optional telemetry for metrics
-      def initialize(logger:, settings:, telemetry: nil)
+      def initialize(logger:, settings:)
         @logger = logger
         @settings = settings
-        @telemetry = telemetry
       end
 
       # Extract symbols from a single module or class.
@@ -125,7 +122,6 @@ module Datadog
         wrap_in_file_scope(source_file, [inner_scope])
       rescue => e
         @logger.debug { "symdb: failed to extract #{mod_name || '<unknown>'}: #{e.class}: #{e.message}" }
-        @telemetry&.inc('tracers', 'symbol_database.extract_error', 1)
         nil
       end
 
@@ -147,7 +143,6 @@ module Datadog
         convert_trees_to_scopes(file_trees)
       rescue => e
         @logger.debug { "symdb: error in extract_all: #{e.class}: #{e.message}" }
-        @telemetry&.inc('tracers', 'symbol_database.extract_all_error', 1)
         []
       end
 

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -9,10 +9,6 @@ module Datadog
   module SymbolDatabase
     # Extracts symbol metadata from loaded Ruby modules and classes via introspection.
     #
-    # Instance created by Component with injected dependencies (logger, settings).
-    # All methods are instance methods accessing @logger, @settings directly —
-    # no parameter threading needed.
-    #
     # Uses Ruby's reflection APIs (Module#constants, Class#instance_methods, Method#parameters)
     # to build hierarchical Scope structures representing code organization.
     # Filters to user code only (excludes gems, stdlib, test files).

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -9,9 +9,8 @@ module Datadog
 
       @logger: untyped
       @settings: untyped
-      @telemetry: untyped?
 
-      def initialize: (logger: untyped, settings: untyped, ?telemetry: untyped?) -> void
+      def initialize: (logger: untyped, settings: untyped) -> void
 
       def extract: (Module mod) -> Scope?
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     s
   end
   let(:logger) { instance_double(Logger, debug: nil) }
-  let(:extractor) { described_class.new(logger: logger, settings: settings, telemetry: nil) }
+  let(:extractor) { described_class.new(logger: logger, settings: settings) }
 
   # Temporary directory for user code test files
   around do |example|
@@ -1668,16 +1668,13 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     end
 
     context 'top-level rescue' do
-      let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component, inc: nil) }
-      let(:extractor_with_telemetry) do
-        described_class.new(logger: logger, settings: settings, telemetry: telemetry)
-      end
+      it 'returns [] and logs when collection raises' do
+        allow(extractor).to receive(:collect_extractable_modules).and_raise(StandardError, 'boom')
+        expect(logger).to receive(:debug) { |&block| expect(block.call).to match(/extract_all.*StandardError.*boom/i) }
 
-      it 'returns [] and increments telemetry when collection raises' do
-        allow(extractor_with_telemetry).to receive(:collect_extractable_modules).and_raise(StandardError, 'boom')
-        result = extractor_with_telemetry.extract_all
+        result = extractor.extract_all
+
         expect(result).to eq([])
-        expect(telemetry).to have_received(:inc).with('tracers', 'symbol_database.extract_all_error', 1)
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

Removes the `telemetry` parameter from `Datadog::SymbolDatabase::Extractor` and the two `@telemetry&.inc(...)` counter calls in Extractor's top-level rescue blocks. The rescue blocks still log at debug level.

**Constructor change:** `Extractor.new(logger:, settings:, telemetry: nil)` becomes `Extractor.new(logger:, settings:)`. Callers passing `telemetry:` will get `unknown keyword: :telemetry`. Master has no non-test callers of `Extractor.new` — only spec files instantiate it directly — so this is contained to the tests in this PR.

The `returns [] and increments telemetry when collection raises` test in `extract_all`'s top-level rescue context is replaced with `returns [] and logs when collection raises` — same coverage of the rescue path, asserting on the log message instead of the dropped telemetry counter.

**Motivation:**

Telemetry reporting for symbol database extraction is moving to Component (the orchestrator that decides when to extract and what to do with failures), so Extractor itself no longer needs to depend on telemetry.

Extracted from #5431 to land the change independently of the broader symbol-database upload work.

**Change log entry**

None.

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/extractor_spec.rb
```

Verification on this branch:
- 124 examples, 0 failures
- `bundle exec steep check lib/datadog/symbol_database/extractor.rb` — No type error detected
- `bundle exec rake standard` — clean