### PR TITLE
[APPSEC-61865] Fix AppSec component initialization when crashing

### DIFF
--- a/lib/datadog/appsec/component.rb
+++ b/lib/datadog/appsec/component.rb
@@ -46,7 +46,10 @@ module Datadog
 
           security_engine = SecurityEngine::Engine.new(appsec_settings: settings.appsec, telemetry: telemetry)
           new(security_engine: security_engine)
-        rescue => e
+        # NOTE: At this point we should capture all possible exceptions and
+        #       gracefully fail component initialization, preventing propagation
+        #       into the host application code.
+        rescue Exception => e # standard:disable Lint/RescueException
           Datadog.logger.warn("AppSec is disabled: #{e.class}: #{e.message}; there may be additional logged errors above")
 
           # Not reporting to telemetry here because some of the rescued exceptions

--- a/spec/datadog/appsec/component_spec.rb
+++ b/spec/datadog/appsec/component_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe Datadog::AppSec::Component do
 
         expect(described_class.build_appsec_component(settings, telemetry: telemetry)).to be_nil
       end
+
+      context 'when require of libddwaf raises non standard exception' do
+        before do
+          allow(described_class).to receive(:require_libddwaf).and_raise(LoadError, 'libddwaf not found')
+        end
+
+        it 'returns nil and logs a warning' do
+          expect(Datadog.logger).to receive(:warn).with(/LoadError.*libddwaf not found/)
+
+          expect(described_class.build_appsec_component(settings, telemetry: telemetry)).to be_nil
+        end
+      end
     end
 
     context 'when appsec is not enabled' do


### PR DESCRIPTION
**What does this PR do?**

Handles `Exception`-top level errors in AppSec component.

**Motivation:**

With Serverless team we discover that when AppSec failed to initialize it will crash host application as unhandled error bubbles up.

**Change log entry**

Yes. AppSec: Prevent crashing host application on initialization failure.

**Additional Notes:**

None.

**How to test the change?**

CI