### PR TITLE
SymDB: extraction performance benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,6 +9,7 @@
    - `tracing_` (spec in `./spec/datadog/tracing/validate_benchmarks_spec.rb`)
    - `di_` (spec in `./spec/datadog/di/validate_benchmarks_spec.rb`)
    - `error_tracking` (spec in `./spec/datadog/error_tracing/validate_benchmarks_spec.rb`)
+   - `symbol_database_` (spec in `./spec/datadog/symbol_database/validate_benchmarks_spec.rb`)
 
 2. Ensure the benchmark outputs results to `<filename>-results.json` (or `<filename>-<variant>-results.json` for multiple outputs).
 

--- a/benchmarks/execution.yml
+++ b/benchmarks/execution.yml
@@ -30,6 +30,7 @@
       tracing_trace.rb
       di_instrument.rb
       library_gem_loading.rb
+      symbol_database_extraction.rb
 
 .execution:
   variables:

--- a/benchmarks/execution.yml
+++ b/benchmarks/execution.yml
@@ -31,6 +31,7 @@
       di_instrument.rb
       library_gem_loading.rb
       symbol_database_extraction.rb
+      symbol_database_background_impact.rb
 
 .execution:
   variables:

--- a/benchmarks/symbol_database_background_impact.rb
+++ b/benchmarks/symbol_database_background_impact.rb
@@ -1,0 +1,332 @@
+#
+# Symbol Database background-impact benchmark.
+#
+# Measures how SymDB extraction running on a background thread impacts a
+# concurrent main-thread workload. Surfaces GVL contention as a p99 latency
+# ratio between two arms:
+#
+#   baseline_pre   — main-thread workload alone, no extraction running
+#   treatment      — same workload while a background thread runs Extractor#extract_all
+#   baseline_post  — workload alone again, to detect order effects (GC state,
+#                    warm caches, etc.) that would bias the comparison
+#
+# Reported statistic: p99_ratio = treatment_p99 / baseline_pre_p99.
+# A ratio near 1.0 means extraction is non-blocking from the main thread's
+# perspective; a large ratio means extraction substantially delays the main
+# thread. The threshold is decided by the results doc, not this script.
+#
+# This is the synthetic-workload counterpart to the request-load test that
+# requirements.md item 23 ("Extraction must not block the application's
+# request handling") asks for — which was originally scoped to require Rails
+# and deferred. A pure-Ruby CPU-bound workload is sufficient: the impact
+# vector is GVL hold time during ObjectSpace traversal.
+#
+# Design choices:
+#   - Background extraction is driven directly via Extractor#extract_all on
+#     a benchmark-owned Thread rather than through Component#start_upload.
+#     The GVL contention on the main thread is identical either way, and this
+#     avoids the 5s debounce, force_upload plumbing, and uploader stubbing
+#     that Component would require.
+#   - Samples are timestamped against MONOTONIC and filtered to those that
+#     fell inside the extraction window. This isolates the treatment effect
+#     even when the main loop runs longer than extraction.
+#
+# Output: symbol_database_background_impact-results.json
+#
+
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'fileutils'
+require 'json'
+require 'logger'
+require 'tmpdir'
+
+require 'datadog/symbol_database/extractor'
+
+class SymbolDatabaseBackgroundImpactBenchmark
+  CLASS_COUNT = VALIDATE_BENCHMARK_MODE ? 10 : 2500
+
+  # Main-thread workload iteration count per arm. Tuned so each arm runs
+  # several seconds in real mode — longer than extraction wall time on 2500
+  # classes — so the treatment arm has samples both during and after the
+  # extraction window.
+  WORKLOAD_ITERATIONS = VALIDATE_BENCHMARK_MODE ? 200 : 1_000_000
+
+  # Warmup iteration count run before the first measured arm. Stabilizes
+  # JIT, inline caches, and GC heap state so the first arm doesn't pay
+  # cold-start costs the later arms have already amortized. Without this,
+  # baseline_pre p99 is inflated by cold-GC noise and the
+  # p99-treatment-over-baseline ratio understates the extraction impact.
+  WARMUP_ITERATIONS = VALIDATE_BENCHMARK_MODE ? 100 : 500_000
+
+  # Minimum fraction of treatment-arm samples that must fall inside the
+  # extraction window for the benchmark to be valid. Below this we cannot
+  # claim to have measured the in-extraction p99 with any confidence.
+  MIN_OVERLAP_FRACTION = VALIDATE_BENCHMARK_MODE ? 0.0 : 0.10
+
+  class StubSettings
+    def method_missing(_name, *_args, **_kwargs)
+      self
+    end
+
+    def respond_to_missing?(_name, _include_private = false)
+      true
+    end
+  end
+
+  def run
+    Dir.mktmpdir('symdb_bgimpact_') do |dir|
+      generate_class_files(dir)
+      load_class_files(dir)
+
+      results = measure
+      results[:class_count] = CLASS_COUNT
+      results[:workload_iterations] = WORKLOAD_ITERATIONS
+      results[:warmup_iterations] = WARMUP_ITERATIONS
+      results[:ruby_version] = RUBY_VERSION
+      results[:platform] = RUBY_PLATFORM
+
+      emit(results)
+    end
+  end
+
+  private
+
+  def generate_class_files(dir)
+    CLASS_COUNT.times do |i|
+      File.write(File.join(dir, "bgimpact_class_#{i}.rb"), class_source(i))
+    end
+  end
+
+  def class_source(i)
+    name = "BgImpactClass#{i}"
+    <<~RUBY
+      class #{name}
+        CONST_VALUE = #{i}
+        @@class_counter = 0
+
+        def method_a(positional, keyword:, with_default: nil)
+          [positional, keyword, with_default]
+        end
+
+        def method_b(*args, **kwargs)
+          [args, kwargs]
+        end
+
+        def method_c(x, y, z)
+          x + y + z
+        end
+
+        def method_d
+          CONST_VALUE
+        end
+
+        def method_e(value)
+          @@class_counter = value
+        end
+      end
+    RUBY
+  end
+
+  def load_class_files(dir)
+    CLASS_COUNT.times do |i|
+      require File.join(dir, "bgimpact_class_#{i}")
+    end
+  end
+
+  def measure
+    extractor = Datadog::SymbolDatabase::Extractor.new(
+      logger: Logger.new(File::NULL),
+      settings: StubSettings.new
+    )
+
+    # Warmup pass — discarded. Without this, the first measured arm pays for
+    # cold-GC and cold-JIT costs the later arms don't, biasing the comparison.
+    WARMUP_ITERATIONS.times { |i| workload_op(i) }
+
+    3.times { GC.start }
+
+    baseline_pre = time_workload_arm(WORKLOAD_ITERATIONS)
+
+    3.times { GC.start }
+
+    treatment = time_workload_with_extraction(WORKLOAD_ITERATIONS, extractor)
+
+    3.times { GC.start }
+
+    baseline_post = time_workload_arm(WORKLOAD_ITERATIONS)
+
+    {
+      baseline_pre: baseline_pre,
+      treatment: treatment,
+      baseline_post: baseline_post,
+      summary: build_summary(baseline_pre, treatment, baseline_post),
+    }
+  end
+
+  # Run the workload N times with no background activity. Returns the arm stats.
+  def time_workload_arm(iterations)
+    samples_ns = Array.new(iterations)
+    gc_count_before = GC.count
+
+    wall_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    iterations.times do |i|
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      workload_op(i)
+      samples_ns[i] = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+    end
+    wall_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    stats_for(samples_ns, wall_end - wall_start, GC.count - gc_count_before)
+  end
+
+  # Run the workload while a background thread runs extract_all. Captures
+  # per-sample timestamps and filters them to those that fell during the
+  # extraction window so the treatment stat reflects in-extraction behavior.
+  def time_workload_with_extraction(iterations, extractor)
+    samples_ns = Array.new(iterations)
+    sample_starts_ns = Array.new(iterations)
+    gc_count_before = GC.count
+
+    extraction_started_q = Queue.new
+    extraction_start_ns = nil
+    extraction_end_ns = nil
+    file_scope_count = nil
+
+    bg = Thread.new do
+      extraction_started_q << true
+      extraction_start_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      scopes = extractor.extract_all
+      extraction_end_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      file_scope_count = scopes.size
+    end
+
+    # Wait for the extraction thread to be scheduled before starting the
+    # workload. The Queue handshake guarantees the thread is running; the
+    # nanosecond timestamp captured inside the thread marks the actual start
+    # of extraction work.
+    extraction_started_q.pop
+
+    wall_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    iterations.times do |i|
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      workload_op(i)
+      t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      sample_starts_ns[i] = t0
+      samples_ns[i] = t1 - t0
+    end
+    wall_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    bg.join
+
+    # If the workload finished before extraction did, that's expected and
+    # fine — all samples count. If extraction finished before the workload
+    # did, filter out post-extraction samples for the treatment stat.
+    overlap_samples_ns = []
+    samples_ns.each_with_index do |duration, i|
+      sample_start = sample_starts_ns[i]
+      next if sample_start.nil?
+      if sample_start >= extraction_start_ns && sample_start <= extraction_end_ns
+        overlap_samples_ns << duration
+      end
+    end
+
+    overlap_fraction = overlap_samples_ns.size.to_f / iterations
+    extraction_wall_seconds = (extraction_end_ns - extraction_start_ns) / 1e9
+
+    overall = stats_for(samples_ns, wall_end - wall_start, GC.count - gc_count_before)
+
+    arm = overall.merge(
+      extraction_wall_seconds: extraction_wall_seconds,
+      file_scope_count: file_scope_count,
+      overlap_sample_count: overlap_samples_ns.size,
+      overlap_fraction: overlap_fraction,
+    )
+
+    if overlap_samples_ns.size >= 2
+      arm[:in_window] = percentile_stats(overlap_samples_ns)
+    end
+
+    if overlap_fraction < MIN_OVERLAP_FRACTION
+      arm[:warning] =
+        "overlap_fraction #{'%.3f' % overlap_fraction} below MIN_OVERLAP_FRACTION " \
+        "#{MIN_OVERLAP_FRACTION} — extraction completed before enough workload " \
+        "samples were captured; in-window p99 is not statistically meaningful"
+    end
+
+    arm
+  end
+
+  # Non-allocating arithmetic workload. Deterministic per i so JIT and
+  # inline caches behave identically across arms. Pure integer ops produce
+  # no garbage, so GC frequency doesn't drift between arms and the p99
+  # comparison reflects GVL contention from extraction rather than GC
+  # variability. Sized to ~1-5 μs per call so per-sample clock_gettime
+  # overhead (~50 ns) is negligible.
+  def workload_op(i)
+    acc = i
+    200.times do
+      acc = ((acc * 1_103_515_245) + 12_345) & 0x7fff_ffff
+    end
+    acc
+  end
+
+  def stats_for(samples_ns, wall_seconds, gc_count_delta)
+    percentile_stats(samples_ns).merge(
+      ops: samples_ns.size,
+      wall_seconds: wall_seconds,
+      ops_per_sec: (wall_seconds > 0) ? samples_ns.size / wall_seconds : 0.0,
+      gc_count_delta: gc_count_delta,
+    )
+  end
+
+  def percentile_stats(samples_ns)
+    sorted = samples_ns.sort
+    n = sorted.size
+    {
+      mean_ns: sorted.sum.to_f / n,
+      p50_ns: sorted[n / 2],
+      p90_ns: sorted[(n * 0.90).to_i],
+      p99_ns: sorted[(n * 0.99).to_i],
+      max_ns: sorted[-1],
+    }
+  end
+
+  def build_summary(baseline_pre, treatment, baseline_post)
+    base_p99 = baseline_pre[:p99_ns].to_f
+    base_mean = baseline_pre[:mean_ns].to_f
+    base_ops = baseline_pre[:ops_per_sec].to_f
+    in_window = treatment[:in_window]
+
+    summary = {
+      p99_ratio_treatment_over_baseline: (base_p99 > 0) ? treatment[:p99_ns] / base_p99 : nil,
+      mean_ratio_treatment_over_baseline: (base_mean > 0) ? treatment[:mean_ns] / base_mean : nil,
+      throughput_ratio_treatment_over_baseline: (treatment[:ops_per_sec] > 0 && base_ops > 0) ? treatment[:ops_per_sec] / base_ops : nil,
+      order_effect_p99_ratio_post_over_pre: (base_p99 > 0) ? baseline_post[:p99_ns] / base_p99 : nil,
+    }
+
+    if in_window
+      summary[:p99_ratio_in_window_over_baseline] =
+        (base_p99 > 0) ? in_window[:p99_ns] / base_p99 : nil
+      summary[:mean_ratio_in_window_over_baseline] =
+        (base_mean > 0) ? in_window[:mean_ns] / base_mean : nil
+    end
+
+    summary
+  end
+
+  def emit(results)
+    json = JSON.pretty_generate(results)
+    puts json
+
+    return if VALIDATE_BENCHMARK_MODE
+
+    File.write("#{File.basename(__FILE__, '.rb')}-results.json", json)
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+SymbolDatabaseBackgroundImpactBenchmark.new.run

--- a/benchmarks/symbol_database_extraction.rb
+++ b/benchmarks/symbol_database_extraction.rb
@@ -1,0 +1,173 @@
+#
+# Symbol Database extraction benchmark.
+#
+# Generates 2500 user-code classes in a tmpdir, requires them, then runs
+# Extractor#extract_all once and captures memory + CPU + wall time.
+#
+# Acceptance thresholds (from projects/symdb/requirements.md):
+#   - memory overhead during extraction < 50 MB
+#   - CPU overhead during extraction    < 5%
+#
+# Output: symbol_database_extraction-results.json
+#
+# Notes on measurement:
+#   - Memory: VmRSS from /proc/self/status, sampled by a thread at ~10ms cadence
+#     during extraction. Overhead = peak − baseline (post-GC.start).
+#   - CPU: (utime + stime) / wall time, expressed as percent of one core. The
+#     5% threshold is interpretable only when amortized over a long-running
+#     process; a single one-shot extraction will report near 100% single-core
+#     utilisation by construction. The harness emits the raw numbers and the
+#     results doc decides PASS/FAIL.
+#
+
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require 'fileutils'
+require 'json'
+require 'logger'
+require 'tmpdir'
+
+require 'datadog/symbol_database/extractor'
+
+class SymbolDatabaseExtractionBenchmark
+  CLASS_COUNT = VALIDATE_BENCHMARK_MODE ? 10 : 2500
+
+  # Settings stub. Extractor stores @settings but extract_all does not consult
+  # it — modelled after the double in spec/datadog/symbol_database/extractor_spec.rb.
+  class StubSettings
+    def method_missing(_name, *_args, **_kwargs)
+      self
+    end
+
+    def respond_to_missing?(_name, _include_private = false)
+      true
+    end
+  end
+
+  def run
+    Dir.mktmpdir('symdb_perf_') do |dir|
+      generate_class_files(dir)
+      load_class_files(dir)
+
+      results = measure_extraction
+      results[:class_count] = CLASS_COUNT
+      results[:ruby_version] = RUBY_VERSION
+      results[:platform] = RUBY_PLATFORM
+
+      emit(results)
+    end
+  end
+
+  private
+
+  def generate_class_files(dir)
+    CLASS_COUNT.times do |i|
+      File.write(File.join(dir, "perf_class_#{i}.rb"), class_source(i))
+    end
+  end
+
+  def class_source(i)
+    name = "PerfClass#{i}"
+    <<~RUBY
+      class #{name}
+        CONST_VALUE = #{i}
+        @@class_counter = 0
+
+        def method_a(positional, keyword:, with_default: nil)
+          [positional, keyword, with_default]
+        end
+
+        def method_b(*args, **kwargs)
+          [args, kwargs]
+        end
+
+        def method_c(x, y, z)
+          x + y + z
+        end
+
+        def method_d
+          CONST_VALUE
+        end
+
+        def method_e(value)
+          @@class_counter = value
+        end
+      end
+    RUBY
+  end
+
+  def load_class_files(dir)
+    CLASS_COUNT.times do |i|
+      require File.join(dir, "perf_class_#{i}")
+    end
+  end
+
+  def measure_extraction
+    extractor = Datadog::SymbolDatabase::Extractor.new(
+      logger: Logger.new(File::NULL),
+      settings: StubSettings.new
+    )
+
+    3.times { GC.start }
+
+    baseline_rss_kb = read_rss_kb
+    baseline_times = Process.times
+    baseline_gc = GC.stat
+
+    peak_rss_kb = baseline_rss_kb
+    sampler_done = false
+    sampler = Thread.new do
+      until sampler_done
+        rss = read_rss_kb
+        peak_rss_kb = rss if rss > peak_rss_kb
+        sleep 0.01
+      end
+    end
+
+    wall_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    scopes = extractor.extract_all
+    wall_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    sampler_done = true
+    sampler.join
+
+    final_times = Process.times
+    final_gc = GC.stat
+
+    wall_time = wall_end - wall_start
+    cpu_time = (final_times.utime + final_times.stime) -
+      (baseline_times.utime + baseline_times.stime)
+    cpu_percent = (wall_time > 0) ? (cpu_time / wall_time) * 100.0 : 0.0
+
+    {
+      wall_time_seconds: wall_time,
+      cpu_time_seconds: cpu_time,
+      cpu_percent: cpu_percent,
+      memory_baseline_kb: baseline_rss_kb,
+      memory_peak_kb: peak_rss_kb,
+      memory_overhead_kb: peak_rss_kb - baseline_rss_kb,
+      heap_live_slots_baseline: baseline_gc[:heap_live_slots],
+      heap_live_slots_peak: final_gc[:heap_live_slots],
+      file_scope_count: scopes.size
+    }
+  end
+
+  def read_rss_kb
+    File.read('/proc/self/status').match(/VmRSS:\s+(\d+) kB/)[1].to_i
+  end
+
+  def emit(results)
+    json = JSON.pretty_generate(results)
+    puts json
+
+    return if VALIDATE_BENCHMARK_MODE
+
+    File.write("#{File.basename(__FILE__, '.rb')}-results.json", json)
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+SymbolDatabaseExtractionBenchmark.new.run

--- a/benchmarks/symbol_database_extraction.rb
+++ b/benchmarks/symbol_database_extraction.rb
@@ -11,8 +11,10 @@
 # Output: symbol_database_extraction-results.json
 #
 # Notes on measurement:
-#   - Memory: VmRSS from /proc/self/status, sampled by a thread at ~10ms cadence
-#     during extraction. Overhead = peak − baseline (post-GC.start).
+#   - Memory: RSS in KB, sampled by a thread at ~10ms cadence during extraction.
+#     Source is VmRSS from /proc/self/status on Linux; falls back to `ps -o rss=`
+#     on macOS and other platforms without /proc. Overhead = peak − baseline
+#     (post-GC.start).
 #   - CPU: (utime + stime) / wall time, expressed as percent of one core. The
 #     5% threshold is interpretable only when amortized over a long-running
 #     process; a single one-shot extraction will report near 100% single-core
@@ -154,8 +156,15 @@ class SymbolDatabaseExtractionBenchmark
     }
   end
 
+  # /proc/self/status is fast and allocation-free on Linux, but doesn't exist on
+  # macOS or BSD. Fall back to `ps -o rss=` on those platforms — slower (forks a
+  # process) but portable. Both return RSS in KB.
   def read_rss_kb
-    File.read('/proc/self/status').match(/VmRSS:\s+(\d+) kB/)[1].to_i
+    if File.exist?('/proc/self/status')
+      File.read('/proc/self/status').match(/VmRSS:\s+(\d+) kB/)[1].to_i
+    else
+      `ps -o rss= -p #{Process.pid}`.strip.to_i
+    end
   end
 
   def emit(results)

--- a/spec/datadog/symbol_database/validate_benchmarks_spec.rb
+++ b/spec/datadog/symbol_database/validate_benchmarks_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe 'Symbol Database benchmarks' do
+  before { skip('Spec requires Ruby VM supporting fork') unless PlatformHelpers.supports_fork? }
+
+  with_env 'VALIDATE_BENCHMARK' => 'true'
+
+  benchmarks_to_validate = %w[
+    symbol_database_extraction
+  ]
+
+  benchmarks_to_validate.each do |benchmark|
+    describe benchmark do
+      it 'runs without raising errors' do
+        expect_in_fork do
+          load "./benchmarks/#{benchmark}.rb"
+        end
+      end
+    end
+  end
+
+  # This test validates that we don't forget to add new benchmarks to benchmarks_to_validate
+  it 'tests all expected benchmarks in the benchmarks folder' do
+    all_benchmarks = Dir['./benchmarks/symbol_database_*'].map { |it| it.gsub('./benchmarks/', '').gsub('.rb', '') }
+
+    expect(benchmarks_to_validate).to contain_exactly(*all_benchmarks)
+  end
+end

--- a/spec/datadog/symbol_database/validate_benchmarks_spec.rb
+++ b/spec/datadog/symbol_database/validate_benchmarks_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Symbol Database benchmarks' do
 
   benchmarks_to_validate = %w[
     symbol_database_extraction
+    symbol_database_background_impact
   ]
 
   benchmarks_to_validate.each do |benchmark|


### PR DESCRIPTION
JIRA: [DEBUG-5671](https://datadoghq.atlassian.net/browse/DEBUG-5671)

**What does this PR do?**

Adds a Symbol Database extraction performance benchmark. The harness generates 2500 user-code classes in a tmpdir, requires them, then runs `Extractor#extract_all` once and captures memory + CPU + wall time, writing `symbol_database_extraction-results.json`.

Wires into existing benchmark infrastructure:
- new `symbol_database_` prefix in `benchmarks/README.md`
- `symbol_database_extraction.rb` added to the `&other` group in `benchmarks/execution.yml` so it runs in dtr CI
- validate spec at `spec/datadog/symbol_database/validate_benchmarks_spec.rb` runs the harness with `VALIDATE_BENCHMARK=true` (10 classes) to catch bitrot

Stdlib only (`Process.times`, `/proc/self/status`, `GC.stat`) — no new gem deps.

**Motivation:**

Verifies the SymDB performance requirements: memory overhead < 50 MB and CPU overhead < 5% during extraction. Backlog item "Performance testing" in the symdb project.

**Change log entry**

None.

**Additional Notes:**

Local run on Ruby 3.2.3, x86_64-linux: 269 ms wall, 27 MB peak memory overhead. The CPU% emitted by the harness is single-core utilisation (near 100% by construction for a one-shot CPU-bound operation); the `< 5%` requirement is interpretable only when amortized over a long-running process — the harness emits raw CPU time and wall time, results doc decides PASS/FAIL.

Branched off `symbol-database-upload` (#5431) so the perf measurement targets the same code as the main tracer PR.

**How to test the change?**

```bash
# Validate spec (fast — 10 classes, run in fork)
bundle exec rspec spec/datadog/symbol_database/validate_benchmarks_spec.rb

# Full benchmark (2500 classes)
bundle exec ruby benchmarks/symbol_database_extraction.rb
cat benchmarks/symbol_database_extraction-results.json
```

[DEBUG-5671]: https://datadoghq.atlassian.net/browse/DEBUG-5671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ