### PR TITLE
Bump to version 2.32.0

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
   test:
     needs:
       - build
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@719baee0abcf58298b0adad609fcd07fd1e99bce  # Automated: This reference is automatically updated.
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@943b4ecad72d48c55716211f2b01f1f5d97d6de2  # Automated: This reference is automatically updated.
     permissions:
       contents: read
       id-token: write
@@ -88,7 +88,7 @@ jobs:
       desired_execution_time: 300 # 5 minutes
       scenarios_groups: tracer_release
       skip_empty_scenarios: ${{ !(github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master')) }}
-      ref: 719baee0abcf58298b0adad609fcd07fd1e99bce # Automated: This reference is automatically updated.
+      ref: 943b4ecad72d48c55716211f2b01f1f5d97d6de2 # Automated: This reference is automatically updated.
       force_execute: ${{ needs.build.outputs.forced_tests }}
       parametric_job_count: 8
       push_to_test_optimization: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: 719baee0abcf58298b0adad609fcd07fd1e99bce # Automated: This reference is automatically updated.
+    SYSTEM_TESTS_REF: 943b4ecad72d48c55716211f2b01f1f5d97d6de2 # Automated: This reference is automatically updated.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 


### PR DESCRIPTION
### Added

* Open Feature: Add flag evaluation metrics (`feature_flag.evaluations`) via OpenTelemetry for OpenFeature provider. (#5599)
* Profiling: Add metric for total time spent waiting for the GVL. (#5569)
* Dynamic Instrumentation: Live Debugger line probes can now target third-party and Ruby standard library code loaded before datadog gem is loaded. (#5501)
### Changed

* Profiling: Print failure info when native extension setup fails (#5657)
* Tracing: Add parsing limits to `tracestate` and `traceparent` propagation headers and remove whitespace around list members. (#5674)
* Tracing: Limit extracted [baggage](https://www.w3.org/TR/2024/CR-baggage-20240530/) header parsing to 64 items and 8192 bytes. (#5672)
### Fixed

* Tracing: Enforce `x-datadog-tags` propagation header size limits by byte size. (#5687)
* Tracing: Return empty baggage on invalid UTF-8 baggage extraction (#5689)
