### PR TITLE
Validate fix for flaky: DSM Kafka consumer backlogs serialization

### DIFF
--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -293,6 +293,12 @@ RSpec.describe Datadog::DataStreams::Processor do
 
       it 'serializes consumer backlogs with type:kafka_commit tag' do
         processor.track_kafka_consume('orders', 0, 100, base_time)
+        # Reproducer for ruby-guild#281: give the auto-spawned background worker
+        # time to run its first iteration between the two pushes. The worker's
+        # process_events drains event1 into @consumer_stats, then flush_stats
+        # clears @consumer_stats — losing event1 before event2 is added.
+        # DO NOT MERGE — this branch deliberately forces the race condition.
+        sleep 0.5
         processor.track_kafka_consume('payments', 1, 50, base_time + 1)
 
         # Process events and trigger flush

--- a/spec/datadog/data_streams/processor_spec.rb
+++ b/spec/datadog/data_streams/processor_spec.rb
@@ -292,6 +292,17 @@ RSpec.describe Datadog::DataStreams::Processor do
       end
 
       it 'serializes consumer backlogs with type:kafka_commit tag' do
+        # Stop the auto-spawned background worker thread before exercising
+        # process_events synchronously. Otherwise the worker can race with the
+        # test thread: its first perform_loop iteration runs immediately
+        # (loop_wait_before_first_iteration? is false), and if the OS schedules
+        # it after the first track_kafka_consume but before the second, the
+        # worker drains @event_buffer (consuming event1 into @consumer_stats)
+        # and flush_stats then clears @consumer_stats — so the test's later
+        # process_events only sees event2 and serialize_consumer_backlogs
+        # returns one entry instead of two. See ruby-guild#281.
+        processor.stop(true)
+
         processor.track_kafka_consume('orders', 0, 100, base_time)
         processor.track_kafka_consume('payments', 1, 50, base_time + 1)
 


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the forced failure. This branch merges:

- Reproducer PR: #5759 (forces the race with `sleep 0.5` between pushes)
- Fix PR: #5760 (stops the BG worker at the start of the test)

If CI passes, the fix addresses the exact failure mode the reproducer
forces. If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for CI validation only.

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the forced failure. CI fails = fix is
insufficient.

**Companion PRs:**
- Reproducer: #5759
- Fix: #5760