### PR TITLE
Reproduce flaky: DSM Kafka consumer backlogs serialization

### DIFF
--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -293,6 +293,12 @@ RSpec.describe Datadog::DataStreams::Processor do
 
       it 'serializes consumer backlogs with type:kafka_commit tag' do
         processor.track_kafka_consume('orders', 0, 100, base_time)
+        # Reproducer for ruby-guild#281: give the auto-spawned background worker
+        # time to run its first iteration between the two pushes. The worker's
+        # process_events drains event1 into @consumer_stats, then flush_stats
+        # clears @consumer_stats — losing event1 before event2 is added.
+        # DO NOT MERGE — this branch deliberately forces the race condition.
+        sleep 0.5
         processor.track_kafka_consume('payments', 1, 50, base_time + 1)
 
         # Process events and trigger flush


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test `spec/datadog/data_streams/processor_spec.rb:294`
(`Datadog::DataStreams::Processor Kafka tracking methods #track_kafka_consume serializes consumer backlogs with type:kafka_commit tag`).
Forces the suspected race condition with `sleep 0.5` between the two
`track_kafka_consume` calls so the auto-spawned background worker is
guaranteed to run its first iteration in between. Expected result: the
test fails deterministically with `expected: 2, got: 1`.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test reported in [ruby-guild#281](https://github.com/DataDog/ruby-guild/issues/281).
First-attempt failure on [Ruby 3.2 / build & test (standard) [1]](https://github.com/DataDog/dd-trace-rb/actions/runs/20353409682/job/58483474995?pr=5168);
attempt 2 (rerun) passed.

**Hypothesis:** the auto-spawned background worker thread races with the
test thread. The worker's first `perform_loop` iteration runs immediately
([`loop_wait_before_first_iteration?`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/core/workers/interval_loop.rb#L124) is false). If the OS schedules
it after the first `track_kafka_consume` but before the second:

1. Test pushes event1 to `@event_buffer`.
2. Worker wakes up, calls `process_events` → drains `[event1]` →
   `@consumer_stats = [event1]`.
3. Worker continues to `flush_stats` → executes `@consumer_stats.clear` at
   [`processor.rb:313`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/data_streams/processor.rb#L313)
   → `@consumer_stats = []`.
4. Test pushes event2.
5. Test calls `process_events` → drains `[event2]` →
   `@consumer_stats = [event2]`.
6. `serialize_consumer_backlogs` returns one entry → `expected 2, got 1`.

Same race class as the one [PR #5715](https://github.com/DataDog/dd-trace-rb/pull/5715)
fixed for `#flush_stats` (commit [`76683752f7`](https://github.com/DataDog/dd-trace-rb/commit/76683752f7));
this sibling test was missed.

**Reproducer technique:** insert `sleep 0.5` between the two pushes to
deterministically let the BG worker complete its first iteration. The race
window is otherwise microseconds wide.

**Change log entry**

None.

**How to test the change?**

CI should show the test failing deterministically with
`expected: 2, got: 1`. If it doesn't, the hypothesis is wrong.

**Companion PRs:**
- Fix: #5760
- Validation: #5761