### PR TITLE
Fix flaky: DSM Processor#flush_stats test

### DIFF
--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -341,6 +341,17 @@ RSpec.describe Datadog::DataStreams::Processor do
     let(:sent_payload) { @sent_payload }
 
     before do
+      # Stop the auto-spawned background worker thread before exercising
+      # flush_stats synchronously. Otherwise the worker can race with the
+      # test thread: its first perform_loop iteration runs immediately
+      # (loop_wait_before_first_iteration? is false), and if the OS
+      # schedules it after set_produce_checkpoint pushes its event, the
+      # worker drains @event_buffer and runs flush_stats — which clears
+      # @buckets via serialize_buckets and calls the unmocked
+      # send_stats_to_agent. The test's later flush_stats then early-returns
+      # at processor.rb:307 (empty @buckets) and @sent_payload stays nil.
+      flush_processor.stop(true)
+
       flush_processor.set_produce_checkpoint(type: 'kafka', destination: 'orders')
       flush_processor.send(:process_events)
 


### PR DESCRIPTION
**What does this PR do?**

Fixes flaky test `spec/datadog/data_streams/processor_spec.rb:367` — `Datadog::DataStreams::Processor#flush_stats when env is configured includes Env from settings in the payload`.

**Motivation:**

Flaky test in [Test (macos-15, 3.0)](https://github.com/DataDog/dd-trace-rb/actions/runs/25531332144/job/74938089326). Same test passed in `Test (macos-15, 4.0)` and on every Linux Ruby version for the same commit `acebecfc`.

**Failure:**

```
Failure/Error: expect(sent_payload).not_to be_nil
  expected: not nil
       got: nil
# ./spec/datadog/data_streams/processor_spec.rb:359:in `block (4 levels) in <top (required)>'
```

**Root cause:**

`Datadog::DataStreams::Processor` includes `Core::Workers::Polling`, and its `initialize` calls `perform`, which (via `Async::Thread`) spawns a background worker thread. `perform_loop`'s first iteration runs immediately — `loop_wait_before_first_iteration?` returns `false` (`lib/datadog/core/workers/interval_loop.rb:124-126`).

The `#flush_stats` spec's `before` block was racy with that worker. If the OS scheduled the worker after the test thread's `set_produce_checkpoint` pushed its event but before the test installed its `send_stats_to_agent` mock, the worker:

1. Drained `@event_buffer` (`process_events`).
2. Populated `@buckets`.
3. Ran `flush_stats`, which clears `@buckets` via `serialize_buckets` (`processor.rb:471`) and called the **unmocked** `send_stats_to_agent`.

The test's later `flush_stats` then hit the early-return at `processor.rb:307` (`return if @buckets.empty? && @consumer_stats.empty?`), so the mock was never invoked and `@sent_payload` stayed `nil`.

**Fix:**

Stop the worker thread in the `before` block before exercising `flush_stats` synchronously. The test verifies the synchronous `flush_stats` logic, not the worker thread; stopping the worker eliminates the race without weakening the test.

**Change log entry**

None.

**How to test the change?**

The existing two `#flush_stats` examples in `spec/datadog/data_streams/processor_spec.rb` continue to assert the payload's `Env` and `Service` values. They now run deterministically without the race.

Validation across the 3-PR pattern:

- Reproducer #5714 forces the race deterministically (test fails).
- Validation PR (link added once created) merges the reproducer and this fix; if CI passes, the fix neutralizes the forced failure.

**Companion PRs:**
- Reproducer: #5714
- Validation: #5716

**Validation results:**
- Reproducer #5714 — CI failed deterministically on every macOS Ruby version (3.0–4.0) and on Linux Ruby 2.5 with `expect(sent_payload).not_to be_nil` got `nil`, confirming the hypothesis (closed).
- Validation #5716 — CI passed across the full matrix with both reproducer and fix applied, confirming the fix neutralizes the forced failure (closed).