### PR TITLE
TEST ONLY: SymDB extractor without throttle (regression detection check for #5776)

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -614,26 +614,10 @@ module Datadog
 
       # ── extract_all helpers ──────────────────────────────────────────────
 
-      # Sleep between chunks of modules processed in collect_extractable_modules so
-      # request-handling threads have guaranteed CPU time while extraction is in
-      # flight. Unlike Thread.pass (which only offers the GVL among runnable
-      # threads and leaves the extractor immediately re-runnable), sleep removes
-      # the extractor thread from the runnable set for a fixed duration, capping
-      # its CPU share at sleep_work_ratio regardless of GVL scheduling.
-      #
-      # The cadence is measured in modules that pass the singleton-class fast-path
-      # skip — singleton classes are discarded in microseconds and counting them
-      # would add wall-clock delay disproportionate to the work being done (e.g.
-      # on heavily monkey-patched processes that retain large singleton chains).
-      SLEEP_EVERY_N_MODULES = 100
-      SLEEP_SECONDS = 0.001
-      private_constant :SLEEP_EVERY_N_MODULES, :SLEEP_SECONDS
-
       # Pass 1: Collect all extractable modules with methods grouped by source file.
       # @return [Hash] { mod_name => { mod:, methods_by_file: { path => [{name:, method:, type:}] } } }
       def collect_extractable_modules
         entries = {}
-        seen = 0
 
         ObjectSpace.each_object(Module) do |mod|
           # Singleton classes (per-object metaclasses) are never user-code classes.
@@ -644,9 +628,6 @@ module Datadog
           # — measured ~20ms per call, which dominates extract_all on heavily-loaded
           # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
           next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
-
-          seen += 1
-          sleep SLEEP_SECONDS if (seen % SLEEP_EVERY_N_MODULES).zero?
 
           mod_name = safe_mod_name(mod)
           next unless mod_name

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -7,8 +7,6 @@ module Datadog
       TARGETABLE_LINE_EVENTS: Array[::Symbol]
       MODULE_SINGLETON_CLASS_PRED: ::UnboundMethod
       MODULE_NAME: ::UnboundMethod
-      SLEEP_EVERY_N_MODULES: Integer
-      SLEEP_SECONDS: Float
 
       @logger: untyped
       @settings: untyped


### PR DESCRIPTION
JIRA: [DEBUG-5668](https://datadoghq.atlassian.net/browse/DEBUG-5668)

## Summary

**Do not merge.** This is a sibling-branch test for [#5776](https://github.com/DataDog/dd-trace-rb/pull/5776).

Branches from #5776's tip and reverts only the throttle implementation in `lib/datadog/symbol_database/extractor.rb` + `sig/datadog/symbol_database/extractor.rbs`. The benchmarks and helper additions from #5776 are kept.

The point is to verify that the benchmarks added in #5776 actually catch a throttle regression, by running CI against a branch where the throttle has been removed.

## What's removed vs #5776's tip

- `SLEEP_EVERY_N_MODULES = 100` constant
- `SLEEP_SECONDS = 0.001` constant
- `private_constant :SLEEP_EVERY_N_MODULES, :SLEEP_SECONDS`
- The `sleep SLEEP_SECONDS if (seen % SLEEP_EVERY_N_MODULES).zero?` call (and its `seen` counter) in `collect_extractable_modules`
- Matching RBS lines

## What to check in CI

Compare CI output here vs #5776:

1. `symbol_database_background_impact` — `p99_ratio_treatment_over_baseline` should jump from ~1.05 (PR 5776 with throttle) to well above 1.5 (this PR). The in-script `enforce_requirement` gate at threshold 1.50 should fire `exit 1`.
2. `symbol_database_baseline_matrix` — the 100%-arm `rps_drop` should jump from ~8% to materially higher. Lower-baseline arms are noisier in microbenchmark form (documented limitation), but should also shift.
3. bp-runner microbenchmarks (gitlab) — large ops/sec drop on the workload arms of both benchmarks vs master.
4. `symbol_database_extraction` — `wall_time_seconds` should drop ~2x (no per-chunk sleep) and `cpu_percent` should approach 100%. Memory should be unchanged.

## Cleanup

Delete this branch once the comparison has been recorded.

## Change log entry

None.

[DEBUG-5668]: https://datadoghq.atlassian.net/browse/DEBUG-5668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ