### PR TITLE
Detect non-JSON transport responses before parsing

### DIFF
--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -23,6 +23,10 @@ module Datadog
 
                 raise AgentErrorResponse.new(http_response.code, http_response.payload) if http_response.code != 200
 
+                unless http_response.json_content_type?
+                  raise Datadog::Core::Transport::HTTP::NotJsonResponseError, http_response
+                end
+
                 begin
                   payload = JSON.parse(http_response.payload, symbolize_names: true)
                 rescue JSON::ParserError => e

--- a/lib/datadog/core/remote/transport/http/negotiation.rb
+++ b/lib/datadog/core/remote/transport/http/negotiation.rb
@@ -55,7 +55,14 @@ module Datadog
                   http_response = super
 
                   # Process the response
-                  body = JSON.parse(http_response.payload, symbolize_names: true) if http_response.ok?
+                  body = nil
+                  if http_response.ok?
+                    unless http_response.json_content_type?
+                      raise Datadog::Core::Transport::HTTP::NotJsonResponseError, http_response
+                    end
+
+                    body = JSON.parse(http_response.payload, symbolize_names: true)
+                  end
 
                   # TODO: there should be more processing here to ensure a proper response_options
                   response_options = body.is_a?(Hash) ? body : {}

--- a/lib/datadog/core/transport/http/adapters/net.rb
+++ b/lib/datadog/core/transport/http/adapters/net.rb
@@ -132,6 +132,15 @@ module Datadog
                 http_response.code.to_i
               end
 
+              def content_type
+                return super if http_response.nil?
+
+                # Net::HTTPResponse#content_type returns the media type without parameters
+                # (e.g. "application/json" from "application/json; charset=utf-8") and nil
+                # when the Content-Type header is absent.
+                http_response.content_type
+              end
+
               def ok?
                 return super if http_response.nil?
 

--- a/lib/datadog/core/transport/http/adapters/test.rb
+++ b/lib/datadog/core/transport/http/adapters/test.rb
@@ -47,11 +47,13 @@ module Datadog
 
               attr_reader \
                 :body,
-                :code
+                :code,
+                :content_type
 
-              def initialize(code, body = nil)
+              def initialize(code, body = nil, content_type: nil)
                 @code = code
                 @body = body
+                @content_type = content_type
               end
 
               def payload

--- a/lib/datadog/core/transport/http/response.rb
+++ b/lib/datadog/core/transport/http/response.rb
@@ -57,6 +57,42 @@ module Datadog
           def headers
             @http_response.respond_to?(:headers) ? @http_response.headers : {}
           end
+
+          # (see Datadog::Core::Transport::Response#content_type)
+          def content_type
+            @http_response.respond_to?(:content_type) ? @http_response.content_type : nil
+          end
+
+          # True if the response declares its body as JSON via the Content-Type header.
+          # Matches "application/json" and "application/<sub>+json" (e.g. application/vnd.api+json),
+          # case-insensitively, ignoring any media-type parameters such as ";charset=utf-8".
+          def json_content_type?
+            ct = content_type
+            return false unless ct.is_a?(String)
+
+            normalized = ct.downcase
+            normalized == 'application/json' || normalized.end_with?('+json')
+          end
+        end
+
+        # Raised when a response that was expected to contain JSON did not declare a
+        # JSON Content-Type. Carries the offending response so callers (and the
+        # transport client's exception logger) can include status, content type, and
+        # payload in their diagnostics.
+        class NotJsonResponseError < StandardError
+          attr_reader :http_response
+
+          def initialize(http_response)
+            @http_response = http_response
+            payload = http_response.payload.to_s
+            truncated_payload = payload.length > 1000 ? "#{payload[0, 1000]}... (truncated)" : payload
+            super(
+              "Response is not declared as JSON " \
+              "(Content-Type: #{http_response.content_type.inspect}, " \
+              "status: #{http_response.code.inspect}, " \
+              "payload: #{truncated_payload.inspect})"
+            )
+          end
         end
       end
     end

--- a/lib/datadog/core/transport/http/response.rb
+++ b/lib/datadog/core/transport/http/response.rb
@@ -11,6 +11,10 @@ module Datadog
         # Used by endpoints to wrap responses from adapters with
         # fields or behavior that's specific to that endpoint.
         module Response
+          # Inherit the abstract transport response interface so includers pick up the
+          # shared default methods (e.g. json_content_type?) without re-declaring them here.
+          include Datadog::Core::Transport::Response
+
           def initialize(http_response)
             @http_response = http_response
           end
@@ -62,17 +66,6 @@ module Datadog
           def content_type
             @http_response.respond_to?(:content_type) ? @http_response.content_type : nil
           end
-
-          # True if the response declares its body as JSON via the Content-Type header.
-          # Matches "application/json" and "application/<sub>+json" (e.g. application/vnd.api+json),
-          # case-insensitively, ignoring any media-type parameters such as ";charset=utf-8".
-          def json_content_type?
-            ct = content_type
-            return false unless ct.is_a?(String)
-
-            normalized = ct.downcase
-            normalized == 'application/json' || normalized.end_with?('+json')
-          end
         end
 
         # Raised when a response that was expected to contain JSON did not declare a
@@ -85,7 +78,7 @@ module Datadog
           def initialize(http_response)
             @http_response = http_response
             payload = http_response.payload.to_s
-            truncated_payload = payload.length > 1000 ? "#{payload[0, 1000]}... (truncated)" : payload
+            truncated_payload = (payload.length > 1000) ? "#{payload[0, 1000]}... (truncated)" : payload
             super(
               "Response is not declared as JSON " \
               "(Content-Type: #{http_response.content_type.inspect}, " \

--- a/lib/datadog/core/transport/response.rb
+++ b/lib/datadog/core/transport/response.rb
@@ -33,6 +33,12 @@ module Datadog
           nil
         end
 
+        # Content-Type of the response body, without parameters (e.g. "application/json").
+        # Returns nil if the transport does not expose response headers.
+        def content_type
+          nil
+        end
+
         def inspect
           maybe_code = if respond_to?(:code)
             # Steep: `code` method may be defined by classes extending this module.

--- a/lib/datadog/core/transport/response.rb
+++ b/lib/datadog/core/transport/response.rb
@@ -46,7 +46,7 @@ module Datadog
           ct = content_type
           return false unless ct.is_a?(String)
 
-          normalized = ct.downcase
+          normalized = ct.split(';', 2).first.to_s.strip.downcase
           normalized == 'application/json' || normalized.end_with?('+json')
         end
 

--- a/lib/datadog/core/transport/response.rb
+++ b/lib/datadog/core/transport/response.rb
@@ -39,6 +39,17 @@ module Datadog
           nil
         end
 
+        # True if the response declares its body as JSON via the Content-Type header.
+        # Matches "application/json" and "application/<sub>+json" (e.g. application/vnd.api+json),
+        # case-insensitively, ignoring any media-type parameters such as ";charset=utf-8".
+        def json_content_type?
+          ct = content_type
+          return false unless ct.is_a?(String)
+
+          normalized = ct.downcase
+          normalized == 'application/json' || normalized.end_with?('+json')
+        end
+
         def inspect
           maybe_code = if respond_to?(:code)
             # Steep: `code` method may be defined by classes extending this module.

--- a/lib/datadog/tracing/transport/http/traces.rb
+++ b/lib/datadog/tracing/transport/http/traces.rb
@@ -56,6 +56,10 @@ module Datadog
                 response_options = {trace_count: env.request.parcel.trace_count}.tap do |options|
                   # Parse service rates, if configured to do so.
                   if service_rates? && !http_response.payload.to_s.empty?
+                    unless http_response.json_content_type?
+                      raise Datadog::Core::Transport::HTTP::NotJsonResponseError, http_response
+                    end
+
                     body = JSON.parse(http_response.payload)
                     options[:service_rates] = body[SERVICE_RATE_KEY] if body.is_a?(Hash) && body.key?(SERVICE_RATE_KEY)
                   end

--- a/sig/datadog/core/transport/http/adapters/test.rbs
+++ b/sig/datadog/core/transport/http/adapters/test.rbs
@@ -29,13 +29,17 @@ module Datadog
 
               @body: untyped
 
+              @content_type: untyped
+
               include Datadog::Core::Transport::Response
 
               attr_reader body: untyped
 
               attr_reader code: untyped
 
-              def initialize: (untyped code, ?untyped? body) -> void
+              attr_reader content_type: untyped
+
+              def initialize: (untyped code, ?untyped? body, ?content_type: untyped) -> void
 
               def payload: () -> untyped
 

--- a/sig/datadog/core/transport/http/response.rbs
+++ b/sig/datadog/core/transport/http/response.rbs
@@ -16,6 +16,15 @@ module Datadog
 
           def code: () -> (untyped | nil)
           def headers: () -> ::Hash[::String, ::String]
+          def content_type: () -> (::String | nil)
+        end
+
+        class NotJsonResponseError < StandardError
+          @http_response: untyped
+
+          attr_reader http_response: untyped
+
+          def initialize: (untyped http_response) -> void
         end
       end
     end

--- a/sig/datadog/core/transport/response.rbs
+++ b/sig/datadog/core/transport/response.rbs
@@ -16,6 +16,10 @@ module Datadog
 
         def internal_error?: () -> nil
 
+        def content_type: () -> (::String | nil)
+
+        def json_content_type?: () -> bool
+
         def inspect: () -> ::String
       end
 

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -558,8 +558,16 @@ RSpec.describe Datadog::Core::Configuration::Components do
       shared_context 'stub remote configuration agent response' do
         before do
           WebMock.enable!
-          stub_request(:get, %r{/info}).to_return(body: info_response, status: 200)
-          stub_request(:post, %r{/v0\.7/config}).to_return(body: '{}', status: 200)
+          stub_request(:get, %r{/info}).to_return(
+            body: info_response,
+            status: 200,
+            headers: {'Content-Type' => 'application/json'},
+          )
+          stub_request(:post, %r{/v0\.7/config}).to_return(
+            body: '{}',
+            status: 200,
+            headers: {'Content-Type' => 'application/json'},
+          )
         end
 
         after { WebMock.disable! }

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe Datadog::Core::Remote::Client do
       allow(http_connection).to receive(:use_ssl=)
 
       allow(http_connection).to receive(:start).and_yield(http_connection)
-      http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+      http_response = instance_double(
+        ::Net::HTTPResponse,
+        body: response_body,
+        code: response_code,
+        content_type: respond_to?(:response_content_type) ? response_content_type : 'application/json',
+      )
       allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
     end
   end

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Datadog::Core::Remote::Client do
         ::Net::HTTPResponse,
         body: response_body,
         code: response_code,
-        content_type: respond_to?(:response_content_type) ? response_content_type : 'application/json',
+        content_type: response_content_type,
       )
       allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
     end
@@ -44,6 +44,7 @@ RSpec.describe Datadog::Core::Remote::Client do
 
   let(:http_connection) { instance_double(::Net::HTTP) }
   let(:logger) { logger_allowing_debug }
+  let(:response_content_type) { 'application/json' }
   let(:transport) do
     Datadog::Core::Remote::Transport::HTTP.v7(
       agent_settings: test_agent_settings, logger: logger,

--- a/spec/datadog/core/remote/negotiation_spec.rb
+++ b/spec/datadog/core/remote/negotiation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
           ::Net::HTTPResponse,
           body: response_body,
           code: response_code,
-          content_type: respond_to?(:response_content_type) ? response_content_type : 'application/json',
+          content_type: response_content_type,
         )
         allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
       end
@@ -36,6 +36,7 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
   let(:settings) { Datadog::Core::Configuration::Settings.new }
   let(:logger) { logger_allowing_debug }
   let(:agent_settings) { Datadog::Core::Configuration::AgentSettingsResolver.call(settings, logger: nil) }
+  let(:response_content_type) { 'application/json' }
 
   describe '#initialize' do
     context 'when instantiated without logger parameter like datadog-ci gem does' do

--- a/spec/datadog/core/remote/negotiation_spec.rb
+++ b/spec/datadog/core/remote/negotiation_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe Datadog::Core::Remote::Negotiation do
       if respond_to?(:request_exception)
         allow(http_connection).to receive(:request).with(http_request).and_raise(request_exception)
       else
-        http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+        http_response = instance_double(
+          ::Net::HTTPResponse,
+          body: response_body,
+          code: response_code,
+          content_type: respond_to?(:response_content_type) ? response_content_type : 'application/json',
+        )
         allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
       end
     end

--- a/spec/datadog/core/remote/transport/http_spec.rb
+++ b/spec/datadog/core/remote/transport/http_spec.rb
@@ -28,7 +28,12 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
 
       allow(http_connection).to receive(:start).and_yield(http_connection)
 
-      http_response = instance_double(::Net::HTTPResponse, body: response_body, code: response_code)
+      http_response = instance_double(
+        ::Net::HTTPResponse,
+        body: response_body,
+        code: response_code,
+        content_type: response_content_type,
+      )
       allow(http_connection).to receive(:request).with(http_request).and_return(http_response)
     end
   end
@@ -51,6 +56,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
       let(:request_verb) { :get }
 
       let(:response_code) { 200 }
+      let(:response_content_type) { 'application/json' }
       let(:response_body) do
         JSON.dump(
           {
@@ -153,6 +159,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
       let(:request_verb) { :post }
 
       let(:response_code) { 200 }
+      let(:response_content_type) { 'application/json' }
       let(:response_body) do
         encode = proc do |obj|
           Datadog::Core::Utils::Base64.strict_encode64(obj).chomp

--- a/spec/datadog/core/transport/http/adapters/net/response_spec.rb
+++ b/spec/datadog/core/transport/http/adapters/net/response_spec.rb
@@ -160,4 +160,22 @@ RSpec.describe Datadog::Core::Transport::HTTP::Adapters::Net::Response do
       expect(response.inspect).to match(/code:202/)
     end
   end
+
+  describe '#content_type' do
+    subject(:content_type) { response.content_type }
+
+    let(:http_response) { instance_double(::Net::HTTPResponse, content_type: header_value) }
+
+    context 'when the HTTP response declares a content type' do
+      let(:header_value) { 'application/json' }
+
+      it { is_expected.to eq('application/json') }
+    end
+
+    context 'when the HTTP response has no Content-Type header' do
+      let(:header_value) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
 end

--- a/spec/datadog/core/transport/http/response_spec.rb
+++ b/spec/datadog/core/transport/http/response_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Datadog::Core::Transport::HTTP::Response do
 
     describe 'Datadog::Core::Transport::Response methods' do
       it 'are forwarded to the HTTP response' do
-        (Datadog::Core::Transport::Response.instance_methods - [:inspect]).each do |method|
+        # :inspect is overridden, :json_content_type? is a computed predicate that
+        # calls #content_type internally rather than forwarding directly.
+        non_forwarded = [:inspect, :json_content_type?]
+        (Datadog::Core::Transport::Response.instance_methods - non_forwarded).each do |method|
           expect(http_response).to receive(method)
           response.send(method)
         end

--- a/spec/datadog/core/transport/http/response_spec.rb
+++ b/spec/datadog/core/transport/http/response_spec.rb
@@ -40,5 +40,99 @@ RSpec.describe Datadog::Core::Transport::HTTP::Response do
         it { is_expected.to be nil }
       end
     end
+
+    describe '#content_type' do
+      subject(:content_type) { response.content_type }
+
+      let(:http_response) { double('http response') }
+
+      context 'when HTTP response responds to #content_type' do
+        before { allow(http_response).to receive(:content_type).and_return('application/json') }
+
+        it 'forwards to the HTTP response' do
+          is_expected.to eq('application/json')
+        end
+      end
+
+      context 'when HTTP response does not respond to #content_type' do
+        it { is_expected.to be nil }
+      end
+    end
+
+    describe '#json_content_type?' do
+      subject(:json_content_type?) { response.json_content_type? }
+
+      let(:http_response) { double('http response', content_type: header_value) }
+
+      context 'when Content-Type is "application/json"' do
+        let(:header_value) { 'application/json' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when Content-Type is "application/json" with a different case' do
+        let(:header_value) { 'Application/JSON' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when Content-Type is a "+json" media type' do
+        let(:header_value) { 'application/vnd.api+json' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when Content-Type is text/plain' do
+        let(:header_value) { 'text/plain' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'when Content-Type is missing' do
+        let(:header_value) { nil }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end
+
+RSpec.describe Datadog::Core::Transport::HTTP::NotJsonResponseError do
+  subject(:error) { described_class.new(http_response) }
+
+  let(:http_response) do
+    double(
+      'http response',
+      content_type: 'text/html',
+      code: 500,
+      payload: payload,
+    )
+  end
+
+  context 'with a short payload' do
+    let(:payload) { '<html>oops</html>' }
+
+    it 'includes the content type, status code, and payload in the message' do
+      expect(error.message).to include('Content-Type: "text/html"')
+      expect(error.message).to include('status: 500')
+      expect(error.message).to include('payload: "<html>oops</html>"')
+    end
+  end
+
+  context 'with a long payload' do
+    let(:payload) { 'a' * 2000 }
+
+    it 'truncates the payload in the message' do
+      expect(error.message).to include('... (truncated)')
+      expect(error.message.length).to be < payload.length + 200
+    end
+  end
+
+  context 'with a nil payload' do
+    let(:payload) { nil }
+
+    it 'does not raise when formatting' do
+      expect { error.message }.not_to raise_error
+    end
   end
 end

--- a/spec/datadog/core/transport/http/response_spec.rb
+++ b/spec/datadog/core/transport/http/response_spec.rb
@@ -85,6 +85,24 @@ RSpec.describe Datadog::Core::Transport::HTTP::Response do
         it { is_expected.to be true }
       end
 
+      context 'when Content-Type has a charset parameter' do
+        let(:header_value) { 'application/json; charset=utf-8' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when Content-Type has a charset parameter without surrounding space' do
+        let(:header_value) { 'application/json;charset=utf-8' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when Content-Type is "+json" with a parameter' do
+        let(:header_value) { 'application/vnd.api+json; charset=utf-8' }
+
+        it { is_expected.to be true }
+      end
+
       context 'when Content-Type is text/plain' do
         let(:header_value) { 'text/plain' }
 

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -36,8 +36,16 @@ RSpec.describe 'contrib integration testing', :integration do
     before do
       WebMock.enable!
 
-      stub_request(:get, %r{/info}).to_return(body: info_response, status: 200)
-      stub_request(:post, %r{/v0\.7/config}).to_return(body: '{}', status: 200)
+      stub_request(:get, %r{/info}).to_return(
+        body: info_response,
+        status: 200,
+        headers: {'Content-Type' => 'application/json'},
+      )
+      stub_request(:post, %r{/v0\.7/config}).to_return(
+        body: '{}',
+        status: 200,
+        headers: {'Content-Type' => 'application/json'},
+      )
 
       Datadog.configure { |c| c.remote.poll_interval_seconds = 0.001 }
     end
@@ -54,7 +62,11 @@ RSpec.describe 'contrib integration testing', :integration do
     end
 
     def stub_dynamic_configuration_request(*dynamic_configurations)
-      stub_request(:post, %r{/v0\.7/config}).to_return(body: build(*dynamic_configurations), status: 200)
+      stub_request(:post, %r{/v0\.7/config}).to_return(
+        body: build(*dynamic_configurations),
+        status: 200,
+        headers: {'Content-Type' => 'application/json'},
+      )
     end
 
     def build(*dynamic_configurations)

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -721,7 +721,11 @@ RSpec.describe 'Tracer integration tests' do
 
     context 'with agent rates', webmock: true do
       before do
-        stub_request(:post, %r{/v0.4/traces}).to_return(status: 200, body: service_rates.to_json)
+        stub_request(:post, %r{/v0.4/traces}).to_return(
+          status: 200,
+          body: service_rates.to_json,
+          headers: {'Content-Type' => 'application/json'},
+        )
       end
 
       let(:service_rates) { {rate_by_service: {'service:kept,env:' => 1.0, 'service:dropped,env:' => Float::MIN}} }

--- a/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/net_integration_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'Adapters::Net tracing integration tests' do
     let(:server_proc) do
       proc do |req, res|
         messages << req.tap { req.body } # Read body, store message before socket closes.
+        res['Content-Type'] = 'application/json'
         res.body = '{}'
       end
     end

--- a/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
+++ b/spec/datadog/tracing/transport/http/adapters/unix_socket_integration_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Adapters::UnixSocket integration tests' do
     let(:server_proc) do
       proc do |req, res|
         messages << req
+        res['Content-Type'] = 'application/json'
         res.body = '{}'
       end
     end

--- a/spec/datadog/tracing/transport/http/traces_spec.rb
+++ b/spec/datadog/tracing/transport/http/traces_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Datadog::Tracing::Transport::HTTP::Traces::API::Endpoint do
         it 'raises NotJsonResponseError' do
           expect { call }.to raise_error(Datadog::Core::Transport::HTTP::NotJsonResponseError) do |error|
             expect(error.message).to include('Content-Type: "text/html"')
-            expect(error.message).to include(json_payload[0, 50])
+            expect(error.message).to include('rate_by_service')
           end
         end
       end

--- a/spec/datadog/tracing/transport/http/traces_spec.rb
+++ b/spec/datadog/tracing/transport/http/traces_spec.rb
@@ -155,14 +155,10 @@ RSpec.describe Datadog::Tracing::Transport::HTTP::Traces::API::Endpoint do
       end
 
       context 'when the response is not declared as JSON' do
-        before { allow(http_response).to receive(:json_content_type?).and_return(false) }
-
-        let(:logger) { logger_allowing_debug }
-        let(:code) { 200 }
-
         before do
+          allow(http_response).to receive(:json_content_type?).and_return(false)
           allow(http_response).to receive(:content_type).and_return('text/html')
-          allow(http_response).to receive(:code).and_return(code)
+          allow(http_response).to receive(:code).and_return(200)
         end
 
         it 'raises NotJsonResponseError' do

--- a/spec/datadog/tracing/transport/http/traces_spec.rb
+++ b/spec/datadog/tracing/transport/http/traces_spec.rb
@@ -144,11 +144,33 @@ RSpec.describe Datadog::Tracing::Transport::HTTP::Traces::API::Endpoint do
       let(:sampling_response) { {described_class::SERVICE_RATE_KEY => service_rates} }
       let(:service_rates) { {'service:a,env:test' => 0.1, 'service:b,env:test' => 0.5} }
 
-      before { allow(http_response).to receive(:payload).and_return(json_payload) }
+      before do
+        allow(http_response).to receive(:payload).and_return(json_payload)
+        allow(http_response).to receive(:json_content_type?).and_return(true)
+      end
 
       it_behaves_like 'traces request'
       it 'includes service rates' do
         expect(call.service_rates).to eq(service_rates)
+      end
+
+      context 'when the response is not declared as JSON' do
+        before { allow(http_response).to receive(:json_content_type?).and_return(false) }
+
+        let(:logger) { logger_allowing_debug }
+        let(:code) { 200 }
+
+        before do
+          allow(http_response).to receive(:content_type).and_return('text/html')
+          allow(http_response).to receive(:code).and_return(code)
+        end
+
+        it 'raises NotJsonResponseError' do
+          expect { call }.to raise_error(Datadog::Core::Transport::HTTP::NotJsonResponseError) do |error|
+            expect(error.message).to include('Content-Type: "text/html"')
+            expect(error.message).to include(json_payload[0, 50])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Three transport endpoints parse response bodies with `JSON.parse` without first checking that the response declares JSON via Content-Type:

- `lib/datadog/tracing/transport/http/traces.rb` (service rates extraction)
- `lib/datadog/core/remote/transport/http/negotiation.rb` (agent info `/info`)
- `lib/datadog/core/remote/transport/http/config.rb` (remote config)

When the agent or an upstream proxy returns HTML, an empty body, or anything else that isn't JSON, `JSON.parse` raises with a message like `expected ':' after object key, got: EOF` and the user can't tell from the resulting log whether the response was a 500 page, a misrouted request, or a real protocol error.

This adds Content-Type plumbing through the response chain, a `json_content_type?` helper, and a typed `NotJsonResponseError` whose message includes the offending Content-Type, status code, and a truncated payload — so the existing transport-client exception logger emits all the context needed for diagnosis. The three parse sites raise it when the response is otherwise eligible for parsing but doesn't declare JSON.

The status-code handling at each site is left unchanged. The original report flagged that as a possibly separate concern, and untangling it would be a wider change than this PR's scope.

**Behavioral note (no Content-Type header):** responses with a valid JSON body but no `Content-Type` header (or a non-JSON Content-Type) will now raise `NotJsonResponseError` where the old code would have parsed them successfully. The Datadog agent sets `Content-Type: application/json` for these endpoints, so this should not affect normal deployments, but a custom proxy or non-conforming agent that strips the header will now surface as a `NotJsonResponseError` rather than parsing silently.

**Motivation:**

Reported in https://github.com/DataDog/ruby-guild/issues/280.

Customer-facing example log line from the original report:

```
ERROR -- datadog: Internal error during Datadog::Tracing::Transport::HTTP::Client request.
Cause: JSON::ParserError: expected ':' after object key, got: EOF at line 1 column 91
Location: /usr/local/bundle/gems/json-2.18.0/lib/json/common.rb:353:in `parse'
```

That message gives no clue what the agent actually returned. After this change, the same scenario surfaces as:

```
ERROR -- datadog: Internal error during Datadog::Tracing::Transport::HTTP::Client request.
Cause: Datadog::Core::Transport::HTTP::NotJsonResponseError: Response is not declared as JSON
(Content-Type: "text/html", status: 502, payload: "<html><head><title>502 Bad Gateway</title>...")
```

**Change log entry**

None.

**Additional Notes:**

Content-Type detection follows the standard RFC 6838 conventions: matches `application/json` and any `application/...+json` media type (case-insensitive, parameters stripped). `json_content_type?` strips parameters itself, so it handles `application/json; charset=utf-8` correctly regardless of whether the adapter pre-strips them. The Net adapter additionally delegates to `Net::HTTPResponse#content_type`, which also strips parameters.

The Test adapter gained an optional `content_type:` keyword arg, defaulting to `nil` — backward compatible with existing callers.

**How to test the change?**

New specs:

- `spec/datadog/core/transport/http/response_spec.rb` — `#content_type`, `#json_content_type?` matching matrix (json, +json, case variants, charset parameter forms, missing, non-json), and the `NotJsonResponseError` message contents.
- `spec/datadog/core/transport/http/adapters/net/response_spec.rb` — `#content_type` delegation.
- `spec/datadog/tracing/transport/http/traces_spec.rb` — non-JSON response raises with message details.

Existing specs that stub `Net::HTTPResponse` were updated to also stub `content_type` via an explicit top-level `let(:response_content_type) { 'application/json' }`, since `instance_double` verifies the new call.

Local verification: ran the affected specs after `bundle install` resolved the dependency state — 102 examples, 0 failures across `spec/datadog/tracing/transport/http/traces_spec.rb`, `spec/datadog/core/transport/http/response_spec.rb`, `spec/datadog/core/transport/http/adapters/net/response_spec.rb`, `spec/datadog/core/remote/transport/http_spec.rb`, `spec/datadog/core/remote/negotiation_spec.rb`, and `spec/datadog/core/remote/client_spec.rb`. `bundle exec rake standard` is clean. Integration specs (`*_integration_spec.rb`) fail on master identically without a running agent and are unaffected by this change.