### PR TITLE
symdb: Rails 7 integration test for extraction correctness

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,60 @@
+name: Integration Apps
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+permissions: {}
+
+jobs:
+  rails-seven:
+    name: rails-seven (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.4"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The script/ci scripts shell out to `docker-compose` (v1). Ubuntu 24.04
+      # runners ship Docker Compose v2 (invoked as `docker compose`) but not the
+      # standalone v1 binary. Shim `docker-compose` so the existing scripts work
+      # unchanged on CI while remaining compatible with local v1 setups.
+      - name: Shim docker-compose to Compose v2
+        run: |
+          shim=/usr/local/bin/docker-compose
+          sudo tee "$shim" >/dev/null <<'SHIM'
+          #!/bin/bash
+          exec docker compose "$@"
+          SHIM
+          sudo chmod +x "$shim"
+
+      - name: Build integration base image
+        run: ./integration/script/build-images -v ${{ matrix.ruby }}
+
+      - name: Build rails-seven image
+        run: ./integration/apps/rails-seven/script/build-images -v ${{ matrix.ruby }}
+
+      - name: Run rails-seven integration tests
+        run: ./integration/apps/rails-seven/script/ci -v ${{ matrix.ruby }}
+
+  complete:
+    name: Integration Apps (complete)
+    needs:
+      - rails-seven
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Done"

--- a/integration/apps/rails-seven/docker-compose.ci.yml
+++ b/integration/apps/rails-seven/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
       - redis
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
-      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306
+      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306/acme_production
       - DATABASE_ROOT_USER=root
       - DATABASE_ROOT_PASSWORD=root
       - DD_AGENT_HOST=ddagent

--- a/integration/apps/rails-seven/spec/integration/symdb_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/symdb_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+# Runs symbol database extraction inside the rails-seven process via `rails runner`.
+# Exercises the real Rails environment — Zeitwerk autoloading, ActiveRecord method
+# generation, gem path filtering — without needing a running web server or mock agent.
+#
+# Guards match di_spec.rb (JRuby and Ruby < 2.6 unsupported by symdb).
+RSpec.describe 'Symbol database extraction' do
+  di_test # reuse DI skip guards: JRuby and Ruby < 2.6 unsupported
+
+  # Script executed inside the Rails process via `bin/rails runner`.
+  # Force-loads all classes so ObjectSpace is fully populated before extraction.
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  EXTRACTION_SCRIPT = <<~RUBY
+    require 'json'
+    Rails.application.eager_load!
+
+    extractor = Datadog::SymbolDatabase::Extractor.new(
+      logger: Datadog.logger,
+      settings: Datadog.configuration,
+      telemetry: nil,
+    )
+
+    file_scopes = extractor.extract_all
+
+    # Flatten to a list of { type:, name:, file:, method_names: [] } for easy assertion
+    entries = file_scopes.flat_map do |file_scope|
+      file_scope.scopes.map do |scope|
+        {
+          type: scope.scope_type,
+          name: scope.name,
+          file: file_scope.name,
+          method_names: scope.scopes.select { |s| s.scope_type == 'METHOD' }.map(&:name),
+        }
+      end
+    end
+
+    print JSON.generate(entries)
+  RUBY
+
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+
+  let(:extraction_output) { `bin/rails runner '#{EXTRACTION_SCRIPT.tr("'", '"')}'` }
+  let(:entries) { JSON.parse(extraction_output, symbolize_names: true) }
+
+  # Helpers
+  def find_class(name)
+    entries.find { |e| e[:name] == name && e[:type] == 'CLASS' }
+  end
+
+  def find_module(name)
+    entries.find { |e| e[:name] == name && e[:type] == 'MODULE' }
+  end
+
+  it 'produces at least one FILE scope' do
+    expect(entries).not_to be_empty
+  end
+
+  describe 'DiController' do
+    subject(:scope) { find_class('DiController') }
+
+    it 'is extracted' do
+      expect(scope).not_to be_nil
+    end
+
+    it 'has user-defined methods' do
+      expect(scope[:method_names]).to include('ar_serializer')
+    end
+
+    it 'source file is in app/controllers' do
+      expect(scope[:file]).to include('/app/controllers/')
+    end
+  end
+
+  describe 'Test model (empty AR model)' do
+    subject(:scope) { find_class('Test') }
+
+    it 'is extracted even with no user-defined methods' do
+      expect(scope).not_to be_nil
+    end
+
+    it 'source file is in app/models' do
+      expect(scope[:file]).to include('/app/models/')
+    end
+  end
+
+  describe 'ApplicationController' do
+    subject(:scope) { find_class('ApplicationController') }
+
+    it 'is extracted as empty CLASS on Ruby 2.7+',
+      skip: (RUBY_VERSION < '2.7') ? 'const_source_location unavailable on Ruby 2.6' : false do
+      expect(scope).not_to be_nil
+    end
+  end
+
+  describe 'filtering' do
+    it 'excludes Datadog:: namespace' do
+      datadog_scopes = entries.select { |e| e[:name]&.start_with?('Datadog::') }
+      expect(datadog_scopes).to be_empty
+    end
+
+    it 'excludes ActiveRecord::Base (gem code)' do
+      expect(find_class('ActiveRecord::Base')).to be_nil
+    end
+
+    it 'excludes ActionController::Base (gem code)' do
+      expect(find_class('ActionController::Base')).to be_nil
+    end
+
+    it 'produces no scope names with a leading dot' do
+      leading_dot = entries.select { |e| e[:name]&.start_with?('.') }
+      expect(leading_dot).to be_empty
+    end
+  end
+end

--- a/integration/apps/rails-seven/spec/integration/symdb_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/symdb_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Symbol database extraction' do
     extractor = Datadog::SymbolDatabase::Extractor.new(
       logger: Datadog.logger,
       settings: Datadog.configuration,
-      telemetry: nil,
     )
 
     file_scopes = extractor.extract_all

--- a/integration/apps/rails-seven/spec/integration/symdb_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/symdb_spec.rb
@@ -42,8 +42,15 @@ RSpec.describe 'Symbol database extraction' do
 
   # rubocop:enable Lint/ConstantDefinitionInBlock
 
-  let(:extraction_output) { `bin/rails runner '#{EXTRACTION_SCRIPT.tr("'", '"')}'` }
-  let(:entries) { JSON.parse(extraction_output, symbolize_names: true) }
+  # Booting Rails + extracting takes ~25s. The output is read-only across all
+  # examples, so capture once per example group and share via instance variables.
+  before(:all) do
+    @extraction_output = `bin/rails runner '#{EXTRACTION_SCRIPT.tr("'", '"')}'`
+    @entries = JSON.parse(@extraction_output, symbolize_names: true)
+  end
+
+  let(:extraction_output) { @extraction_output }
+  let(:entries) { @entries }
 
   # Helpers
   def find_class(name)

--- a/integration/images/ruby/3.4/Dockerfile
+++ b/integration/images/ruby/3.4/Dockerfile
@@ -13,10 +13,11 @@ RUN set -ex && \
         apt-get install -y --force-yes --no-install-recommends nodejs && \
         \
         echo "===> Installing Yarn" && \
-        curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+        install -d -m 0755 /etc/apt/keyrings && \
+        curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
         apt-get update && \
-        apt-get install -y --force-yes --no-install-recommends yarn && \
+        apt-get install -y --no-install-recommends yarn && \
         \
         echo "===> Installing database libraries" && \
         apt-get install -y --force-yes --no-install-recommends \


### PR DESCRIPTION
JIRA: [DEBUG-5364](https://datadoghq.atlassian.net/browse/DEBUG-5364)

**What does this PR do?**

Adds a Rails 7 integration test for symbol database extraction. The test runs inside the rails-seven integration app via `bin/rails runner`, exercises extraction in a real Rails environment, and asserts on the extracted CLASS/METHOD scopes.

**Motivation:**

Unit tests cover the extractor in isolation. Several real-world failures (AR model path filtering, Zeitwerk lazy-loading timing, module naming edge cases) only reproduce in a production-like Rails context. This test catches those regressions at the Rails seam.

Assertions:
- `DiController` extracted with `ar_serializer` method
- `Test` (empty AR model with no user-defined methods) extracted via `const_source_location` fallback
- `ApplicationController` extracted as empty CLASS on Ruby 2.7+
- `Datadog::` namespace excluded
- `ActiveRecord::Base` / `ActionController::Base` (gem code) excluded
- No scope names have a leading dot

**Approach:**

Uses the `bin/rails runner` pattern already established in `basic_spec.rb`. Runs extraction in-process — no running web server or mock agent needed. Forces `Rails.application.eager_load!` before extraction to ensure Zeitwerk has loaded all classes into ObjectSpace.

**Change log entry**

None.

**Additional Notes:**

- Requires `TEST_INTEGRATION=1` to run (same guard as all integration tests)
- Base branch is `symbol-database-upload` — targets PR #5431
- Does not test upload wire format (no mock agent) — that's covered by the existing system test

[DEBUG-5364]: https://datadoghq.atlassian.net/browse/DEBUG-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ