### PR TITLE
[NO-TICKET] Remove `links` from `docker-compose.yml` and use network alias instead

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - presto
       - redis
       - testagent
-    links: &common-links
-      - mongodb:mongodb_secondary
     env_file: ./.env
     environment: &common-environment
       BUNDLE_GEMFILE: /app/ruby-2.5.gemfile
@@ -45,7 +43,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -62,7 +59,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -79,7 +75,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -96,7 +91,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -113,7 +107,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -130,7 +123,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -147,7 +139,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -164,7 +155,6 @@ services:
     working_dir: /app
     command: /bin/bash
     depends_on: *common-depends-on
-    links: *common-links
     env_file: ./.env
     environment:
       <<: *common-environment
@@ -241,6 +231,10 @@ services:
       - "27017"
     ports:
       - "127.0.0.1:${TEST_MONGODB_PORT}:27017"
+    networks:
+      default:
+        aliases:
+          - mongodb_secondary
   mysql:
     image: mysql:8.0
     environment:


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
This PR removes links from docker-compose.yml and use network alias instead

**Motivation:**
<!-- What inspired you to submit this pull request? -->
I switched to Podman Desktop with Docker compatibility, and `links` is not supported (because `link` in docker is deprecated)

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
CI + running locally docker compose locally using podman or colima should just work

<!-- Unsure? Have a question? Request a review! -->
