### PR TITLE
DEBUG-4675 DI: fix off-by-one in serializer max capture depth

### DIFF
--- a/.github/forced-tests-list.cfg
+++ b/.github/forced-tests-list.cfg
@@ -10,7 +10,3 @@
 
 # Example :
 # tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence
-
-# Force-run while DataDog/system-tests#6918 (companion PR removing the DEBUG-4675
-# bug marker) is in draft. Remove this line before merging this PR.
-tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth

--- a/.github/forced-tests-list.cfg
+++ b/.github/forced-tests-list.cfg
@@ -10,3 +10,7 @@
 
 # Example :
 # tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence
+
+# Force-run while DataDog/system-tests#6918 (companion PR removing the DEBUG-4675
+# bug marker) is in draft. Remove this line before merging this PR.
+tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth

--- a/lib/datadog/di/contrib/active_record.rb
+++ b/lib/datadog/di/contrib/active_record.rb
@@ -23,7 +23,11 @@ Datadog::DI::Serializer.register(
   #
   # +depth+ is the remaining depth for serializing collections and objects.
   # It should always be an integer.
-  # Reduce it by 1 when invoking +serialize_value+ on the contents of +value+.
+  # Pass it through to +serialize_value+ when the structure you produce
+  # represents +value+ directly (a transparent wrapper); +serialize_value+
+  # decrements depth itself when it recurses into Array/Hash/object entries.
+  # Decrement +depth+ only if your wrapper introduces real additional
+  # nesting levels in the output.
   # This serializer could also potentially do its own depth limiting.
   #
   # Steep: steep thinks all of the arguments are nil here
@@ -33,5 +37,5 @@ Datadog::DI::Serializer.register(
     attributes: value.attributes,
     new_record: value.new_record?,
   }
-  serializer.serialize_value(value_to_serialize, depth: depth - 1, type: value.class)
+  serializer.serialize_value(value_to_serialize, depth: depth, type: value.class)
 end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -255,7 +255,7 @@ module Datadog
 
             serialized.update(value: value)
           when Array
-            if depth < 0
+            if depth <= 0
               serialized.update(notCapturedReason: "depth")
             else
               max = settings.dynamic_instrumentation.max_capture_collection_size
@@ -271,7 +271,7 @@ module Datadog
               serialized.update(elements: entries)
             end
           when Hash
-            if depth < 0
+            if depth <= 0
               serialized.update(notCapturedReason: "depth")
             else
               max = settings.dynamic_instrumentation.max_capture_collection_size
@@ -288,7 +288,7 @@ module Datadog
               serialized.update(entries: entries)
             end
           else
-            if depth < 0
+            if depth <= 0
               serialized.update(notCapturedReason: "depth")
             else
               fields = {}

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -216,28 +216,22 @@ RSpec.describe Datadog::DI::Serializer do
        expected: {x: {type: "DISerializerSpecRedactedInstanceVariable", fields: {
          "@session": {type: "Integer", notCapturedReason: "redactedIdent"},
        }}}},
-      {name: "depth exceeded: array", input: {v: {a: {b: {c: []}}}},
+      {name: "depth exceeded: array", input: {v: {a: {b: []}}},
        expected: {v: {type: "Hash", entries: [
          [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
-           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
-             [{type: "Symbol", value: "c"}, {type: "Array", notCapturedReason: "depth"}],
-           ]}],
+           [{type: "Symbol", value: "b"}, {type: "Array", notCapturedReason: "depth"}],
          ]}],
        ]}}},
-      {name: "depth exceeded: hash", input: {v: {a: {b: {c: {}}}}},
+      {name: "depth exceeded: hash", input: {v: {a: {b: {}}}},
        expected: {v: {type: "Hash", entries: [
          [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
-           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
-             [{type: "Symbol", value: "c"}, {type: "Hash", notCapturedReason: "depth"}],
-           ]}],
+           [{type: "Symbol", value: "b"}, {type: "Hash", notCapturedReason: "depth"}],
          ]}],
        ]}}},
-      {name: "depth exceeded: object", input: {v: {a: {b: {c: Object.new}}}},
+      {name: "depth exceeded: object", input: {v: {a: {b: Object.new}}},
        expected: {v: {type: "Hash", entries: [
          [{type: "Symbol", value: "a"}, {type: "Hash", entries: [
-           [{type: "Symbol", value: "b"}, {type: "Hash", entries: [
-             [{type: "Symbol", value: "c"}, {type: "Object", notCapturedReason: "depth"}],
-           ]}],
+           [{type: "Symbol", value: "b"}, {type: "Object", notCapturedReason: "depth"}],
          ]}],
        ]}}},
       {name: "object with no attributes", input: {v: DISerializerSpecTestClass.new},


### PR DESCRIPTION
**What does this PR do?**

Fixes an off-by-one bug in the Dynamic Instrumentation snapshot serializer: with `max_capture_depth=N`, the serializer was capturing N+1 levels of nested objects (the top-level value plus N nested levels) instead of N levels.

The truncation check is in three branches of `Serializer#serialize_value` — `Array`, `Hash`, and the catch-all object branch. Each used `if depth < 0`, which only fires after one extra recursion. Changed to `if depth <= 0` so truncation fires when the next recursion would exceed the configured depth.

**Motivation:**

System test [`Test_Debugger_Line_Probe_Snaphots::test_default_max_reference_depth`](https://github.com/DataDog/system-tests/blob/main/tests/debugger/test_debugger_probe_snapshot.py) (added in DataDog/system-tests#5624) is filed against Ruby as `bug (DEBUG-4675)` with the note "Ruby has off-by-one bug: captures 4 levels instead of 3". The test sets `max_capture_depth=3` (default) and asserts exactly 3 levels of nesting are captured before truncation.

The previous behavior was inconsistent with the default-depth documentation and with other Datadog tracer libraries.

**Change log entry**

Yes. Dynamic Instrumentation: Fix off-by-one in `max_capture_depth` so snapshots respect the configured nesting limit exactly (previously captured one extra level).

**Additional Notes:**

Three existing "depth exceeded" cases in [`spec/datadog/di/serializer_spec.rb`](spec/datadog/di/serializer_spec.rb) tested the buggy behavior (inputs nested one level deeper than `max_capture_depth=2`). Inputs are reduced by one level so the truncation hits the typed value (`Array`/`Hash`/`Object`) the test name promises.

The serializer test setup in [`spec/datadog/di/serializer_helper.rb`](spec/datadog/di/serializer_helper.rb) uses `max_capture_depth=2`. Other DI specs that mock `max_capture_depth=2` (`instrumenter_spec`, `probe_notification_builder_spec`, `integration/probe_notification_builder_spec`) only exercise objects with at most one level of nesting and remain unaffected.

Companion system-tests PR (draft) removing the bug marker: DataDog/system-tests#6918.

**System-tests validation result:**

A force-run entry was added to `.github/forced-tests-list.cfg` to exercise `test_default_max_reference_depth` in this PR's End-to-end CI runs (commit `1392e5ecd8`). Results on commit `161ab4a373`:

- `rails72`: 21/21 SUCCESS
- `rails80`: 21/21 SUCCESS
- `uds-rails`: 22/22 SUCCESS

The forced test passed on every End-to-end run against the manifest-supported weblogs (the three the test's parent declaration is scoped to). The force-list format has no weblog scoping, so the entry also ran the test against weblogs the manifest marks `irrelevant` (rack, sinatra14, sinatra22/32/41, rails42, rails52, rails61, uds-sinatra) — those failed at `Failed to get /debugger/init: expected status code: 200, actual status code: 404` because those weblogs do not have the debugger controller endpoints. Those failures are not fix-related.

The force entry has been reverted in commit `36995dec85` now that the supported-weblog evidence is captured. Going forward, the test re-activates through the companion system-tests PR DataDog/system-tests#6918.

**How to test the change?**

- `bundle exec rake test:di` — the three updated "depth exceeded" cases in `serializer_spec.rb` cover the new truncation point for `Array`, `Hash`, and `Object`.
- System tests: `./run.sh DEBUGGER_PROBES_SNAPSHOT --library ruby` — the supported-weblog runs in this PR's CI (links above) show the forced test passing on each.