### PR TITLE
SymDB: Stop defaulting empty/nil env and version to 'none' in ServiceVersion

### DIFF
--- a/lib/datadog/symbol_database/service_version.rb
+++ b/lib/datadog/symbol_database/service_version.rb
@@ -20,8 +20,8 @@ module Datadog
 
       # Initialize a new ServiceVersion
       # @param service [String] Service name (required, from DD_SERVICE)
-      # @param env [String] Environment (from DD_ENV, defaults to "none")
-      # @param version [String] Version (from DD_VERSION, defaults to "none")
+      # @param env [String, nil] Environment (from DD_ENV, passed through unchanged)
+      # @param version [String, nil] Version (from DD_VERSION, passed through unchanged)
       # @param scopes [Array<Scope>] Top-level scopes (required)
       # @raise [ArgumentError] if service empty or scopes not an array
       def initialize(service:, env:, version:, scopes:)
@@ -29,8 +29,8 @@ module Datadog
         raise ArgumentError, 'scopes must be an array' unless scopes.is_a?(Array)
 
         @service = service
-        @env = env.to_s.empty? ? 'none' : env.to_s
-        @version = version.to_s.empty? ? 'none' : version.to_s
+        @env = env
+        @version = version
         @language = 'ruby'
         @scopes = scopes
       end

--- a/sig/datadog/symbol_database/service_version.rbs
+++ b/sig/datadog/symbol_database/service_version.rbs
@@ -3,9 +3,9 @@ module Datadog
     class ServiceVersion
       @service: String
 
-      @env: String
+      @env: String?
 
-      @version: String
+      @version: String?
 
       @language: String
 
@@ -20,9 +20,9 @@ module Datadog
 
       attr_reader service: String
 
-      attr_reader env: String
+      attr_reader env: String?
 
-      attr_reader version: String
+      attr_reader version: String?
 
       attr_reader language: String
 

--- a/spec/datadog/symbol_database/service_version_spec.rb
+++ b/spec/datadog/symbol_database/service_version_spec.rb
@@ -2,6 +2,7 @@
 
 require 'datadog/symbol_database/service_version'
 require 'datadog/symbol_database/scope'
+require 'datadog/symbol_database/symbol'
 
 RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
   describe '#initialize' do

--- a/spec/datadog/symbol_database/service_version_spec.rb
+++ b/spec/datadog/symbol_database/service_version_spec.rb
@@ -38,24 +38,24 @@ RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
       }.to raise_error(ArgumentError, /scopes must be an array/)
     end
 
-    it 'converts empty env to "none"' do
+    it 'passes empty env through unchanged' do
       sv = described_class.new(service: 'svc', env: '', version: '1.0', scopes: [])
-      expect(sv.env).to eq('none')
+      expect(sv.env).to eq('')
     end
 
-    it 'converts nil env to "none"' do
+    it 'passes nil env through unchanged' do
       sv = described_class.new(service: 'svc', env: nil, version: '1.0', scopes: [])
-      expect(sv.env).to eq('none')
+      expect(sv.env).to be_nil
     end
 
-    it 'converts empty version to "none"' do
+    it 'passes empty version through unchanged' do
       sv = described_class.new(service: 'svc', env: 'prod', version: '', scopes: [])
-      expect(sv.version).to eq('none')
+      expect(sv.version).to eq('')
     end
 
-    it 'converts nil version to "none"' do
+    it 'passes nil version through unchanged' do
       sv = described_class.new(service: 'svc', env: 'prod', version: nil, scopes: [])
-      expect(sv.version).to eq('none')
+      expect(sv.version).to be_nil
     end
 
     it 'sets language' do
@@ -105,14 +105,14 @@ RSpec.describe Datadog::SymbolDatabase::ServiceVersion do
       )
     end
 
-    it 'handles empty env as "none"' do
+    it 'passes empty env through to the hash' do
       sv = described_class.new(service: 'svc', env: '', version: '1.0', scopes: [])
-      expect(sv.to_h[:env]).to eq('none')
+      expect(sv.to_h[:env]).to eq('')
     end
 
-    it 'handles empty version as "none"' do
-      sv = described_class.new(service: 'svc', env: 'prod', version: '', scopes: [])
-      expect(sv.to_h[:version]).to eq('none')
+    it 'passes nil version through to the hash' do
+      sv = described_class.new(service: 'svc', env: 'prod', version: nil, scopes: [])
+      expect(sv.to_h[:version]).to be_nil
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

Drops the empty/nil → `"none"` rewriting of `env` and `version` in `Datadog::SymbolDatabase::ServiceVersion#initialize`. Both fields now pass through unchanged.

Before:
```ruby
@env     = env.to_s.empty? ? 'none' : env.to_s
@version = version.to_s.empty? ? 'none' : version.to_s
```

After:
```ruby
@env     = env
@version = version
```

ServiceVersion's role is to wrap a payload, not to sanitize inputs; defaulting belongs at the caller (Component) where the source of env/version is known and the sentinel choice (if any) can be made deliberately.

Master has no non-test callers of `ServiceVersion.new` (verified via `grep -rn 'ServiceVersion.new' lib/` — no matches), so this is contained to the spec changes in this PR.

The four `converts ... to "none"` tests are replaced with four `passes ... through unchanged` tests covering the same nil/empty inputs, asserting on the new pass-through behavior. The two `to_h` tests for `"none"` defaulting are similarly replaced.

**Motivation:**

Extracted from #5431 to land the behavior change independently of the broader symbol-database upload work. ServiceVersion is currently only used by tests — no production callers exist on master.

**Change log entry**

None.

**Note on pre-existing failure**

`to_json produces valid JSON for complete Ruby payload` (line 142) was already failing on master with `NameError: uninitialized constant Datadog::SymbolDatabase::Symbol` — the spec file is missing `require 'datadog/symbol_database/symbol'`. This PR does not address it (out of scope).

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/service_version_spec.rb
```

Verification on this branch: 14 pass, 1 fail (the pre-existing failure described above).

- `bundle exec steep check lib/datadog/symbol_database/service_version.rb` — No type error detected
- `bundle exec rake standard` — clean