### PR TITLE
Reproduce flaky: thread_context_spec cpu-time accumulation

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1484,12 +1484,21 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         let(:context_tracking) { [] }
 
         before do
-          5.times do
-            on_gc_start
-            on_gc_finish
-
-            context_tracking << gc_tracking
-          end
+          # REPRODUCER for flaky failure on macOS:
+          #
+          # The Mach-API CPU clock (clock_id_from_mach.c) has microsecond resolution.
+          # When 5 fast GC cycles all complete within a single microsecond on macOS,
+          # every accumulated_cpu_time_ns snapshot is identical (first == last), and
+          # the strict `<` assertion on the test below fails with
+          # "expected: < 2000, got: 2000".
+          #
+          # This reproducer forces the failure deterministically on every platform by
+          # running a single cycle and replicating its snapshot 5 times. CI should
+          # show the test failing with the same error message seen on macOS in CI.
+          on_gc_start
+          on_gc_finish
+          snapshot = gc_tracking
+          5.times { context_tracking << snapshot }
         end
 
         it "accumulates the cpu-time and wall-time from the multiple GCs" do


### PR DESCRIPTION
**What does this PR do?**

Reproducer for the flaky test `Datadog::Profiling::Collectors::ThreadContext#on_gc_finish ... accumulates the cpu-time and wall-time from the multiple GCs` at [`spec/datadog/profiling/collectors/thread_context_spec.rb`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/profiling/collectors/thread_context_spec.rb). Forces the suspected failure mode to validate the hypothesis in CI. Expected result: this test fails deterministically.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky failure observed in [Test (macos-15, 4.0) — job 75017626164](https://github.com/DataDog/dd-trace-rb/actions/runs/25556761669/job/75017626164):

```
Failure/Error: expect(all_accumulated_cpu_time.first).to be < all_accumulated_cpu_time.last if all_accumulated_cpu_time.first > 0
  expected: < 2000
       got:   2000
```

**Hypothesis:** Commit [41afec16e0](https://github.com/DataDog/dd-trace-rb/commit/41afec16e0) ("Implement CPU profiling on macOS using Mach thread APIs") replaced the no-op macOS CPU clock with a real one based on Mach `thread_info` — which has microsecond resolution. The test runs 5 fast `on_gc_start`/`on_gc_finish` cycles. When all 5 cycles complete within a single microsecond on macOS, every `accumulated_cpu_time_ns` snapshot is identical (first == last) and the strict `<` assertion fails.

**Reproducer technique:** Replace the 5 GC cycles with one cycle whose snapshot is replicated 5 times. This forces `first == last` (with `first > 0`) on every platform, every run.

**Change log entry**

None.

**How to test the change?**

CI should show the test failing deterministically with the same `expected: < 2000, got: 2000`–shaped error. If it doesn't, the hypothesis is wrong.

**Companion PRs:**
- Fix: #5729
- Validation: #5730