### PR TITLE
SymDB: comment why scopes are marked uploaded before perform_upload

### DIFF
--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -91,6 +91,14 @@ module Datadog
             return
           end
 
+          # Marked uploaded before perform_upload runs. This is intentional:
+          # symdb extraction is a one-shot operation per process — extract_all
+          # walks ObjectSpace once and never revisits a module within the same
+          # process. The Set deduplicates within a single extraction run, not
+          # across upload attempts. Failed uploads are not retried; symbols
+          # from a failed batch are lost until the next process restart, by
+          # design (matches Python and Go; Java retries via OkHttp, .NET via
+          # exponential backoff — Ruby does neither).
           @uploaded_modules.add(scope.name)
           @file_count += 1
 


### PR DESCRIPTION
**What does this PR do?**

Adds an 8-line comment at `lib/datadog/symbol_database/scope_batcher.rb:94` explaining why scopes are added to `@uploaded_modules` before `perform_upload` runs.

**Motivation:**

A [review comment on #5748](https://github.com/DataDog/dd-trace-rb/pull/5748#discussion_r3233235614) flagged the early-mark as a potential data-loss bug. The behavior is intentional: `extract_all` walks ObjectSpace once per process and never revisits a module, and failed uploads are not retried (matches Python and Go). The inline comment captures the design intent so the next reviewer does not have to rediscover it.

**Change log entry**

None.

**Additional Notes:**

The concern becomes relevant once the deferred TracePoint `:class` hot-load hook lands — each Component would then receive multiple extraction passes, and `@uploaded_modules.add` should move into the success path.

**How to test the change?**

No behavior change — comment only.