### PR TITLE
Validate fix for flaky: DSM Processor#flush_stats test

### DIFF
--- a/lib/datadog/data_streams/processor.rb
+++ b/lib/datadog/data_streams/processor.rb
@@ -150,6 +150,11 @@ module Datadog
 
       # Called periodically by the worker to flush stats to the agent
       def perform
+        # REPRODUCER for flaky DSM #flush_stats test: delay the worker thread's
+        # first perform_loop iteration so it runs AFTER the test thread has
+        # called set_produce_checkpoint. Simulates OS scheduling delays observed
+        # on macOS arm64 in CI. Should be reverted once the flake is fixed.
+        sleep(0.1) if Thread.current != Thread.main
         process_events
         flush_stats
         true

--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -341,6 +341,17 @@ RSpec.describe Datadog::DataStreams::Processor do
     let(:sent_payload) { @sent_payload }
 
     before do
+      # Stop the auto-spawned background worker thread before exercising
+      # flush_stats synchronously. Otherwise the worker can race with the
+      # test thread: its first perform_loop iteration runs immediately
+      # (loop_wait_before_first_iteration? is false), and if the OS
+      # schedules it after set_produce_checkpoint pushes its event, the
+      # worker drains @event_buffer and runs flush_stats — which clears
+      # @buckets via serialize_buckets and calls the unmocked
+      # send_stats_to_agent. The test's later flush_stats then early-returns
+      # at processor.rb:307 (empty @buckets) and @sent_payload stays nil.
+      flush_processor.stop(true)
+
       flush_processor.set_produce_checkpoint(type: 'kafka', destination: 'orders')
       flush_processor.send(:process_events)
 

--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -342,6 +342,15 @@ RSpec.describe Datadog::DataStreams::Processor do
 
     before do
       flush_processor.set_produce_checkpoint(type: 'kafka', destination: 'orders')
+
+      # REPRODUCER: yield the GVL long enough for the auto-spawned worker
+      # thread's first perform_loop iteration (delayed by the matching sleep
+      # in Processor#perform) to drain @event_buffer and run flush_stats,
+      # which serialize_buckets clears and which calls the unmocked
+      # send_stats_to_agent. By the time the test resumes, @buckets is empty
+      # and the test's flush_stats hits the early-return at processor.rb:307.
+      sleep 0.5
+
       flush_processor.send(:process_events)
 
       @sent_payload = nil


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the forced failure. This branch merges:

- Reproducer PR: #5714 (forces the worker thread to drain `@event_buffer` before the test installs its mock)
- Fix PR: #5715 (stops the worker thread before exercising `flush_stats` synchronously)

If CI passes, the fix addresses the exact failure mode the reproducer forces. If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for validation only.

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the forced failure. CI fails = fix is insufficient.

**Companion PRs:**
- Reproducer: #5714
- Fix: #5715