### PR TITLE
test: surface fork exit status in expect_in_fork failure message

### DIFF
--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -3,7 +3,8 @@ require 'English'
 module SynchronizationHelpers
   def expect_in_fork(fork_expectations: nil, timeout_seconds: 10, trigger_stacktrace_on_kill: false, debug: false)
     fork_expectations ||= proc { |status:, stdout:, stderr:|
-      expect(status && status.success?).to be(true), "STDOUT:`#{stdout}` STDERR:`#{stderr}"
+      expect(status && status.success?).to be(true),
+        "Status:#{status.inspect} STDOUT:`#{stdout}` STDERR:`#{stderr}"
     }
 
     if debug


### PR DESCRIPTION
**What does this PR do?**

Adds `Process::Status#inspect` to the default failure message of `expect_in_fork`. When the inline assertion `status && status.success?` fails, the message will now include the fork's exit reason, e.g. `pid 1234 SIGKILL (signal 9)` or `pid 1234 exit 17`, alongside STDOUT and STDERR.

**Motivation:**

The recent profiling_allocation flake on macOS Ruby 3.4 ([run 25456463219, job 74687137844](https://github.com/DataDog/dd-trace-rb/actions/runs/25456463219/job/74687137844?pr=5693)) printed only the first benchmark's output to STDOUT, an empty STDERR, and a failure message that did not say whether the fork exited non-zero or was killed by a signal — so root-cause analysis had no anchor. Two prior workarounds for the same family of failures on Ruby 2.5 (#5225) and Ruby 2.6 (#5077) both ran into the same diagnostic gap.

This PR doesn't fix the flake. It makes the next instance cheaper to diagnose by showing the exit reason in the failure message.

**Change log entry**

None.

**Additional Notes:**

`Process::Status#inspect` covers all relevant cases:
- Clean exit: `#<Process::Status: pid 1234 exit 0>`
- Non-zero exit: `#<Process::Status: pid 1234 exit 17>`
- Signal: `#<Process::Status: pid 1234 SIGSEGV (signal 11)>`
- Signal with core dump: `#<Process::Status: pid 1234 SIGSEGV (signal 11) (core dumped)>`

No callers depend on the current message text. Custom `fork_expectations` blocks (e.g. `spec/datadog/core/crashtracking/component_spec.rb`) supply their own message and are unaffected.

**How to test the change?**

Diagnostic-only change to a test helper. No new tests; existing specs that use `expect_in_fork` will continue to behave the same. The change is exercised the next time any `expect_in_fork` assertion fails — the failure message will include the additional `Status:` field.

Local verification gap: `bundle install` is not set up in my dev environment, so `bundle exec rake standard` was not run. The change is a single-line edit (split into two lines) inside an existing string interpolation; `ruby -c` confirms the file parses.