### PR TITLE
Expand doc comment on gem_datadog_version_semver2

### DIFF
--- a/lib/datadog/core/environment/identity.rb
+++ b/lib/datadog/core/environment/identity.rb
@@ -76,7 +76,21 @@ module Datadog
           Core::Environment::Ext::GEM_DATADOG_VERSION
         end
 
-        # Returns tracer version, comforming to https://semver.org/spec/v2.0.0.html
+        # Returns the tracer version in SemVer-2 form (https://semver.org/spec/v2.0.0.html).
+        #
+        # Converts the RubyGems-style version returned by {.gem_datadog_version}
+        # (dot-separated prerelease/build segments, e.g. "2.34.0.dev") into the
+        # SemVer-2 form expected by cross-language Datadog consumers (hyphen-separated
+        # prerelease, "+" build metadata, e.g. "2.34.0-dev").
+        #
+        # Called by reporters that emit a tracer version on the wire and must match
+        # the format used by other-language tracers:
+        # - process discovery memfd (`Core::ProcessDiscovery.get_metadata` → `tracer_version`)
+        # - telemetry payloads (`Core::Telemetry::Request#application`)
+        # - remote configuration client identification (`Core::Remote::Client#tracer_version`)
+        #
+        # Use {.gem_datadog_version} (not this method) when a RubyGems-style string is
+        # required (e.g. gem-internal contexts, gemspec interop).
         def gem_datadog_version_semver2
           major, minor, patch, rest = gem_datadog_version.split('.', 4)
 


### PR DESCRIPTION
Related: #5108

**What does this PR do?**

Expands the one-line `# Returns tracer version, comforming to https://semver.org/spec/v2.0.0.html` comment above `Datadog::Core::Environment::Identity.gem_datadog_version_semver2` (`lib/datadog/core/environment/identity.rb`) to document:

- The source format (RubyGems-style, dot-separated prerelease/build, from `gem_datadog_version`).
- The target format (SemVer-2, hyphen prerelease, `+` build metadata).
- The consumers that emit the SemVer-2 form on the wire: process discovery memfd, telemetry payloads, remote-config client identification.
- That `gem_datadog_version` (not this method) is the right choice when a RubyGems-style string is required.

No behavior change. Comment only.

**Motivation:**

The two coexisting version conventions (RubyGems-style in `version.rb` / gemspec vs. SemVer-2 on the wire) are not documented anywhere in the source. The rationale ("RFC mandates Semantic Versioning 2.0.0") lives only in git history (commit 4b0ff5b). This came up while investigating a system-tests parametric failure caused by the format split, and a future reader benefits from finding the explanation next to the code.

**Change log entry**

None.

**Additional Notes:**

None.

**How to test the change?**

Not applicable — comment-only change.
