### PR TITLE
[snapshot] Pre-rebase state of #5774 (drop **opts + per-version split)

### DIFF
--- a/lib/datadog/core/utils/spawn_monkey_patch.rb
+++ b/lib/datadog/core/utils/spawn_monkey_patch.rb
@@ -12,9 +12,24 @@ module Datadog
         end
 
         module ProcessSpawnPatch
-          def spawn(*args)
-            args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
-            super
+          # Per-Ruby-version signature. On Ruby 3+, `**opts` preserves caller kwargs as
+          # kwargs through `super`. On Ruby 2.5/2.6/2.7, `**opts` would auto-extract
+          # Symbol-keyed entries from a mixed-keys positional options Hash (e.g.
+          # childprocess's `options[fileno] = :close` on duplex pipes), splitting the
+          # Hash and raising `TypeError` inside `Process.spawn`. Dropping it on 2.x
+          # keeps the options Hash positional and intact. Same pattern as
+          # `lib/datadog/core/utils/forking.rb`.
+          if RUBY_VERSION >= '3'
+            # Steep doesn't follow RUBY_VERSION conditionals; sig declares the 2.x form.
+            def spawn(*args, **opts) # steep:ignore DifferentMethodParameterKind
+              args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
+              super
+            end
+          else
+            def spawn(*args)
+              args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
+              super
+            end
           end
         end
 

--- a/lib/datadog/core/utils/spawn_monkey_patch.rb
+++ b/lib/datadog/core/utils/spawn_monkey_patch.rb
@@ -12,7 +12,7 @@ module Datadog
         end
 
         module ProcessSpawnPatch
-          def spawn(*args, **opts)
+          def spawn(*args)
             args.replace(SpawnMonkeyPatch.inject_lineage_envs(args))
             super
           end

--- a/sig/datadog/core/utils/spawn_monkey_patch.rbs
+++ b/sig/datadog/core/utils/spawn_monkey_patch.rbs
@@ -8,7 +8,7 @@ module Datadog
         def self.apply!: (lineage_envs_provider: ^() -> ::Hash[::String, ::String]) -> true
 
         module ProcessSpawnPatch
-          def spawn: (*untyped args, **untyped opts) -> untyped
+          def spawn: (*untyped args) -> untyped
         end
 
         def self.inject_lineage_envs: (untyped args) -> ::Array[untyped]

--- a/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
@@ -24,6 +24,53 @@ RSpec.describe Datadog::Core::Utils::SpawnMonkeyPatch do
     end
   end
 
+  # The wrapper accepts both kwargs-syntax options and a trailing positional
+  # options Hash — Ruby's two distinct ways to pass Process.spawn options.
+  # Without `**opts` in the wrapper signature, kwargs at the call site
+  # collapse into the trailing positional arg in *args; `super` then
+  # forwards them to Process.spawn which accepts either form.
+  describe 'option-syntax compatibility' do
+    before do
+      skip 'Fork not supported' unless Process.respond_to?(:fork)
+      skip 'Process.spawn not supported' unless Process.respond_to?(:spawn)
+    end
+
+    def run_spawn_capture(*spawn_args)
+      read_io, write_io = IO.pipe
+      pipe_opts = { out: write_io, err: write_io, in: File::NULL }
+      if spawn_args.last.is_a?(Hash) && spawn_args.last.keys.all? { |k| k.is_a?(Symbol) || k.is_a?(Integer) }
+        spawn_args[-1] = spawn_args.last.merge(pipe_opts)
+      else
+        spawn_args << pipe_opts
+      end
+      pid = Process.spawn(*spawn_args)
+      write_io.close
+      out = read_io.read
+      read_io.close
+      _, status = Process.wait2(pid)
+      [status.exitstatus, out]
+    end
+
+    it 'kwargs-syntax options work (Process.spawn(cmd, kw: value))' do
+      expect_in_fork do
+        described_class.apply!(lineage_envs_provider: -> { {} })
+        status, out = run_spawn_capture(%(printf 'hello\n'), pgroup: true)
+        expect(status).to eq(0)
+        expect(out).to include('hello')
+      end
+    end
+
+    it 'positional Hash options work (opts = {...}; Process.spawn(cmd, opts))' do
+      expect_in_fork do
+        described_class.apply!(lineage_envs_provider: -> { {} })
+        options = { pgroup: true }
+        status, out = run_spawn_capture(%(printf 'hello\n'), options)
+        expect(status).to eq(0)
+        expect(out).to include('hello')
+      end
+    end
+  end
+
   describe 'Components initialization' do
     reset_at_fork_monkey_patch_for_components!
 

--- a/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Datadog::Core::Utils::SpawnMonkeyPatch do
 
     def run_spawn_capture(*spawn_args)
       read_io, write_io = IO.pipe
-      pipe_opts = { out: write_io, err: write_io, in: File::NULL }
+      pipe_opts = {out: write_io, err: write_io, in: File::NULL}
       if spawn_args.last.is_a?(Hash) && spawn_args.last.keys.all? { |k| k.is_a?(Symbol) || k.is_a?(Integer) }
         spawn_args[-1] = spawn_args.last.merge(pipe_opts)
       else
@@ -63,10 +63,43 @@ RSpec.describe Datadog::Core::Utils::SpawnMonkeyPatch do
     it 'positional Hash options work (opts = {...}; Process.spawn(cmd, opts))' do
       expect_in_fork do
         described_class.apply!(lineage_envs_provider: -> { {} })
-        options = { pgroup: true }
+        options = {pgroup: true}
         status, out = run_spawn_capture(%(printf 'hello\n'), options)
         expect(status).to eq(0)
         expect(out).to include('hello')
+      end
+    end
+
+    # Regression test for the bug this PR fixes. `childprocess` sets
+    # `options[writer.fileno] = :close` on duplex pipes, producing an options
+    # Hash with mixed Integer + Symbol keys (https://github.com/enkessler/childprocess/blob/master/lib/childprocess/process_spawn_process.rb).
+    #
+    # On Ruby 2.5/2.6/2.7, the prior wrapper signature `def spawn(*args, **opts)`
+    # partially extracted the Symbol-keyed entries of that Hash into `**opts`
+    # while leaving the Integer-keyed entries in the trailing positional Hash —
+    # mangling the call and raising `TypeError: no implicit conversion of Hash
+    # into String` inside `super`. Ruby 3+ does not auto-extract positional
+    # Hashes so the bug was invisible there.
+    #
+    # Dropping `**opts` from the wrapper means the entire options Hash stays
+    # positional in `*args`, regardless of its key shape, and `Process.spawn`
+    # receives it intact.
+    #
+    # No env-Hash is passed here so the test is independent of the constant-
+    # shadow fix in PR #5773.
+    it 'positional options Hash with mixed Symbol + Integer keys (childprocess close-on-exec form)' do
+      expect_in_fork do
+        described_class.apply!(lineage_envs_provider: -> { {} })
+        spare_r, spare_w = IO.pipe
+        begin
+          options = {:pgroup => true, spare_r.fileno => :close, spare_w.fileno => :close}
+          status, out = run_spawn_capture(%(printf 'hello\n'), options)
+          expect(status).to eq(0)
+          expect(out).to include('hello')
+        ensure
+          spare_r.close
+          spare_w.close
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**

Snapshot of [#5774](https://github.com/DataDog/dd-trace-rb/pull/5774) at SHA `6f93283e10`, before rebasing onto the post-#5773 master.

Branch tip is the same set of changes (per-Ruby-version split of `ProcessSpawnPatch#spawn` + regression test), but built on the pre-#5773 master — so this PR's diff against current master shows both the per-version split AND the `Hash` → `::Hash` constant-shadow fix that landed in #5773.

This PR exists for reference/preservation only — the rebased version of #5774 is the one being landed.

**Change log entry**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
