### PR TITLE
Drop unused **opts from Process.spawn wrapper signature

### DIFF
--- a/lib/datadog/core/utils/spawn_monkey_patch.rb
+++ b/lib/datadog/core/utils/spawn_monkey_patch.rb
@@ -12,9 +12,24 @@ module Datadog
         end
 
         module ProcessSpawnPatch
-          def spawn(*args, **opts)
-            args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
-            super
+          # Per-Ruby-version signature. On Ruby 3+, `**opts` preserves caller kwargs as
+          # kwargs through `super`. On Ruby 2.5/2.6/2.7, `**opts` would auto-extract
+          # Symbol-keyed entries from a mixed-keys positional options Hash (e.g.
+          # childprocess's `options[fileno] = :close` on duplex pipes), splitting the
+          # Hash and raising `TypeError` inside `Process.spawn`. Dropping it on 2.x
+          # keeps the options Hash positional and intact. Same pattern as
+          # `lib/datadog/core/utils/forking.rb`.
+          if RUBY_VERSION >= '3'
+            # Steep doesn't follow RUBY_VERSION conditionals; sig declares the 2.x form.
+            def spawn(*args, **opts) # steep:ignore DifferentMethodParameterKind
+              args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
+              super
+            end
+          else
+            def spawn(*args)
+              args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
+              super
+            end
           end
         end
 

--- a/sig/datadog/core/utils/spawn_monkey_patch.rbs
+++ b/sig/datadog/core/utils/spawn_monkey_patch.rbs
@@ -8,7 +8,7 @@ module Datadog
         def self.apply!: (lineage_envs_provider: ^() -> ::Hash[::String, ::String]) -> true
 
         module ProcessSpawnPatch
-          def spawn: (*untyped args, **untyped opts) -> untyped
+          def spawn: (*untyped args) -> untyped
         end
 
         def self.inject_lineage_envs: (untyped args) -> ::Array[untyped]

--- a/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
@@ -142,11 +142,30 @@ RSpec.describe Datadog::Core::Utils::SpawnMonkeyPatch do
       end
     end
 
-    # NOTE: childprocess's close-on-exec form (`options[writer.fileno] = :close`)
-    # produces an options Hash with mixed Integer + Symbol keys. On Ruby 2.5/2.6/2.7
-    # the wrapper's `**opts` parameter partially extracts that Hash into kwargs,
-    # mangling the call. That's a distinct bug from the constant shadow fixed here;
-    # see PR #5774 (drops `**opts`) for the fix and its regression test.
+    # ChildProcess sets `options[writer.fileno] = :close` on duplex pipes, producing
+    # an options Hash with mixed Integer + Symbol keys. On Ruby 2.5/2.6/2.7 the prior
+    # wrapper signature `def spawn(*args, **opts)` auto-extracted the Symbol-keyed
+    # entries into `**opts` while leaving Integer-keyed entries in the trailing
+    # positional Hash — mangling the call and raising `TypeError`. The per-version
+    # split in the wrapper (Ruby 2.x drops `**opts`) keeps the options Hash positional
+    # and intact. No env-Hash is passed here so the test is independent of the
+    # constant-shadow fix in PR #5773.
+    it 'spawn(cmd, options_hash_with_mixed_symbol_and_integer_keys) — childprocess close-on-exec shape' do
+      expect_in_fork do
+        described_class.apply!(lineage_envs_provider: -> { {lineage_var => lineage_val} })
+        spare_r, spare_w = IO.pipe
+        begin
+          options = {:pgroup => true, spare_r.fileno => :close, spare_w.fileno => :close}
+          ok, status, out = run_spawn(probe_cmd, options)
+          expect(ok).to be(true)
+          expect(status).to eq(0)
+          expect(out).to include("LINEAGE=#{lineage_val}")
+        ensure
+          spare_r.close
+          spare_w.close
+        end
+      end
+    end
 
     it 'spawn(env, cmd, **opts) — caller uses kwargs splat' do
       expect_in_fork do


### PR DESCRIPTION
**What does this PR do?**

Restructures `Datadog::Core::Utils::SpawnMonkeyPatch::ProcessSpawnPatch#spawn` to use a per-Ruby-version signature (matching the existing pattern in `lib/datadog/core/utils/forking.rb`):

- Ruby 3+: `def spawn(*args, **opts)` — unchanged from master. With bare `super`, kwargs at the call site flow to `Process.spawn` as kwargs.
- Ruby 2.5/2.6/2.7: `def spawn(*args)` — drops `**opts`. This is the bug fix.

**Motivation:**

Master's wrapper signature was `def spawn(*args, **opts)` for every Ruby. The method body never reads `opts`. On Ruby 3+ the signature works fine — kwargs flow to `super` as kwargs and `Process.spawn` accepts either form. On Ruby 2.5/2.6/2.7 the `**opts` actively breaks one call shape:

- Caller passes an options Hash with mixed Symbol + Integer keys — e.g. [`childprocess`'s `options[writer.fileno] = :close`](https://github.com/enkessler/childprocess/blob/master/lib/childprocess/process_spawn_process.rb) on duplex pipes.
- Ruby 2.x auto-extraction siphons the Symbol-keyed entries into `**opts` while leaving the Integer-keyed entries behind in the trailing positional Hash.
- Bare `super` then forwards the broken split. `Process.spawn` interprets the partially-stripped Hash as a command argument and raises `TypeError: no implicit conversion of Hash into String`.

Ruby 3+ removed positional-Hash auto-extraction into kwargs, so this bug is invisible there.

Dropping `**opts` on Ruby 2.x keeps the entire options Hash positional regardless of key shape, and `Process.spawn` receives it intact. Keeping `**opts` on Ruby 3+ preserves the original kwargs-forwarding behaviour (see [#5774 (review)](https://github.com/DataDog/dd-trace-rb/pull/5774#issuecomment-4486340530)).

This is independent from the constant-shadow bug fixed in [#5773](https://github.com/DataDog/dd-trace-rb/pull/5773): that one fires whenever the caller passes an env-Hash (any Ruby), this one fires whenever the caller passes a mixed-keys options Hash without an env-Hash (Ruby 2.x only). With both PRs landed, both shapes work on every Ruby.

**Change log entry**

Yes. Fix `TypeError: no implicit conversion of Hash into String` raised by `Process.spawn` on Ruby 2.5/2.6/2.7 when the caller passes an options Hash with mixed Symbol + Integer keys (e.g. `childprocess` on duplex pipes).

**Additional Notes:**

One of two independent splits from [#5634](https://github.com/DataDog/dd-trace-rb/pull/5634):
- [#5773](https://github.com/DataDog/dd-trace-rb/pull/5773) — constant-shadow fix (`Hash` → `::Hash`) for [#5621](https://github.com/DataDog/dd-trace-rb/issues/5621), all Rubies
- this PR — per-version split to fix the Ruby 2.x mixed-keys options Hash bug

Marco's [#5634](https://github.com/DataDog/dd-trace-rb/pull/5634) bundles these along with a `lineage_envs_provider` → `env_provider` rename, an idempotency guard in `apply!`, doc edits, and a `execute_in_fork` doc tweak. I deliberately did not split those out — the rename is cosmetic and breaks the API, the idempotency guard has no observable effect (`Module#prepend` is already idempotent), and the doc edits are unrelated.

**How to test the change?**

Three regression specs in `spec/datadog/core/utils/spawn_monkey_patch_spec.rb` under `describe 'option-syntax compatibility'`:

1. `kwargs-syntax options work` — `Process.spawn(cmd, kw: value)`
2. `positional Hash options work` — `opts = {...}; Process.spawn(cmd, opts)`
3. `positional options Hash with mixed Symbol + Integer keys (childprocess close-on-exec form)` — the falsifiable test for the bug above. Triggers `TypeError` on master against Ruby 2.5/2.6/2.7; passes on every Ruby with the per-version split.

The third test does not pass an env-Hash argument, so it is independent of the constant-shadow fix in #5773 — confirmed by reproducing on master's lib with `::Hash` still bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
