### PR TITLE
SymDB: review follow-ups for #5717

### DIFF
--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -107,7 +107,7 @@ module Datadog
         end
       end
 
-      attr_reader :settings, :last_upload_time, :last_upload_scope_count, :upload_in_progress
+      attr_reader :settings, :logger, :last_upload_time, :last_upload_scope_count, :upload_in_progress
 
       # Initialize component.
       # @param settings [Configuration::Settings] Tracer settings
@@ -224,7 +224,10 @@ module Datadog
       def wait_for_idle(timeout: 30)
         deadline = Datadog::Core::Utils::Time.get_time + timeout
         Component.upload_done_mutex.synchronize do
-          until Component.send(:instance_variable_get, :@uploaded_this_process)
+          # Read @uploaded_this_process directly: we already hold
+          # Component.upload_done_mutex here, and uploaded_this_process?
+          # would try to re-acquire it (non-reentrant), deadlocking.
+          until Component.instance_variable_get(:@uploaded_this_process)
             remaining = deadline - Datadog::Core::Utils::Time.get_time
             return false if remaining <= 0
             Component.upload_done_cv.wait(Component.upload_done_mutex, remaining)

--- a/lib/datadog/symbol_database/remote.rb
+++ b/lib/datadog/symbol_database/remote.rb
@@ -102,11 +102,13 @@ module Datadog
             disable_upload(component)
             change.previous&.applied
           else
-            Datadog.logger.debug { "symdb: unrecognized change type: #{change.type}" }
+            component.logger.debug { "symdb: unrecognized change type: #{change.type}" }
+            # Steep cannot narrow `change.content` from a respond_to? check — it sees
+            # the Repository::Change union type where `Deleted` lacks `content`.
             change.content.errored("Unrecognized change type: #{change.type}") if change.respond_to?(:content) # steep:ignore NoMethod
           end
         rescue => e
-          Datadog.logger.debug { "symdb: error processing remote config change: #{e.class}: #{e.message}" }
+          component.logger.debug { "symdb: error processing remote config change: #{e.class}: #{e.message}" }
           telemetry&.report(e, description: 'symdb: error processing remote config change')
           # Rescue runs regardless of which branch raised — Steep cannot narrow the
           # union type from a respond_to? check.
@@ -120,17 +122,17 @@ module Datadog
         # @return [void]
         # @api private
         def enable_upload(component, content)
-          config = parse_config(content)
+          config = parse_config(content, component.logger)
 
           unless config
             return
           end
 
           if config['upload_symbols']
-            Datadog.logger.debug { "symdb: upload enabled via remote config" }
+            component.logger.debug { "symdb: upload enabled via remote config" }
             component.start_upload
           else
-            Datadog.logger.debug { "symdb: upload disabled in config" }
+            component.logger.debug { "symdb: upload disabled in config" }
           end
         end
 
@@ -139,28 +141,29 @@ module Datadog
         # @return [void]
         # @api private
         def disable_upload(component)
-          Datadog.logger.debug { "symdb: upload disabled via remote config" }
+          component.logger.debug { "symdb: upload disabled via remote config" }
           component.stop_upload
         end
 
         # Parse and validate remote config content.
         # @param content [Content] Remote config content
+        # @param logger [SymbolDatabase::Logger] Logger for invalid-config diagnostics
         # @return [Hash, nil] Parsed config or nil if invalid
         # @api private
         #
         # JSON::ParserError is intentionally NOT rescued here — it propagates to
         # process_change's rescue, which logs and reports to telemetry. Catching
         # it locally would swallow the error from telemetry observability.
-        def parse_config(content)
+        def parse_config(content, logger)
           config = JSON.parse(content.data)
 
           unless config.is_a?(Hash)
-            Datadog.logger.debug { "symdb: invalid config format: expected Hash, got #{config.class}" }
+            logger.debug { "symdb: invalid config format: expected Hash, got #{config.class}" }
             return nil
           end
 
           unless config.key?('upload_symbols')
-            Datadog.logger.debug { "symdb: missing 'upload_symbols' key in config" }
+            logger.debug { "symdb: missing 'upload_symbols' key in config" }
             return nil
           end
 

--- a/lib/datadog/symbol_database/scope.rb
+++ b/lib/datadog/symbol_database/scope.rb
@@ -22,8 +22,10 @@ module Datadog
         # - nil: not computed (source unreadable, native/C-extension method)
         # - []: computed but no executable lines found (comments/whitespace only)
         # - non-empty: computed, contains executable line ranges
-        # nil and [] both serialize as targetable_lines?: false on METHOD
-        # scopes. Key is absent on non-METHOD scopes.
+        # nil and [] both serialize as has_injectible_lines: false on METHOD
+        # scopes. Key is absent on non-METHOD scopes. The wire format key
+        # name keeps the historical spelling +injectible+ for backend
+        # compatibility; the Ruby identifier is +targetable_lines+.
         :targetable_lines,
         :language_specifics, :symbols, :scopes
 

--- a/sig/datadog/symbol_database/component.rbs
+++ b/sig/datadog/symbol_database/component.rbs
@@ -37,6 +37,7 @@ module Datadog
       def initialize: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettings agent_settings, SymbolDatabase::Logger logger, ?telemetry: Datadog::Core::Telemetry::Component?) -> void
 
       attr_reader settings: Datadog::Core::Configuration::Settings
+      attr_reader logger: SymbolDatabase::Logger
       attr_reader last_upload_time: ::Time?
       attr_reader last_upload_scope_count: ::Integer?
       attr_reader upload_in_progress: bool

--- a/sig/datadog/symbol_database/remote.rbs
+++ b/sig/datadog/symbol_database/remote.rbs
@@ -19,7 +19,7 @@ module Datadog
 
       def self.disable_upload: (Component component) -> void
 
-      def self.parse_config: (Datadog::Core::Remote::Configuration::Content content) -> ::Hash[::String, untyped]?
+      def self.parse_config: (Datadog::Core::Remote::Configuration::Content content, SymbolDatabase::Logger logger) -> ::Hash[::String, untyped]?
     end
   end
 end

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -173,6 +173,33 @@ RSpec.describe Datadog::Core::Configuration::Components do
         end
       end
     end
+
+    describe '@symbol_database' do
+      context 'when symbol_database is disabled' do
+        before { settings.symbol_database.enabled = false }
+
+        it 'does not build a symbol_database component' do
+          expect(components.symbol_database).to be nil
+        end
+      end
+
+      context 'when symbol_database is enabled with remote config' do
+        before(:all) do
+          skip 'Symbol database requires MRI Ruby 2.6+' if PlatformHelpers.jruby? || RUBY_VERSION < '2.6'
+        end
+
+        before do
+          settings.symbol_database.enabled = true
+          settings.remote.enabled = true
+        end
+
+        after { components.symbol_database&.shutdown! }
+
+        it 'builds a SymbolDatabase::Component' do
+          expect(components.symbol_database).to be_a(Datadog::SymbolDatabase::Component)
+        end
+      end
+    end
   end
 
   describe '::build_health_metrics' do
@@ -631,6 +658,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
         expect(components.remote).to receive(:shutdown!) unless components.remote.nil?
         expect(components.profiler).to receive(:shutdown!) unless components.profiler.nil?
         expect(components.dynamic_instrumentation).to receive(:shutdown!) unless components.dynamic_instrumentation.nil?
+        expect(components.symbol_database).to receive(:shutdown!) unless components.symbol_database.nil?
         expect(components.appsec).to receive(:shutdown!) unless components.appsec.nil?
         expect(components.runtime_metrics).to receive(:stop)
           .with(true, close_metrics: false)

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
       context 'when symbol_database is disabled' do
         before { settings.symbol_database.enabled = false }
 
-        it 'does not build a symbol_database component' do
+        it 'does not build a symbol database component' do
           expect(components.symbol_database).to be nil
         end
       end
@@ -195,7 +195,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
         after { components.symbol_database&.shutdown! }
 
-        it 'builds a SymbolDatabase::Component' do
+        it 'builds a symbol database component' do
           expect(components.symbol_database).to be_a(Datadog::SymbolDatabase::Component)
         end
       end

--- a/spec/datadog/core/remote/client/capabilities_spec.rb
+++ b/spec/datadog/core/remote/client/capabilities_spec.rb
@@ -147,6 +147,52 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
     end
   end
 
+  context 'Symbol Database component' do
+    context 'when DI is disabled' do
+      let(:settings) do
+        settings = Datadog::Core::Configuration::Settings.new
+        settings.dynamic_instrumentation.enabled = false
+        settings.symbol_database.enabled = true
+        settings
+      end
+
+      it 'does not register symbol database product' do
+        expect(capabilities.products).to_not include('LIVE_DEBUGGING_SYMBOL_DB')
+      end
+    end
+
+    context 'when DI is enabled and symbol_database is disabled' do
+      let(:settings) do
+        settings = Datadog::Core::Configuration::Settings.new
+        settings.dynamic_instrumentation.enabled = true
+        settings.symbol_database.enabled = false
+        settings
+      end
+
+      it 'does not register symbol database product' do
+        expect(capabilities.products).to_not include('LIVE_DEBUGGING_SYMBOL_DB')
+      end
+    end
+
+    context 'when DI is enabled and symbol_database is enabled' do
+      let(:settings) do
+        settings = Datadog::Core::Configuration::Settings.new
+        settings.dynamic_instrumentation.enabled = true
+        settings.symbol_database.enabled = true
+        settings
+      end
+
+      it 'registers symbol database product and a receiver matching its path' do
+        expect(capabilities.products).to include('LIVE_DEBUGGING_SYMBOL_DB')
+        expect(capabilities.receivers).to include(
+          lambda { |r|
+            r.match? Datadog::Core::Remote::Configuration::Path.parse('datadog/2/LIVE_DEBUGGING_SYMBOL_DB/_/_')
+          }
+        )
+      end
+    end
+  end
+
   context 'Tracing component' do
     it 'register capabilities, products, and receivers' do
       expect(capabilities.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29)

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -1667,6 +1667,17 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       extractor.extract_all
     end
 
+    context 'top-level rescue' do
+      it 'returns [] and logs when collection raises' do
+        allow(extractor).to receive(:collect_extractable_modules).and_raise(StandardError, 'boom')
+        expect(logger).to receive(:debug) { |&block| expect(block.call).to match(/extract_all.*StandardError.*boom/i) }
+
+        result = extractor.extract_all
+
+        expect(result).to eq([])
+      end
+    end
+
     context 'simple class in one file' do
       before do
         @file = create_test_file('user.rb', <<~RUBY)

--- a/spec/datadog/symbol_database/remote_spec.rb
+++ b/spec/datadog/symbol_database/remote_spec.rb
@@ -13,7 +13,8 @@ require 'datadog/symbol_database/remote'
 require 'datadog/symbol_database/component'
 
 RSpec.describe Datadog::SymbolDatabase::Remote do
-  let(:component) { instance_double(Datadog::SymbolDatabase::Component) }
+  let(:logger) { instance_double(Datadog::SymbolDatabase::Logger, debug: nil) }
+  let(:component) { instance_double(Datadog::SymbolDatabase::Component, logger: logger) }
 
   # Helper to create a mock change object
   def mock_change(type:, data:)
@@ -166,26 +167,26 @@ RSpec.describe Datadog::SymbolDatabase::Remote do
   describe '.parse_config' do
     it 'parses valid upload_symbols config' do
       content = instance_double('Content', data: '{"upload_symbols": true}')
-      result = described_class.send(:parse_config, content)
+      result = described_class.send(:parse_config, content, logger)
       expect(result).to eq({'upload_symbols' => true})
     end
 
     it 'returns nil for missing upload_symbols key' do
       content = instance_double('Content', data: '{"other": true}')
-      result = described_class.send(:parse_config, content)
+      result = described_class.send(:parse_config, content, logger)
       expect(result).to be_nil
     end
 
     it 'raises JSON::ParserError for invalid JSON (caller process_change rescues + reports)' do
       content = instance_double('Content', data: 'bad json')
       expect {
-        described_class.send(:parse_config, content)
+        described_class.send(:parse_config, content, logger)
       }.to raise_error(JSON::ParserError)
     end
 
     it 'returns nil for non-Hash JSON' do
       content = instance_double('Content', data: '[1, 2, 3]')
-      result = described_class.send(:parse_config, content)
+      result = described_class.send(:parse_config, content, logger)
       expect(result).to be_nil
     end
   end

--- a/spec/datadog/symbol_database/scope_spec.rb
+++ b/spec/datadog/symbol_database/scope_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Datadog::SymbolDatabase::Scope do
       expect(hash[:injectible_lines]).to eq([{start: 10, end: 12}, {start: 15, end: 15}])
     end
 
-    it 'includes targetable_lines?: false on METHOD scope without ranges' do
+    it 'emits has_injectible_lines: false on METHOD scope without ranges' do
       scope = described_class.new(
         scope_type: 'METHOD',
         name: 'native_method',


### PR DESCRIPTION
**What does this PR do?**

Addresses the review findings raised against #5717 (already merged). Each commit is one focused finding.

| # | Commit | Issue |
|---|---|---|
| 1 | [SymDB scope: restore wire-format-vs-Ruby-identifier comment](https://github.com/DataDog/dd-trace-rb/commit/0da6cc281a) | `Scope` `:targetable_lines` comment at `scope.rb:25` was rewritten in #5717 and lost the Ruby-identifier vs wire-format-key distinction. The same file at lines 83-88 still serializes with the historical `has_injectible_lines`/`injectible_lines` keys, so the comment contradicted the implementation. Restored the original comment and renamed one `scope_spec.rb` test description that propagated the same wrong wording. |
| 2 | [SymDB extractor spec: restore top-level rescue test](https://github.com/DataDog/dd-trace-rb/commit/78301e1eff) | #5717 deleted the spec that exercised the top-level rescue in `Extractor#extract_all`. The production rescue is still in place — the deletion was an unintentional squash artifact, leaving the path uncovered. |
| 3 + 6 + 7 | [SymDB remote: route diagnostics through component.logger](https://github.com/DataDog/dd-trace-rb/commit/794fa9855c) | Three Component-Pattern / clarity fixes in `SymbolDatabase::Remote` and `Component`: (a) added `Component#logger` reader and replaced `Datadog.logger` with `component.logger` in `Remote.process_change` / `enable_upload` / `disable_upload` / `parse_config` (the receiver-block fallback at `remote.rb:48` keeps `Datadog.logger` because the component lookup itself may return nil there); (b) added a justification comment to the `# steep:ignore NoMethod` at `remote.rb:106` matching the pattern at line 113; (c) replaced the over-defensive `Component.send(:instance_variable_get, ...)` in `wait_for_idle` with `Component.instance_variable_get(...)` and added a comment explaining why the public predicate isn't used (deadlock — already holding `Component.upload_done_mutex`). |
| 4 | [SymDB capabilities spec: cover the new symbol_database branch](https://github.com/DataDog/dd-trace-rb/commit/5f2dad9f50) | #5717 added a new conditional in `Core::Remote::Client::Capabilities` that registers SymDB capabilities only when both DI and `symbol_database` are enabled. Neither branch was tested. Added three contexts covering both sides of the conditional plus its outer guard. |
| 5 | [SymDB components spec: cover symbol_database wiring and shutdown](https://github.com/DataDog/dd-trace-rb/commit/b259d2192b) | #5717 wired `SymbolDatabase::Component` into `Core::Configuration::Components#initialize` and `#shutdown!` but did not extend `components_spec.rb`. Added an `@symbol_database` describe block (disabled / enabled-with-RC contexts) and extended `#shutdown!` to assert SymDB receives `shutdown!` when present. |

(Issue 8 from the review was the merged PR's description; updated separately via `gh pr edit` on #5717.)

**Motivation:**

Cleanup of follow-up review findings on the merged #5717 wiring PR. None of these are functional bugs in shipped code — they're documentation drift, coverage gaps, and Component-Pattern hygiene. Folded together because they all touch the same surface area and individually wouldn't justify a PR.

**Change log entry**

None.

**Additional Notes:**

Yes — AI was used; I read and understood the changes.

**How to test the change?**

```
bundle exec rspec spec/datadog/symbol_database/ \
                  spec/datadog/core/configuration/components_spec.rb \
                  spec/datadog/core/remote/client/capabilities_spec.rb
bundle exec steep check sig/datadog/symbol_database lib/datadog/symbol_database
```

All passing locally: 220+ symbol_database examples + 40 components + 17 capabilities, Steep clean. CI must validate across the supported Ruby matrix.
