### PR TITLE
Add mixed Symbol + Integer keys regression test for #5634

### DIFF
--- a/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/spawn_monkey_patch_spec.rb
@@ -248,11 +248,28 @@ RSpec.describe Datadog::Core::Utils::SpawnMonkeyPatch do
       end
     end
 
-    # NOTE: childprocess's close-on-exec form (`options[writer.fileno] = :close`)
-    # produces an options Hash with mixed Integer + Symbol keys. On Ruby 2.5/2.6/2.7
-    # the wrapper's `**opts` parameter partially extracts that Hash into kwargs,
-    # mangling the call. That's a distinct bug from the constant shadow fixed here;
-    # see PR #5774 (drops `**opts`) for the fix and its regression test.
+    # ChildProcess sets `options[writer.fileno] = :close` on duplex pipes, producing
+    # an options Hash with mixed Integer + Symbol keys. The prior wrapper signature
+    # `def spawn(*args, **opts)` auto-extracted the Symbol-keyed entries into `**opts`
+    # on Ruby 2.5/2.6/2.7 while leaving Integer-keyed entries in the trailing positional
+    # Hash — mangling the call and raising `TypeError`. Dropping `**opts` (this PR)
+    # keeps the options Hash positional and intact across all supported Rubies.
+    it 'spawn(cmd, options_hash_with_mixed_symbol_and_integer_keys) — childprocess close-on-exec shape' do
+      expect_in_fork do
+        described_class.apply!(env_provider: -> { {lineage_var => lineage_val} })
+        spare_r, spare_w = IO.pipe
+        begin
+          options = {:pgroup => true, spare_r.fileno => :close, spare_w.fileno => :close}
+          ok, status, out = run_spawn(probe_cmd, options)
+          expect(ok).to be(true)
+          expect(status).to eq(0)
+          expect(out).to include("LINEAGE=#{lineage_val}")
+        ensure
+          spare_r.close
+          spare_w.close
+        end
+      end
+    end
 
     it 'spawn(env, cmd, **opts) — caller uses kwargs splat' do
       expect_in_fork do


### PR DESCRIPTION
**What does this PR do?**

Adds a regression test for the Ruby 2.5/2.6/2.7 mixed Symbol + Integer keys options Hash bug (childprocess close-on-exec form). Targets the [#5634](https://github.com/DataDog/dd-trace-rb/pull/5634) branch.

**Motivation:**

5634 fixes the bug by dropping `**opts` from the wrapper signature, but the test suite has no regression coverage for this specific call shape — only a NOTE block at `spec/datadog/core/utils/spawn_monkey_patch_spec.rb:251-255` deferring to [#5774](https://github.com/DataDog/dd-trace-rb/pull/5774). Since 5634 fixes the same bug, the deferral is stale and a test should live alongside the fix.

The new test exercises the exact childprocess close-on-exec form: an options Hash with `IO.pipe` filenos as Integer keys with `:close` values, mixed with Symbol keys (`:pgroup => true`). On Ruby 2.5/2.6/2.7 this triggers `TypeError: no implicit conversion of Hash into String` against the pre-fix wrapper. With `**opts` dropped (as 5634 does), the options Hash stays positional and intact.

Uses the shared `run_spawn` helper and `env_provider:` API already established in the surrounding `Process.spawn argument forms (issue #5621 regression)` describe block.

**Change log entry**

None.

**Additional Notes:**

- 20 examples pass locally on Ruby 3.x.
- Replaces the NOTE block at `spec/datadog/core/utils/spawn_monkey_patch_spec.rb:251-255` (the one that pointed at #5774) with an inline `it` block. The cross-reference to #5774 is no longer needed because 5634 fixes the same bug.
- This is the test coverage that [#5774](https://github.com/DataDog/dd-trace-rb/pull/5774) carries but 5634 was missing. Identified during a comparison of the two PRs.

**How to test the change?**

```bash
bundle exec rspec spec/datadog/core/utils/spawn_monkey_patch_spec.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
