### PR TITLE
SymDB: Emit payload_size distribution metric from Uploader

### DIFF
--- a/lib/datadog/symbol_database/uploader.rb
+++ b/lib/datadog/symbol_database/uploader.rb
@@ -59,6 +59,9 @@ module Datadog
         json_data = build_symbol_payload(scopes)
         compressed_data = Zlib.gzip(json_data)
 
+        # Emitted unconditionally so the rare oversized case is observable.
+        @telemetry&.distribution('tracers', 'symbol_database.payload_size', compressed_data.bytesize)
+
         # Symbols for very large applications (>50MB after gzip) are dropped:
         # the upload is skipped and the customer sees no autocomplete /
         # symbol probe results for those classes. Java handles the same case

--- a/spec/datadog/symbol_database/uploader_spec.rb
+++ b/spec/datadog/symbol_database/uploader_spec.rb
@@ -111,6 +111,54 @@ RSpec.describe Datadog::SymbolDatabase::Uploader do
       end
     end
 
+    context 'with telemetry payload size metric' do
+      let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component, distribution: nil, report: nil) }
+
+      it 'emits payload_size distribution on successful upload with compressed bytesize' do
+        allow(mock_transport).to receive(:send_symbols).and_return(mock_response)
+
+        captured_size = nil
+        allow(Zlib).to receive(:gzip).and_wrap_original do |orig, *args|
+          result = orig.call(*args)
+          captured_size = result.bytesize
+          result
+        end
+
+        uploader.upload_scopes([test_scope])
+
+        expect(telemetry).to have_received(:distribution)
+          .with('tracers', 'symbol_database.payload_size', captured_size)
+      end
+
+      it 'emits payload_size distribution on the oversized-skip path' do
+        oversized = 'x' * (described_class::MAX_PAYLOAD_SIZE + 1)
+        allow(Zlib).to receive(:gzip).and_return(oversized)
+        expect(mock_transport).not_to receive(:send_symbols)
+
+        uploader.upload_scopes([test_scope])
+
+        expect(telemetry).to have_received(:distribution)
+          .with('tracers', 'symbol_database.payload_size', oversized.bytesize)
+      end
+
+      it 'does not emit payload_size when serialization raises before compression' do
+        allow_any_instance_of(Datadog::SymbolDatabase::ServiceVersion)
+          .to receive(:to_json).and_raise('Serialization error')
+
+        uploader.upload_scopes([test_scope])
+
+        expect(telemetry).not_to have_received(:distribution)
+      end
+
+      it 'does not emit payload_size when compression itself raises' do
+        allow(Zlib).to receive(:gzip).and_raise(Zlib::Error, 'compress failed')
+
+        uploader.upload_scopes([test_scope])
+
+        expect(telemetry).not_to have_received(:distribution)
+      end
+    end
+
     context 'with network errors' do
       it 'does not retry on connection errors — single attempt, logs and continues' do
         allow(mock_transport).to receive(:send_symbols).and_raise(Errno::ECONNREFUSED, 'Connection refused')


### PR DESCRIPTION
**What does this PR do?**

Adds a single telemetry call to `Datadog::SymbolDatabase::Uploader#upload_scopes`:

```ruby
@telemetry&.distribution('tracers', 'symbol_database.payload_size', compressed_data.bytesize)
```

emitted unconditionally after GZIP compression and before the `MAX_PAYLOAD_SIZE` check. The metric records the compressed payload size in bytes for every upload attempt, including ones that get dropped for being too large (so the oversized case is observable instead of silently lost).

Four new specs cover:
- successful upload: `distribution` called with the compressed bytesize
- oversized-skip path: `distribution` still called before the skip
- serialization-raises path: `distribution` not called
- compression-raises path: `distribution` not called

No constructor or API changes — the `telemetry:` parameter already exists on Uploader.

**Motivation:**

Uploader is the externally-observable boundary of the SymDB subsystem. The `payload_size` distribution gives ops/customer visibility into the size of uploaded symbol databases.

Extracted from #5717 to land independently.

**Change log entry**

None.

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/uploader_spec.rb
```

Verification on this branch:
- 21 examples, 0 failures
- `bundle exec steep check lib/datadog/symbol_database/uploader.rb` — No type error detected
- `bundle exec standardrb …` — clean