### PR TITLE
Skip sampling threads which did not have the GVL since the last sample

### DIFF
--- a/benchmarks/profiling_sample_overhead.rb
+++ b/benchmarks/profiling_sample_overhead.rb
@@ -1,0 +1,85 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require_relative 'benchmarks_helper'
+
+class CaptureFlush
+  attr_reader :flush
+  def export(flush)
+    @flush = flush
+  end
+  INSTANCE = new
+end
+
+Datadog.configure do |c|
+  c.profiling.enabled = true
+  c.profiling.exporter.transport = CaptureFlush::INSTANCE
+  # c.profiling.advanced.experimental_cpu_sampling_interval_ms = 1
+end
+Datadog::Profiling.wait_until_running
+
+DURATION = VALIDATE_BENCHMARK_MODE ? 1.0 : 10.0
+
+sleep DURATION
+
+Datadog.shutdown!
+
+flush = CaptureFlush::INSTANCE.flush
+
+unless VALIDATE_BENCHMARK_MODE
+  require "zstd-ruby"
+  File.write("profiler-sample-overhead.pprof", Zstd.decompress(flush.encoded_profile._native_bytes))
+end
+
+data = JSON.parse(flush.internal_metadata_json)
+duration = flush.finish - flush.start
+duration_ns = duration * 1e9
+samples = data.dig("worker_stats", "cpu_sampled")
+cpu_sampling_time_ns_total = data.dig("worker_stats", "cpu_sampling_time_ns_total")
+serialization_time_ns_total = data.dig("recorder_stats", "serialization_time_ns_total")
+inactive_thread_samples_skipped = data.dig("worker_stats", "inactive_thread_samples_skipped")
+cpu_sampling_overhead = cpu_sampling_time_ns_total / duration_ns
+
+overhead = ->(total) {
+  "%.2f%%" % ((total / duration_ns) * 100.0)
+}
+
+pp data
+
+pp({
+  duration: duration,
+  samples: samples,
+  trigger_simulated_signal_delivery_attempts: data.dig("worker_stats", "trigger_simulated_signal_delivery_attempts"),
+  cpu_sampling_time_ns_total: cpu_sampling_time_ns_total,
+  cpu_sampling_overhead: overhead[cpu_sampling_time_ns_total],
+  serialization_time_ns_total: serialization_time_ns_total,
+  serialization_overhead: overhead[serialization_time_ns_total],
+  sampling_rate: samples / duration,
+  sample_every_n_ms: (duration / samples) * 1000,
+  inactive_thread_samples_skipped: inactive_thread_samples_skipped,
+})
+
+unless VALIDATE_BENCHMARK_MODE
+  # Generate output for bp-analyzer parser:
+  # https://github.com/DataDog/benchmarking-platform-tools/blob/main/bp-analyzer/cli/src/src/converter/benchmark_ips.py
+  require 'json'
+  file = "#{File.basename(__FILE__, '.rb')}-results.json"
+  json = [
+    {
+      # Invert since higher must be better
+      item: "profiling - 1 / cpu sampling overhead",
+      samples: [1 / cpu_sampling_overhead]
+    },
+    {
+      item: "profiling - samples",
+      samples: [samples]
+    },
+    {
+      item: "profiling - skipped samples",
+      samples: [inactive_thread_samples_skipped]
+    },
+  ]
+  File.write(file, JSON.dump(json))
+end

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -182,6 +182,11 @@ typedef struct {
     unsigned int allocations_during_sample;
 
     // # GVL profiling stats
+    // Note that this tracks two kind of samples from RESUMED:
+    // * samples when Waiting for GVL for more than the threshold
+    // * samples for the skip-samples-while-without-GVL optimization,
+    //   which are needed to attribute the time without GVL to the correct Ruby stack
+
     // How many times we triggered the after_gvl_running sampling
     unsigned int after_gvl_running;
     // How many times we skipped the after_gvl_running sampling
@@ -869,6 +874,7 @@ static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
         (
           // For now we're only asking for these events, even though there's more
           // (e.g. check docs or gvl-tracing gem)
+          RUBY_INTERNAL_THREAD_EVENT_SUSPENDED | /* released gvl */
           RUBY_INTERNAL_THREAD_EVENT_READY /* waiting for gvl */ |
           RUBY_INTERNAL_THREAD_EVENT_RESUMED /* running/runnable */
         ),
@@ -1127,6 +1133,9 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("gvl_waiting_time_ns_total")),  /* => */ state->gvl_profiling_enabled ? ULL2NUM(state->stats.vm_metrics.gvl_waiting_time_ns_total) : Qnil,
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
+
+  thread_context_collector_stats(state->thread_context_collector_instance, stats_as_hash);
+
   return stats_as_hash;
 }
 
@@ -1134,6 +1143,7 @@ static VALUE _native_stats_reset_not_thread_safe(DDTRACE_UNUSED VALUE self, VALU
   cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(instance, cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
   reset_stats_not_thread_safe(state);
+  thread_context_collector_stats_reset_not_thread_safe(state->thread_context_collector_instance);
   return Qnil;
 }
 
@@ -1443,7 +1453,9 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
     if (!thread_context) return;
     // If non-NULL the thread is profiled and from the main Ractor
 
-    if (event_id == RUBY_INTERNAL_THREAD_EVENT_READY) { /* waiting for gvl */
+    if (event_id == RUBY_INTERNAL_THREAD_EVENT_SUSPENDED) { /* released gvl */
+      thread_context_collector_on_gvl_released(thread_context);
+    } else if (event_id == RUBY_INTERNAL_THREAD_EVENT_READY) { /* waiting for gvl */
       thread_context_collector_on_gvl_waiting(thread_context);
     } else if (event_id == RUBY_INTERNAL_THREAD_EVENT_RESUMED) { /* running/runnable */
       // Interesting note: A RUBY_INTERNAL_THREAD_EVENT_RESUMED is guaranteed to be called with the GVL being acquired
@@ -1453,7 +1465,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
       cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
       if (state == NULL) return; // This should not happen, but just in case...
 
-      on_gvl_running_result result = thread_context_collector_on_gvl_running(state->thread_context_collector_instance, thread_context);
+      on_gvl_running_result result = thread_context_collector_on_gvl_running(state->thread_context_collector_instance, target_thread, thread_context);
 
       if (result.waiting_for_gvl_duration_ns > 0) {
         state->stats.vm_metrics.gvl_waiting_time_ns_total += (uint64_t) result.waiting_for_gvl_duration_ns;
@@ -1469,8 +1481,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
         state->stats.gvl_dont_sample++;
       }
     } else {
-      // This is a very delicate time and it's hard for us to raise an exception so let's at least complain to stderr
-      fprintf(stderr, "[ddtrace] Unexpected value in on_gvl_event (%d)\n", event_id);
+      rb_bug("[ddtrace] Unexpected value in on_gvl_event (%d)\n", event_id);
     }
   }
 

--- a/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -208,7 +208,7 @@ void idle_sampling_helper_request_action(VALUE self_instance, void (*run_action_
   if (!rb_typeddata_is_kind_of(self_instance, &idle_sampling_helper_typed_data)) {
     grab_gvl_and_raise(rb_eTypeError, "Wrong argument for idle_sampling_helper_request_action");
   }
-  // This should never fail the the above check passes
+  // This should never fail when the above check passes
   TypedData_Get_Struct(self_instance, idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
 
   ENFORCE_SUCCESS_NO_GVL(pthread_mutex_lock(&state->wakeup_mutex));

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -79,6 +79,8 @@
 #define IS_CPU_TIME false
 #define MISSING_TRACER_CONTEXT_KEY 0
 #define TIME_BETWEEN_GC_EVENTS_NS MILLIS_AS_NS(10)
+#define GVL_SUSPENDED ((uint64_t)1)
+#define GVL_RUNNING ((uint64_t)0)
 
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
 
@@ -155,6 +157,9 @@ typedef struct {
     unsigned int gc_samples;
     // See thread_context_collector_on_gc_start for details
     unsigned int gc_samples_missed_due_to_missing_context;
+    // How many per-thread samples were skipped because the thread has been continuously suspended
+    // (no GVL) since its previous sample, so its Ruby stack cannot have changed.
+    unsigned int inactive_thread_samples_skipped;
   } stats;
 
   struct {
@@ -177,7 +182,7 @@ struct per_thread_context {
   long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
   long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
 
-  // There are 3 possible states for the GVL (per thread), and 3 transitions for which we received GVL events:
+  // There are 3 possible states for the GVL (per thread), and 3 transitions for which we receive GVL events:
   // Thread holds the GVL
   //   on_gvl_released() the thread releases the GVL (RUBY_INTERNAL_THREAD_EVENT_SUSPENDED)
   // Thread runs without the GVL
@@ -208,6 +213,26 @@ struct per_thread_context {
   // The field is accessed under the GVL for most functions EXCEPT on_gvl_waiting() which writes to it without the GVL.
   // So we need to pack the above state in a single long to ensure atomicity.
   long gvl_waiting_at;
+
+  // Per-thread "state + version" word, updated on every GVL state transition. The encoding is:
+  //   - low bit:  current state (1 = currently suspended, 0 = currently running)
+  //   - bits 1+:  monotonic event counter (incremented on every RESUMED)
+  // The hooks set the state bit explicitly rather than relying on parity, so the encoding stays
+  // correct even when events are not paired properly (as in tests).
+  //
+  // Note that SUSPENDED can happen multiple times in a row on Ruby 3.2,
+  // see https://github.com/DataDog/dd-trace-rb/pull/5777#discussion_r3388560254,
+  // the encoding is designed to naturally not change the field in such a case.
+  uint64_t gvl_state_change_count;
+  // Snapshot of the thread's gvl_state_change_count at the moment we last sampled it.
+  // Equality with this snapshot means no GVL transition since the last sample.
+  uint64_t gvl_state_change_count_at_previous_sample;
+  // True when the previous per-tick sample was skipped by the SUSPENDED-skip optimization, so the
+  // flush-before-serialize pass knows it needs to report this thread.
+  // As a result, we will accumulate all wall & CPU time as a single batch per reporting period,
+  // but this is deemed worth it for this optimization. In any case we don't know exactly
+  // at what time a thread was doing CPU work (unless it's on CPU 100% of the time).
+  bool was_skipped_at_last_sample;
 
   struct {
     // Both of these fields are set by on_gc_start and kept until on_gc_finish is called.
@@ -247,7 +272,8 @@ static void update_metrics_and_sample(
   per_thread_context *thread_context,
   sampling_buffer* sampling_buffer,
   long current_cpu_time_ns,
-  long current_monotonic_wall_time_ns
+  long current_monotonic_wall_time_ns,
+  bool force_sample
 );
 static void trigger_sample_for_thread(
   thread_context_collector_state *state,
@@ -266,7 +292,7 @@ static per_thread_context *get_or_create_context_for(VALUE thread, thread_contex
 static void initialize_context(VALUE thread, per_thread_context *thread_context, thread_context_collector_state *state);
 static VALUE _native_inspect(VALUE self, VALUE collector_instance);
 static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context);
-static VALUE stats_as_ruby_hash(thread_context_collector_state *state);
+static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE hash);
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state);
 static VALUE _native_per_thread_context(VALUE self, VALUE collector_instance);
 static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, long gc_start_time_ns, bool is_wall_time);
@@ -307,6 +333,7 @@ static bool handle_gvl_waiting(
   static VALUE _native_on_gvl_waiting(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_gvl_waiting_at_for(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread);
+  static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception);
   static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 #endif
@@ -322,6 +349,7 @@ static VALUE safely_lookup_hash_without_going_into_ruby_code(VALUE hash, VALUE k
 static VALUE _native_system_epoch_time_now_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
 static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self);
 static VALUE _native_clear_per_thread_context_for(DDTRACE_UNUSED VALUE self, VALUE thread);
+static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample_suspended);
 
 void collectors_thread_context_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -360,6 +388,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
     rb_define_singleton_method(testing_module, "_native_on_gvl_waiting", _native_on_gvl_waiting, 1);
     rb_define_singleton_method(testing_module, "_native_gvl_waiting_at_for", _native_gvl_waiting_at_for, 1);
     rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 2);
+    rb_define_singleton_method(testing_module, "_native_on_gvl_released", _native_on_gvl_released, 1);
     rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 3);
     rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
   #endif
@@ -532,6 +561,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   state->locations.len = sampling_buffer_check_max_frames(NUM2INT(max_frames));
   state->locations.ptr = ruby_xcalloc(state->locations.len, sizeof(ddog_prof_Location));
   state->recorder_instance = enforce_recorder_instance(recorder_instance);
+  recorder_install_on_serialize(recorder_instance, self_instance);
   state->endpoint_collection_enabled = (endpoint_collection_enabled == Qtrue);
   state->native_filenames_enabled = (native_filenames_enabled == Qtrue);
   state->overhead_filename = overhead_filename;
@@ -689,8 +719,8 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
       thread_context,
       &thread_context->sampling_buffer,
       current_cpu_time_ns,
-      current_monotonic_wall_time_ns
-    );
+      current_monotonic_wall_time_ns,
+      false);
   }
 
   state->stats.sample_count++;
@@ -703,10 +733,13 @@ static void update_metrics_and_sample(
   per_thread_context *thread_context,
   sampling_buffer* sampling_buffer,
   long current_cpu_time_ns,
-  long current_monotonic_wall_time_ns
+  long current_monotonic_wall_time_ns,
+  bool force_sample_suspended
 ) {
   bool is_gvl_waiting_state =
     handle_gvl_waiting(state, thread_being_sampled, thread_context, sampling_buffer, current_cpu_time_ns);
+
+  if (skip_sample(state, thread_context, is_gvl_waiting_state, force_sample_suspended)) return;
 
   // Don't assign/update cpu during "Waiting for GVL"
   long cpu_time_elapsed_ns = is_gvl_waiting_state ? 0 : update_time_since_previous_sample(
@@ -726,7 +759,7 @@ static void update_metrics_and_sample(
   // A thread enters "Waiting for GVL", well, as the name implies, without the GVL.
   //
   // As a consequence, it's possible that a thread enters "Waiting for GVL" in parallel with the current thread working
-  // on sampling, and thus for the  `current_monotonic_wall_time_ns` (which is recorded at the start of sampling)
+  // on sampling, and thus for the `current_monotonic_wall_time_ns` (which is recorded at the start of sampling)
   // to be < the time at which we started Waiting for GVL.
   //
   // All together, this means that when `handle_gvl_waiting` creates an extra sample (see comments on that function for
@@ -752,6 +785,32 @@ static void update_metrics_and_sample(
   );
 }
 
+static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample_suspended) {
+  // Racy read but harmless, can only cause an extra sample
+  uint64_t gvl_state_change_count = thread_context->gvl_state_change_count;
+
+  // Skip this per-tick sample entirely when the thread does not have the GVL and did not acquire
+  // it since the previous sample: its Ruby-level stack has not changed. The skipped wall-time will
+  // be picked up by either by an extra sample when the thread acquires the GVL, or by
+  // the on-serialize flush in the stack recorder (using was_skipped_at_last_sample).
+  // The check is gated by `!is_gvl_waiting_state` so the existing "Waiting for GVL" machinery
+  // in handle_gvl_waiting (situation 1 extra sample, situation 2 regular sample) keeps running.
+  // TODO: we could probably also skip while "Waiting for GVL"
+  if (!is_gvl_waiting_state &&
+      !force_sample_suspended &&
+      (gvl_state_change_count & GVL_SUSPENDED) &&
+      gvl_state_change_count == thread_context->gvl_state_change_count_at_previous_sample) {
+    state->stats.inactive_thread_samples_skipped++;
+    thread_context->was_skipped_at_last_sample = true;
+    return true; // Do NOT update wall_time_at_previous_sample_ns or cpu_time_at_previous_sample_ns
+  } else {
+    // We are going to sample, update the state accordingly:
+    thread_context->gvl_state_change_count_at_previous_sample = gvl_state_change_count;
+    thread_context->was_skipped_at_last_sample = false;
+    return false;
+  }
+}
+
 // This function gets called when Ruby is about to start running the Garbage Collector on the current thread.
 // It updates the per_thread_context of the current thread to include the current cpu/wall times, to be used to later
 // create an event including the cpu/wall time spent in garbage collector work.
@@ -765,7 +824,7 @@ static void update_metrics_and_sample(
 void thread_context_collector_on_gc_start(VALUE self_instance) {
   thread_context_collector_state *state;
   if (!rb_typeddata_is_kind_of(self_instance, &thread_context_collector_typed_data)) return;
-  // This should never fail the the above check passes
+  // This should never fail when the above check passes
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   per_thread_context *thread_context = get_per_thread_context(rb_thread_current());
@@ -798,7 +857,7 @@ __attribute__((warn_unused_result))
 bool thread_context_collector_on_gc_finish(VALUE self_instance) {
   thread_context_collector_state *state;
   if (!rb_typeddata_is_kind_of(self_instance, &thread_context_collector_typed_data)) return false;
-  // This should never fail the the above check passes
+  // This should never fail when the above check passes
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   per_thread_context *thread_context = get_per_thread_context(rb_thread_current());
@@ -1157,6 +1216,7 @@ static void initialize_context(VALUE thread, per_thread_context *thread_context,
   thread_context->gc_tracking.wall_time_at_start_ns = INVALID_TIME;
 
   thread_context->gvl_waiting_at = 0;
+  thread_context->gvl_state_change_count = 0;
 }
 
 static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {
@@ -1170,7 +1230,7 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
   rb_str_concat(result, rb_sprintf(" recorder_instance=%"PRIsVALUE, state->recorder_instance));
   VALUE tracer_context_key = state->tracer_context_key == MISSING_TRACER_CONTEXT_KEY ? Qnil : ID2SYM(state->tracer_context_key);
   rb_str_concat(result, rb_sprintf(" tracer_context_key=%+"PRIsVALUE, tracer_context_key));
-  rb_str_concat(result, rb_sprintf(" stats=%"PRIsVALUE, stats_as_ruby_hash(state)));
+  rb_str_concat(result, rb_sprintf(" stats=%"PRIsVALUE, stats_to_ruby_hash(state, rb_hash_new())));
   rb_str_concat(result, rb_sprintf(" endpoint_collection_enabled=%"PRIsVALUE, state->endpoint_collection_enabled ? Qtrue : Qfalse));
   rb_str_concat(result, rb_sprintf(" native_filenames_enabled=%"PRIsVALUE, state->native_filenames_enabled ? Qtrue : Qfalse));
   // Note: `st_table_size()` is available from Ruby 3.2+ but not before
@@ -1208,22 +1268,25 @@ static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context)
     ID2SYM(rb_intern("gc_tracking.wall_time_at_start_ns")),  /* => */ LONG2NUM(thread_context->gc_tracking.wall_time_at_start_ns),
 
     ID2SYM(rb_intern("gvl_waiting_at")), /* => */ LONG2NUM(thread_context->gvl_waiting_at),
+    ID2SYM(rb_intern("gvl_state_change_count")), /* => */ ULL2NUM(thread_context->gvl_state_change_count),
+    ID2SYM(rb_intern("gvl_state_change_count_at_previous_sample")), /* => */ ULL2NUM(thread_context->gvl_state_change_count_at_previous_sample),
+    ID2SYM(rb_intern("was_skipped_at_last_sample")), /* => */ thread_context->was_skipped_at_last_sample ? Qtrue : Qfalse,
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 
   return context_as_hash;
 }
 
-static VALUE stats_as_ruby_hash(thread_context_collector_state *state) {
+static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE hash) {
   // Update this when modifying state struct (stats inner struct)
-  VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
     ID2SYM(rb_intern("sample_count")),                             /* => */ UINT2NUM(state->stats.sample_count),
     ID2SYM(rb_intern("gc_samples")),                               /* => */ UINT2NUM(state->stats.gc_samples),
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
+    ID2SYM(rb_intern("inactive_thread_samples_skipped")),          /* => */ UINT2NUM(state->stats.inactive_thread_samples_skipped),
   };
-  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(stats_as_hash, arguments[i], arguments[i+1]);
-  return stats_as_hash;
+  for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
+  return hash;
 }
 
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state) {
@@ -1354,7 +1417,7 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE _self, VALUE collector_instance)
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  return stats_as_ruby_hash(state);
+  return stats_to_ruby_hash(state, rb_hash_new());
 }
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
@@ -1897,7 +1960,54 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     ((uint64_t)span_bytes[7]);
 }
 
+void thread_context_collector_stats(VALUE self_instance, VALUE stats_hash) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+  stats_to_ruby_hash(state, stats_hash);
+}
+
+void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+  state->stats = (struct stats) {};
+}
+
 #ifndef NO_GVL_INSTRUMENTATION
+  void thread_context_collector_on_gvl_released(per_thread_context *thread_context) {
+    thread_context->gvl_state_change_count |= GVL_SUSPENDED;
+  }
+
+  // Called by the stack recorder at the start of _native_serialize, so that threads whose last
+  // per-tick sample was skipped by the SUSPENDED-skip optimization still get their accumulated
+  // time recorded in this reporting period. Without this, a thread that sleeps across the whole
+  // period would not be reported at all.
+  void thread_context_collector_on_serialize(VALUE self_instance) {
+    thread_context_collector_state *state;
+    TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
+    long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+    VALUE threads = thread_list(state);
+    const long thread_count = RARRAY_LEN(threads);
+
+    for (long i = 0; i < thread_count; i++) {
+      VALUE thread = RARRAY_AREF(threads, i);
+      per_thread_context *thread_context = get_per_thread_context(thread);
+
+      if (thread_context != NULL && thread_context->was_skipped_at_last_sample) {
+        long current_cpu_time_ns = cpu_time_now_ns(thread_context);
+        // We need to force_sample_suspended=true otherwise this sample would be skipped too
+        update_metrics_and_sample(
+          state,
+          thread,
+          thread_context,
+          &thread_context->sampling_buffer,
+          current_cpu_time_ns,
+          current_monotonic_wall_time_ns,
+          true);
+      }
+    }
+  }
+
   void thread_context_collector_on_gvl_waiting(per_thread_context *thread_context) {
     long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
     if (current_monotonic_wall_time_ns <= 0) return;
@@ -1907,17 +2017,19 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
   // This function runs on the passed thread and has the GVL because it gets called just after the Ruby thread acquired the GVL
   __attribute__((warn_unused_result))
-  on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, per_thread_context *thread_context) {
+  on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread, per_thread_context *thread_context) {
     thread_context_collector_state *state;
     TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-    long gvl_waiting_at = thread_context->gvl_waiting_at;
+    // Bump the event counter and clears the state bit to "running"
+    uint64_t counter_portion = thread_context->gvl_state_change_count >> 1;
+    thread_context->gvl_state_change_count = ((counter_portion + 1) << 1) | GVL_RUNNING;
 
+    long gvl_waiting_at = thread_context->gvl_waiting_at;
     // Thread was not waiting on gvl
     if (gvl_waiting_at == 0) {
       return (on_gvl_running_result) {.action = ON_GVL_RUNNING_UNKNOWN, .waiting_for_gvl_duration_ns = 0};
     }
-
     // @ivoanjo: I'm not sure if this can happen -- It means we should've sampled already but haven't gotten the chance yet?
     if (gvl_waiting_at < 0) {
       return (on_gvl_running_result) {.action = ON_GVL_RUNNING_SAMPLE, .waiting_for_gvl_duration_ns = 0};
@@ -1934,6 +2046,21 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
       thread_context->gvl_waiting_at = gvl_waiting_at_is_now_running;
     } else {
       thread_context->gvl_waiting_at = 0;
+
+      // Even though the GVL wait itself was below threshold, if the thread had skipped samples
+      // (was suspended for a long time without the GVL), we still need to force a sample now.
+      // Otherwise, the accumulated idle wall-time would be reported against whatever stack the
+      // thread runs next, misrepresenting the time spent idle.
+      if (thread_context->was_skipped_at_last_sample) {
+        should_sample = true;
+      }
+    }
+
+    if (should_sample) {
+      // We prepare the sample here because the postponed job might be called some time later,
+      // possibly after some Ruby calls which change the Ruby stack,
+      // and we want to attribute the time acquiring or without the GVL to the correct Ruby stack.
+      prepare_sample_thread(thread, &thread_context->sampling_buffer);
     }
 
     return (on_gvl_running_result) {
@@ -1959,7 +2086,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
   //
   // Stack:
   // If the thread starts working without the end of the Waiting for GVL sample, then by the time the thread is sampled
-  // via the regular cpu/wall-time samples mechanism, the stack can be be inaccurate (e.g. does not correctly pinpoint
+  // via the regular cpu/wall-time samples mechanism, the stack can be inaccurate (e.g. does not correctly pinpoint
   // where the waiting happened).
   //
   // Arguably, the last sample after Waiting for GVL ended (when gvl_waiting_at < 0) should always come from this method
@@ -1980,7 +2107,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     long gvl_waiting_at = thread_context->gvl_waiting_at;
 
-    if (gvl_waiting_at >= 0) {
+    if (gvl_waiting_at >= 0 && !thread_context->was_skipped_at_last_sample) {
       // @ivoanjo: I'm not sure if this can ever happen. This means that we're not on the same thread
       // that ran `thread_context_collector_on_gvl_running` and made the decision to sample OR a regular sample was
       // triggered ahead of us.
@@ -1988,7 +2115,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
       return Qfalse;
     }
 
-    // We don't actually account for cpu-time during Waiting for GVL. BUT, we may chose to push an
+    // We don't actually account for cpu-time during Waiting for GVL. BUT, we may choose to push an
     // extra sample to represent the period prior to Waiting for GVL. To support that, we retrieve the current
     // cpu-time of the thread and let `update_metrics_and_sample` decide what to do with it.
     long cpu_time_for_thread = cpu_time_now_ns(thread_context);
@@ -2001,8 +2128,8 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
       thread_context,
       &thread_context->sampling_buffer,
       cpu_time_for_thread,
-      current_monotonic_wall_time_ns
-    );
+      current_monotonic_wall_time_ns,
+      false);
 
     return Qtrue;
   }
@@ -2139,7 +2266,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     per_thread_context *thread_context = get_per_thread_context(thread);
     VALUE result;
     if (thread_context) {
-      result = thread_context_collector_on_gvl_running(collector_instance, thread_context).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
+      result = thread_context_collector_on_gvl_running(collector_instance, thread, thread_context).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
     } else {
       result = Qfalse;
     }
@@ -2147,6 +2274,19 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     debug_leave_unsafe_context();
 
     return result;
+  }
+
+  static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread) {
+    ENFORCE_THREAD(thread);
+
+    debug_enter_unsafe_context();
+
+    per_thread_context *thread_context = get_per_thread_context(thread);
+    if (thread_context) thread_context_collector_on_gvl_released(thread_context);
+
+    debug_leave_unsafe_context();
+
+    return Qnil;
   }
 
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception) {
@@ -2185,6 +2325,8 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     DDTRACE_UNUSED sampling_buffer* sampling_buffer,
     DDTRACE_UNUSED long current_cpu_time_ns
   ) { return false; }
+
+  void thread_context_collector_on_serialize(DDTRACE_UNUSED VALUE self_instance) { }
 #endif // NO_GVL_INSTRUMENTATION
 
 #define MAX_SAFE_LOOKUP_SIZE 16

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -18,7 +18,9 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 __attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);
-
+void thread_context_collector_stats(VALUE self_instance, VALUE stats_hash);
+void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance);
+void thread_context_collector_on_serialize(VALUE self_instance);
 
 #ifndef NO_GVL_INSTRUMENTATION
   typedef enum {
@@ -33,6 +35,7 @@ VALUE enforce_thread_context_collector_instance(VALUE object);
   } on_gvl_running_result;
 
   void thread_context_collector_on_gvl_waiting(per_thread_context *thread_context);
-  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, per_thread_context *thread_context);
+  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread, per_thread_context *thread_context);
   VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance, VALUE current_thread, long current_monotonic_wall_time_ns);
+  void thread_context_collector_on_gvl_released(per_thread_context *thread_context);
 #endif

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -306,7 +306,7 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
   // simply be noticed on next heap_recorder_prepare_iteration.
   //
   // There is one small caveat though: fork only preserves one thread and in a Ruby app, that
-  // will be the thread holding on to the GVL. Since we support iteration on the heap recorder
+  // will be the thread holding the GVL. Since we support iteration on the heap recorder
   // outside of the GVL, any state specific to that interaction may be inconsistent after fork
   // (e.g. an acquired lock for thread safety). Iteration operates on object_records_snapshot
   // though and that one will be updated on next heap_recorder_prepare_iteration so we really

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -9,6 +9,7 @@
 #include "time_helpers.h"
 #include "heap_recorder.h"
 #include "encoded_profile.h"
+#include "collectors_thread_context.h"
 
 // Used to wrap a ddog_prof_Profile in a Ruby object and expose Ruby-level serialization APIs
 // This file implements the native bits of the Datadog::Profiling::StackRecorder class
@@ -177,6 +178,10 @@ typedef struct {
   heap_recorder *heap_recorder;
   bool heap_clean_after_gc_enabled;
 
+  // When set, _native_serialize will call thread_context_collector_on_serialize on this instance
+  // before serializing, so that threads suspended across the whole profile period still get sampled.
+  VALUE thread_context_collector_instance;
+
   pthread_mutex_t mutex_slot_one;
   profile_slot profile_slot_one;
   pthread_mutex_t mutex_slot_two;
@@ -320,6 +325,7 @@ static VALUE _native_new(VALUE klass) {
   // being leaked.
 
   state->heap_clean_after_gc_enabled = false;
+  state->thread_context_collector_instance = Qnil;
 
   ddog_prof_Slice_SampleType sample_types = {.ptr = all_sample_types, .len = ALL_VALUE_TYPES_COUNT};
 
@@ -391,6 +397,7 @@ static void initialize_profiles(stack_recorder_state *state, ddog_prof_Slice_Sam
 static void stack_recorder_typed_data_mark(void *state_ptr) {
   stack_recorder_state *state = (stack_recorder_state *) state_ptr;
 
+  rb_gc_mark(state->thread_context_collector_instance);
   heap_recorder_mark_pending_recordings(state->heap_recorder);
 }
 
@@ -515,12 +522,16 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
   ddog_Timespec finish_timestamp = system_epoch_now_timespec();
-  // Need to do this while still holding on to the Global VM Lock; see comments on method for why
+  // Need to do this while still holding the Global VM Lock; see comments on method for why
   serializer_set_start_timestamp_for_next_profile(state, finish_timestamp);
+
+  if (state->thread_context_collector_instance != Qnil) {
+    thread_context_collector_on_serialize(state->thread_context_collector_instance);
+  }
 
   long heap_iteration_prep_start_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
   // Prepare the iteration on heap recorder we'll be doing outside the GVL. The preparation needs to
-  // happen while holding on to the GVL.
+  // happen while holding the GVL.
   // NOTE: While rare, it's possible for the GVL to be released inside this function (see comments on `heap_recorder_update`)
   // and thus don't assume this is an "atomic" step -- other threads may get some running time in the meanwhile.
   heap_recorder_prepare_iteration(state->heap_recorder);
@@ -548,7 +559,7 @@ static VALUE _native_serialize(DDTRACE_UNUSED VALUE _self, VALUE recorder_instan
     rb_thread_call_without_gvl2(call_serialize_without_gvl, &args, NULL /* No interruption function needed in this case */, NULL /* Not needed */);
   }
 
-  // Cleanup after heap recorder iteration. This needs to happen while holding on to the GVL.
+  // Cleanup after heap recorder iteration. This needs to happen while holding the GVL.
   heap_recorder_finish_iteration(state->heap_recorder);
 
   // NOTE: We are focusing on the serialization time outside of the GVL in this stat here. This doesn't
@@ -1149,4 +1160,11 @@ static VALUE _native_finalize_pending_heap_recordings(DDTRACE_UNUSED VALUE _self
   heap_recorder_finalize_pending_recordings(state->heap_recorder);
 
   return Qtrue;
+}
+
+void recorder_install_on_serialize(VALUE recorder_instance, VALUE thread_context_collector_instance) {
+  stack_recorder_state *state;
+  TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
+
+  state->thread_context_collector_instance = enforce_thread_context_collector_instance(thread_context_collector_instance);
 }

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -29,4 +29,5 @@ void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_
 __attribute__((warn_unused_result)) bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class);
 void recorder_after_sample(VALUE recorder_instance);
 void recorder_after_gc_step(VALUE recorder_instance);
+void recorder_install_on_serialize(VALUE recorder_instance, VALUE thread_context_collector_instance);
 VALUE enforce_recorder_instance(VALUE object);

--- a/ext/datadog_profiling_native_extension/unsafe_api_calls_check.h
+++ b/ext/datadog_profiling_native_extension/unsafe_api_calls_check.h
@@ -4,7 +4,7 @@
 //
 // Specifically, when the profiler is sampling, we're never supposed to call into Ruby code (e.g. methods
 // implemented using Ruby code) or allocate Ruby objects.
-// That's because those events introduce thread switch points, and really we don't the VM switching between threads
+// That's because those events introduce thread switch points, and really we don't want the VM switching between threads
 // in the middle of the profiler sampling. This includes raising exceptions.
 //
 // Raising exceptions as the very last operation, to stop the profiler is ok, but comes a caveat: raising exceptions
@@ -22,6 +22,8 @@
 //
 // If, however, we have a bug and there's a thread switch point, our postponed job will see the flag and immediately
 // stop the Ruby VM before further damage happens (and hopefully giving us a stack trace clearly pointing to the culprit).
+//
+// Note that this check currently does not detect Ruby object allocations, as those do not check for interrupts.
 
 void unsafe_api_calls_check_init(void);
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:gvl_profiling_enabled) { false }
   let(:sighandler_sampling_enabled) { false }
   let(:cpu_sampling_interval_ms) { 10 }
+  let(:thread_context_collector) { build_thread_context_collector(recorder) }
   let(:worker_settings) do
     {
       gc_profiling_enabled: gc_profiling_enabled,
       no_signals_workaround_enabled: no_signals_workaround_enabled,
-      thread_context_collector: build_thread_context_collector(recorder),
+      thread_context_collector: thread_context_collector,
       dynamic_sampling_rate_overhead_target_percentage: 2.0,
       allocation_profiling_enabled: allocation_profiling_enabled,
       allocation_counting_enabled: allocation_counting_enabled,
@@ -39,7 +40,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     }
   end
   let(:sample) {
-    Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(worker_settings[:thread_context_collector], false)
+    Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(thread_context_collector, false)
   }
 
   subject(:cpu_and_wall_time_worker) { described_class.new(**worker_settings, **options) }
@@ -550,13 +551,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         context "when 'Waiting for GVL' periods are below waiting_for_gvl_threshold_ns" do
           let(:options) do
-            ten_seconds_as_ns = 1_000_000_000
-            collector = build_thread_context_collector(recorder, waiting_for_gvl_threshold_ns: ten_seconds_as_ns)
+            one_second_as_ns = 1_000_000_000
+            collector = build_thread_context_collector(recorder, waiting_for_gvl_threshold_ns: one_second_as_ns)
 
             {thread_context_collector: collector}
           end
 
-          it "does not trigger extra samples" do
+          it "does not trigger extra samples due to GVL wait duration" do
             background_thread_affected_by_gvl_contention
             ready_queue_2.pop
 
@@ -573,13 +574,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
             expect(cpu_and_wall_time_worker.stats.fetch(:gvl_dont_sample)).to be > 0
 
+            # after_gvl_running may be > 0 due to skip-recovery samples (was_skipped_at_last_sample),
+            # but gvl_dont_sample being > 0 confirms the GVL wait threshold is working correctly.
             expect(cpu_and_wall_time_worker.stats).to match(
               hash_including(
-                after_gvl_running: 0,
-                gvl_sampling_time_ns_min: nil,
-                gvl_sampling_time_ns_max: nil,
-                gvl_sampling_time_ns_total: nil,
-                gvl_sampling_time_ns_avg: nil,
                 gvl_waiting_time_ns_total: be >= 0,
               )
             )
@@ -1339,6 +1337,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     it "resets all stats" do
       cpu_and_wall_time_worker.stop
 
+      allow(thread_context_collector).to receive(:reset_after_fork).and_call_original
       reset_after_fork
 
       expect(cpu_and_wall_time_worker.stats).to match(
@@ -1374,6 +1373,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           gvl_sampling_time_ns_total: nil,
           gvl_sampling_time_ns_avg: nil,
           gvl_waiting_time_ns_total: nil,
+          sample_count: 0,
+          gc_samples: 0,
+          gc_samples_missed_due_to_missing_context: 0,
+          inactive_thread_samples_skipped: 0,
         }
       )
     end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2153,7 +2153,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       end
 
       it "sets the wall_time_at_previous_sample_ns to the current wall clock value" do
-        expect(per_thread_context.values).to all(
+        not_skipped = per_thread_context.values.reject { |ctx| ctx.fetch(:was_skipped_at_last_sample) }
+        expect(not_skipped).to all(
           include(wall_time_at_previous_sample_ns: be_between(@wall_time_before_sample_ns, @wall_time_after_sample_ns))
         )
       end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_on_gvl_running(thread_context_collector, thread)
   end
 
+  def on_gvl_released(thread)
+    described_class::Testing._native_on_gvl_released(thread)
+  end
+
   def sample_after_gvl_running(thread, allow_exception: false)
     described_class::Testing._native_sample_after_gvl_running(thread_context_collector, thread, allow_exception)
   end
@@ -1872,6 +1876,44 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
       end
     end
+
+    context "when thread had skipped samples (was_skipped_at_last_sample)" do
+      let(:waiting_for_gvl_threshold_ns) { 1_000_000_000 }
+
+      before do
+        sample
+        on_gvl_released(t1)
+        sample # first sample updates the snapshot to the suspended counter
+        sample # second sample sees unchanged counter, skips and sets was_skipped_at_last_sample
+        expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be true
+
+        on_gvl_waiting(t1)
+      end
+
+      it "flags that a sample is needed to cut the accumulated idle wall-time" do
+        expect(on_gvl_running(t1)).to be true
+      end
+
+      it "produces a sample via sample_after_gvl_running that consumes the accumulated idle wall-time" do
+        wall_time_before = per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
+
+        on_gvl_running(t1)
+        sample_after_gvl_running(t1)
+
+        wall_time_after = per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
+        expect(wall_time_after).to be > wall_time_before
+      end
+
+      it "produces a sample via sample_after_gvl_running that consumes the accumulated CPU time" do
+        apply_delta_to_cpu_time_at_previous_sample_ns(t1, -12345) # Rewind back to ensure it's > 0
+
+        on_gvl_running(t1)
+        sample_after_gvl_running(t1)
+
+        latest_sample = samples_for_thread(samples_from_pprof(recorder.serialize!), t1).last
+        expect(latest_sample.values.fetch(:"cpu-time")).to be >= 12345
+      end
+    end
   end
 
   describe "#sample_after_gvl_running" do
@@ -1946,6 +1988,75 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
           expect(samples.first.labels).to include(state: "waiting for gvl")
         end
+      end
+    end
+  end
+
+  describe "SUSPENDED-skip optimization" do
+    before { skip_if_gvl_profiling_not_supported(self) }
+
+    context "when a thread is suspended (does not hold the GVL)" do
+      before do
+        sample # create thread context
+        recorder.serialize! # flush the initial sample
+        on_gvl_released(t1)
+      end
+
+      it "skips per-tick samples for the suspended thread" do
+        ctx = per_thread_context.fetch(t1)
+        expect(ctx.fetch(:gvl_state_change_count_at_previous_sample)).to_not eq(ctx.fetch(:gvl_state_change_count))
+
+        # first sample updates the snapshot to the suspended counter
+        sample
+        ctx = per_thread_context.fetch(t1)
+        gvl_state_change_count = ctx.fetch(:gvl_state_change_count)
+        expect(ctx.fetch(:gvl_state_change_count_at_previous_sample)).to eq(gvl_state_change_count)
+        expect(ctx.fetch(:was_skipped_at_last_sample)).to be false
+        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 0
+
+        # second sample sees unchanged counter and skips
+        sample
+        ctx = per_thread_context.fetch(t1)
+        expect(ctx.fetch(:gvl_state_change_count)).to eq(gvl_state_change_count)
+        expect(ctx.fetch(:gvl_state_change_count_at_previous_sample)).to eq(gvl_state_change_count)
+        expect(ctx.fetch(:was_skipped_at_last_sample)).to be true
+        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 1
+      end
+
+      it "still records at least one sample per profile period via serialize" do
+        # We test that the optimization applies with consecutive samples, that serialize causes an extra sample,
+        # and also that the optimization applies again after serialize,
+        # causing only 1 sample per profile period if the thread does not acquire the GVL
+
+        sample # updates the snapshot
+        expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be false
+
+        sample # skips, sets was_skipped_at_last_sample
+        expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be true
+        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 1
+
+        # End of profile period 1: serialize flushes the skipped thread
+        result = recorder.serialize!
+        expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be false
+        t1_samples = samples_for_thread(samples_from_pprof(result), t1)
+        # 2 samples: the first sample (updates snapshot) + the on-serialize flush
+        expect(t1_samples.size).to eq(2)
+        expect(t1_samples.sum { |s| s.values.fetch(:"wall-time") }).to be > 0
+
+        # All of these are skipped
+        10.times {
+          sample
+          expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be true
+        }
+        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 11
+
+        # End of profile period 2: serialize again flushes the skipped thread
+        result = recorder.serialize!
+        expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be false
+        t1_samples = samples_for_thread(samples_from_pprof(result), t1)
+        # Exactly 1 sample from the on-serialize flush
+        expect(t1_samples.size).to eq(1)
+        expect(t1_samples.sum { |s| s.values.fetch(:"wall-time") }).to be > 0
       end
     end
   end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2012,7 +2012,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         gvl_state_change_count = ctx.fetch(:gvl_state_change_count)
         expect(ctx.fetch(:gvl_state_change_count_at_previous_sample)).to eq(gvl_state_change_count)
         expect(ctx.fetch(:was_skipped_at_last_sample)).to be false
-        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 0
 
         # second sample sees unchanged counter and skips
         sample
@@ -2020,7 +2019,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         expect(ctx.fetch(:gvl_state_change_count)).to eq(gvl_state_change_count)
         expect(ctx.fetch(:gvl_state_change_count_at_previous_sample)).to eq(gvl_state_change_count)
         expect(ctx.fetch(:was_skipped_at_last_sample)).to be true
-        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 1
       end
 
       it "still records at least one sample per profile period via serialize" do
@@ -2033,7 +2031,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         sample # skips, sets was_skipped_at_last_sample
         expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be true
-        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 1
 
         # End of profile period 1: serialize flushes the skipped thread
         result = recorder.serialize!
@@ -2048,7 +2045,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           sample
           expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be true
         }
-        expect(stats.fetch(:inactive_thread_samples_skipped)).to eq 11
 
         # End of profile period 2: serialize again flushes the skipped thread
         result = recorder.serialize!

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1595,8 +1595,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
   describe "#sample_allocation" do
     let(:single_sample) do
-      expect(samples.size).to be 1
-      samples.first
+      sample_for_thread(samples, Thread.current)
     end
 
     it "samples the caller thread" do
@@ -1655,7 +1654,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         after { Datadog::Tracing.shutdown! }
 
         it 'gathers the "local root span id", "span id" and "trace endpoint"' do
-          expect(single_sample.labels).to include(
+          expect(sample_for_thread(samples, t1).labels).to include(
             "local root span id": @t1_local_root_span_id.to_i,
             "span id": @t1_span_id.to_i,
             "trace endpoint": "trace_resource",
@@ -1749,8 +1748,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
   describe "#sample_skipped_allocation_samples" do
     let(:single_sample) do
-      expect(samples.size).to be 1
-      samples.first
+      alloc_samples = samples.select { |s| s.values[:"alloc-samples"]&.positive? }
+      expect(alloc_samples.size).to be 1
+      alloc_samples.first
     end
     before { sample_skipped_allocation_samples(123) }
 

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
     "profiling_sample_loop_v2",
     "profiling_sample_serialize",
     "profiling_sample_gvl",
+    "profiling_sample_overhead",
     "profiling_string_storage_intern",
   ].freeze
 


### PR DESCRIPTION
* Since such threads did not get the GVL then their Ruby-level stack must
  be the same and there is no need to sample them, we can just adjust the
  duration/weight of the next sample instead.
  The next sample will have the correct stack because it will be just after
  GVL acquire.
* Emit a catch-up sample for still-suspended threads before serialization
  so we still sample at least once per upload period (60 seconds).
* The per-Ruby-Thread state is an integer:
  - low bit: current state (1 = suspended/no-GVL, 0 = running/has-GVL)
  - bits 1+: monotonic event counter, incremented on every SUSPENDED or RESUMED for that Thread

**What does this PR do?**

Reduce profiling overhead by skipping redundant samples of threads which did not have the GVL since the last sample.

**Motivation:**
Reduce profiling overhead.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Reduce profiling overhead for threads which do not hold the GVL.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
