### PR TITLE
benchmarks: add dummy benchmark

### DIFF
--- a/benchmarks/dummy.rb
+++ b/benchmarks/dummy.rb
@@ -1,0 +1,29 @@
+# Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
+VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'
+
+return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
+
+require_relative 'benchmarks_helper'
+
+# Minimal benchmark that emits a benchmark-ips-shaped result JSON.
+# Used to verify the microbenchmarks: [other] CI job and its analyzer
+# pipeline are healthy end-to-end without depending on any product code path.
+class DummyBenchmark
+  def run_benchmark
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(**benchmark_time)
+
+      x.report('dummy - integer add') { 1 + 1 }
+
+      x.save! "#{File.basename(__FILE__, '.rb')}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
+end
+
+puts "Current pid is #{Process.pid}"
+
+DummyBenchmark.new.instance_exec do
+  run_benchmark
+end

--- a/benchmarks/execution.yml
+++ b/benchmarks/execution.yml
@@ -30,9 +30,6 @@
       tracing_trace.rb
       di_instrument.rb
       library_gem_loading.rb
-      symbol_database_extraction.rb
-      symbol_database_background_impact.rb
-      symbol_database_baseline_matrix.rb
 
 .execution:
   variables:

--- a/benchmarks/execution.yml
+++ b/benchmarks/execution.yml
@@ -30,6 +30,7 @@
       tracing_trace.rb
       di_instrument.rb
       library_gem_loading.rb
+      dummy.rb
 
 .execution:
   variables:


### PR DESCRIPTION
**What does this PR do?**

Stacks on #5795 and adds a minimal no-op benchmark (`benchmarks/dummy.rb`) wired into the `microbenchmarks: [other]` group. The benchmark measures `1 + 1` and emits a benchmark-ips-shaped result JSON.

**Motivation:**

Smoke-test the `microbenchmarks: [other]` CI job and the analyzer pipeline end-to-end without depending on any product code path. Useful as a stable baseline when the analyzer or runner infrastructure changes; the dummy's results are insensitive to anything in `lib/`.

**Change log entry**

None.

**Additional Notes:**

Draft because it depends on #5795 (the disable of the broken SymDB benchmarks). Once #5795 lands, this PR's diff against master collapses to just the dummy benchmark addition.

**How to test the change?**

- `ruby -c benchmarks/dummy.rb` passes
- `yamllint --strict benchmarks/execution.yml` passes
- After merge: the next `microbenchmarks: [other]` run shows a `dummy - integer add` line in the analyzer report