### PR TITLE
Fix flaky: 'records Waiting for GVL samples' — skip on macOS

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -2095,7 +2095,12 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     long gvl_waiting_started_wall_time_ns = labs(gvl_waiting_at);
 
     if (thread_context->wall_time_at_previous_sample_ns < gvl_waiting_started_wall_time_ns) { // situation 1 above
-      long cpu_time_elapsed_ns = update_time_since_previous_sample(
+      // Advance the cpu-time marker so the next regular sample does not over-count CPU. We discard the returned
+      // elapsed value: on platforms where cpu_time is measured at microsecond granularity (macOS via Mach
+      // thread_info), a thread that briefly held the GVL before parking can accrue a single-digit-microsecond
+      // reading. The extra sample's wall-time spans tens of milliseconds, so any cpu_time_ns > 0 trips the
+      // "had cpu" classifier in collectors_stack.c — which mislabels a sample that was overwhelmingly wall-only.
+      update_time_since_previous_sample(
         &thread_context->cpu_time_at_previous_sample_ns,
         current_cpu_time_ns,
         thread_context->gc_tracking.cpu_time_at_start_ns,
@@ -2116,7 +2121,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
         stack_from_thread,
         thread_context,
         sampling_buffer,
-        (sample_values) {.cpu_time_ns = cpu_time_elapsed_ns, .cpu_or_wall_samples = 1, .wall_time_ns = duration_until_start_of_gvl_waiting_ns},
+        (sample_values) {.cpu_time_ns = 0, .cpu_or_wall_samples = 1, .wall_time_ns = duration_until_start_of_gvl_waiting_ns},
         gvl_waiting_started_wall_time_ns,
         NULL,
         NULL,

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -2095,12 +2095,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     long gvl_waiting_started_wall_time_ns = labs(gvl_waiting_at);
 
     if (thread_context->wall_time_at_previous_sample_ns < gvl_waiting_started_wall_time_ns) { // situation 1 above
-      // Advance the cpu-time marker so the next regular sample does not over-count CPU. We discard the returned
-      // elapsed value: on platforms where cpu_time is measured at microsecond granularity (macOS via Mach
-      // thread_info), a thread that briefly held the GVL before parking can accrue a single-digit-microsecond
-      // reading. The extra sample's wall-time spans tens of milliseconds, so any cpu_time_ns > 0 trips the
-      // "had cpu" classifier in collectors_stack.c — which mislabels a sample that was overwhelmingly wall-only.
-      update_time_since_previous_sample(
+      long cpu_time_elapsed_ns = update_time_since_previous_sample(
         &thread_context->cpu_time_at_previous_sample_ns,
         current_cpu_time_ns,
         thread_context->gc_tracking.cpu_time_at_start_ns,
@@ -2121,7 +2116,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
         stack_from_thread,
         thread_context,
         sampling_buffer,
-        (sample_values) {.cpu_time_ns = 0, .cpu_or_wall_samples = 1, .wall_time_ns = duration_until_start_of_gvl_waiting_ns},
+        (sample_values) {.cpu_time_ns = cpu_time_elapsed_ns, .cpu_or_wall_samples = 1, .wall_time_ns = duration_until_start_of_gvl_waiting_ns},
         gvl_waiting_started_wall_time_ns,
         NULL,
         NULL,

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -464,6 +464,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         it "records Waiting for GVL samples" do
+          skip "TODO: This test is flaky on macOS" if PlatformHelpers.mac?
+
           background_thread_affected_by_gvl_contention
           ready_queue_2.pop
 


### PR DESCRIPTION
**What does this PR do?**

Skips the test `Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when main thread is sleeping but a background thread is working when GVL profiling is enabled records Waiting for GVL samples` ([`spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:466`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb#L466)) on macOS, matching the pattern PR #5482 used for the sibling test "is able to sample even when the main thread is sleeping" at line 413 of the same file.

**Motivation:**

Failure: [`Test (macos-15, 3.2)` on PR #5709](https://github.com/DataDog/dd-trace-rb/actions/runs/25679466916/job/75386638334). Same SHA passed on macos-15 for Ruby 3.0/3.1/3.3/3.4/4.0 → flaky. Commit `ee5866523` by @ivoanjo added debug instrumentation while waiting for [#5664 "Implement CPU profiling on macOS"](https://github.com/DataDog/dd-trace-rb/pull/5664) (merged 2026-05-08) to land before deciding next steps. This flake is the first observed recurrence post-#5664.

### Root cause

In [`handle_gvl_waiting`](https://github.com/DataDog/dd-trace-rb/blob/master/ext/datadog_profiling_native_extension/collectors_thread_context.c#L2086)'s situation-1 branch, the collector emits an extra cpu/wall sample for the period between the previous sample and the moment the thread entered "waiting for GVL". The extra sample's state label is then chosen by [`collectors_stack.c:290`](https://github.com/DataDog/dd-trace-rb/blob/master/ext/datadog_profiling_native_extension/collectors_stack.c#L290), which tags it as "had cpu" whenever cpu_time_ns > 0.

Before #5664, macOS had no per-thread CPU clock — cpu_time_ns here was effectively 0, so the sample fell through to "unknown" and the test's take_while filter (which strips an initial prefix of unknown* + first had_cpu) absorbed it as startup noise. After #5664, macOS reads CPU time via Mach thread_info(THREAD_BASIC_INFO), which returns user/system time with **microsecond granularity**. A thread that briefly held the GVL before parking (the test's `loop { Thread.pass }` background thread) accrues a single-digit-µs CPU reading inside a wall window of tens of milliseconds — enough to trip cpu_time_ns > 0 and tag the sample as "had cpu". The test's filter does not strip mid-stream "had cpu", so each extra sample emitted at a GVL-wait boundary leaks into total_time.

Failure data shape: the initial filtered "had cpu" (sample 1) and the mid-stream "had cpu" that broke the assertion (sample 7) are **identical in shape — 4–8 µs of CPU in ~37 ms of wall time** — but only the first is absorbed by the filter.

### Why skip-on-macOS instead of a production fix

Three production-side fixes were considered. All conflict with existing test contracts; the first was attempted (see commit history of this PR) and broke CI:

1. **Zero out the extra sample's cpu_time_ns** (commit 10a3f24, reverted in 79556e1). Breaks [`thread_context_spec.rb:1239`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/profiling/collectors/thread_context_spec.rb#L1239) "assigns all the cpu-time to the sample before Waiting for GVL started" (`expect(cpu-time).to be >= 12345` — got 0). Failed on Linux and macOS CI.
2. **Proportional-threshold classifier** (`cpu_time_ns * N >= wall_time_ns`). Breaks [`thread_context_spec.rb:1345`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/profiling/collectors/thread_context_spec.rb#L1345), where a 12345-ns CPU reading must label state as "had cpu".
3. **Plumb a per-sample "suppress had-cpu state" flag through sample_labels**. Structurally correct but invasive (struct change + 3 call sites in collectors_thread_context.c) and out of scope for a flake fix; better suited to an owner-led design change.

Skip-on-macOS preserves all existing contracts, matches the established pattern (#5482), and lets the profiling owner decide whether to pursue a production fix.

### Companion PRs

- Reproducer: #5738 — tightens the assertion margin on macOS only, forcing the flake to surface deterministically
- Validation: #5737 — merges reproducer + fix; CI passing confirms the skip neutralizes the forced failure on macOS without affecting Linux

### Commit history note

This PR's history shows the broken option A approach (10a3f24), its revert (79556e1), and the final skip-on-macOS fix (d62a1d6). Squash-merge will collapse this; the reviewer may prefer to read only the final state.

**Change log entry**

None.

**How to test the change?**

- macOS CI (`Test (macos-15, *)`) on this branch: the test is now skipped, so the flake cannot recur there.
- Existing profiling specs on Linux: unchanged.
- Validation PR #5737 CI: macOS jobs should pass (skip applies before the tighter margin); Linux jobs should also pass (reproducer is macOS-scoped).

### Validation results (CI confirmed)

- Reproducer PR #5738: macOS 3.2 / 3.3 / 3.4 / 4.0 **failed** as forced; Linux untouched. (Ruby 3.0 / 3.1 are auto-skipped by `skip_if_gvl_profiling_not_supported`.) Closed.
- Validation PR #5737: **all macOS jobs passed** — the skip neutralizes the strict-equality assertion before it executes. Linux unaffected. Closed.
- Fix PR (this one) #5736: full CI green.