### PR TITLE
ci: fail build-gem job when bundle install fails, retry on transient errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,7 @@ build-gem:
   script:
     - mkdir -p pkg tmp
     - |
+      set -eo pipefail
       if [ -n "$CI_COMMIT_TAG" ]; then
         .gitlab/check_gem_presence.sh
         VERSION=${CI_COMMIT_TAG#v}
@@ -106,7 +107,19 @@ build-gem:
         echo CI_COMMIT_REF_NAME=$CI_COMMIT_REF_NAME
         echo CI_COMMIT_SHA=$CI_COMMIT_SHA
         .gitlab/patch_gem_version.sh glci $CI_JOB_ID $CI_COMMIT_REF_NAME $CI_COMMIT_SHA
-        bundle install && chmod go-w -R . && bundle exec rake build
+        for attempt in 1 2 3 4; do
+          if bundle install; then
+            break
+          fi
+          if [ "$attempt" -eq 4 ]; then
+            echo "bundle install failed after 4 attempts" >&2
+            exit 1
+          fi
+          echo "bundle install attempt $attempt failed; sleeping 10s before retry" >&2
+          sleep 10
+        done
+        chmod go-w -R .
+        bundle exec rake build
         ruby -Ilib -rdatadog/version -e 'puts Gem::Version.new(Datadog::VERSION::STRING).to_s' >> tmp/version
       fi
   artifacts:


### PR DESCRIPTION
**What does this PR do?**

Hardens the `build-gem` GitLab CI job so that a failed `bundle install` actually fails the job, and retries `bundle install` on transient network errors.

Three changes to the `build-gem` script in `.gitlab-ci.yml`:

1. Adds `set -eo pipefail` to the script block.
2. Replaces the `bundle install && chmod && rake build` chain with sequential commands.
3. Wraps `bundle install` in a 4-attempt loop with a 10s sleep between attempts.

**Motivation:**

A recent master pipeline ([install-dependencies job 1667279788](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/jobs/1667279788)) failed with `gem install --local pkg/datadog-*.gem` receiving an unexpanded glob. Investigation showed the upstream [build-gem job 1667279774](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-rb/-/jobs/1667279774) reported success but uploaded an empty `pkg/` directory.

Root cause: `bundle install` failed with a TCP timeout to rubygems.org. The build-gem script chained `bundle install && chmod go-w -R . && bundle exec rake build` on one line. Under bash `set -e`, failure of any non-final command in an `&&` list is exempted from triggering exit. The chain returned non-zero, the script continued past it, the empty `pkg/` was uploaded as an artifact, and the job exited 0.

The retry loop also addresses the underlying flake. Bundler 2.3.27's built-in `--retry` performs immediate retries with no backoff, which does not help against TCP timeouts; a shell-level loop with a fixed sleep does.

**Change log entry**

None.

**Additional Notes:**

The `if [ -n "$CI_COMMIT_TAG" ]` branch is unchanged: it does not run `bundle install`, so neither the silent-failure nor the retry concern applies.

**How to test the change?**

The change cannot be tested by re-running existing CI, since the rubygems.org timeout was transient. Manual verification of the bash semantics:

```
$ bash -c 'set -e; false && true; echo "still here"'
still here
$ bash -c 'set -e; false; echo "never prints"'
$ echo $?
1
```

The first form (the previous behavior) keeps running after a failed `false`. The second form (the new behavior) aborts.