### PR TITLE
Auto-label Dynamic Instrumentation and Symbol Database PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,4 +68,8 @@ single-step:
 # Changes to Dynamic Instrumentation or Symbol Database
 debugger:
 - changed-files:
-  - any-glob-to-any-file: ['lib/datadog/di/**', 'lib/datadog/symbol_database/**']
+  - any-glob-to-any-file:
+    - 'lib/datadog/di.rb'
+    - 'lib/datadog/di/**'
+    - 'lib/datadog/symbol_database.rb'
+    - 'lib/datadog/symbol_database/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -65,7 +65,7 @@ single-step:
 - changed-files:
   - any-glob-to-any-file: ['lib-injection/**']
 
-# Changes to Debugging
-debugging:
+# Changes to Dynamic Instrumentation or Symbol Database
+debugger:
 - changed-files:
-  - any-glob-to-any-file: ['lib/datadog/debugging/**']
+  - any-glob-to-any-file: ['lib/datadog/di/**', 'lib/datadog/symbol_database/**']


### PR DESCRIPTION
**What does this PR do?**

Renames the `debugging` rule in `.github/labeler.yml` to `debugger` and updates its file globs to cover both directory contents and top-level entry files for Dynamic Instrumentation and Symbol Database (`lib/datadog/di.rb`, `lib/datadog/di/**`, `lib/datadog/symbol_database.rb`, `lib/datadog/symbol_database/**`).

**Motivation:**

The previous rule pointed to `lib/datadog/debugging/**`, which does not exist — DI code lives at `lib/datadog/di/` and symbol database at `lib/datadog/symbol_database/`. The rule has never matched any PR.

The new name `debugger` aligns with how other Datadog tracers label live-debugger / DI work:

| Tracer | Label(s) |
|---|---|
| dd-trace-cpp | _(none)_ |
| dd-trace-dotnet | `area:debugger`, `exception-replay` |
| dd-trace-go | _(none)_ |
| dd-trace-java | `comp: debugger` |
| dd-trace-js | `debugger` |
| dd-trace-php | _(none)_ |
| dd-trace-py | `Dynamic Instrumentation`, `Exception Replay` |
| dd-trace-rb (before) | `debugging` (rule broken; never applied) |
| dd-trace-rb (after) | `debugger` |

**Change log entry**

None.

**Additional Notes:**

The `debugger` label has been created in the repo and the orphaned `debugging` label has been removed.

**How to test the change?**

The labeler workflow runs on `pull_request` events. The next PR touching `lib/datadog/di.rb`, `lib/datadog/di/**`, `lib/datadog/symbol_database.rb`, or `lib/datadog/symbol_database/**` should be auto-tagged with `debugger`.