### PR TITLE
Fix #expect_in_fork helper to check mock expectations

### DIFF
--- a/spec/datadog/expect_in_fork_spec.rb
+++ b/spec/datadog/expect_in_fork_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe "SynchronizationHelpers#expect_in_fork" do
+  it "works" do
+    pid1 = Process.pid
+    pid2 = nil
+    expect_in_fork do
+      pid2 = Process.pid
+      expect(pid2).not_to eq(pid1)
+    end
+    expect(pid1).not_to eq(pid2)
+  end
+
+  it "errors for failing regular expectations" do
+    expect {
+      expect_in_fork do
+        expect(1).to eq(2)
+      end
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  it "errors for failing mock expectations" do
+    expect {
+      expect_in_fork do
+        expect(Process).to receive(:pid)
+        # Not calling Process.pid, should fail
+      end
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+end

--- a/spec/support/synchronization_helpers.rb
+++ b/spec/support/synchronization_helpers.rb
@@ -30,7 +30,9 @@ module SynchronizationHelpers
         $stderr.reopen(fork_stderr) # STDERR captures RSpec failures. We print it in case the fork fails on exit.
         $stderr.sync = true
 
-        yield
+        RSpec::Mocks.with_temporary_scope do
+          yield
+        end
       end
 
       # Wait for fork to finish, retrieve its status.


### PR DESCRIPTION
* Before this, all mock expectations would be ignored,
  since they are checked after the `after` hooks run,
  but the fork only ran the passed block and stopped before any `after` hook.
* RSpec::Mocks.with_temporary_scope creates a separate scope
  so only child process mock expectations are checked there.
  RSpec::Mocks.with_temporary_scope does the same as RSpec::Mocks.verify after calling the block.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
What the title says.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, a brief summary to be placed
into the change log. This will be the ONLY mention of the change in the
release notes; it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I added a spec for `SynchronizationHelpers#expect_in_fork` and verified it fails without the fix.
I also did some manual tests.

<!-- Unsure? Have a question? Request a review! -->
