### PR TITLE
Fix Dynamic::TracingSamplingRules spec to use string keys

### DIFF
--- a/spec/datadog/tracing/configuration/dynamic_spec.rb
+++ b/spec/datadog/tracing/configuration/dynamic_spec.rb
@@ -99,11 +99,13 @@ RSpec.describe Datadog::Tracing::Configuration::Dynamic::TracingSamplingRules do
       config_key: :rules,
       value: RSpec::Matchers::BuiltIn::Match.new(
         lambda do |rules|
-          rules == '[{"sample_rate":1,"tags":[{"key":"k","value_glob":"v"}]}]'
+          rules == '[{"sample_rate":1,"tags":{"k":"v"}}]'
         end
       ),
       config_object: Datadog.configuration.tracing.sampling do
-        let(:new_value) { [{sample_rate: 1, tags: [{key: 'k', value_glob: 'v'}]}] }
+        # Match the shape Remote Config delivers: JSON.parse produces string keys
+        # throughout, which is what TracingSamplingRules#call reads via rule['tags'].
+        let(:new_value) { [{'sample_rate' => 1, 'tags' => [{'key' => 'k', 'value_glob' => 'v'}]}] }
       end
   end
 

--- a/spec/datadog/tracing/configuration/dynamic_spec.rb
+++ b/spec/datadog/tracing/configuration/dynamic_spec.rb
@@ -106,6 +106,11 @@ RSpec.describe Datadog::Tracing::Configuration::Dynamic::TracingSamplingRules do
         # Match the shape Remote Config delivers: JSON.parse produces string keys
         # throughout, which is what TracingSamplingRules#call reads via rule['tags'].
         let(:new_value) { [{'sample_rate' => 1, 'tags' => [{'key' => 'k', 'value_glob' => 'v'}]}] }
+
+        # Regression guard for DataDog/ruby-guild#282: if the array-to-hash tag
+        # conversion in TracingSamplingRules#call regresses, the resulting JSON is
+        # unparseable by RuleSampler.parse and emits a WARN. Fail loudly if so.
+        before { expect(Datadog.logger).not_to receive(:warn) }
       end
   end
 


### PR DESCRIPTION
**What does this PR do?**

Fixes the 'with tags' context in `spec/datadog/tracing/configuration/dynamic_spec.rb` so the test exercises the real array-to-hash conversion in `TracingSamplingRules#call` instead of silently skipping it, and adds a regression guard that fails if the WARN ever returns.

**Motivation:**

Reported in [DataDog/ruby-guild#282](https://github.com/DataDog/ruby-guild/issues/282): the spec was emitting `WARN -- datadog: Could not parse trace sampling rules ... NoMethodError undefined method 'transform_values' for [...]:Array at lib/datadog/tracing/sampling/matcher.rb:81`.

Root cause:

- `lib/datadog/tracing/configuration/dynamic.rb:65-75` converts `tags` from RC's wire shape (`[{key, value_glob}, ...]`) into the hash shape `SimpleMatcher` expects. The guard reads `rule['tags']` — string key.
- The spec built `new_value` with symbol keys: `[{sample_rate: 1, tags: [{key: 'k', value_glob: 'v'}]}]`.
- In Ruby, `h['tags']` and `h[:tags]` are different lookups. The string-key read on the symbol-keyed hash returned nil, so the conversion was skipped.
- `to_json` serialized the unconverted shape; downstream `RuleSampler.parse` then passed an Array as `tags:` to `SimpleMatcher.new`, which immediately ran `tags.transform_values` and raised — caught and logged as the WARN.

In production, `lib/datadog/tracing/remote.rb:72` parses RC payloads with `JSON.parse`, producing string keys throughout, so this mismatch does not occur.

The previous assertion also locked in the unconverted shape (`'[...,"tags":[{"key":"k","value_glob":"v"}]}]'`), masking the bug.

**Fix:**

- Switch `new_value` to string keys, matching what Remote Config delivers.
- Update the value matcher to the converted JSON shape (`'[...,"tags":{"k":"v"}}]'`).
- Add `before { expect(Datadog.logger).not_to receive(:warn) }` as a regression guard.
- Add comments explaining the key-shape requirement and the guard's purpose.

**Change log entry**

None.

**Additional Notes:**

Test-only change. The conversion code in `dynamic.rb` is unchanged; this PR only makes the test exercise the conversion path the production code is written against and locks in that the path stays warning-free.

**How to test the change?**

Local verification on Ruby 3.2:

1. **Baseline (fix applied):**
    ```
    $ bundle exec rspec spec/datadog/tracing/configuration/dynamic_spec.rb
    23 examples, 0 failures
    ```
    No `Could not parse trace sampling rules` warning emitted.

2. **Regression check** — temporarily disabled the array-to-hash conversion in `lib/datadog/tracing/configuration/dynamic.rb` and re-ran:
    ```
    23 examples, 2 failures
    ```
    Both failures point directly at `Datadog.logger.warn` (`rule_sampler.rb:87`):
    - `Dynamic::TracingSamplingRules with tags #call changes rules to ...`
    - `Dynamic::TracingSamplingRules with tags #call with nil value restores original value ...`

    Restoring the converter brings the suite back to green. Confirms the assertion catches the regression the PR was filed for.