### PR TITLE
Fill out concrete types in DI rbs signatures

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -106,7 +106,7 @@ module Datadog
         serializer = self.serializer
         method_name = probe.method_name
         loc = begin
-          cls.instance_method(method_name).source_location
+          cls.instance_method(method_name).source_location # steep:ignore ArgumentTypeMismatch
         rescue NameError
           # The target method is not defined.
           # This could be because it will be explicitly defined later
@@ -668,7 +668,7 @@ module Datadog
 
       # TODO test that this resolves qualified names e.g. A::B
       def symbolize_class_name(cls_name)
-        Object.const_get(cls_name)
+        Object.const_get(cls_name) # steep:ignore ArgumentTypeMismatch
       rescue NameError => exc
         raise Error::DITargetNotDefined, "Class not defined: #{cls_name}: #{exc.class}: #{exc.message}"
       end

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -369,7 +369,7 @@ module Datadog
         rescue => exc
           evaluation_errors << {
             message: "#{exc.class}: #{exc.message}",
-            expr: segment.dsl_expr,
+            expr: segment.dsl_expr, # steep:ignore NoMethod
           }
           '[evaluation error]'
         end.join

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -42,14 +42,14 @@ module Datadog
               changes.each do |change|
                 case change.type
                 when :insert
-                  add_probe(change.content, component)
+                  add_probe(change.content, component) # steep:ignore NoMethod
                 when :update
                   # We do not implement updates at the moment, remove the
                   # probe and reinstall.
-                  remove_probe(change.content, component)
-                  add_probe(change.content, component)
+                  remove_probe(change.content, component) # steep:ignore NoMethod
+                  add_probe(change.content, component) # steep:ignore NoMethod
                 when :delete
-                  remove_probe(change.previous, component)
+                  remove_probe(change.previous, component) # steep:ignore NoMethod
                 else
                   # This really should never happen since we generate the
                   # change types in the library.

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -369,7 +369,7 @@ module Datadog
         when String
           serialize_string_or_symbol_for_message(value)
         when Symbol
-          ':' + serialize_string_or_symbol_for_message(value)
+          ':' + serialize_string_or_symbol_for_message(value) # steep:ignore ArgumentTypeMismatch
         when Array
           return '...' if depth <= 0
 
@@ -482,7 +482,7 @@ module Datadog
             if max % 2 == 0
               upper += 1
             end
-            value[0...max / 2 - 1] + '...' + value[upper...length]
+            value[0...max / 2 - 1] + '...' + value[upper...length] # steep:ignore NoMethod
           end
         else
           value

--- a/sig/datadog/core/configuration/settings.rbs
+++ b/sig/datadog/core/configuration/settings.rbs
@@ -101,14 +101,6 @@ module Datadog
 
           def enabled=: (bool) -> void
 
-          def untargeted_trace_points: () -> bool
-
-          def untargeted_trace_points=: (bool) -> void
-
-          def propagate_all_exceptions: () -> bool
-
-          def propagate_all_exceptions=: (bool) -> void
-
           def redacted_identifiers: () -> Array[String]
 
           def redacted_identifiers=: (Array[String]) -> void
@@ -136,6 +128,38 @@ module Datadog
           def max_capture_attribute_count: () -> Integer
 
           def max_capture_attribute_count=: (Integer) -> void
+
+          def internal: () -> _DIInternal
+        end
+
+        interface _DIInternal
+          def untargeted_trace_points: () -> bool
+
+          def untargeted_trace_points=: (bool) -> void
+
+          def propagate_all_exceptions: () -> bool
+
+          def propagate_all_exceptions=: (bool) -> void
+
+          def min_send_interval: () -> Float
+
+          def min_send_interval=: (Float) -> void
+
+          def snapshot_queue_capacity: () -> Integer
+
+          def snapshot_queue_capacity=: (Integer) -> void
+
+          def development: () -> bool
+
+          def development=: (bool) -> void
+
+          def trace_logging: () -> bool
+
+          def trace_logging=: (bool) -> void
+
+          def max_processing_time: () -> Float?
+
+          def max_processing_time=: (Float?) -> void
         end
 
         interface _TemplatesBlock

--- a/sig/datadog/di/code_tracker.rbs
+++ b/sig/datadog/di/code_tracker.rbs
@@ -13,7 +13,7 @@ module Datadog
       def backfill_registry: () -> void
       def start: () -> void
       def active?: () -> bool
-      def iseqs_for_path_suffix: (String suffix) -> untyped
+      def iseqs_for_path_suffix: (String suffix) -> [String, RubyVM::InstructionSequence]?
       def iseq_for_line: (String suffix, Integer line) -> [String, RubyVM::InstructionSequence]?
       def stop: () -> void
       def clear: () -> void

--- a/sig/datadog/di/component.rbs
+++ b/sig/datadog/di/component.rbs
@@ -1,13 +1,13 @@
 module Datadog
   module DI
     class Component
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @agent_settings: untyped
+      @agent_settings: Datadog::Core::Configuration::AgentSettings
 
-      @logger: untyped
+      @logger: DI::Logger
 
-      @telemetry: untyped
+      @telemetry: Core::Telemetry::Component?
 
       @redactor: Redactor
 
@@ -15,9 +15,7 @@ module Datadog
 
       @instrumenter: Instrumenter
 
-      @code_tracker: CodeTracker
-
-      @transport: untyped
+      @code_tracker: CodeTracker?
 
       @probe_repository: ProbeRepository
 
@@ -27,25 +25,23 @@ module Datadog
 
       @probe_manager: ProbeManager
 
-      def self.build: (untyped settings, untyped agent_settings, Core::Logger logger, ?telemetry: untyped?) -> (nil | untyped)
+      def self.build: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettings agent_settings, Core::Logger logger, ?telemetry: Core::Telemetry::Component?) -> Component?
 
-      def self.environment_supported?: (untyped settings, Core::Logger logger) -> (false | true)
+      def self.environment_supported?: (Datadog::Core::Configuration::Settings settings, Core::Logger logger) -> bool
 
-      def initialize: (untyped settings, untyped agent_settings, Core::Logger logger, ?code_tracker: untyped?, ?telemetry: untyped?) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, Datadog::Core::Configuration::AgentSettings agent_settings, Core::Logger logger, ?code_tracker: CodeTracker?, ?telemetry: Core::Telemetry::Component?) -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
-      attr_reader agent_settings: untyped
+      attr_reader agent_settings: Datadog::Core::Configuration::AgentSettings
 
-      attr_reader logger: untyped
+      attr_reader logger: DI::Logger
 
-      attr_reader telemetry: untyped
+      attr_reader telemetry: Core::Telemetry::Component?
 
-      attr_reader code_tracker: CodeTracker
+      attr_reader code_tracker: CodeTracker?
 
       attr_reader instrumenter: Instrumenter
-
-      attr_reader transport: untyped
 
       attr_reader probe_repository: ProbeRepository
 
@@ -57,10 +53,11 @@ module Datadog
 
       attr_reader redactor: Redactor
 
-      attr_reader serializer: untyped
-      def shutdown!: (?untyped? replacement) -> untyped
-      
-      def parse_probe_spec_and_notify: (untyped) -> untyped
+      attr_reader serializer: Serializer
+
+      def shutdown!: (?Component? replacement) -> void
+
+      def parse_probe_spec_and_notify: (Hash[String, untyped] probe_spec) -> Probe
     end
   end
 end

--- a/sig/datadog/di/configuration.rbs
+++ b/sig/datadog/di/configuration.rbs
@@ -2,8 +2,8 @@ module Datadog
   module DI
     module Configuration
       module Settings
-        def self.extended: (untyped base) -> untyped
-        def self.add_settings!: (untyped base) -> untyped
+        def self.extended: (Module base) -> void
+        def self.add_settings!: (Module base) -> void
       end
     end
   end

--- a/sig/datadog/di/context.rbs
+++ b/sig/datadog/di/context.rbs
@@ -1,52 +1,52 @@
 module Datadog
   module DI
     class Context
-      @probe: untyped
+      @probe: Probe
 
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @serializer: untyped
+      @serializer: Serializer
 
-      @locals: untyped
+      @locals: Hash[Symbol, untyped]?
 
       @target_self: untyped
 
-      @path: untyped
+      @path: String?
 
-      @caller_locations: untyped
+      @caller_locations: Array[Thread::Backtrace::Location]?
 
-      @serialized_entry_args: untyped
+      @serialized_entry_args: Hash[Symbol, untyped]?
 
       @return_value: untyped
 
-      @duration: untyped
+      @duration: Float?
 
-      @exception: untyped
+      @exception: Exception?
 
-      def initialize: (probe: untyped, settings: untyped, serializer: untyped, ?locals: untyped?, ?target_self: untyped?, ?path: untyped?, ?caller_locations: untyped?, ?serialized_entry_args: untyped?, ?return_value: untyped?, ?duration: untyped?, ?exception: untyped?) -> void
+      def initialize: (probe: Probe, settings: Datadog::Core::Configuration::Settings, serializer: Serializer, ?locals: Hash[Symbol, untyped]?, ?target_self: untyped?, ?path: String?, ?caller_locations: Array[Thread::Backtrace::Location]?, ?serialized_entry_args: Hash[Symbol, untyped]?, ?return_value: untyped?, ?duration: Float?, ?exception: Exception?) -> void
 
-      attr_reader probe: untyped
+      attr_reader probe: Probe
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
-      attr_reader serializer: untyped
+      attr_reader serializer: Serializer
 
-      attr_reader locals: untyped
+      attr_reader locals: Hash[Symbol, untyped]?
 
       attr_reader target_self: untyped
-      attr_reader path: untyped
-      attr_reader caller_locations: untyped
+      attr_reader path: String?
+      attr_reader caller_locations: Array[Thread::Backtrace::Location]?
 
-      attr_reader serialized_entry_args: untyped
+      attr_reader serialized_entry_args: Hash[Symbol, untyped]?
       attr_reader return_value: untyped
-      attr_reader duration: untyped
-      attr_reader exception: untyped
+      attr_reader duration: Float?
+      attr_reader exception: Exception?
 
-      def serialized_locals: () -> untyped
+      def serialized_locals: () -> Hash[Symbol, untyped]?
 
-      def fetch: (untyped var_name) -> (nil | untyped)
+      def fetch: ((Symbol | String) var_name) -> untyped
 
-      def fetch_ivar: (untyped var_name) -> untyped
+      def fetch_ivar: ((Symbol | String) var_name) -> untyped
     end
   end
 end

--- a/sig/datadog/di/el/compiler.rbs
+++ b/sig/datadog/di/el/compiler.rbs
@@ -2,7 +2,7 @@ module Datadog
   module DI
     module EL
       class Compiler
-        def compile: (untyped ast) -> untyped
+        def compile: (untyped ast) -> String
 
         private
 
@@ -14,10 +14,10 @@ module Datadog
 
         MULTI_ARG_METHODS: { "and" => "&&", "or" => "||" }
 
-        def compile_partial: (untyped ast) -> untyped
-        def var_name_maybe: (untyped target) -> (untyped | "(expression)")
+        def compile_partial: (untyped ast) -> String
+        def var_name_maybe: (untyped target) -> String
 
-        def escape: (untyped needle) -> untyped
+        def escape: (String needle) -> String
       end
     end
   end

--- a/sig/datadog/di/el/evaluator.rbs
+++ b/sig/datadog/di/el/evaluator.rbs
@@ -2,43 +2,43 @@ module Datadog
   module DI
     module EL
       class Evaluator
-        @context: untyped
+        @context: Context
 
-        def initialize: (untyped context) -> void
+        def initialize: (Context context) -> void
 
-        def evaluate: (untyped compiled) -> untyped
+        def evaluate: (Context compiled) -> untyped
 
-        def ref: (untyped var) -> untyped
+        def ref: ((Symbol | String) var) -> untyped
 
-        def iref: (untyped var) -> untyped
+        def iref: ((Symbol | String) var) -> untyped
 
-        def len: (untyped var, untyped var_name) -> untyped
+        def len: (untyped var, (Symbol | String) var_name) -> Integer
 
-        def is_empty: (untyped var, untyped var_name) -> (false | untyped)
+        def is_empty: (untyped var, (Symbol | String) var_name) -> bool
 
-        def is_undefined: (untyped var, untyped var_name) -> untyped
+        def is_undefined: (untyped var, (Symbol | String) var_name) -> bool
 
-        def contains: (untyped haystack, untyped needle) -> untyped
+        def contains: (untyped haystack, untyped needle) -> bool
 
-        def matches: (untyped haystack, untyped needle) -> untyped
+        def matches: (String haystack, String needle) -> bool
 
-        def getmember: (untyped object, untyped field) -> untyped
+        def getmember: (untyped object, (Symbol | String) field) -> untyped
 
-        def index: (untyped array_or_hash, untyped index_or_key) -> untyped
+        def index: (Array[untyped] | Hash[untyped, untyped] array_or_hash, untyped index_or_key) -> untyped
 
-        def substring: (untyped object, untyped from, untyped to) -> untyped
+        def substring: (String object, Integer from, Integer to) -> String?
 
-        def starts_with: (untyped haystack, untyped needle) -> untyped
+        def starts_with: (untyped haystack, String needle) -> bool
 
-        def ends_with: (untyped haystack, untyped needle) -> untyped
+        def ends_with: (untyped haystack, String needle) -> bool
 
-        def all: (untyped collection) { (?) -> untyped } -> untyped
+        def all: (Array[untyped] | Hash[untyped, untyped] collection) { (?) -> untyped } -> bool
 
-        def any: (untyped collection) { (?) -> untyped } -> untyped
+        def any: (Array[untyped] | Hash[untyped, untyped] collection) { (?) -> untyped } -> bool
 
-        def filter: (untyped collection) { (?) -> untyped } -> untyped
+        def filter: (Array[untyped] | Hash[untyped, untyped] collection) { (?) -> untyped } -> (Array[untyped] | Hash[untyped, untyped])
 
-        def instanceof: (untyped object, untyped cls_name) -> (true | false | untyped)
+        def instanceof: (untyped object, String cls_name) -> bool
       end
     end
   end

--- a/sig/datadog/di/el/expression.rbs
+++ b/sig/datadog/di/el/expression.rbs
@@ -2,19 +2,19 @@ module Datadog
   module DI
     module EL
       class Expression
-        @dsl_expr: untyped
+        @dsl_expr: String
 
-        @evaluator: untyped
+        @evaluator: Evaluator
 
-        def initialize: (untyped dsl_expr, untyped compiled_expr) -> void
+        def initialize: (String dsl_expr, String compiled_expr) -> void
 
-        attr_reader dsl_expr: untyped
+        attr_reader dsl_expr: String
 
-        attr_reader evaluator: untyped
+        attr_reader evaluator: Evaluator
 
-        def evaluate: (untyped context) -> untyped
+        def evaluate: (Context context) -> untyped
 
-        def satisfied?: (untyped context) -> untyped
+        def satisfied?: (Context context) -> bool
       end
     end
   end

--- a/sig/datadog/di/extensions.rbs
+++ b/sig/datadog/di/extensions.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module DI
     module Extensions
-      def self.activate!: () -> untyped
+      def self.activate!: () -> void
     end
   end
 end

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -33,14 +33,14 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def hook_method: (Probe probe, ProbeManager | ProcResponder responder) -> void
+      def hook_method: (Probe probe, untyped responder) -> void
 
       def unhook_method: (Probe probe) -> void
-      def hook_line: (Probe probe, ProbeManager | ProcResponder responder) -> bool
+      def hook_line: (Probe probe, untyped responder) -> bool?
 
       def unhook_line: (Probe probe) -> void
 
-      def hook: (Probe probe, ProbeManager | ProcResponder responder) -> void
+      def hook: (Probe probe, untyped responder) -> void
 
       def unhook: (Probe probe) -> void
 
@@ -51,13 +51,13 @@ module Datadog
 
       attr_reader lock: Mutex
 
-      def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, ProbeManager | ProcResponder responder, TracePoint tp) -> void
+      def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 
       def build_trace_point_context: (Probe probe, TracePoint tp) -> Context
 
-      def check_and_disable_if_exceeded: (Probe probe, ProbeManager | ProcResponder responder, Float di_start_time, ?Float accumulated_duration) -> void
+      def check_and_disable_if_exceeded: (Probe probe, untyped responder, Float di_start_time, ?Float accumulated_duration) -> void
 
-      def symbolize_class_name: (String cls_name) -> Module
+      def symbolize_class_name: (String? cls_name) -> Module
       def raise_if_probe_in_loaded_features: (Probe probe, Integer line_no, CodeTracker? code_tracker) -> void
     end
   end

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -9,7 +9,7 @@ module Datadog
         def label: () -> String?
       end
 
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
       @serializer: Serializer
 
@@ -21,9 +21,9 @@ module Datadog
 
       @lock: Mutex
 
-      def initialize: (untyped settings, Serializer serializer, DI::Logger logger, ?code_tracker: CodeTracker?, ?telemetry: Core::Telemetry::Component?) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, Serializer serializer, DI::Logger logger, ?code_tracker: CodeTracker?, ?telemetry: Core::Telemetry::Component?) -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
       attr_reader serializer: Serializer
 
@@ -33,31 +33,31 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def hook_method: (Probe probe, untyped responder) -> void
+      def hook_method: (Probe probe, ProbeManager | ProcResponder responder) -> void
 
       def unhook_method: (Probe probe) -> void
-      def hook_line: (Probe probe, untyped responder) -> void
+      def hook_line: (Probe probe, ProbeManager | ProcResponder responder) -> bool
 
       def unhook_line: (Probe probe) -> void
 
-      def hook: (Probe probe, untyped responder) -> void
+      def hook: (Probe probe, ProbeManager | ProcResponder responder) -> void
 
       def unhook: (Probe probe) -> void
 
-      def self.get_local_variables: (TracePoint trace_point) -> Hash[untyped, untyped]
-      def self.get_instance_variables: (Object self) -> Hash[untyped, untyped]
+      def self.get_local_variables: (TracePoint trace_point) -> Hash[Symbol, untyped]
+      def self.get_instance_variables: (Object self) -> Hash[Symbol, untyped]
 
       private
 
-      attr_reader lock: untyped
+      attr_reader lock: Mutex
 
-      def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
+      def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, ProbeManager | ProcResponder responder, TracePoint tp) -> void
 
       def build_trace_point_context: (Probe probe, TracePoint tp) -> Context
 
-      def check_and_disable_if_exceeded: (Probe probe, untyped responder, Float di_start_time, ?Float accumulated_duration) -> void
+      def check_and_disable_if_exceeded: (Probe probe, ProbeManager | ProcResponder responder, Float di_start_time, ?Float accumulated_duration) -> void
 
-      def symbolize_class_name: (untyped cls_name) -> untyped
+      def symbolize_class_name: (String cls_name) -> Module
       def raise_if_probe_in_loaded_features: (Probe probe, Integer line_no, CodeTracker? code_tracker) -> void
     end
   end

--- a/sig/datadog/di/logger.rbs
+++ b/sig/datadog/di/logger.rbs
@@ -3,13 +3,13 @@ module Datadog
     class Logger
       extend Forwardable
 
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
       @target: ::Logger
 
-      def initialize: (untyped settings, ::Logger target) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, ::Logger target) -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
       attr_reader target: ::Logger
 

--- a/sig/datadog/di/probe.rbs
+++ b/sig/datadog/di/probe.rbs
@@ -65,6 +65,7 @@ module Datadog
       def location: () -> ::String
       def file_matches?: (String path) -> bool
       def emitting_notified?: () -> bool
+      attr_writer emitting_notified: bool
 
       def executed_on_line!: -> void
       def executed_on_line?: -> bool

--- a/sig/datadog/di/probe.rbs
+++ b/sig/datadog/di/probe.rbs
@@ -16,7 +16,7 @@ module Datadog
       @method_name: String?
 
       @template: String?
-      @template_segments: Array[untyped]?
+      @template_segments: Array[String | DI::EL::Expression]?
 
       @capture_snapshot: bool
 
@@ -30,7 +30,7 @@ module Datadog
 
       @enabled: bool
 
-      def initialize: (id: String, type: Symbol, ?file: String?, ?line_no: Integer?, ?type_name: String?, ?method_name: String?, ?template: String?, ?template_segments: Array[untyped]?, ?capture_snapshot: bool,
+      def initialize: (id: String, type: Symbol, ?file: String?, ?line_no: Integer?, ?type_name: String?, ?method_name: String?, ?template: String?, ?template_segments: Array[String | DI::EL::Expression]?, ?capture_snapshot: bool,
 	?condition: DI::EL::Expression?,
 	?max_capture_depth: Integer?, ?max_capture_attribute_count: Integer?, ?rate_limit: Integer?) -> void
 
@@ -53,7 +53,7 @@ module Datadog
       attr_reader max_capture_attribute_count: Integer?
 
       attr_reader template: String?
-      attr_reader template_segments: Array[untyped]?
+      attr_reader template_segments: Array[String | DI::EL::Expression]?
       attr_reader rate_limiter: Datadog::Core::RateLimiter
 
       attr_reader condition_evaluation_failed_rate_limiter: Datadog::Core::RateLimiter?

--- a/sig/datadog/di/probe_builder.rbs
+++ b/sig/datadog/di/probe_builder.rbs
@@ -3,9 +3,9 @@ module Datadog
     module ProbeBuilder
       PROBE_TYPES: { "LOG_PROBE" => :log }
 
-      def self?.build_from_remote_config: (Hash[untyped,untyped] config) -> Probe
+      def self?.build_from_remote_config: (Hash[String, untyped] config) -> Probe
 
-      def self?.build_template_segments: (untyped segments) -> untyped
+      def self?.build_template_segments: (Array[Hash[String, untyped]]? segments) -> Array[String | DI::EL::Expression]?
     end
   end
 end

--- a/sig/datadog/di/probe_file_loader.rbs
+++ b/sig/datadog/di/probe_file_loader.rbs
@@ -1,8 +1,8 @@
 module Datadog
   module DI
     module ProbeFileLoader
-      def self?.load_now_or_later: () -> untyped
-      def self?.load_now: () -> untyped
+      def self?.load_now_or_later: () -> void
+      def self?.load_now: () -> void
     end
   end
 end

--- a/sig/datadog/di/probe_manager.rbs
+++ b/sig/datadog/di/probe_manager.rbs
@@ -1,59 +1,59 @@
 module Datadog
   module DI
     class ProbeManager
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @instrumenter: untyped
+      @instrumenter: Instrumenter
 
-      @probe_notification_builder: untyped
+      @probe_notification_builder: ProbeNotificationBuilder
 
-      @probe_notifier_worker: untyped
+      @probe_notifier_worker: ProbeNotifierWorker
 
-      @logger: untyped
+      @logger: DI::Logger
 
-      @telemetry: untyped
+      @telemetry: Core::Telemetry::Component?
 
       @probe_repository: ProbeRepository
 
-      @definition_trace_point: untyped
+      @definition_trace_point: TracePoint
 
-      def initialize: (untyped settings, untyped instrumenter, untyped probe_notification_builder, untyped probe_notifier_worker, untyped logger, ProbeRepository probe_repository, ?telemetry: untyped?) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, Instrumenter instrumenter, ProbeNotificationBuilder probe_notification_builder, ProbeNotifierWorker probe_notifier_worker, DI::Logger logger, ProbeRepository probe_repository, ?telemetry: Core::Telemetry::Component?) -> void
 
-      attr_reader logger: untyped
+      attr_reader logger: DI::Logger
 
-      attr_reader telemetry: untyped
+      attr_reader telemetry: Core::Telemetry::Component?
 
       attr_reader probe_repository: ProbeRepository
 
-      def close: () -> untyped
+      def close: () -> void
 
-      def clear_hooks: () -> untyped
+      def clear_hooks: () -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
-      attr_reader instrumenter: untyped
+      attr_reader instrumenter: Instrumenter
 
-      attr_reader probe_notification_builder: untyped
+      attr_reader probe_notification_builder: ProbeNotificationBuilder
 
-      attr_reader probe_notifier_worker: untyped
+      attr_reader probe_notifier_worker: ProbeNotifierWorker
 
-      def add_probe: (untyped probe) -> untyped
+      def add_probe: (Probe probe) -> bool
 
-      def remove_probe: (untyped probe_id) -> untyped
+      def remove_probe: (String probe_id) -> void
 
       private
-      def install_pending_method_probes: (untyped cls) -> untyped
+      def install_pending_method_probes: (Module cls) -> void
 
       public
-      def install_pending_line_probes: (untyped path) -> untyped
+      def install_pending_line_probes: (String? path) -> void
 
-      def probe_executed_callback: (untyped context) -> untyped
+      def probe_executed_callback: (Context context) -> void
 
-      def probe_condition_evaluation_failed_callback: (untyped context, untyped expr, untyped exc) -> untyped
+      def probe_condition_evaluation_failed_callback: (Context context, EL::Expression expr, Exception exc) -> void
 
       def probe_disabled_callback: (Probe probe, Float duration) -> void
 
-      attr_reader definition_trace_point: untyped
+      attr_reader definition_trace_point: TracePoint
     end
   end
 end

--- a/sig/datadog/di/probe_notification_builder.rbs
+++ b/sig/datadog/di/probe_notification_builder.rbs
@@ -5,11 +5,12 @@ module Datadog
       MILLISECONDS: Integer
       BACKTRACE_FRAME_PATTERN: Regexp
 
+      @settings: Datadog::Core::Configuration::Settings
       @serializer: Serializer
 
-      def initialize: (untyped settings, Serializer serializer) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, Serializer serializer) -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
       attr_reader serializer: Serializer
 
       def build_received: (Probe probe) -> Hash[Symbol,untyped]
@@ -29,15 +30,15 @@ module Datadog
       def format_backtrace_locations: (Array[Thread::Backtrace::Location] locations) -> Array[Hash[Symbol, String | Integer | nil]]
       def format_backtrace_strings: (Array[String]? backtrace) -> Array[Hash[Symbol, String | Integer | nil]]
 
-      def build_snapshot_base: (Context context, ?evaluation_errors: Array[untyped]?, ?captures: untyped?, ?message: String?) -> Hash[Symbol,untyped]
+      def build_snapshot_base: (Context context, ?evaluation_errors: Array[Hash[Symbol, String]]?, ?captures: Hash[Symbol, untyped]?, ?message: String?) -> Hash[Symbol,untyped]
 
-      def build_condition_evaluation_failed: (Context context, untyped expr, untyped exception) -> Hash[Symbol,untyped]
+      def build_condition_evaluation_failed: (Context context, EL::Expression expr, Exception exception) -> Hash[Symbol,untyped]
 
-      def build_status: (Probe probe, message: untyped, status: untyped, ?exception: Exception?) -> Hash[Symbol,untyped]
+      def build_status: (Probe probe, message: String, status: String, ?exception: Exception?) -> Hash[Symbol,untyped]
 
-      def format_caller_locations: (Array[untyped] callers) -> Array[Hash[Symbol,untyped]]
+      def format_caller_locations: (Array[Thread::Backtrace::Location] callers) -> Array[Hash[Symbol,untyped]]
 
-      def evaluate_template: (untyped template, Context context) -> [String, Array[String]]
+      def evaluate_template: (Array[String | EL::Expression] template, Context context) -> [String, Array[Hash[Symbol, String]]]
 
       def tag_process_tags!: (Hash[Symbol | String, untyped] payload, Core::Configuration::Settings settings) -> void
 

--- a/sig/datadog/di/probe_notifier_worker.rbs
+++ b/sig/datadog/di/probe_notifier_worker.rbs
@@ -4,13 +4,13 @@ module Datadog
 
       MIN_SEND_INTERVAL: 1
 
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @status_queue: Array[Hash[String, untyped]]
+      @status_queue: Array[Hash[Symbol, untyped]]
 
       @snapshot_queue: Array[Hash[Symbol, untyped]]
 
-      @agent_settings: untyped
+      @agent_settings: Datadog::Core::Configuration::AgentSettings
 
       @lock: Mutex
 
@@ -18,7 +18,7 @@ module Datadog
 
       @io_in_progress: bool
 
-      @thread: Thread
+      @thread: Thread?
 
       @stop_requested: bool
 
@@ -30,9 +30,9 @@ module Datadog
 
       @probe_notification_builder: ProbeNotificationBuilder
 
-      def initialize: (untyped settings, DI::Logger logger, agent_settings: untyped, probe_repository: ProbeRepository, probe_notification_builder: ProbeNotificationBuilder, ?telemetry: Core::Telemetry::Component?) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, DI::Logger logger, agent_settings: Datadog::Core::Configuration::AgentSettings, probe_repository: ProbeRepository, probe_notification_builder: ProbeNotificationBuilder, ?telemetry: Core::Telemetry::Component?) -> void
 
-      attr_reader settings: untyped
+      attr_reader settings: Datadog::Core::Configuration::Settings
 
       attr_reader logger: DI::Logger
 
@@ -46,8 +46,8 @@ module Datadog
       def stop: (?::Integer timeout) -> void
       def flush: () -> void
 
-      def add_status: (Hash[Symbol, untyped], ?probe: DI::Probe?) -> void
-      def add_snapshot: (Hash[Symbol, untyped]) -> void
+      def add_status: (Hash[Symbol, untyped] event, ?probe: DI::Probe?) -> void
+      def add_snapshot: (Hash[Symbol, untyped] event) -> void
 
       def status_transport: () -> DI::Transport::Diagnostics::Transport
       def snapshot_transport: () -> DI::Transport::Input::Transport
@@ -58,15 +58,15 @@ module Datadog
 
       def set_sleep_remaining: () -> Numeric
 
-      def status_queue: () -> Array[Hash[String, untyped]]
+      def status_queue: () -> Array[Hash[Symbol, untyped]]
 
       def snapshot_queue: () -> Array[Hash[Symbol, untyped]]
 
-      attr_reader agent_settings: untyped
+      attr_reader agent_settings: Datadog::Core::Configuration::AgentSettings
 
       attr_reader wake: Core::Semaphore
 
-      attr_reader thread: Thread
+      attr_reader thread: Thread?
 
       def io_in_progress?: () -> bool
 

--- a/sig/datadog/di/proc_responder.rbs
+++ b/sig/datadog/di/proc_responder.rbs
@@ -1,19 +1,19 @@
 module Datadog
   module DI
     class ProcResponder
-      @executed_proc: untyped
+      @executed_proc: Proc
 
-      @failed_proc: untyped
+      @failed_proc: Proc?
 
-      def initialize: (untyped executed_proc, ?untyped? failed_proc) -> void
+      def initialize: (Proc executed_proc, ?Proc? failed_proc) -> void
 
-      attr_reader executed_proc: untyped
+      attr_reader executed_proc: Proc
 
-      attr_reader failed_proc: untyped
+      attr_reader failed_proc: Proc?
 
-      def probe_executed_callback: (untyped context) -> untyped
+      def probe_executed_callback: (Context context) -> untyped
 
-      def probe_condition_evaluation_failed_callback: (untyped context, untyped exc) -> untyped
+      def probe_condition_evaluation_failed_callback: (Context context, Exception exc) -> untyped
 
       def probe_disabled_callback: (Probe probe, Float duration) -> void
     end

--- a/sig/datadog/di/redactor.rbs
+++ b/sig/datadog/di/redactor.rbs
@@ -1,27 +1,27 @@
 module Datadog
   module DI
     class Redactor
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @redacted_identifiers: untyped
+      @redacted_identifiers: Set[String]
 
       @redacted_type_names_regexp: Regexp
 
-      def initialize: (untyped settings) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings) -> void
 
       attr_reader settings: Datadog::Core::Configuration::Settings
 
-      def redact_identifier?: (String name) -> (true | false)
+      def redact_identifier?: (Symbol | String name) -> bool
 
-      def redact_type?: (untyped value) -> (true | false)
+      def redact_type?: (untyped value) -> bool
 
       private
 
-      def redacted_identifiers: () -> untyped
+      def redacted_identifiers: () -> Set[String]
 
-      def redacted_type_names_regexp: () -> untyped
+      def redacted_type_names_regexp: () -> Regexp
       DEFAULT_REDACTED_IDENTIFIERS: ::Array["2fa" | "accesstoken" | "aiohttpsession" | "apikey" | "apisecret" | "apisignature" | "appkey" | "applicationkey" | "auth" | "authorization" | "authtoken" | "ccnumber" | "certificatepin" | "cipher" | "clientid" | "clientsecret" | "connectionstring" | "connectsid" | "cookie" | "credentials" | "creditcard" | "csrf" | "csrftoken" | "cvv" | "databaseurl" | "dburl" | "encryptionkey" | "encryptionkeyid" | "env" | "geolocation" | "gpgkey" | "ipaddress" | "jti" | "jwt" | "licensekey" | "masterkey" | "mysqlpwd" | "nonce" | "oauth" | "oauthtoken" | "otp" | "passhash" | "passwd" | "password" | "passwordb" | "pemfile" | "pgpkey" | "phpsessid" | "pin" | "pincode" | "pkcs8" | "privatekey" | "publickey" | "pwd" | "recaptchakey" | "refreshtoken" | "routingnumber" | "salt" | "secret" | "secretkey" | "secrettoken" | "securityanswer" | "securitycode" | "securityquestion" | "serviceaccountcredentials" | "session" | "sessionid" | "sessionkey" | "setcookie" | "signature" | "signaturekey" | "sshkey" | "ssn" | "symfony" | "token" | "transactionid" | "twiliotoken" | "usersession" | "voterid" | "xapikey" | "xauthtoken" | "xcsrftoken" | "xforwardedfor" | "xrealip" | "xsrf" | "xsrftoken"]
-      def normalize: (untyped str) -> untyped
+      def normalize: (Symbol | String str) -> String
     end
   end
 end

--- a/sig/datadog/di/remote.rbs
+++ b/sig/datadog/di/remote.rbs
@@ -9,7 +9,7 @@ module Datadog
 
       def self.receivers: (Core::Telemetry::Component? telemetry) -> ::Array[Core::Remote::Dispatcher::Receiver]
 
-      def self.receiver: (?::Array[String] products) { (Core::Remote::Configuration::Repository, Core::Remote::Configuration::Repository::ChangeSet) -> void } -> ::Array[Core::Remote::Dispatcher::Receiver]
+      def self.receiver: (?::Array[String] products) { (Core::Remote::Configuration::Repository, ::Array[Core::Remote::Configuration::Repository::change]) -> void } -> ::Array[Core::Remote::Dispatcher::Receiver]
 
       private
 

--- a/sig/datadog/di/remote.rbs
+++ b/sig/datadog/di/remote.rbs
@@ -3,20 +3,20 @@ module Datadog
     module Remote
       PRODUCT: "LIVE_DEBUGGING"
 
-      def self.products: () -> ::Array[untyped]
+      def self.products: () -> ::Array[String]
 
-      def self.capabilities: () -> ::Array[untyped]
+      def self.capabilities: () -> ::Array[Integer]
 
-      def self.receivers: (untyped telemetry) -> untyped
+      def self.receivers: (Core::Telemetry::Component? telemetry) -> ::Array[Core::Remote::Dispatcher::Receiver]
 
-      def self.receiver: (?::Array[untyped] products) { (?) -> untyped } -> ::Array[untyped]
+      def self.receiver: (?::Array[String] products) { (Core::Remote::Configuration::Repository, Core::Remote::Configuration::Repository::ChangeSet) -> void } -> ::Array[Core::Remote::Dispatcher::Receiver]
 
       private
 
-      def self.parse_content: (untyped content) -> untyped
-      
-      def self.add_probe: (untyped content, untyped component) -> void
-      def self.remove_probe: (untyped previous_content, untyped component) -> void
+      def self.parse_content: (untyped content) -> Hash[String, untyped]
+
+      def self.add_probe: (untyped content, Component component) -> void
+      def self.remove_probe: (untyped previous_content, Component component) -> void
     end
   end
 end

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -7,13 +7,13 @@ module Datadog
 
       @@flat_registry: ::Array[{condition: ::Proc?, proc: ^(Serializer serializer, untyped value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped}]
 
-      @settings: untyped
+      @settings: Datadog::Core::Configuration::Settings
 
-      @redactor: untyped
+      @redactor: Redactor
 
       @telemetry: Core::Telemetry::Component?
 
-      def initialize: (untyped settings, untyped redactor, ?telemetry: Core::Telemetry::Component?) -> void
+      def initialize: (Datadog::Core::Configuration::Settings settings, Redactor redactor, ?telemetry: Core::Telemetry::Component?) -> void
 
       attr_reader settings: Datadog::Core::Configuration::Settings
 
@@ -21,11 +21,11 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (untyped args, untyped kwargs, untyped target_self) -> untyped
-      def serialize_args: (untyped args, untyped kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?) -> untyped
-      def serialize_vars: (untyped vars, ?depth: Integer, ?attribute_count: Integer?) -> untyped
-      def serialize_value: (untyped value, ?name: String?, ?depth: Integer, ?attribute_count: Integer?, ?type: Class?) -> untyped
-      def serialize_value_for_message: (untyped value, ?::Integer depth) -> untyped
+      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped target_self) -> Hash[Symbol, untyped]
+      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?) -> Hash[Symbol, untyped]
+      def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?) -> Hash[Symbol, untyped]
+      def serialize_value: (untyped value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
+      def serialize_value_for_message: (untyped value, ?::Integer depth) -> String
 
       def self.register: (?condition: Proc?) {
         (Serializer serializer, untyped value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped } -> void
@@ -34,9 +34,9 @@ module Datadog
       def max_capture_collection_size_for_message: () -> Integer
 
       def max_capture_attribute_count_for_message: () -> Integer
-      def class_name: (untyped cls) -> String
+      def class_name: (Class cls) -> String
 
-      def serialize_string_or_symbol_for_message: (untyped value) -> untyped
+      def serialize_string_or_symbol_for_message: (String | Symbol value) -> String
 
       def escape_binary_string: (String binary_string) -> String
     end

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -25,7 +25,7 @@ module Datadog
       def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?) -> Hash[Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (untyped value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
-      def serialize_value_for_message: (untyped value, ?::Integer depth) -> String
+      def serialize_value_for_message: (untyped value, ?::Integer depth) -> String?
 
       def self.register: (?condition: Proc?) {
         (Serializer serializer, untyped value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped } -> void
@@ -36,7 +36,7 @@ module Datadog
       def max_capture_attribute_count_for_message: () -> Integer
       def class_name: (Class cls) -> String
 
-      def serialize_string_or_symbol_for_message: (String | Symbol value) -> String
+      def serialize_string_or_symbol_for_message: (String | Symbol value) -> String?
 
       def escape_binary_string: (String binary_string) -> String
     end

--- a/sig/datadog/di/transport/diagnostics.rbs
+++ b/sig/datadog/di/transport/diagnostics.rbs
@@ -6,7 +6,7 @@ module Datadog
         end
 
         class Transport < Core::Transport::Transport
-          def send_diagnostics: (Array[Hash[Symbol, untyped]] payload) -> Core::Transport::Response
+          def send_diagnostics: (Array[Hash[Symbol, untyped]] payload) -> (Core::Transport::HTTP::Response | Core::Transport::InternalErrorResponse)
         end
       end
     end

--- a/sig/datadog/di/transport/diagnostics.rbs
+++ b/sig/datadog/di/transport/diagnostics.rbs
@@ -6,7 +6,7 @@ module Datadog
         end
 
         class Transport < Core::Transport::Transport
-          def send_diagnostics: (untyped payload) -> untyped
+          def send_diagnostics: (Array[Hash[Symbol, untyped]] payload) -> Core::Transport::Response
         end
       end
     end

--- a/sig/datadog/di/transport/http.rbs
+++ b/sig/datadog/di/transport/http.rbs
@@ -5,8 +5,8 @@ module Datadog
         DIAGNOSTICS: Diagnostics::API::Endpoint
         INPUT: Input::API::Endpoint
         LEGACY_INPUT: Input::API::Endpoint
-        def self.diagnostics: (agent_settings: untyped, logger: untyped, ?headers: untyped?) ?{ (untyped) -> untyped } -> untyped
-        def self.input: (agent_settings: untyped, logger: untyped, ?headers: untyped?, ?telemetry: Datadog::Core::Telemetry::Component?) ?{ (untyped) -> untyped } -> untyped
+        def self.diagnostics: (agent_settings: Datadog::Core::Configuration::AgentSettings, logger: Datadog::Core::Logger, ?headers: Hash[String, String]?) ?{ (Datadog::Core::Transport::HTTP::Builder) -> void } -> DI::Transport::Diagnostics::Transport
+        def self.input: (agent_settings: Datadog::Core::Configuration::AgentSettings, logger: Datadog::Core::Logger, ?headers: Hash[String, String]?, ?telemetry: Datadog::Core::Telemetry::Component?) ?{ (Datadog::Core::Transport::HTTP::Builder) -> void } -> DI::Transport::Input::Transport
       end
     end
   end

--- a/sig/datadog/di/transport/http/diagnostics.rbs
+++ b/sig/datadog/di/transport/http/diagnostics.rbs
@@ -4,16 +4,16 @@ module Datadog
       module HTTP
         module Diagnostics
           class Client < Core::Transport::HTTP::Client
-            def send_diagnostics_payload: (untyped request) -> untyped
+            def send_diagnostics_payload: (Core::Transport::Request request) -> Core::Transport::Response
           end
 
           module API
             class Endpoint < Datadog::Core::Transport::HTTP::API::Endpoint
-              @encoder: untyped
+              @encoder: singleton(Core::Encoding::JSONEncoder)
 
-              attr_reader encoder: untyped
+              attr_reader encoder: singleton(Core::Encoding::JSONEncoder)
 
-              def initialize: (untyped path, untyped encoder) -> void
+              def initialize: (String path, singleton(Core::Encoding::JSONEncoder) encoder) -> void
 
               def call: (untyped env) { (?) -> untyped } -> untyped
             end

--- a/sig/datadog/di/transport/http/input.rbs
+++ b/sig/datadog/di/transport/http/input.rbs
@@ -4,18 +4,18 @@ module Datadog
       module HTTP
         module Input
           class Client < Core::Transport::HTTP::Client
-            def send_input_payload: (untyped request) -> untyped
+            def send_input_payload: (Core::Transport::Request request) -> Core::Transport::Response
           end
 
           module API
             class Endpoint < Datadog::Core::Transport::HTTP::API::Endpoint
-              @encoder: untyped
+              @encoder: singleton(Core::Encoding::JSONEncoder)
 
               HEADER_CONTENT_TYPE: "Content-Type"
 
-              attr_reader encoder: untyped
+              attr_reader encoder: singleton(Core::Encoding::JSONEncoder)
 
-              def initialize: (untyped path, untyped encoder) -> void
+              def initialize: (String path, singleton(Core::Encoding::JSONEncoder) encoder) -> void
 
               def call: (untyped env) { (?) -> untyped } -> untyped
             end

--- a/sig/datadog/di/transport/input.rbs
+++ b/sig/datadog/di/transport/input.rbs
@@ -3,11 +3,11 @@ module Datadog
     module Transport
       module Input
         class Request < Datadog::Core::Transport::Request
-          @serialized_tags: untyped
+          @serialized_tags: String
 
-          attr_reader serialized_tags: untyped
+          attr_reader serialized_tags: String
 
-          def initialize: (untyped parcel, untyped serialized_tags) -> void
+          def initialize: (Core::Transport::Parcel parcel, String serialized_tags) -> void
         end
 
         class Transport < Core::Transport::Transport
@@ -26,9 +26,9 @@ module Datadog
             ?telemetry: Datadog::Core::Telemetry::Component?
           ) -> void
 
-          def send_input: (untyped payload, untyped tags, on_serialization_error: ^(String, Exception) -> void) -> untyped
+          def send_input: (Array[Hash[Symbol, untyped]] payload, Hash[String, String] tags, on_serialization_error: ^(String, Exception) -> void) -> Array[Hash[Symbol, untyped]]
 
-          def send_input_chunk: (untyped chunked_payload, untyped serialized_tags) -> untyped
+          def send_input_chunk: (String chunked_payload, String serialized_tags) -> Core::Transport::Response
 
           def encoder: () -> singleton(Core::Encoding::JSONEncoder)
         end

--- a/sig/datadog/di/transport/input.rbs
+++ b/sig/datadog/di/transport/input.rbs
@@ -28,7 +28,7 @@ module Datadog
 
           def send_input: (Array[Hash[Symbol, untyped]] payload, Hash[String, String] tags, on_serialization_error: ^(String, Exception) -> void) -> Array[Hash[Symbol, untyped]]
 
-          def send_input_chunk: (String chunked_payload, String serialized_tags) -> Core::Transport::Response
+          def send_input_chunk: (String chunked_payload, String serialized_tags) -> (Core::Transport::HTTP::Response | Core::Transport::InternalErrorResponse)
 
           def encoder: () -> singleton(Core::Encoding::JSONEncoder)
         end


### PR DESCRIPTION
**What does this PR do?**

Replaces `untyped` placeholders in `sig/datadog/di/**/*.rbs` with concrete types derived from the corresponding `lib/datadog/di` implementations. Touches 25 rbs files across the dynamic instrumentation surface (Component, ProbeManager, Instrumenter, Serializer, Redactor, ProbeNotificationBuilder, ProbeNotifierWorker, Context, Probe, EL::Compiler/Evaluator/Expression, ProcResponder, Remote, Transport, etc.).

Remaining `untyped` uses are limited to genuinely opaque values: serialized snapshot payload fragments, customer-method return values and locals captured by probes, and Expression Language evaluator inputs that accept arbitrary user data.

**Motivation:**

Improves type coverage and signal-to-noise for DI when running Steep, both for catching regressions on this code and for downstream callers that depend on these signatures.

**Change log entry**

None.

**Additional Notes:**

Verified with `bundle exec steep check sig/datadog/di lib/datadog/di` — no type errors.

**How to test the change?**

- `bundle exec steep check sig/datadog/di lib/datadog/di` — must pass cleanly.
- `bundle exec rake test:di` and related component test suites to confirm no behavioral regression (rbs-only change).