### PR TITLE
extend integration CI workflow to rails-five and rails-six

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - app: rails-five
-            ruby: "3.0"
+            ruby: "2.7"
           - app: rails-six
             ruby: "3.3"
           - app: rails-seven

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,15 +15,20 @@ concurrency:
 permissions: {}
 
 jobs:
-  rails-seven:
-    name: rails-seven (Ruby ${{ matrix.ruby }})
+  rails:
+    name: ${{ matrix.app }} (Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - "3.4"
+        include:
+          - app: rails-five
+            ruby: "3.0"
+          - app: rails-six
+            ruby: "3.3"
+          - app: rails-seven
+            ruby: "3.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,11 +50,11 @@ jobs:
       - name: Build integration base image
         run: ./integration/script/build-images -v ${{ matrix.ruby }}
 
-      - name: Build rails-seven image
-        run: ./integration/apps/rails-seven/script/build-images -v ${{ matrix.ruby }}
+      - name: Build ${{ matrix.app }} image
+        run: ./integration/apps/${{ matrix.app }}/script/build-images -v ${{ matrix.ruby }}
 
-      - name: Run rails-seven integration tests
-        run: ./integration/apps/rails-seven/script/ci -v ${{ matrix.ruby }}
+      - name: Run ${{ matrix.app }} integration tests
+        run: ./integration/apps/${{ matrix.app }}/script/ci -v ${{ matrix.ruby }}
 
   other-apps:
     name: ${{ matrix.app }} (Ruby ${{ matrix.ruby }})
@@ -95,7 +100,7 @@ jobs:
   complete:
     name: Integration Apps (complete)
     needs:
-      - rails-seven
+      - rails
       - other-apps
     runs-on: ubuntu-24.04
     steps:

--- a/integration/apps/rails-five/Gemfile
+++ b/integration/apps/rails-five/Gemfile
@@ -51,7 +51,7 @@ gem 'rack-cors'
 gem 'rake'
 # Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
 gem 'redis', '< 5'
-gem 'resque'
+gem 'resque', '~> 2'
 # gem 'resque-pool' # Incompatible with Redis 4.0+
 gem 'resque-scheduler'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]

--- a/integration/apps/rails-five/docker-compose.ci.yml
+++ b/integration/apps/rails-five/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
       - redis
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
-      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306
+      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306/acme_production
       - DATABASE_ROOT_USER=root
       - DATABASE_ROOT_PASSWORD=root
       - DD_AGENT_HOST=ddagent

--- a/integration/apps/rails-six/Gemfile
+++ b/integration/apps/rails-six/Gemfile
@@ -55,7 +55,7 @@ gem 'rack-cors'
 gem 'rake'
 # Known compatibility issue: https://github.com/redis/redis-rb/issues/1142
 gem 'redis', '< 5'
-gem 'resque'
+gem 'resque', '~> 2'
 # gem 'resque-pool' # Incompatible with Redis 4.0+
 gem 'resque-scheduler'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]

--- a/integration/apps/rails-six/docker-compose.ci.yml
+++ b/integration/apps/rails-six/docker-compose.ci.yml
@@ -13,7 +13,7 @@ services:
       - redis
     environment:
       - BUNDLE_GEMFILE=/app/Gemfile
-      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306
+      - DATABASE_URL=mysql2://mysql:mysql@mysql:3306/acme_production
       - DATABASE_ROOT_USER=root
       - DATABASE_ROOT_PASSWORD=root
       - DD_AGENT_HOST=ddagent

--- a/integration/images/ruby/3.0/Dockerfile
+++ b/integration/images/ruby/3.0/Dockerfile
@@ -13,10 +13,11 @@ RUN set -ex && \
         apt-get install -y --force-yes --no-install-recommends nodejs && \
         \
         echo "===> Installing Yarn" && \
-        curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+        install -d -m 0755 /etc/apt/keyrings && \
+        curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
         apt-get update && \
-        apt-get install -y --force-yes --no-install-recommends yarn && \
+        apt-get install -y --no-install-recommends yarn && \
         \
         echo "===> Installing database libraries" && \
         apt-get install -y --force-yes --no-install-recommends \

--- a/integration/images/ruby/3.3/Dockerfile
+++ b/integration/images/ruby/3.3/Dockerfile
@@ -13,10 +13,11 @@ RUN set -ex && \
         apt-get install -y --force-yes --no-install-recommends nodejs && \
         \
         echo "===> Installing Yarn" && \
-        curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+        install -d -m 0755 /etc/apt/keyrings && \
+        curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
         apt-get update && \
-        apt-get install -y --force-yes --no-install-recommends yarn && \
+        apt-get install -y --no-install-recommends yarn && \
         \
         echo "===> Installing database libraries" && \
         apt-get install -y --force-yes --no-install-recommends \


### PR DESCRIPTION
**What does this PR do?**

Extends the integration test workflow added in #5696 to also run `rails-five` (Ruby 2.7) and `rails-six` (Ruby 3.3) integration apps. Stacks on top of #5696 — once that lands, this diff narrows to just the rails-five/six additions.

**Depends on:** #5786 (for the 2.7 base image `apt-key` → keyring fix used by the rails-five row).

**Motivation:**

The rails-seven workflow restored execution for the `rails-seven/spec/integration/di_spec.rb` that had been silently skipped since CircleCI was retired (commit 3e3511bed8, Feb 2025). The same orphan exists in `rails-five/spec/integration/di_spec.rb` and `rails-six/spec/integration/di_spec.rb`. This PR wires them up.

**Approach:**

- Workflow re-shaped as a single matrix-driven job covering `{rails-five, 2.7}`, `{rails-six, 3.3}`, `{rails-seven, 3.4}`.
- Same two bit-rot fixes the rails-seven path needed are applied to the new versions:
  - Ruby 3.0 / 3.3 base images: switch the yarn repo install from the removed `apt-key add` to the modern `gpg --dearmor` + signed-by keyring pattern. (The 2.7 base image needs the same fix; it lives in #5786.)
  - `rails-five/rails-six` `docker-compose.ci.yml`: add the database name to `DATABASE_URL` so `bin/rails db:prepare` does not abort with "No database selected" under Rails 7's URL-merging rules.

**Change log entry**

None.
