### PR TITLE
Skip flaky stack_recorder heap serialization-ongoing test under ASan

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -781,6 +781,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             context "when there's a heap serialization ongoing" do
               it "does nothing" do
+                skip_asan_flaky
+
                 described_class::Testing._native_start_fake_slow_heap_serialization(stack_recorder)
 
                 test_object_id = sample_and_clear


### PR DESCRIPTION
**What does this PR do?**

Adds `skip_asan_flaky` to the `Datadog::Profiling::StackRecorder#serialize ... #recorder_after_gc_step when heap_clean_after_gc_enabled is true when there's a heap serialization ongoing does nothing` test in `spec/datadog/profiling/stack_recorder_spec.rb:783`.

Two-line change matching the precedent set by [#5666](https://github.com/DataDog/dd-trace-rb/pull/5666):

```ruby
it "does nothing" do
  skip_asan_flaky
  ...
```

**Motivation:**

The test failed in [`test-asan` on run 25819203103](https://github.com/DataDog/dd-trace-rb/actions/runs/25819203103/job/75855706999) while passing in 84 other jobs on the same commit (Ruby 2.5–4.0 × build & test batches). The failure mode matches the documented one in `spec/datadog/profiling/spec_helper.rb:121`:

> "We suspect this may be the ASAN fake stack keeping things alive, although we're not entirely sure..."

The specific failure is the **sanity check** at line 799, which asserts that after `_native_end_fake_slow_heap_serialization` the test object DOES get cleared by `recorder_after_gc_step`. Under ASan, the test object sometimes remains "alive" from Ruby's conservative GC's perspective (the ASan fake stack appears to retain a reference), so the heap recorder correctly keeps its record and the assertion fails.

The recorder behaves correctly. The test's GC-cleanup assumption doesn't hold under ASan.

**Change log entry**

None.

**Additional Notes:**

Note on the 3-PR validation flow recommended by the flaky-test skill: I deviated and pushed a single PR because (a) the failure is ASan-specific and I can't reproduce it on a non-ASan local Ruby, so the skill's "force the failure locally" step isn't actionable; (b) the precedent (#5666) handled the identical pattern as a single PR; (c) the change is two lines.

**How to test the change?**

Run the `test-asan` job in CI. The failing test will now skip (visible as a pending example in rspec output) under ASan and continue to run normally everywhere else (84 other CI jobs still verify both assertions strictly).