### PR TITLE
Promote macOS sampler thread to THREAD_TIME_CONSTRAINT_POLICY

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -17,6 +17,10 @@
 #include "setup_signal_handler.h"
 #include "time_helpers.h"
 
+#ifdef __APPLE__
+  #include "macos_sampler_thread.h"
+#endif
+
 // Used to trigger the execution of Collectors::ThreadContext, which implements all of the sampling logic
 // itself; this class only implements the "when to do it" part.
 //
@@ -535,6 +539,14 @@ static VALUE _native_sampling_loop(DDTRACE_UNUSED VALUE _self, VALUE instance) {
 
   block_sigprof_signal_handler_from_running_in_current_thread(); // We want to interrupt the thread with the global VM lock, never this one
 
+  #ifdef __APPLE__
+    // Promote the native thread that will run the sampling loop to a realtime scheduling policy so
+    // its periodic wake-ups are not subject to the default ~1-2ms timeshare wake latency. The matching
+    // demote happens below in this same function, alongside the SIGPROF unblock dance, so both per-thread
+    // policy changes are reverted before Ruby reuses this native thread for an unrelated Ruby thread.
+    promote_sampler_thread_to_realtime(MILLIS_AS_NS(state->cpu_sampling_interval_ms));
+  #endif
+
   // Release GVL, get to the actual work!
   int exception_state;
   rb_protect(release_gvl_and_run_sampling_trigger_loop, instance, &exception_state);
@@ -555,6 +567,14 @@ static VALUE _native_sampling_loop(DDTRACE_UNUSED VALUE _self, VALUE instance) {
   // send SIGPROF signals to it, and oops it could fail if it got the reused native thread from the worker which still
   // had SIGPROF delivery blocked. :hide_the_pain_harold:
   unblock_sigprof_signal_handler_from_running_in_current_thread();
+
+  #ifdef __APPLE__
+    // Pairs with promote_sampler_thread_to_realtime above. Same reasoning as the SIGPROF unblock:
+    // Ruby may reuse this native thread for an unrelated Ruby thread that would otherwise inherit
+    // our scheduler policy. Doing it here also covers the exception path, since grab_gvl_and_sample
+    // can raise and unwind out of the sampling loop.
+    demote_sampler_thread_from_realtime();
+  #endif
 
   // Why replace and not use remove the signal handler? We do this because when a process receives a SIGPROF without
   // having an explicit signal handler set up, the process will instantly terminate with a confusing

--- a/ext/datadog_profiling_native_extension/macos_sampler_thread.h
+++ b/ext/datadog_profiling_native_extension/macos_sampler_thread.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#include <mach/thread_policy.h>
+#include <pthread.h>
+#include <stdio.h>
+
+#include "time_helpers.h"
+
+// On macOS the default scheduler wake latency for a timeshare thread is ~1-2ms,
+// so nanosleep regularly overshoots a 10ms request by ~2ms. Marking the worker
+// thread with THREAD_TIME_CONSTRAINT_POLICY tells the scheduler this thread has
+// a periodic deadline; the kernel then wakes it close to the requested time.
+//
+// This only affects the sampler worker thread. We pair it with a demote call
+// before the thread can be reused by Ruby for unrelated Ruby threads (see the
+// SIGPROF unblock dance in _native_sampling_loop).
+static inline void promote_sampler_thread_to_realtime(uint64_t period_ns) {
+  mach_timebase_info_data_t timebase = (mach_timebase_info_data_t) {};
+  mach_timebase_info(&timebase);
+
+  // ns -> mach ticks: each mach tick is (numer/denom) ns, so divide by that.
+  #define NS_TO_MACH_TICKS(ns) ((uint32_t) (((uint64_t)(ns) * (uint64_t) timebase.denom) / (uint64_t) timebase.numer))
+
+  struct thread_time_constraint_policy policy = {
+    .period      = NS_TO_MACH_TICKS(period_ns),
+    .computation = NS_TO_MACH_TICKS(MICROS_AS_NS(200)),  // 200us upper bound on the work we do per period
+    .constraint  = NS_TO_MACH_TICKS(MILLIS_AS_NS(1)),    // wake us within 1ms of the deadline
+    .preemptible = TRUE,
+  };
+
+  #undef NS_TO_MACH_TICKS
+
+  kern_return_t kr = thread_policy_set(
+    pthread_mach_thread_np(pthread_self()),
+    THREAD_TIME_CONSTRAINT_POLICY,
+    (thread_policy_t) &policy,
+    THREAD_TIME_CONSTRAINT_POLICY_COUNT
+  );
+  if (kr != KERN_SUCCESS) {
+    // Non-fatal: we'll fall back to the default scheduler behavior (overshoot ~2ms).
+    fprintf(stderr, "[ddtrace] Failed to set real-time policy on profiler sampler thread (kr=%d); sample cadence may be imprecise\n", kr);
+  }
+}
+
+static inline void demote_sampler_thread_from_realtime(void) {
+  struct thread_standard_policy policy = {.no_data = 0};
+  thread_policy_set(
+    pthread_mach_thread_np(pthread_self()),
+    THREAD_STANDARD_POLICY,
+    (thread_policy_t) &policy,
+    THREAD_STANDARD_POLICY_COUNT
+  );
+}


### PR DESCRIPTION
The default timeshare scheduler on macOS wakes a sleeping thread ~1-2ms after its requested deadline, so a 10ms nanosleep in run_sampling_trigger_loop regularly came back at ~12ms and skewed sample cadence.

Marking the worker thread with THREAD_TIME_CONSTRAINT_POLICY tells the kernel this thread has a periodic deadline, which keeps the actual sleep within ~1ms of the requested duration without busy-waiting. Paired with a demote-on-exit call because Ruby caches and may reuse the native thread for unrelated Ruby threads (same reason we unblock SIGPROF on exit).

Using `bundle exec ruby benchmarks/profiling_sample_overhead.rb` with the benchmark from the first commit of https://github.com/DataDog/dd-trace-rb/pull/5751:
```
Before:
sampling_rate: 96.65737238131413, sample_every_n_ms: 12.243711491442543
After:
sampling_rate: 81.67458051416244, sample_every_n_ms: 10.345822314049588
```

So it was constantly off by 2ms before, and now is much closer to the sleep we request.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

It fixes `sleep(10ms)` to actually be 10ms and not 12ms on macOS.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

I wanted to figure out why it was 12ms and if that was overhead but no, it's just macOS being lazy about timer resolution by default.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
