### PR TITLE
Fix flaky: DSM Kafka consumer backlogs serialization

### DIFF
--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -292,6 +292,17 @@ RSpec.describe Datadog::DataStreams::Processor do
       end
 
       it 'serializes consumer backlogs with type:kafka_commit tag' do
+        # Stop the auto-spawned background worker thread before exercising
+        # process_events synchronously. Otherwise the worker can race with the
+        # test thread: its first perform_loop iteration runs immediately
+        # (loop_wait_before_first_iteration? is false), and if the OS schedules
+        # it after the first track_kafka_consume but before the second, the
+        # worker drains @event_buffer (consuming event1 into @consumer_stats)
+        # and flush_stats then clears @consumer_stats — so the test's later
+        # process_events only sees event2 and serialize_consumer_backlogs
+        # returns one entry instead of two. See ruby-guild#281.
+        processor.stop(true)
+
         processor.track_kafka_consume('orders', 0, 100, base_time)
         processor.track_kafka_consume('payments', 1, 50, base_time + 1)
 


### PR DESCRIPTION
**What does this PR do?**

Fixes flaky test `spec/datadog/data_streams/processor_spec.rb:294`
(`Datadog::DataStreams::Processor Kafka tracking methods #track_kafka_consume serializes consumer backlogs with type:kafka_commit tag`)
by stopping the auto-spawned background worker thread at the start of the
test.

**Motivation:**

Flaky test reported in [ruby-guild#281](https://github.com/DataDog/ruby-guild/issues/281).
First-attempt failure on [Ruby 3.2 / build & test (standard) [1]](https://github.com/DataDog/dd-trace-rb/actions/runs/20353409682/job/58483474995?pr=5168);
attempt 2 (rerun) passed.

**Failure:**
```
expect(backlogs.length).to eq(2)
  expected: 2
       got: 1
```

**Root cause:** the auto-spawned background worker thread races with the
test thread. `Processor.new` schedules a worker that runs `perform_loop`'s
first iteration immediately ([`loop_wait_before_first_iteration?`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/core/workers/interval_loop.rb#L124) is false).
If the OS schedules the worker after the first `track_kafka_consume` but
before the second:

1. Test pushes event1 to `@event_buffer`.
2. Worker wakes up, calls `process_events` → drains `[event1]` →
   `@consumer_stats = [event1]`.
3. Worker continues to `flush_stats` → executes `@consumer_stats.clear` at
   [`processor.rb:313`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/data_streams/processor.rb#L313)
   → `@consumer_stats = []`.
4. Test pushes event2.
5. Test calls `process_events` → drains `[event2]` →
   `@consumer_stats = [event2]`.
6. `serialize_consumer_backlogs` returns one entry → `expected 2, got 1`.

**Fix:** Stop the worker at the start of the test so the test owns the
buffer and `@consumer_stats` lifecycle synchronously. Mirrors the fix
applied in [PR #5715](https://github.com/DataDog/dd-trace-rb/pull/5715)
(commit [`76683752f7`](https://github.com/DataDog/dd-trace-rb/commit/76683752f7))
for the adjacent `#flush_stats` test, which has the same race class.

**Change log entry**

None.

**How to test the change?**

Reproducer is in companion PR — that PR's CI shows the race-forcing variant
(`sleep 0.5` between pushes) failing deterministically. The validation
companion PR merges this fix with the reproducer and CI passes, proving
the fix neutralizes the forced failure.

**Companion PRs:**
- Reproducer: #5759
- Validation: #5761

**Validation results:**
- Reproducer PR #5759 — failed deterministically across the full Ruby matrix: 9 Linux Unit Tests shards (Ruby 2.5 → 4.0), 6 macOS Test jobs (Ruby 3.0 → 4.0), and test-memcheck. All failures were the same assertion (`expected 2, got 1`) on this exact test. Closed.
- Validation PR #5761 — merged reproducer + fix, CI green. Fix neutralizes the forced failure. Closed.