### PR TITLE
Bump to version 2.33.0

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
   test:
     needs:
       - build
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f8d0a3f223df149098dfb5a00e192ff3e139220  # Automated: Updated by .github/workflows/update-system-tests.yml.
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@7f26dc104339457759314a81bfe2b531637057c1  # Automated: Updated by .github/workflows/update-system-tests.yml.
     permissions:
       contents: read
       id-token: write
@@ -88,7 +88,7 @@ jobs:
       desired_execution_time: 300 # 5 minutes
       scenarios_groups: tracer_release
       skip_empty_scenarios: ${{ !(github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master')) }}
-      ref: 4f8d0a3f223df149098dfb5a00e192ff3e139220 # Automated: Updated by .github/workflows/update-system-tests.yml.
+      ref: 7f26dc104339457759314a81bfe2b531637057c1 # Automated: Updated by .github/workflows/update-system-tests.yml.
       force_execute: ${{ needs.build.outputs.forced_tests }}
       parametric_job_count: 8
       push_to_test_optimization: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,7 +167,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: 4f8d0a3f223df149098dfb5a00e192ff3e139220 # Automated: Updated by .github/workflows/update-system-tests.yml.
+    SYSTEM_TESTS_REF: 7f26dc104339457759314a81bfe2b531637057c1 # Automated: Updated by .github/workflows/update-system-tests.yml.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 


### PR DESCRIPTION
### Added

* AI Guard: Ensure client IP is always collected when AI Guard is enabled (#5677)
* AppSec: Add support for AWS Lambda (#5663)
* Tracing: Add inferred proxy spans for services behind AWS Gateway (#5681)
* Open Telemetry: Add support for `DD_HOSTNAME` to set trace hostname and OTel `host.name` when `DD_TRACE_REPORT_HOSTNAME` is enabled (#5705)

### Changed

* Core: Collect all threads in crash reports to provide full thread context during crashes (#5724)
* Core: Update `libdatadog` dependency to version 33.0.0 (#5723)
