### PR TITLE
DEBUG-5107 DEBUG-5111 DI: tolerant probe path matching

### DIFF
--- a/.github/forced-tests-list.cfg
+++ b/.github/forced-tests-list.cfg
@@ -10,3 +10,8 @@
 
 # Example :
 # tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence
+
+# Force-run while the companion system-tests PR (removing the DEBUG-5107 /
+# DEBUG-5111 bug markers) is in draft. Remove these lines before merging.
+tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing
+tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path

--- a/.github/forced-tests-list.cfg
+++ b/.github/forced-tests-list.cfg
@@ -10,8 +10,3 @@
 
 # Example :
 # tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence
-
-# Force-run while the companion system-tests PR (removing the DEBUG-5107 /
-# DEBUG-5111 bug markers) is in draft. Remove these lines before merging.
-tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing
-tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_windows_path

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -249,6 +249,11 @@ module Datadog
           exact = registry[suffix]
           return [suffix, exact] if exact
 
+          # Normalize Windows-style backslash separators (DEBUG-5111) upfront
+          # so the suffix-shortening loop's "/+" regex can strip leading
+          # components on probes whose sourceFile uses backslashes.
+          suffix = Utils.normalize_windows_separators(suffix)
+
           # Per the design comment in utils.rb, attempt case-sensitive
           # matching first (steps 5-6) and only fall back to case-insensitive
           # matching (steps 7-8) when no case-sensitive match is found.
@@ -370,6 +375,11 @@ module Datadog
       def resolve_path_suffix(suffix, paths)
         # Exact match.
         return suffix if paths.include?(suffix)
+
+        # Normalize Windows-style backslash separators (DEBUG-5111) upfront
+        # so the suffix-shortening loop's "/+" regex can strip leading
+        # components on probes whose sourceFile uses backslashes.
+        suffix = Utils.normalize_windows_separators(suffix)
 
         # Suffix match. Per the design comment in utils.rb, attempt
         # case-sensitive matching first (steps 5-6) and only fall back to

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -249,23 +249,29 @@ module Datadog
           exact = registry[suffix]
           return [suffix, exact] if exact
 
-          suffix = suffix.dup
-          loop do
-            inexact = []
-            registry.each do |path, iseq|
-              if Utils.path_matches_suffix?(path, suffix)
-                inexact << [path, iseq]
+          # Per the design comment in utils.rb, attempt case-sensitive
+          # matching first (steps 5-6) and only fall back to case-insensitive
+          # matching (steps 7-8) when no case-sensitive match is found.
+          [false, true].each do |case_insensitive|
+            working_suffix = suffix.dup
+            loop do
+              inexact = []
+              registry.each do |path, iseq|
+                if Utils.path_matches_suffix?(path, working_suffix, case_insensitive: case_insensitive)
+                  inexact << [path, iseq]
+                end
               end
+              if inexact.length > 1
+                raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix"
+              end
+              if inexact.any?
+                return inexact.first
+              end
+              break unless working_suffix.include?('/')
+              working_suffix.sub!(%r{.*/+}, '')
             end
-            if inexact.length > 1
-              raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix"
-            end
-            if inexact.any?
-              return inexact.first
-            end
-            return nil unless suffix.include?('/')
-            suffix.sub!(%r{.*/+}, '')
           end
+          nil
         end
       end
 
@@ -365,15 +371,20 @@ module Datadog
         # Exact match.
         return suffix if paths.include?(suffix)
 
-        # Suffix match.
-        suffix = suffix.dup
-        loop do
-          matches = paths.select { |p| Utils.path_matches_suffix?(p, suffix) }
-          raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix" if matches.length > 1
-          return matches.first if matches.any?
-          return nil unless suffix.include?('/')
-          suffix.sub!(%r{.*/+}, '')
+        # Suffix match. Per the design comment in utils.rb, attempt
+        # case-sensitive matching first (steps 5-6) and only fall back to
+        # case-insensitive (steps 7-8) when no case-sensitive match is found.
+        [false, true].each do |case_insensitive|
+          working_suffix = suffix.dup
+          loop do
+            matches = paths.select { |p| Utils.path_matches_suffix?(p, working_suffix, case_insensitive: case_insensitive) }
+            raise Error::MultiplePathsMatch, "Multiple paths matched requested suffix" if matches.length > 1
+            return matches.first if matches.any?
+            break unless working_suffix.include?('/')
+            working_suffix.sub!(%r{.*/+}, '')
+          end
         end
+        nil
       end
     end
   end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -618,12 +618,15 @@ module Datadog
       def raise_if_probe_in_loaded_features(probe, line_no, code_tracker)
         return unless probe.file
 
-        # Find the loaded path matching the probe file.
+        # Find the loaded path matching the probe file. Case-sensitive
+        # matching is attempted first, with case-insensitive matching as a
+        # fallback (see the design comment in utils.rb, steps 5-8).
         loaded_path = if $LOADED_FEATURES.include?(probe.file)
           probe.file
         else
           # Expensive suffix check.
-          $LOADED_FEATURES.find { |path| Utils.path_matches_suffix?(path, probe.file) }
+          $LOADED_FEATURES.find { |path| Utils.path_matches_suffix?(path, probe.file) } ||
+            $LOADED_FEATURES.find { |path| Utils.path_matches_suffix?(path, probe.file, case_insensitive: true) }
         end
 
         return unless loaded_path

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -620,13 +620,30 @@ module Datadog
 
         # Find the loaded path matching the probe file. Case-sensitive
         # matching is attempted first, with case-insensitive matching as a
-        # fallback (see the design comment in utils.rb, steps 5-8).
+        # fallback (see the design comment in utils.rb, steps 5-8). Leading
+        # directory components are stripped so probes whose sourceFile carries
+        # a source-repo prefix that does not exist on disk still resolve to
+        # the loaded file — matching the behavior of
+        # CodeTracker#iseqs_for_path_suffix.
         loaded_path = if $LOADED_FEATURES.include?(probe.file)
           probe.file
         else
           # Expensive suffix check.
-          $LOADED_FEATURES.find { |path| Utils.path_matches_suffix?(path, probe.file) } ||
-            $LOADED_FEATURES.find { |path| Utils.path_matches_suffix?(path, probe.file, case_insensitive: true) }
+          suffix = Utils.normalize_windows_separators(probe.file)
+          found = nil #: ::String?
+          [false, true].each do |case_insensitive|
+            working_suffix = suffix.dup
+            loop do
+              found = $LOADED_FEATURES.find do |path|
+                Utils.path_matches_suffix?(path, working_suffix, case_insensitive: case_insensitive)
+              end
+              break if found
+              break unless working_suffix.include?('/')
+              working_suffix.sub!(%r{.*/+}, '')
+            end
+            break if found
+          end
+          found
         end
 
         return unless loaded_path

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -85,9 +85,13 @@ module Datadog
       # Returns whether the provided +path+ matches the user-designated
       # file suffix (of a line probe).
       #
-      # Matching is case-insensitive (DEBUG-5107) and tolerates Windows-style
-      # backslash separators in +suffix+ (DEBUG-5111), since probe source paths
-      # often originate from IDE tooling that does not normalize either.
+      # Backslash separators in +suffix+ are translated to forward slashes
+      # (DEBUG-5111) so paths typed by IDE tooling on Windows can match.
+      # Case-insensitive matching (DEBUG-5107) is opt-in via
+      # +case_insensitive: true+; callers that orchestrate matching against a
+      # set of known paths perform case-sensitive comparisons first and only
+      # fall back to case-insensitive when no case-sensitive match is found
+      # (see the design comment above, steps 5-8).
       #
       # If suffix is an absolute path (i.e., it starts with a slash, possibly
       # after backslash normalization), the path must be identical for it to
@@ -95,7 +99,7 @@ module Datadog
       #
       # If suffix is not an absolute path, the path matches if its suffix is
       # the provided suffix, at a path component boundary.
-      module_function def path_matches_suffix?(path, suffix)
+      module_function def path_matches_suffix?(path, suffix, case_insensitive: false)
         if path.nil?
           raise ArgumentError, "nil path passed"
         end
@@ -103,8 +107,11 @@ module Datadog
           raise ArgumentError, "nil suffix passed"
         end
 
-        path = path.downcase
-        suffix = suffix.tr('\\', '/').downcase
+        suffix = suffix.tr('\\', '/')
+        if case_insensitive
+          path = path.downcase
+          suffix = suffix.downcase
+        end
 
         if suffix.start_with?('/')
           path == suffix
@@ -128,18 +135,26 @@ module Datadog
       # +spec+. Attempts all of the fuzzy matches by stripping directories
       # from the front of +spec+. Does not consider othr known paths to
       # identify the case of (potentially) multiple matching paths for +spec+.
+      #
+      # Matching is attempted case-sensitively first (steps 5-6 in the design
+      # comment above) and only falls back to case-insensitive (steps 7-8)
+      # when no case-sensitive match is found.
       module_function def path_can_match_spec?(path, spec)
         # Normalize Windows-style backslash separators (DEBUG-5111) so the
         # suffix-shortening loop's "/+" regex can strip leading components.
         spec = spec.tr('\\', '/')
 
-        return true if path_matches_suffix?(path, spec)
+        [false, true].each do |case_insensitive|
+          working_spec = spec.dup
+          return true if path_matches_suffix?(path, working_spec, case_insensitive: case_insensitive)
 
-        loop do
-          return false unless spec.include?('/')
-          spec.sub!(%r{.*/+}, '')
-          return true if path_matches_suffix?(path, spec)
+          loop do
+            break unless working_spec.include?('/')
+            working_spec.sub!(%r{.*/+}, '')
+            return true if path_matches_suffix?(path, working_spec, case_insensitive: case_insensitive)
+          end
         end
+        false
       end
     end
   end

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -85,8 +85,13 @@ module Datadog
       # Returns whether the provided +path+ matches the user-designated
       # file suffix (of a line probe).
       #
-      # If suffix is an absolute path (i.e., it starts with a slash), the path
-      # must be identical for it to match.
+      # Matching is case-insensitive (DEBUG-5107) and tolerates Windows-style
+      # backslash separators in +suffix+ (DEBUG-5111), since probe source paths
+      # often originate from IDE tooling that does not normalize either.
+      #
+      # If suffix is an absolute path (i.e., it starts with a slash, possibly
+      # after backslash normalization), the path must be identical for it to
+      # match.
       #
       # If suffix is not an absolute path, the path matches if its suffix is
       # the provided suffix, at a path component boundary.
@@ -98,6 +103,9 @@ module Datadog
           raise ArgumentError, "nil suffix passed"
         end
 
+        path = path.downcase
+        suffix = suffix.tr('\\', '/').downcase
+
         if suffix.start_with?('/')
           path == suffix
         else
@@ -105,11 +113,6 @@ module Datadog
           # has to be longer than the suffix. Require full component matches,
           # meaning either the first character of the suffix is a slash
           # or the previous character in the path is a slash.
-          # For now only check for forward slashes for Unix-like OSes;
-          # backslash is a legitimate character of a file name in Unix
-          # therefore simply permitting forward or back slash is not
-          # sufficient, we need to perform an OS check to know which
-          # path separator to use.
           !!
           if path.length > suffix.length && path.end_with?(suffix)
             previous_char = path[path.length - suffix.length - 1]
@@ -126,9 +129,12 @@ module Datadog
       # from the front of +spec+. Does not consider othr known paths to
       # identify the case of (potentially) multiple matching paths for +spec+.
       module_function def path_can_match_spec?(path, spec)
+        # Normalize Windows-style backslash separators (DEBUG-5111) so the
+        # suffix-shortening loop's "/+" regex can strip leading components.
+        spec = spec.tr('\\', '/')
+
         return true if path_matches_suffix?(path, spec)
 
-        spec = spec.dup
         loop do
           return false unless spec.include?('/')
           spec.sub!(%r{.*/+}, '')

--- a/lib/datadog/di/utils.rb
+++ b/lib/datadog/di/utils.rb
@@ -82,6 +82,13 @@ module Datadog
       # we just strip leading directory components from the "probe path"
       # until we get a match via a "suffix of the suffix".
 
+      # Returns +path+ with Windows-style backslash separators translated to
+      # forward slashes (DEBUG-5111). Used to normalize probe source paths
+      # that originate from IDE tooling running on Windows.
+      module_function def normalize_windows_separators(path)
+        path.tr('\\', '/')
+      end
+
       # Returns whether the provided +path+ matches the user-designated
       # file suffix (of a line probe).
       #
@@ -107,7 +114,7 @@ module Datadog
           raise ArgumentError, "nil suffix passed"
         end
 
-        suffix = suffix.tr('\\', '/')
+        suffix = normalize_windows_separators(suffix)
         if case_insensitive
           path = path.downcase
           suffix = suffix.downcase
@@ -142,7 +149,7 @@ module Datadog
       module_function def path_can_match_spec?(path, spec)
         # Normalize Windows-style backslash separators (DEBUG-5111) so the
         # suffix-shortening loop's "/+" regex can strip leading components.
-        spec = spec.tr('\\', '/')
+        spec = normalize_windows_separators(spec)
 
         [false, true].each do |case_insensitive|
           working_spec = spec.dup

--- a/sig/datadog/di/utils.rbs
+++ b/sig/datadog/di/utils.rbs
@@ -1,8 +1,8 @@
 module Datadog
   module DI
     module Utils
-      def self?.normalize_windows_separators: (String path) -> String
-      def self?.path_matches_suffix?: (String path, String suffix, ?case_insensitive: bool) -> bool
+      def self?.normalize_windows_separators: (::String path) -> ::String
+      def self?.path_matches_suffix?: (::String path, ::String suffix, ?case_insensitive: bool) -> bool
       def self?.path_can_match_spec?: (String path, String suffix) -> bool
     end
   end

--- a/sig/datadog/di/utils.rbs
+++ b/sig/datadog/di/utils.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module DI
     module Utils
-      def self?.path_matches_suffix?: (String path, String suffix) -> bool
+      def self?.path_matches_suffix?: (String path, String suffix, ?case_insensitive: bool) -> bool
       def self?.path_can_match_spec?: (String path, String suffix) -> bool
     end
   end

--- a/sig/datadog/di/utils.rbs
+++ b/sig/datadog/di/utils.rbs
@@ -1,6 +1,7 @@
 module Datadog
   module DI
     module Utils
+      def self?.normalize_windows_separators: (String path) -> String
       def self?.path_matches_suffix?: (String path, String suffix, ?case_insensitive: bool) -> bool
       def self?.path_can_match_spec?: (String path, String suffix) -> bool
     end

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -652,6 +652,44 @@ RSpec.describe Datadog::DI::CodeTracker do
     end
   end
 
+  describe "#iseqs_for_path_suffix with Windows backslash suffix" do
+    # Verifies that backslash separators (DEBUG-5111) are normalized upfront so
+    # the suffix-shortening loop can strip leading components. Probe paths from
+    # IDE tooling on Windows arrive with backslashes; the runtime registry path
+    # has forward slashes and typically lacks the leading directory components
+    # of the source repository path.
+    around do |example|
+      tracker.define_singleton_method(:backfill_registry) {}
+      tracker.start
+
+      registry = tracker.send(:registry)
+      # Runtime path on the deployed weblog — no shared/rails/ prefix.
+      registry["/app/controllers/debugger_controller.rb"] = "/app/controllers/debugger_controller.rb"
+
+      example.run
+
+      tracker.stop
+    end
+
+    it "matches when the probe path uses backslashes and needs prefix stripping" do
+      expect(
+        tracker.iseqs_for_path_suffix('shared\rails\app\controllers\debugger_controller.rb'),
+      ).to eq(["/app/controllers/debugger_controller.rb", "/app/controllers/debugger_controller.rb"])
+    end
+
+    it "matches when the probe path uses backslashes and uppercase, needing both fallbacks" do
+      expect(
+        tracker.iseqs_for_path_suffix('SHARED\RAILS\APP\CONTROLLERS\DEBUGGER_CONTROLLER.RB'),
+      ).to eq(["/app/controllers/debugger_controller.rb", "/app/controllers/debugger_controller.rb"])
+    end
+
+    it "matches when the probe path is an absolute Windows-style path" do
+      expect(
+        tracker.iseqs_for_path_suffix('\app\controllers\debugger_controller.rb'),
+      ).to eq(["/app/controllers/debugger_controller.rb", "/app/controllers/debugger_controller.rb"])
+    end
+  end
+
   describe '#iseq_for_line' do
     before do
       allow(Datadog::DI).to receive(:respond_to?).and_call_original

--- a/spec/datadog/di/code_tracker_spec.rb
+++ b/spec/datadog/di/code_tracker_spec.rb
@@ -608,6 +608,50 @@ RSpec.describe Datadog::DI::CodeTracker do
     end
   end
 
+  describe "#iseqs_for_path_suffix with case-different known paths" do
+    # Verifies the case-sensitive-first / case-insensitive-fallback ordering
+    # described in the design comment in utils.rb (steps 5-8). When two
+    # registry paths differ only in case, a correctly-cased probe path must
+    # uniquely match the corresponding entry; the case-insensitive fallback
+    # is only consulted when no case-sensitive match was found.
+    around do |example|
+      tracker.define_singleton_method(:backfill_registry) {}
+      tracker.start
+
+      registry = tracker.send(:registry)
+      registry["/app/foo.rb"] = "/app/foo.rb"
+      registry["/app/FOO.rb"] = "/app/FOO.rb"
+
+      example.run
+
+      tracker.stop
+    end
+
+    it "uniquely matches a lowercase probe path" do
+      expect(tracker.iseqs_for_path_suffix("foo.rb")).to eq(["/app/foo.rb", "/app/foo.rb"])
+    end
+
+    it "uniquely matches an uppercase probe path" do
+      expect(tracker.iseqs_for_path_suffix("FOO.rb")).to eq(["/app/FOO.rb", "/app/FOO.rb"])
+    end
+
+    it "falls back to case-insensitive when no case-sensitive match exists" do
+      tracker.send(:registry).delete("/app/foo.rb")
+      expect(tracker.iseqs_for_path_suffix("foo.rb")).to eq(["/app/FOO.rb", "/app/FOO.rb"])
+    end
+
+    it "raises when the case-insensitive fallback is ambiguous" do
+      tracker.send(:registry).clear
+      tracker.send(:registry)["/app/foo.rb"] = "/app/foo.rb"
+      tracker.send(:registry)["/app/bar/foo.rb"] = "/app/bar/foo.rb"
+      # "FOO.RB" matches nothing case-sensitively at any suffix; the
+      # case-insensitive pass matches both registry entries.
+      expect do
+        tracker.iseqs_for_path_suffix("FOO.RB")
+      end.to raise_error(Datadog::DI::Error::MultiplePathsMatch)
+    end
+  end
+
   describe '#iseq_for_line' do
     before do
       allow(Datadog::DI).to receive(:respond_to?).and_call_original

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -1328,6 +1328,20 @@ RSpec.describe Datadog::DI::Instrumenter do
             end
           end.to raise_error(Datadog::DI::Error::DITargetNotInRegistry, /no surviving iseqs/)
         end
+
+        context 'with Windows-style probe path requiring prefix stripping' do
+          let(:probe) do
+            Datadog::DI::Probe.new(file: 'shared\rails\hook_line.rb', line_no: 3,
+              id: 1, type: :log)
+          end
+
+          it 'raises DITargetNotInRegistry after backslash normalization and prefix stripping' do
+            expect do
+              hook_line(probe) do |payload|
+              end
+            end.to raise_error(Datadog::DI::Error::DITargetNotInRegistry, /no surviving iseqs/)
+          end
+        end
       end
 
       include_examples 'multiple invocations'

--- a/spec/datadog/di/utils_spec.rb
+++ b/spec/datadog/di/utils_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Datadog::DI::Utils do
 
       # We expect path to always be an absolute path.
       ['path is relative', 'bar.rb', 'bar.rb', false],
+
+      # Probe source paths are matched case-insensitively (DEBUG-5107).
+      ['case-insensitive - exact match', '/FOO/BAR.RB', '/foo/bar.rb', true],
+      ['case-insensitive - suffix at basename', 'BAR.RB', '/foo/bar.rb', true],
+      ['case-insensitive - multiple components', 'FOO/BAR.RB', '/foo/bar.rb', true],
+
+      # Probe source paths may use Windows-style backslashes (DEBUG-5111).
+      ['backslash - suffix at basename', 'foo\bar.rb', '/foo/bar.rb', true],
+      ['backslash - absolute path', '\foo\bar.rb', '/foo/bar.rb', true],
+      ['backslash + uppercase', 'FOO\BAR.RB', '/foo/bar.rb', true],
     ].each do |name, suffix_, path_, result_|
       suffix, path, result = suffix_, path_, result_
 
@@ -53,6 +63,15 @@ RSpec.describe Datadog::DI::Utils do
 
       # We expect path to always be an absolute path.
       ['path is relative', 'bar.rb', 'bar.rb', false],
+
+      # Probe source paths are matched case-insensitively (DEBUG-5107).
+      ['case-insensitive - exact match', '/FOO/BAR.RB', '/foo/bar.rb', true],
+      ['case-insensitive - suffix at basename', 'BAR.RB', '/foo/bar.rb', true],
+
+      # Probe source paths may use Windows-style backslashes (DEBUG-5111).
+      ['backslash - suffix at basename', 'foo\bar.rb', '/foo/bar.rb', true],
+      ['backslash - prefix to strip', 'c:\some\dir\foo\bar.rb', '/foo/bar.rb', true],
+      ['backslash + uppercase + prefix to strip', 'C:\Some\Dir\FOO\BAR.RB', '/foo/bar.rb', true],
     ].each do |name, suffix_, path_, result_|
       suffix, path, result = suffix_, path_, result_
 

--- a/spec/datadog/di/utils_spec.rb
+++ b/spec/datadog/di/utils_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Datadog::DI::Utils do
   describe '.path_matches_suffix?' do
     # NB; when updating this list also add to the list in
     # path_can_match_spec? test below.
+
+    # Cases that match the same way regardless of case sensitivity.
     [
       ['exact match - absolute path', '/foo/bar.rb', '/foo/bar.rb', true],
       # Suffix matching is only applicable to relative paths.
@@ -22,21 +24,46 @@ RSpec.describe Datadog::DI::Utils do
       # We expect path to always be an absolute path.
       ['path is relative', 'bar.rb', 'bar.rb', false],
 
-      # Probe source paths are matched case-insensitively (DEBUG-5107).
-      ['case-insensitive - exact match', '/FOO/BAR.RB', '/foo/bar.rb', true],
-      ['case-insensitive - suffix at basename', 'BAR.RB', '/foo/bar.rb', true],
-      ['case-insensitive - multiple components', 'FOO/BAR.RB', '/foo/bar.rb', true],
-
       # Probe source paths may use Windows-style backslashes (DEBUG-5111).
+      # Backslash translation is unconditional.
       ['backslash - suffix at basename', 'foo\bar.rb', '/foo/bar.rb', true],
       ['backslash - absolute path', '\foo\bar.rb', '/foo/bar.rb', true],
-      ['backslash + uppercase', 'FOO\BAR.RB', '/foo/bar.rb', true],
     ].each do |name, suffix_, path_, result_|
       suffix, path, result = suffix_, path_, result_
 
-      context name do
+      context "#{name} (case-sensitive default)" do
         it "is #{result}" do
           expect(described_class.path_matches_suffix?(path, suffix)).to be result
+        end
+      end
+
+      context "#{name} (case_insensitive: true)" do
+        it "is #{result}" do
+          expect(described_class.path_matches_suffix?(path, suffix, case_insensitive: true)).to be result
+        end
+      end
+    end
+
+    # Cases where case sensitivity changes the result.
+    # Default (case-sensitive): mismatched case does NOT match.
+    # case_insensitive: true: mismatched case matches.
+    [
+      ['case mismatch - exact match', '/FOO/BAR.RB', '/foo/bar.rb'],
+      ['case mismatch - suffix at basename', 'BAR.RB', '/foo/bar.rb'],
+      ['case mismatch - multiple components', 'FOO/BAR.RB', '/foo/bar.rb'],
+      ['case mismatch + backslash', 'FOO\BAR.RB', '/foo/bar.rb'],
+    ].each do |name, suffix_, path_|
+      suffix, path = suffix_, path_
+
+      context "#{name} (case-sensitive default)" do
+        it "is false" do
+          expect(described_class.path_matches_suffix?(path, suffix)).to be false
+        end
+      end
+
+      context "#{name} (case_insensitive: true)" do
+        it "is true" do
+          expect(described_class.path_matches_suffix?(path, suffix, case_insensitive: true)).to be true
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

Makes [`Datadog::DI::Utils.path_matches_suffix?`](lib/datadog/di/utils.rb) and [`path_can_match_spec?`](lib/datadog/di/utils.rb) case-insensitive (DEBUG-5107) and tolerant of Windows-style backslash separators (DEBUG-5111) in the user-supplied probe `sourceFile`.

Concretely:
- `path_matches_suffix?` gains an opt-in `case_insensitive:` keyword (default `false`) and unconditionally translates backslashes to forward slashes in the suffix. The case-sensitive default preserves uniqueness on case-sensitive deployments where two files differ only by case.
- Callers that resolve probe paths against a set of known paths (`CodeTracker#iseqs_for_path_suffix`, `CodeTracker#resolve_path_suffix`, `Utils.path_can_match_spec?`, `Instrumenter#raise_if_probe_in_loaded_features`) run two passes: case-sensitive first, then case-insensitive as a fallback when no case-sensitive match exists. This mirrors the algorithm described in the design comment at the top of `utils.rb` (steps 5–8).
- Backslash normalization happens once up-front in the suffix-stripping loops of `iseqs_for_path_suffix`, `resolve_path_suffix`, and `path_can_match_spec?` so the `%r{.*/+}` prefix-stripping regex fires on Windows-style probe paths (otherwise the loop's `'/'` check returns false and no stripping occurs).
- The shared backslash-translation operation is extracted as `Utils.normalize_windows_separators`.

**Motivation:**

System tests [`Test_Debugger_Line_Probe_Statuses::test_probe_status_log_line_with_different_casing`](https://github.com/DataDog/system-tests/blob/main/tests/debugger/test_debugger_probe_status.py) and [`::test_probe_status_log_line_with_windows_path`](https://github.com/DataDog/system-tests/blob/main/tests/debugger/test_debugger_probe_status.py) are filed against Ruby as `bug (DEBUG-5107)` / `bug (DEBUG-5111)`. Both tests deliver line probes with `sourceFile` munged (uppercased / backslashes), simulating IDE tooling that does not normalize either. With the old matcher Ruby probes stayed at RECEIVED instead of moving to INSTALLED.

**Change log entry**

Yes. Dynamic Instrumentation: Line probes now match `sourceFile` case-insensitively and accept Windows-style backslash separators, so probes delivered by IDE tooling that does not normalize the source path are now installed correctly.

**Additional Notes:**

The previous comment in `path_matches_suffix?` explicitly noted that "backslash is a legitimate character of a file name in Unix, therefore simply permitting forward or back slash is not sufficient." That concern applies to the actual on-disk path, not to the user-supplied probe `sourceFile`. The change normalizes only the suffix/spec — the runtime path comes from Ruby's `tp.path` / `$LOADED_FEATURES` / our code tracker and remains in its native form (only `downcase` is applied for case-insensitive comparison, and only when the case-insensitive fallback pass is reached).

Companion system-tests PR (draft) removing the bug markers: DataDog/system-tests#6920. Once #6920 merges and a system-tests refresh lands on master, the two debugger probe-status tests will run without the bug-marker xfail and verify this fix end-to-end on every weblog in the matrix.

**How to test the change?**

- `bundle exec rake test:di` — `spec/datadog/di/utils_spec.rb` covers case-sensitive default behavior, the `case_insensitive: true` parameter, backslash suffixes (basename and absolute), and case-mismatch cases. `spec/datadog/di/code_tracker_spec.rb` covers the two-pass behavior in `iseqs_for_path_suffix` (correctly-cased unique match, case-insensitive fallback, ambiguous fallback raising `MultiplePathsMatch`) and the Windows-backslash + prefix-stripping case that exercises the suffix-shortening loop after normalization.
- System tests: the fix was verified end-to-end while a temporary force-execute entry was on the branch — commit [a4298f6a9b](https://github.com/DataDog/dd-trace-rb/commit/a4298f6a9b) ran `DEBUGGER_PROBES_STATUS` against the rails72 and rails80 weblogs (the two weblog variants whose test apps implement the harness's `/debugger/init` endpoint) and both forced tests passed (`7 passed, 5 skipped, 0 failed`). The force-execute entry has since been reverted in [1aad557244](https://github.com/DataDog/dd-trace-rb/commit/1aad557244); full system-test coverage across the rest of the matrix depends on DataDog/system-tests#6920 landing and a system-tests refresh reaching master.
