### PR TITLE
SymDB: always emit Symbol#type per JSON schema

### DIFF
--- a/lib/datadog/symbol_database/symbol.rb
+++ b/lib/datadog/symbol_database/symbol.rb
@@ -48,6 +48,7 @@ module Datadog
       # `language_specifics` is omitted when nil to reduce payload size.
       # @return [Hash] Symbol as hash with symbol keys
       def to_h
+        # @type var h: Hash[::Symbol, untyped]
         h = {
           symbol_type: symbol_type,
           name: name,

--- a/lib/datadog/symbol_database/symbol.rb
+++ b/lib/datadog/symbol_database/symbol.rb
@@ -42,7 +42,10 @@ module Datadog
       end
 
       # Convert symbol to Hash for JSON serialization.
-      # Removes nil values to reduce payload size.
+      # The `type` key is always present per the symdb JSON schema — emit nil
+      # when the type cannot be determined (the common case in Ruby since
+      # parameters and instance variables carry no declared type).
+      # `language_specifics` is omitted when nil to reduce payload size.
       # @return [Hash] Symbol as hash with symbol keys
       def to_h
         h = {
@@ -50,9 +53,8 @@ module Datadog
           name: name,
           line: line,
           type: type,
-          language_specifics: language_specifics,
         }
-        h.compact!
+        h[:language_specifics] = language_specifics if language_specifics
         h
       end
 

--- a/spec/datadog/symbol_database/symbol_spec.rb
+++ b/spec/datadog/symbol_database/symbol_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Datadog::SymbolDatabase::Symbol do
       expect(symbol.to_h).to eq({
         symbol_type: 'STATIC_FIELD',
         name: 'CONSTANT',
-        line: 5
+        line: 5,
+        type: nil
       })
     end
 
@@ -69,7 +70,7 @@ RSpec.describe Datadog::SymbolDatabase::Symbol do
       )
     end
 
-    it 'removes nil values via compact' do
+    it 'keeps the type key with nil value, omits nil language_specifics' do
       symbol = described_class.new(
         symbol_type: 'FIELD',
         name: '@var',
@@ -83,9 +84,10 @@ RSpec.describe Datadog::SymbolDatabase::Symbol do
       expect(hash).to eq({
         symbol_type: 'FIELD',
         name: '@var',
-        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE
+        line: Datadog::SymbolDatabase::UNKNOWN_MIN_LINE,
+        type: nil
       })
-      expect(hash).not_to have_key(:type)
+      expect(hash).to have_key(:type)
       expect(hash).not_to have_key(:language_specifics)
     end
 


### PR DESCRIPTION
**What does this PR do?**

Keep the `type` key in the JSON output for every uploaded `Symbol`. When the type cannot be determined, emit `null` instead of dropping the key.

**Motivation:**

The symdb JSON schema in `DataDog/system-tests` (`tests/schemas/utils/library/symdb/v1/input-request.json`) requires `type` to be present on every symbol; the value may be `null`. `Symbol#to_h` was calling `Hash#compact!`, which removed the key entirely when `type` was `nil`. Ruby is the only tracer that omits the key today because parameters, instance variables, and most local variables carry no declared type at extraction time. The other tracers serialise the field as `null`. Enabling the Ruby `Test_Debugger_SymDb` system tests surfaced this when `tests/schemas/test_schemas.py::Test_DdtraceSchemas::test_library` failed on the upload payload.

**Change log entry**

None.

**Additional Notes:**

- `language_specifics` stays omitted when nil — it is genuinely optional in the schema.
- The matching system-tests PR (#6962) enables the symdb tests against Ruby Rails weblogs at `v2.34.0-dev`. Once this PR lands and a dev gem build is published, the schema-validation step in those tests should pass.

**How to test the change?**

- `bundle exec rspec spec/datadog/symbol_database/symbol_spec.rb` — updated unit tests assert the `type` key is always present in `to_h` output.
- System tests: the `DEBUGGER_SYMDB` scenario in system-tests will validate the live upload payload against `/library/symdb/v1/input-request.json` once this lands.