### PR TITLE
benchmarks: reduce validation timeout to 4s

### DIFF
--- a/spec/datadog/di/validate_benchmarks_spec.rb
+++ b/spec/datadog/di/validate_benchmarks_spec.rb
@@ -11,13 +11,8 @@ RSpec.describe "Dynamic instrumentation benchmarks", :memcheck_valgrind_skip do
 
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
-      timeout = if benchmark == 'di_snapshot'
-        20
-      else
-        10
-      end
       it "runs without raising errors" do
-        expect_in_fork(timeout_seconds: timeout) do
+        expect_in_fork(timeout_seconds: 4) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end

--- a/spec/datadog/error_tracking/validate_benchmarks_spec.rb
+++ b/spec/datadog/error_tracking/validate_benchmarks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Error Tracking benchmarks', :memcheck_valgrind_skip do
 
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
-      it('runs without raising errors') { expect_in_fork { load "./benchmarks/#{benchmark}.rb" } }
+      it('runs without raising errors') { expect_in_fork(timeout_seconds: 4) { load "./benchmarks/#{benchmark}.rb" } }
     end
   end
 

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
 
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
-      it("runs without raising errors") { expect_in_fork(timeout_seconds: 15, trigger_stacktrace_on_kill: true) { load "./benchmarks/#{benchmark}.rb" } }
+      it("runs without raising errors") { expect_in_fork(timeout_seconds: 4, trigger_stacktrace_on_kill: true) { load "./benchmarks/#{benchmark}.rb" } }
     end
   end
 

--- a/spec/datadog/symbol_database/validate_benchmarks_spec.rb
+++ b/spec/datadog/symbol_database/validate_benchmarks_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Symbol Database benchmarks' do
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
       it 'runs without raising errors' do
-        expect_in_fork do
+        expect_in_fork(timeout_seconds: 4) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end

--- a/spec/datadog/tracing/validate_benchmarks_spec.rb
+++ b/spec/datadog/tracing/validate_benchmarks_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Tracing benchmarks' do
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
       it 'runs without raising errors' do
-        expect_in_fork(timeout_seconds: 20) do
+        expect_in_fork(timeout_seconds: 4) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end

--- a/spec/validate_benchmarks_spec.rb
+++ b/spec/validate_benchmarks_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Library benchmarks' do
   benchmarks_to_validate.each do |benchmark|
     describe benchmark do
       it 'runs without raising errors' do
-        expect_in_fork do
+        expect_in_fork(timeout_seconds: 4) do
           load "./benchmarks/#{benchmark}.rb"
         end
       end


### PR DESCRIPTION
**What does this PR do?**

Tightens `expect_in_fork(timeout_seconds: ...)` in every `validate_benchmarks_spec.rb` to 4 seconds. Six files touched; current values range from no explicit timeout (defaults to 10s in expect_in_fork) up to 20s.

**Motivation:**

Observed validation durations on master @ `07e4d7bc92` (Unit Tests run 26178282614, Ruby 3.4): max is 2.41s (`tracing_trace`), with most under 1s. The 10–20s timeouts have ~5–10x headroom — far too loose to catch bitrot quickly. A 4s cap is ~1.5–2x over the slowest legitimate validation, tightens the bitrot signal, and still gives ample margin.

`symbol_database_baseline_matrix` regularly runs 6–8s — but it is being removed in a separate PR (#5795), so it does not need to fit under the new ceiling here. If 5795 lands first there will be no conflict (the SymDB spec file is deleted by 5795); if this PR lands first, the SymDB validation will start timing out — which is the desired signal that the spec needs to go.

**Change log entry**

None.

**Additional Notes:**

Draft — needs CI to confirm the 4s ceiling holds across all Rubies. Some benchmarks may run slower on Ruby 2.5/2.6 than on 3.4; if any cross 4s on those, the per-benchmark timeout can be selectively raised.

**How to test the change?**

CI will run the validate specs across the full Ruby matrix. Watch for any `expect_in_fork` timeouts and adjust per-benchmark if needed.