### PR TITLE
Reproduce flaky: DSM Processor#flush_stats test

### DIFF
--- a/lib/datadog/data_streams/processor.rb
+++ b/lib/datadog/data_streams/processor.rb
@@ -150,6 +150,11 @@ module Datadog
 
       # Called periodically by the worker to flush stats to the agent
       def perform
+        # REPRODUCER for flaky DSM #flush_stats test: delay the worker thread's
+        # first perform_loop iteration so it runs AFTER the test thread has
+        # called set_produce_checkpoint. Simulates OS scheduling delays observed
+        # on macOS arm64 in CI. Should be reverted once the flake is fixed.
+        sleep(0.1) if Thread.current != Thread.main
         process_events
         flush_stats
         true

--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -342,6 +342,15 @@ RSpec.describe Datadog::DataStreams::Processor do
 
     before do
       flush_processor.set_produce_checkpoint(type: 'kafka', destination: 'orders')
+
+      # REPRODUCER: yield the GVL long enough for the auto-spawned worker
+      # thread's first perform_loop iteration (delayed by the matching sleep
+      # in Processor#perform) to drain @event_buffer and run flush_stats,
+      # which serialize_buckets clears and which calls the unmocked
+      # send_stats_to_agent. By the time the test resumes, @buckets is empty
+      # and the test's flush_stats hits the early-return at processor.rb:307.
+      sleep 0.5
+
       flush_processor.send(:process_events)
 
       @sent_payload = nil


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/data_streams/processor_spec.rb:367` — `Datadog::DataStreams::Processor#flush_stats when env is configured includes Env from settings in the payload`. Forces the suspected race deterministically. Expected result: the flush_stats tests fail in CI.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test in [Test (macos-15, 3.0)](https://github.com/DataDog/dd-trace-rb/actions/runs/25531332144/job/74938089326). Same test passed in `Test (macos-15, 4.0)` and on every Linux Ruby version for the same commit `acebecfc`.

**Hypothesis:** `Processor#initialize` calls `perform`, which (via `Async::Thread`) spawns a worker thread. `perform_loop`'s first iteration runs immediately (`loop_wait_before_first_iteration?` returns false). When the worker's first iteration races with the test thread:

1. Worker `process_events` drains `@event_buffer` (catching the test's pushed event).
2. Worker `flush_stats` runs `serialize_buckets` which clears `@buckets` (`processor.rb:471`) and calls the **unmocked** `send_stats_to_agent`.
3. Test thread's later `flush_stats` hits the early-return at `processor.rb:307` (`@buckets.empty? && @consumer_stats.empty?`). The mock is never called; `@sent_payload` stays `nil`.

**Reproducer technique:**

- `lib/datadog/data_streams/processor.rb`: add `sleep(0.1)` at the top of `Processor#perform` when invoked from a non-main thread, delaying the worker's first iteration past the test's `set_produce_checkpoint`.
- `spec/datadog/data_streams/processor_spec.rb`: add `sleep 0.5` in the `before` block to yield the GVL long enough for the worker to drain the buffer and clear the buckets before the test reaches its own `flush_stats`.

**Change log entry**

None.

**How to test the change?**

CI should show the two `#flush_stats` examples failing deterministically. If they don't, the hypothesis is wrong.

**Companion PRs:**
- Fix: #5715
- Validation: #5716