### PR TITLE
[APPSEC-61865] Change expected payload keys to normalized format

### DIFF
--- a/lib/datadog/appsec/contrib/aws_lambda/waf_addresses.rb
+++ b/lib/datadog/appsec/contrib/aws_lambda/waf_addresses.rb
@@ -42,7 +42,7 @@ module Datadog
 
             headers = parse_headers(payload)
             data = {
-              'server.response.status' => payload['statusCode']&.to_s,
+              'server.response.status' => payload['status_code']&.to_s,
               'server.response.headers' => headers,
               'server.response.headers.no_cookies' => headers.dup.tap { |h| h.delete('set-cookie') }
             }

--- a/spec/datadog/appsec/contrib/aws_lambda/waf_addresses_spec.rb
+++ b/spec/datadog/appsec/contrib/aws_lambda/waf_addresses_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Datadog::AppSec::Contrib::AwsLambda::WAFAddresses do
     context 'when payload has status and headers' do
       let(:payload) do
         {
-          'statusCode' => 201,
+          'status_code' => 201,
           'headers' => {'Content-Type' => 'application/json', 'Set-Cookie' => 'session=xyz'},
         }
       end
@@ -235,13 +235,13 @@ RSpec.describe Datadog::AppSec::Contrib::AwsLambda::WAFAddresses do
       it { expect(result).to eq({}) }
     end
 
-    context 'when statusCode is a string' do
-      let(:payload) { {'statusCode' => '404', 'headers' => {}} }
+    context 'when status code is a string' do
+      let(:payload) { {'status_code' => '404', 'headers' => {}} }
 
       it { expect(result['server.response.status']).to eq('404') }
     end
 
-    context 'when statusCode is missing' do
+    context 'when status code is missing' do
       let(:payload) { {'headers' => {}} }
 
       it { expect(result).not_to have_key('server.response.status') }


### PR DESCRIPTION
**What does this PR do?**

Update camel case keys to snake case for upcoming normalization fix

**Motivation:**

This was overlooked and as it's not used now, I decided to fix it properly on both sides Lambda and AppSec

**Change log entry**

None.

**Additional Notes:**

Fixed in Lambda too https://github.com/DataDog/datadog-lambda-rb/pull/144

**How to test the change?**

CI