### PR TITLE
feat(remote): boot RC from Tracer#trace so non-Rack workloads get remote configuration

### DIFF
--- a/lib/datadog/core/remote/component.rb
+++ b/lib/datadog/core/remote/component.rb
@@ -93,12 +93,25 @@ module Datadog
           @worker.stop
         end
 
-        # Recreates the remote configuration client after a fork.
-        # This ensures each forked process has a unique client ID and fresh state.
+        # Recreates the remote configuration client and restarts the worker after a fork.
+        #
+        # Each forked process gets a unique client ID and fresh worker thread.
+        # The worker thread does not survive `fork` (Ruby kills all non-calling
+        # threads in the child), so we explicitly reset and restart it if the
+        # parent had already started the worker.
         def after_fork
+          was_started = @worker.started?
+
           @client = Client.new(@transport, @capabilities, settings: @settings, logger: @logger)
           @healthy = false
+          @barrier = Barrier.new(@settings.remote.boot_timeout_seconds)
+          @worker.reset_after_fork!
+
           logger.debug { "remote configuration client recreated after fork: #{@client.id} products: #{@capabilities.products.sort.join(', ')}" }
+
+          # Only restart the worker if the parent had it running, so we don't
+          # eagerly start RC in children of processes that hadn't booted it.
+          @worker.start if was_started
         end
 
         # Barrier provides a mechanism to fence execution until a condition happens

--- a/lib/datadog/core/remote/tie.rb
+++ b/lib/datadog/core/remote/tie.rb
@@ -10,32 +10,47 @@ module Datadog
           :time,
         )
 
+        # Returned when boot has already been performed for the current remote
+        # component in this process. barrier == :pass tells Tie::Tracing.tag
+        # not to set per-request boot timing metrics on subsequent spans.
+        PASS = Boot.new(:pass, 0.0)
+
         @mutex = Mutex.new
         @booted_in_pid = nil
-        @last_boot = nil
+        @booted_remote_id = nil
 
         # Boot the Remote Configuration worker for this process.
         #
-        # Idempotent: only the first call per process actually waits on
-        # `barrier(:once)`. Subsequent calls return the cached `Boot` struct.
-        # After a fork, `Process.pid` changes, which invalidates the cache and
-        # the next call boots again in the child.
+        # Idempotent: only the first call per (process, remote component) pair
+        # actually waits on `barrier(:once)`. Subsequent calls return PASS so
+        # that Tie::Tracing.tag skips per-request boot metrics.
+        #
+        # The cache is keyed on both `Process.pid` and the remote component's
+        # `object_id` so that:
+        #   - A fork (new pid) triggers a fresh boot in the child.
+        #   - A new `Datadog.configure` call (new remote component) triggers a
+        #     fresh boot for the replacement component.
         def self.boot
           return if Datadog::Core::Remote.active_remote.nil?
 
+          active = Datadog::Core::Remote.active_remote
+
           @mutex.synchronize do
-            return @last_boot if @booted_in_pid == Process.pid
+            if @booted_in_pid == Process.pid && @booted_remote_id == active.object_id
+              return PASS
+            end
 
             barrier = nil
             t = Datadog::Core::Utils::Time.measure do
-              barrier = Datadog::Core::Remote.active_remote.barrier(:once)
+              barrier = active.barrier(:once)
             end
+
+            @booted_in_pid = Process.pid
+            @booted_remote_id = active.object_id
 
             # steep does not permit the next line due to
             # https://github.com/soutaro/steep/issues/1231
-            @last_boot = Boot.new(barrier, t)
-            @booted_in_pid = Process.pid
-            @last_boot
+            Boot.new(barrier, t)
           end
         end
 
@@ -44,7 +59,7 @@ module Datadog
         def self.reset_for_tests!
           @mutex.synchronize do
             @booted_in_pid = nil
-            @last_boot = nil
+            @booted_remote_id = nil
           end
         end
         private_class_method :reset_for_tests!

--- a/lib/datadog/core/remote/tie.rb
+++ b/lib/datadog/core/remote/tie.rb
@@ -10,19 +10,44 @@ module Datadog
           :time,
         )
 
+        @mutex = Mutex.new
+        @booted_in_pid = nil
+        @last_boot = nil
+
+        # Boot the Remote Configuration worker for this process.
+        #
+        # Idempotent: only the first call per process actually waits on
+        # `barrier(:once)`. Subsequent calls return the cached `Boot` struct.
+        # After a fork, `Process.pid` changes, which invalidates the cache and
+        # the next call boots again in the child.
         def self.boot
           return if Datadog::Core::Remote.active_remote.nil?
 
-          barrier = nil
+          @mutex.synchronize do
+            return @last_boot if @booted_in_pid == Process.pid
 
-          t = Datadog::Core::Utils::Time.measure do
-            barrier = Datadog::Core::Remote.active_remote.barrier(:once)
+            barrier = nil
+            t = Datadog::Core::Utils::Time.measure do
+              barrier = Datadog::Core::Remote.active_remote.barrier(:once)
+            end
+
+            # steep does not permit the next line due to
+            # https://github.com/soutaro/steep/issues/1231
+            @last_boot = Boot.new(barrier, t)
+            @booted_in_pid = Process.pid
+            @last_boot
           end
-
-          # steep does not permit the next line due to
-          # https://github.com/soutaro/steep/issues/1231
-          Boot.new(barrier, t)
         end
+
+        # Test helper. Resets the per-process boot cache.
+        # @!visibility private
+        def self.reset_for_tests!
+          @mutex.synchronize do
+            @booted_in_pid = nil
+            @last_boot = nil
+          end
+        end
+        private_class_method :reset_for_tests!
       end
     end
   end

--- a/lib/datadog/core/remote/tie.rb
+++ b/lib/datadog/core/remote/tie.rb
@@ -16,8 +16,7 @@ module Datadog
         PASS = Boot.new(:pass, 0.0)
 
         @mutex = Mutex.new
-        @booted_in_pid = nil
-        @booted_remote_id = nil
+        @boot_key = nil
 
         # Boot the Remote Configuration worker for this process.
         #
@@ -31,22 +30,23 @@ module Datadog
         #   - A new `Datadog.configure` call (new remote component) triggers a
         #     fresh boot for the replacement component.
         def self.boot
-          return if Datadog::Core::Remote.active_remote.nil?
-
           active = Datadog::Core::Remote.active_remote
+          return if active.nil?
+
+          # Fast path: single reference read is atomic; a stale nil just falls
+          # through to the mutex path which re-checks before acting.
+          key = [Process.pid, active.object_id].freeze
+          return PASS if @boot_key == key
 
           @mutex.synchronize do
-            if @booted_in_pid == Process.pid && @booted_remote_id == active.object_id
-              return PASS
-            end
+            return PASS if @boot_key == key
 
             barrier = nil
             t = Datadog::Core::Utils::Time.measure do
               barrier = active.barrier(:once)
             end
 
-            @booted_in_pid = Process.pid
-            @booted_remote_id = active.object_id
+            @boot_key = key
 
             # steep does not permit the next line due to
             # https://github.com/soutaro/steep/issues/1231
@@ -57,10 +57,7 @@ module Datadog
         # Test helper. Resets the per-process boot cache.
         # @!visibility private
         def self.reset_for_tests!
-          @mutex.synchronize do
-            @booted_in_pid = nil
-            @booted_remote_id = nil
-          end
+          @mutex.synchronize { @boot_key = nil }
         end
         private_class_method :reset_for_tests!
       end

--- a/lib/datadog/core/remote/tie/tracing.rb
+++ b/lib/datadog/core/remote/tie/tracing.rb
@@ -13,13 +13,13 @@ module Datadog
             return if boot.nil?
             return if span.nil?
 
-            return if Datadog::Core::Remote.active_remote.nil?
+            rc = Datadog::Core::Remote.active_remote
+            return if rc.nil?
 
-            # TODO: this is not thread-consistent
-            ready = Datadog::Core::Remote.active_remote.healthy
+            ready = rc.healthy
             status = ready ? 'ready' : 'disconnected'
 
-            span.set_tag('_dd.rc.client_id', Datadog::Core::Remote.active_remote.client.id)
+            span.set_tag('_dd.rc.client_id', rc.client.id)
             span.set_tag('_dd.rc.status', status)
 
             if boot.barrier != :pass

--- a/lib/datadog/core/remote/worker.rb
+++ b/lib/datadog/core/remote/worker.rb
@@ -66,6 +66,20 @@ module Datadog
           logger.debug { 'remote worker stopped' }
         end
 
+        # Resets state after a fork. The worker thread does not survive
+        # `fork` (Ruby kills all non-calling threads in the child), so we
+        # must drop the dead thread reference and clear `@started` /
+        # `@stopped` so `start` can create a fresh thread in the child.
+        # Does not touch `@block`, `@interval`, `@logger`.
+        def reset_after_fork!
+          @mutex.synchronize do
+            @thr = nil
+            @started = false
+            @starting = false
+            @stopped = false
+          end
+        end
+
         def started?
           @started
         end

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -142,16 +142,16 @@ module Datadog
         id: nil,
         &block
       )
+        return skip_trace(name, &block) unless enabled
+
         # Bootstrap Remote Configuration the first time any span is created
         # in this process. After the first call, this is a guarded no-op.
         # Wrapped in rescue to ensure tracing never fails due to RC startup.
         begin
           Datadog::Core::Remote::Tie.boot
         rescue => e
-          logger.debug { "Remote::Tie.boot failed: #{e.class}: #{e.message}" }
+          logger.warn { "Remote::Tie.boot failed: #{e.class}: #{e.message}" }
         end
-
-        return skip_trace(name, &block) unless enabled
 
         # Resolve the trace
         begin

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -2,6 +2,7 @@
 
 require_relative '../core/environment/ext'
 require_relative '../core/environment/socket'
+require_relative '../core/remote/tie'
 
 require_relative 'correlation'
 require_relative 'event'
@@ -141,6 +142,15 @@ module Datadog
         id: nil,
         &block
       )
+        # Bootstrap Remote Configuration the first time any span is created
+        # in this process. After the first call, this is a guarded no-op.
+        # Wrapped in rescue to ensure tracing never fails due to RC startup.
+        begin
+          Datadog::Core::Remote::Tie.boot
+        rescue => e
+          logger.debug { "Remote::Tie.boot failed: #{e.class}: #{e.message}" }
+        end
+
         return skip_trace(name, &block) unless enabled
 
         # Resolve the trace

--- a/sig/datadog/core/remote/tie.rbs
+++ b/sig/datadog/core/remote/tie.rbs
@@ -5,13 +5,12 @@ module Datadog
         PASS: Boot
 
         @mutex: ::Thread::Mutex
-        @booted_in_pid: ::Integer?
-        @booted_remote_id: ::Integer?
+        @boot_key: [ ::Integer, ::Integer ]?
 
-        class Boot < ::Struct[[Component::Barrier, Numeric]]
-          def initialize: (Component::Barrier? barrier, Numeric? time) -> void
+        class Boot < ::Struct[[Symbol, Numeric]]
+          def initialize: (Symbol? barrier, Numeric? time) -> void
 
-          attr_reader barrier: Component::Barrier
+          attr_reader barrier: Symbol
           attr_reader time: Numeric
         end
 

--- a/sig/datadog/core/remote/tie.rbs
+++ b/sig/datadog/core/remote/tie.rbs
@@ -2,6 +2,12 @@ module Datadog
   module Core
     module Remote
       module Tie
+        PASS: Boot
+
+        @mutex: ::Thread::Mutex
+        @booted_in_pid: ::Integer?
+        @booted_remote_id: ::Integer?
+
         class Boot < ::Struct[[Component::Barrier, Numeric]]
           def initialize: (Component::Barrier? barrier, Numeric? time) -> void
 
@@ -10,6 +16,8 @@ module Datadog
         end
 
         def self.boot: () -> Boot?
+
+        def self.reset_for_tests!: () -> void
       end
     end
   end

--- a/sig/datadog/core/remote/worker.rbs
+++ b/sig/datadog/core/remote/worker.rbs
@@ -19,6 +19,8 @@ module Datadog
 
         def stop: () -> void
 
+        def reset_after_fork!: () -> void
+
         def started?: () -> bool
 
         private

--- a/spec/datadog/core/remote/component_forking_spec.rb
+++ b/spec/datadog/core/remote/component_forking_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe Datadog::Core::Remote::Component do
         end
       end
 
+      it 'restarts the worker thread in the forked child' do
+        # In the parent, the worker thread exists and is alive.
+        expect(component.worker.started?).to be true
+        parent_thread = component.worker.instance_variable_get(:@thr)
+        expect(parent_thread).to be_alive
+
+        expect_in_fork do
+          child_component = components.remote
+
+          # The parent's thread is gone in the child.
+          # after_fork must have called reset_after_fork! + start.
+          expect(child_component.worker.started?).to be true
+
+          child_thread = child_component.worker.instance_variable_get(:@thr)
+          expect(child_thread).not_to be_nil
+          expect(child_thread).to be_alive
+        end
+      end
+
       it 'resets healthy flag after fork' do
         # Make the component healthy in the parent
         component.instance_variable_set(:@healthy, true)
@@ -243,13 +262,14 @@ RSpec.describe Datadog::Core::Remote::Component do
         expect(child_runtime_id).not_to eq(parent_runtime_id)
         expect(child_runtime_id).to be_valid_uuid
 
-        # Start the worker in the child process (after_fork recreates the client but doesn't restart the worker).
-        # The barrier call starts the worker via `start`, though `wait_once` immediately returns :pass
-        # because the barrier state was inherited from the parent with @once = true.
+        # after_fork recreates the client, restarts the worker, and resets the
+        # barrier so the child performs its own first sync independently of the
+        # parent.
         result = child_component.barrier(:once)
 
-        # In the child, barrier returns :pass because the barrier was already lifted in the parent before fork
-        expect(result).to eq(:pass)
+        # The child gets a fresh Barrier on fork, so it waits for its own
+        # first sync and returns :lift (or :timeout if the agent is slow).
+        expect(result).to eq(:lift).or eq(:timeout)
 
         # Check if child made requests (server runs in parent, receives requests from child)
         # Note: received_requests is modified by the parent process's HTTP server

--- a/spec/datadog/core/remote/rc_non_rack_spec.rb
+++ b/spec/datadog/core/remote/rc_non_rack_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog'
+
+RSpec.describe 'Remote Configuration bootstrap in non-Rack workloads', :integration do
+  before do
+    WebMock.enable!
+    stub_request(:get, %r{/info}).to_return(
+      body: {endpoints: ['/info', '/v0.7/config']}.to_json,
+      status: 200,
+    )
+    stub_request(:post, %r{/v0\.7/config}).to_return(body: '{}', status: 200)
+
+    Datadog::Core::Remote::Tie.send(:reset_for_tests!)
+  end
+
+  after do
+    Datadog.shutdown!
+    WebMock.disable!
+  end
+
+  it 'starts the RC worker the first time a span is created' do
+    Datadog.configure do |c|
+      c.remote.enabled = true
+      c.remote.poll_interval_seconds = 60 # don't hammer the stub
+      c.remote.boot_timeout_seconds = 2
+    end
+
+    remote = Datadog.send(:components).remote
+    expect(remote).not_to be_nil
+    expect(remote.started?).to be false
+
+    Datadog::Tracing.trace('sidekiq.process') { :noop }
+
+    expect(remote.started?).to be true
+  end
+
+  it 'does not start the RC worker if no span is ever created' do
+    Datadog.configure do |c|
+      c.remote.enabled = true
+      c.remote.poll_interval_seconds = 60
+      c.remote.boot_timeout_seconds = 2
+    end
+
+    remote = Datadog.send(:components).remote
+    expect(remote.started?).to be false
+
+    # Don't create any spans. Worker should still be quiescent.
+    sleep 0.1
+    expect(remote.started?).to be false
+  end
+end

--- a/spec/datadog/core/remote/rc_non_rack_spec.rb
+++ b/spec/datadog/core/remote/rc_non_rack_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe 'Remote Configuration bootstrap in non-Rack workloads', :integrat
     expect(remote.started?).to be false
 
     # Don't create any spans. Worker should still be quiescent.
-    sleep 0.1
     expect(remote.started?).to be false
   end
 end

--- a/spec/datadog/core/remote/tie_spec.rb
+++ b/spec/datadog/core/remote/tie_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/core/remote/tie'
+
+RSpec.describe Datadog::Core::Remote::Tie do
+  before { described_class.send(:reset_for_tests!) }
+
+  describe '.boot' do
+    context 'when remote configuration is not active' do
+      before { allow(Datadog::Core::Remote).to receive(:active_remote).and_return(nil) }
+
+      it 'returns nil' do
+        expect(described_class.boot).to be_nil
+      end
+    end
+
+    context 'when remote configuration is active' do
+      let(:remote) { instance_double(Datadog::Core::Remote::Component) }
+
+      before do
+        allow(Datadog::Core::Remote).to receive(:active_remote).and_return(remote)
+        allow(remote).to receive(:barrier).with(:once).and_return(:lift)
+      end
+
+      it 'calls barrier(:once) on the active remote' do
+        described_class.boot
+        expect(remote).to have_received(:barrier).with(:once).once
+      end
+
+      it 'returns a Boot struct with the barrier result and elapsed time' do
+        result = described_class.boot
+        expect(result).to be_a(Datadog::Core::Remote::Tie::Boot)
+        expect(result.barrier).to eq(:lift)
+        expect(result.time).to be_a(Numeric)
+      end
+
+      it 'is idempotent across many calls in the same process' do
+        10.times { described_class.boot }
+        expect(remote).to have_received(:barrier).with(:once).once
+      end
+
+      it 'reboots after the process pid changes (simulating fork)' do
+        described_class.boot
+
+        # Simulate having forked: bump Process.pid for the duration of the call
+        new_pid = Process.pid + 1
+        allow(Process).to receive(:pid).and_return(new_pid)
+
+        described_class.boot
+        expect(remote).to have_received(:barrier).with(:once).twice
+      end
+    end
+  end
+end

--- a/spec/datadog/core/remote/tie_spec.rb
+++ b/spec/datadog/core/remote/tie_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Datadog::Core::Remote::Tie do
         expect(result.time).to be_a(Numeric)
       end
 
+      it 'returns PASS on subsequent calls in the same process with the same remote' do
+        described_class.boot
+        result = described_class.boot
+        expect(result).to eq(Datadog::Core::Remote::Tie::PASS)
+        expect(result.barrier).to eq(:pass)
+      end
+
       it 'is idempotent across many calls in the same process' do
         10.times { described_class.boot }
         expect(remote).to have_received(:barrier).with(:once).once
@@ -49,6 +56,19 @@ RSpec.describe Datadog::Core::Remote::Tie do
 
         described_class.boot
         expect(remote).to have_received(:barrier).with(:once).twice
+      end
+
+      it 'reboots after the remote component changes (simulating Datadog.configure)' do
+        described_class.boot
+
+        # A new Datadog.configure creates a new remote component with a different object_id.
+        new_remote = instance_double(Datadog::Core::Remote::Component)
+        allow(new_remote).to receive(:barrier).with(:once).and_return(:lift)
+        allow(Datadog::Core::Remote).to receive(:active_remote).and_return(new_remote)
+
+        described_class.boot
+        expect(remote).to have_received(:barrier).with(:once).once
+        expect(new_remote).to have_received(:barrier).with(:once).once
       end
     end
   end

--- a/spec/datadog/core/remote/worker_spec.rb
+++ b/spec/datadog/core/remote/worker_spec.rb
@@ -87,4 +87,35 @@ RSpec.describe Datadog::Core::Remote::Worker do
       worker.stop
     end
   end
+
+  describe '#reset_after_fork!' do
+    subject(:worker) do
+      described_class.new(interval: 0.1, logger: Logger.new(IO::NULL)) { :noop }
+    end
+
+    after { worker.stop }
+
+    it 'wipes started/thread state without invoking the (already dead) thread' do
+      worker.start
+      expect(worker.started?).to be true
+
+      # Simulate post-fork state: thread reference exists but is dead.
+      # We don't actually fork here; we just verify the state machine.
+      worker.instance_variable_get(:@thr).kill
+      worker.reset_after_fork!
+
+      expect(worker.started?).to be false
+      expect(worker.instance_variable_get(:@thr)).to be_nil
+      expect(worker.instance_variable_get(:@stopped)).to be false
+    end
+
+    it 'allows the worker to be started again after reset' do
+      worker.start
+      worker.instance_variable_get(:@thr).kill
+      worker.reset_after_fork!
+
+      worker.start
+      expect(worker.started?).to be true
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
+++ b/spec/datadog/tracing/contrib/propagation/sql_comment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
   let(:tracer) { instance_double(Datadog::Tracing::Tracer) }
 
   before do
-    allow(Datadog).to receive(:send).with(:components).and_return(double(agent_info: agent_info, tracer: tracer))
+    allow(Datadog).to receive(:send).with(:components).and_return(double(agent_info: agent_info, tracer: tracer, remote: nil))
   end
 
   describe '.annotate!' do
@@ -323,7 +323,7 @@ RSpec.describe Datadog::Tracing::Contrib::Propagation::SqlComment do
         end
 
         allow(Datadog).to receive(:send).with(:components).and_return(
-          double(agent_info: agent_info, tracer: tracer)
+          double(agent_info: agent_info, tracer: tracer, remote: nil)
         )
       end
 

--- a/spec/datadog/tracing/contrib/sql_comment_propagation_examples.rb
+++ b/spec/datadog/tracing/contrib/sql_comment_propagation_examples.rb
@@ -127,7 +127,7 @@ RSpec.shared_examples_for 'with sql comment base hash injection' do |span_op_nam
   let(:profiler) { nil }
 
   before do
-    allow(Datadog).to receive(:send).with(:components).and_return(double(agent_info: agent_info, tracer: tracer, profiler: profiler))
+    allow(Datadog).to receive(:send).with(:components).and_return(double(agent_info: agent_info, tracer: tracer, profiler: profiler, remote: nil))
   end
 
   context 'when inject_sql_basehash is enabled and experimental_propagate_process_tags_enabled is true' do

--- a/spec/datadog/tracing/tracer_spec.rb
+++ b/spec/datadog/tracing/tracer_spec.rb
@@ -88,6 +88,28 @@ RSpec.describe Datadog::Tracing::Tracer do
     let(:name) { 'span.name' }
     let(:options) { {} }
 
+    context 'remote configuration bootstrap' do
+      before { Datadog::Core::Remote::Tie.send(:reset_for_tests!) }
+
+      it 'boots Remote Configuration on first trace call' do
+        expect(Datadog::Core::Remote::Tie).to receive(:boot).and_call_original
+
+        tracer.trace('op.test') { :noop }
+      end
+
+      it 'is idempotent across many trace calls' do
+        expect(Datadog::Core::Remote::Tie).to receive(:boot).at_least(:once).and_call_original
+
+        10.times { tracer.trace('op.test') { :noop } }
+      end
+
+      it 'does not raise if Tie.boot errors' do
+        allow(Datadog::Core::Remote::Tie).to receive(:boot).and_raise(StandardError, 'boom')
+
+        expect { tracer.trace('op.test') { :noop } }.not_to raise_error
+      end
+    end
+
     shared_examples 'shared #trace behavior' do
       context 'with options to be forwarded to the span' do
         context 'service:' do


### PR DESCRIPTION
**What does this PR do?**
Calls `Datadog::Core::Remote::Tie.boot` from `Tracer#trace` so the RC worker starts on the first span in any Ruby workload — Sidekiq, gRPC, Karafka, plain scripts — without requiring the Rack middleware.

**Motivation:**
RC was previously only bootstrapped from the Rack request middleware, so non-Rack workloads never received remote configuration (APM sampling rules, ASM WAF updates, DI probes). This PR makes RC bootstrap unconditional for all tracing-enabled workloads.

**Change log entry**
None.

**Additional Notes:**
Key design decisions:
- `Tie.boot` is idempotent, keyed on `(Process.pid, remote_component.object_id)` — only the first call per (process, RC component) pair blocks on `barrier(:once)`. All subsequent calls return `PASS` via a lock-free fast path (single atomic `@boot_key` reference, TTAS pattern).
- Fork safety: `Component#after_fork` now calls `Worker#reset_after_fork!` to clear the dead thread state, then restarts the worker only if it was running in the parent.
- `Tie.boot` is placed after the tracer `enabled` guard so disabled tracers stay inert.
- `Tie::Tracing.tag` fixed to capture `active_remote` once per call (eliminates TOCTOU and redundant lock acquisitions).
- Tests that stub `Datadog.send(:components)` with a strict double now include `remote: nil` so `Tie.boot` returns early (active.nil? guard).

**How to test the change?**
New specs cover all added behavior:
- `spec/datadog/core/remote/tie_spec.rb` — unit tests: nil remote, first boot, PASS on repeat, idempotency, pid-change reboot, component-change reboot
- `spec/datadog/core/remote/worker_spec.rb` — `#reset_after_fork!` state transitions
- `spec/datadog/core/remote/component_forking_spec.rb` — worker restarts in forked child
- `spec/datadog/core/remote/rc_non_rack_spec.rb` — integration: RC starts on first span; stays quiescent when no span is created

```
bundle exec rspec spec/datadog/core/remote/tie_spec.rb \
  spec/datadog/core/remote/rc_non_rack_spec.rb \
  spec/datadog/core/remote/worker_spec.rb \
  spec/datadog/core/remote/component_forking_spec.rb
```