### PR TITLE
SymDB: Remove telemetry from ScopeBatcher

### DIFF
--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -43,13 +43,11 @@ module Datadog
       # Initialize batching context.
       # @param uploader [Uploader] Uploader instance for triggering uploads
       # @param logger [Logger] Logger for diagnostics
-      # @param telemetry [Core::Telemetry::Component, nil] Telemetry for error reporting
       # @param on_upload [Proc, nil] Optional callback called after upload (for testing)
       # @param timer_enabled [Boolean] Enable async timer (default true, false for tests)
-      def initialize(uploader, logger:, telemetry: nil, on_upload: nil, timer_enabled: true)
+      def initialize(uploader, logger:, on_upload: nil, timer_enabled: true)
         @uploader = uploader
         @logger = logger
-        @telemetry = telemetry
         @on_upload = on_upload
         @timer_enabled = timer_enabled
         @scopes = []
@@ -118,7 +116,6 @@ module Datadog
         perform_upload(scopes_to_upload) if scopes_to_upload
       rescue => e
         @logger.debug { "symdb: failed to add scope: #{e.class}: #{e.message}" }
-        @telemetry&.report(e, description: 'symdb: failed to add scope')
         # Don't propagate, continue operation
       end
 
@@ -264,7 +261,6 @@ module Datadog
         end
       rescue => e
         @logger.debug { "symdb: timer thread error: #{e.class}: #{e.message}" }
-        @telemetry&.report(e, description: 'symdb: timer thread error')
       end
 
       # Perform upload via uploader.
@@ -277,7 +273,6 @@ module Datadog
         @on_upload&.call(scopes)  # Notify tests after upload
       rescue => e
         @logger.debug { "symdb: upload failed: #{e.class}: #{e.message}" }
-        @telemetry&.report(e, description: 'symdb: upload failed')
         # Don't propagate, uploader handles retries
       end
     end

--- a/sig/datadog/symbol_database/scope_batcher.rbs
+++ b/sig/datadog/symbol_database/scope_batcher.rbs
@@ -13,8 +13,6 @@ module Datadog
 
       @logger: Logger
 
-      @telemetry: Datadog::Core::Telemetry::Component?
-
       @on_upload: ::Proc?
 
       @timer_enabled: bool
@@ -35,7 +33,7 @@ module Datadog
 
       @uploaded_modules: ::Set[::String?]
 
-      def initialize: (Uploader uploader, logger: Logger, ?telemetry: Datadog::Core::Telemetry::Component?, ?on_upload: ::Proc?, ?timer_enabled: bool) -> void
+      def initialize: (Uploader uploader, logger: Logger, ?on_upload: ::Proc?, ?timer_enabled: bool) -> void
 
       def add_scope: (Scope scope) -> void
 

--- a/spec/datadog/symbol_database/scope_batcher_spec.rb
+++ b/spec/datadog/symbol_database/scope_batcher_spec.rb
@@ -384,12 +384,10 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
   end
 
   describe 'error handling' do
-    let(:telemetry) { instance_double('Datadog::Core::Telemetry::Component', report: nil) }
-
-    subject(:context) { described_class.new(uploader, logger: logger, telemetry: telemetry, timer_enabled: false) }
+    subject(:context) { described_class.new(uploader, logger: logger, timer_enabled: false) }
 
     context 'when add_scope raises unexpectedly' do
-      it 'logs and reports telemetry without propagating' do
+      it 'logs without propagating' do
         # Force the dedup Set lookup to raise — exercises the outer rescue in add_scope
         broken_set = Set.new
         def broken_set.include?(_)
@@ -398,18 +396,16 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
         context.instance_variable_set(:@uploaded_modules, broken_set)
 
         expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/failed to add scope.*StandardError.*set blew up/i) }
-        expect(telemetry).to receive(:report).with(an_instance_of(StandardError), description: 'symdb: failed to add scope')
 
         expect { context.add_scope(test_scope) }.not_to raise_error
       end
     end
 
     context 'when uploader raises during perform_upload' do
-      it 'logs and reports telemetry without propagating' do
+      it 'logs without propagating' do
         allow(uploader).to receive(:upload_scopes).and_raise(StandardError, 'upload blew up')
 
         expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/upload failed.*StandardError.*upload blew up/i) }
-        expect(telemetry).to receive(:report).with(an_instance_of(StandardError), description: 'symdb: upload failed')
 
         context.add_scope(test_scope)
         expect { context.flush }.not_to raise_error
@@ -417,13 +413,12 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
     end
 
     context 'when timer thread raises unexpectedly' do
-      let(:timer_telemetry) { instance_double('Datadog::Core::Telemetry::Component', report: nil) }
       let(:timer_logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
 
       # Use a real timer for this test to exercise the rescue in timer_loop.
-      subject(:timer_context) { described_class.new(uploader, logger: timer_logger, telemetry: timer_telemetry) }
+      subject(:timer_context) { described_class.new(uploader, logger: timer_logger) }
 
-      it 'logs and reports telemetry without crashing the process' do
+      it 'logs without crashing the process' do
         # Stub @scopes.empty? to raise inside the timer loop's mutex section.
         broken_scopes = []
         def broken_scopes.empty?
@@ -431,8 +426,9 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
         end
 
         captured = Queue.new
-        allow(timer_telemetry).to receive(:report) do |error, description:|
-          captured.push([error.message, description])
+        allow(raw_logger).to receive(:debug) do |&block|
+          msg = block.call
+          captured.push(msg) if msg.include?('timer thread error')
         end
 
         timer_context.instance_variable_set(:@scopes, broken_scopes)
@@ -442,10 +438,9 @@ RSpec.describe Datadog::SymbolDatabase::ScopeBatcher do
           timer_context.send(:ensure_timer_running)
         end
 
-        # The timer waits 1s then probes @scopes.empty? — wait for the report.
-        message, description = Timeout.timeout(5) { captured.pop }
-        expect(message).to match(/scope check blew up/)
-        expect(description).to eq('symdb: timer thread error')
+        # The timer waits 1s then probes @scopes.empty? — wait for the log.
+        message = Timeout.timeout(5) { captured.pop }
+        expect(message).to match(/timer thread error.*StandardError.*scope check blew up/i)
 
         timer_context.shutdown
       end


### PR DESCRIPTION
**What does this PR do?**

Removes the `telemetry` parameter from `Datadog::SymbolDatabase::ScopeBatcher` and the three `@telemetry&.report(...)` calls in its rescue blocks (`add_scope`, `timer_loop`, `perform_upload`). The rescue blocks still log at debug level.

**Constructor change:** `ScopeBatcher.new(uploader, logger:, telemetry: nil, on_upload: nil, timer_enabled: true)` becomes `ScopeBatcher.new(uploader, logger:, on_upload: nil, timer_enabled: true)`. Master has no non-test callers of `ScopeBatcher.new` — only its spec instantiates it directly — so this is contained to the tests in this PR.

The three "logs and reports telemetry…" rescue-path tests are rewritten to assert on the log message only (the dropped telemetry assertion).

**Motivation:**

Matches the SymDB direction set by #5693 (telemetry removal from Extractor). Telemetry reporting for internal SymDB lifecycle errors is being replaced by debug-level logging; only the upload boundary (Uploader) retains telemetry reporting.

Extracted from #5717 to land independently.

**Change log entry**

None.

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/scope_batcher_spec.rb
```

Verification on this branch:
- 30 examples, 0 failures
- `bundle exec steep check lib/datadog/symbol_database/scope_batcher.rb` — No type error detected
- `bundle exec standardrb …` — clean