### PR TITLE
Rename constant conflicting with built-in type: Base64

### DIFF
--- a/lib/datadog/appsec/compressed_json.rb
+++ b/lib/datadog/appsec/compressed_json.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'zlib'
 require 'stringio'
 
-require_relative '../core/utils/base64'
+require_relative '../core/utils/base64_codec'
 
 module Datadog
   module AppSec
@@ -27,7 +27,7 @@ module Datadog
       end
 
       private_class_method def self.compress_and_encode(payload)
-        Core::Utils::Base64.strict_encode64(
+        Core::Utils::Base64Codec.strict_encode64(
           Zlib.gzip(payload, level: Zlib::BEST_SPEED, strategy: Zlib::DEFAULT_STRATEGY)
         )
       rescue Zlib::Error, TypeError => e

--- a/lib/datadog/appsec/contrib/aws_lambda/waf_addresses.rb
+++ b/lib/datadog/appsec/contrib/aws_lambda/waf_addresses.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 require_relative '../../utils/http/media_type'
 require_relative '../../utils/http/body'
-require_relative '../../../core/utils/base64'
+require_relative '../../../core/utils/base64_codec'
 require_relative '../../../core/header_collection'
 require_relative '../../../tracing/client_ip'
 
@@ -94,7 +94,7 @@ module Datadog
             body = payload['body']
             return unless body
 
-            body = Core::Utils::Base64.strict_decode64(body) if payload['base64_encoded']
+            body = Core::Utils::Base64Codec.strict_decode64(body) if payload['base64_encoded']
 
             content_type = headers['content-type']
             return unless content_type

--- a/lib/datadog/core/remote/client/capabilities.rb
+++ b/lib/datadog/core/remote/client/capabilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../../utils/base64'
+require_relative '../../utils/base64_codec'
 require_relative '../../../appsec/remote'
 require_relative '../../../tracing/remote'
 require_relative '../../../di/remote'
@@ -77,7 +77,7 @@ module Datadog
             cap_to_hexs = capabilities.reduce(:|).to_s(16).tap { |s| s.size.odd? && s.prepend('0') }.scan(/\h\h/)
             binary = cap_to_hexs.each_with_object([]) { |hex, acc| acc << hex }.map { |e| e.to_i(16) }.pack('C*')
 
-            Datadog::Core::Utils::Base64.strict_encode64(binary)
+            Datadog::Core::Utils::Base64Codec.strict_encode64(binary)
           end
         end
       end

--- a/lib/datadog/core/remote/transport/http/config.rb
+++ b/lib/datadog/core/remote/transport/http/config.rb
@@ -4,7 +4,7 @@ require 'json'
 
 require_relative '../../../transport/http/api/endpoint'
 require_relative '../../../transport/http/response'
-require_relative '../../../utils/base64'
+require_relative '../../../utils/base64_codec'
 require_relative '../../../utils/truncation'
 
 module Datadog
@@ -35,7 +35,7 @@ module Datadog
 
                 # TODO: these fallbacks should be improved
                 roots = payload[:roots] || []
-                targets = payload[:targets] || Datadog::Core::Utils::Base64.strict_encode64('{}')
+                targets = payload[:targets] || Datadog::Core::Utils::Base64Codec.strict_encode64('{}')
                 target_files = payload[:target_files] || []
                 client_configs = payload[:client_configs] || []
 
@@ -45,7 +45,7 @@ module Datadog
                   raise TypeError.new(String, root) unless root.is_a?(String)
 
                   decoded = begin
-                    Datadog::Core::Utils::Base64.strict_decode64(root) # TODO: unprocessed, don't symbolize_names
+                    Datadog::Core::Utils::Base64Codec.strict_decode64(root) # TODO: unprocessed, don't symbolize_names
                   rescue ArgumentError
                     raise DecodeError.new(:roots, root)
                   end
@@ -65,7 +65,7 @@ module Datadog
 
                 @targets = begin
                   decoded = begin
-                    Datadog::Core::Utils::Base64.strict_decode64(targets)
+                    Datadog::Core::Utils::Base64Codec.strict_decode64(targets)
                   rescue ArgumentError
                     raise DecodeError.new(:targets, targets)
                   end
@@ -93,7 +93,7 @@ module Datadog
                   raise TypeError.new(String, raw) unless raw.is_a?(String)
 
                   content = begin
-                    Datadog::Core::Utils::Base64.strict_decode64(raw)
+                    Datadog::Core::Utils::Base64Codec.strict_decode64(raw)
                   rescue ArgumentError
                     raise DecodeError.new(:target_files, raw)
                   end

--- a/lib/datadog/core/utils/base64_codec.rb
+++ b/lib/datadog/core/utils/base64_codec.rb
@@ -4,7 +4,7 @@ module Datadog
   module Core
     module Utils
       # Helper methods for encoding and decoding base64
-      module Base64
+      module Base64Codec
         def self.encode64(bin)
           [bin].pack('m')
         end

--- a/lib/datadog/core/utils/base64_codec.rb
+++ b/lib/datadog/core/utils/base64_codec.rb
@@ -3,7 +3,8 @@
 module Datadog
   module Core
     module Utils
-      # Helper methods for encoding and decoding base64
+      # Base64 encoding/decoding without using the `base64` gem,
+      # which is no longer a default gem since Ruby 3.4.
       module Base64Codec
         def self.encode64(bin)
           [bin].pack('m')

--- a/lib/datadog/data_streams/pathway_context.rb
+++ b/lib/datadog/data_streams/pathway_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'stringio'
-require_relative '../core/utils/base64'
+require_relative '../core/utils/base64_codec'
 
 module Datadog
   module DataStreams
@@ -34,7 +34,7 @@ module Datadog
       end
 
       def encode_b64
-        Core::Utils::Base64.strict_encode64(encode)
+        Core::Utils::Base64Codec.strict_encode64(encode)
       end
 
       # Decode pathway context from base64 encoded string
@@ -42,7 +42,7 @@ module Datadog
         return nil unless encoded_ctx && !encoded_ctx.empty?
 
         begin
-          binary_data = Core::Utils::Base64.strict_decode64(encoded_ctx)
+          binary_data = Core::Utils::Base64Codec.strict_decode64(encoded_ctx)
           decode(binary_data)
         rescue ArgumentError => e
           # Invalid base64 encoding - may indicate version mismatch or corruption

--- a/sig/datadog/core/utils/base64_codec.rbs
+++ b/sig/datadog/core/utils/base64_codec.rbs
@@ -1,7 +1,6 @@
 module Datadog
   module Core
     module Utils
-      # Helper methods for encoding and decoding base64
       module Base64Codec
         def self.encode64: (String bin) -> String
 

--- a/sig/datadog/core/utils/base64_codec.rbs
+++ b/sig/datadog/core/utils/base64_codec.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Utils
       # Helper methods for encoding and decoding base64
-      module Base64
+      module Base64Codec
         def self.encode64: (String bin) -> String
 
         def self.strict_encode64: (String bin) -> String

--- a/spec/datadog/core/remote/client_spec.rb
+++ b/spec/datadog/core/remote/client_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'datadog/core/utils/base64'
+require 'datadog/core/utils/base64_codec'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/client'
 
@@ -212,21 +212,21 @@ RSpec.describe Datadog::Core::Remote::Client do
   let(:rules_data_response) do
     {
       'path' => 'datadog/603646/ASM_DD/latest/config',
-      'raw' => Datadog::Core::Utils::Base64.strict_encode64(rules_data).chomp
+      'raw' => Datadog::Core::Utils::Base64Codec.strict_encode64(rules_data).chomp
     }
   end
 
   let(:blocked_ips_data_response) do
     {
       'path' => 'datadog/603646/ASM_DATA/blocked_ips/config',
-      'raw' => Datadog::Core::Utils::Base64.strict_encode64(blocked_ips).chomp
+      'raw' => Datadog::Core::Utils::Base64Codec.strict_encode64(blocked_ips).chomp
     }
   end
 
   let(:exclusion_data_response) do
     {
       'path' => 'datadog/603646/ASM/exclusion_filters/config',
-      'raw' => Datadog::Core::Utils::Base64.strict_encode64(exclusions).chomp
+      'raw' => Datadog::Core::Utils::Base64Codec.strict_encode64(exclusions).chomp
     }
   end
 
@@ -236,8 +236,8 @@ RSpec.describe Datadog::Core::Remote::Client do
 
   let(:response_body) do
     {
-      'roots' => roots.map { |r| Datadog::Core::Utils::Base64.strict_encode64(r.to_json).chomp },
-      'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json).chomp,
+      'roots' => roots.map { |r| Datadog::Core::Utils::Base64Codec.strict_encode64(r.to_json).chomp },
+      'targets' => Datadog::Core::Utils::Base64Codec.strict_encode64(targets.to_json).chomp,
       'target_files' => target_files,
       'client_configs' => client_configs,
     }.to_json
@@ -393,12 +393,12 @@ RSpec.describe Datadog::Core::Remote::Client do
       context 'invalid response body' do
         let(:response_body) do
           {
-            'roots' => roots.map { |r| Datadog::Core::Utils::Base64.strict_encode64(r.to_json).chomp },
-            'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json).chomp,
+            'roots' => roots.map { |r| Datadog::Core::Utils::Base64Codec.strict_encode64(r.to_json).chomp },
+            'targets' => Datadog::Core::Utils::Base64Codec.strict_encode64(targets.to_json).chomp,
             'target_files' => [
               {
                 'path' => 'datadog/603646/ASM/exclusion_filters/config',
-                'raw' => Datadog::Core::Utils::Base64.strict_encode64(exclusions).chomp
+                'raw' => Datadog::Core::Utils::Base64Codec.strict_encode64(exclusions).chomp
               }
             ],
             'client_configs' => [

--- a/spec/datadog/core/remote/component_forking_spec.rb
+++ b/spec/datadog/core/remote/component_forking_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'datadog/core/remote/component'
-require 'datadog/core/utils/base64'
+require 'datadog/core/utils/base64_codec'
 
 RSpec.describe Datadog::Core::Remote::Component do
   forking_platform_only
@@ -165,7 +165,7 @@ RSpec.describe Datadog::Core::Remote::Component do
 
         # Return an empty but valid response
         jencode = proc do |obj|
-          Datadog::Core::Utils::Base64.strict_encode64(JSON.dump(obj)).chomp
+          Datadog::Core::Utils::Base64Codec.strict_encode64(JSON.dump(obj)).chomp
         end
 
         res.status = 200

--- a/spec/datadog/core/remote/transport/http_spec.rb
+++ b/spec/datadog/core/remote/transport/http_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 require 'ostruct'
-require 'datadog/core/utils/base64'
+require 'datadog/core/utils/base64_codec'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
@@ -144,7 +144,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
               env: Datadog.configuration.env,
               tags: [],
             },
-            capabilities: Datadog::Core::Utils::Base64.encode64(capabilities_binary).chomp,
+            capabilities: Datadog::Core::Utils::Base64Codec.encode64(capabilities_binary).chomp,
           },
           cached_target_files: [],
         }
@@ -155,11 +155,11 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
       let(:response_code) { 200 }
       let(:response_body) do
         encode = proc do |obj|
-          Datadog::Core::Utils::Base64.strict_encode64(obj).chomp
+          Datadog::Core::Utils::Base64Codec.strict_encode64(obj).chomp
         end
 
         jencode = proc do |obj|
-          Datadog::Core::Utils::Base64.strict_encode64(JSON.dump(obj)).chomp
+          Datadog::Core::Utils::Base64Codec.strict_encode64(JSON.dump(obj)).chomp
         end
 
         JSON.dump(

--- a/spec/datadog/core/remote/transport/integration_spec.rb
+++ b/spec/datadog/core/remote/transport/integration_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 require 'ostruct'
-require 'datadog/core/utils/base64'
+require 'datadog/core/utils/base64_codec'
 require 'datadog/core/remote/transport/http'
 require 'datadog/core/remote/transport/http/negotiation'
 require 'datadog/core/remote/transport/negotiation'
@@ -93,7 +93,7 @@ RSpec.describe Datadog::Core::Remote::Transport::HTTP do
               env: Datadog.configuration.env,
               tags: [],
             },
-            capabilities: Datadog::Core::Utils::Base64.encode64(capabilities_binary).chomp,
+            capabilities: Datadog::Core::Utils::Base64Codec.encode64(capabilities_binary).chomp,
           },
           cached_target_files: [],
         }

--- a/spec/datadog/core/utils/base64_codec_spec.rb
+++ b/spec/datadog/core/utils/base64_codec_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+require 'datadog/core/utils/base64_codec'
+
+RSpec.describe Datadog::Core::Utils::Base64Codec do
+  describe '.encode64' do
+    subject(:encoded) { described_class.encode64('hello') }
+
+    it { is_expected.to eq("aGVsbG8=\n") }
+  end
+
+  describe '.strict_encode64' do
+    subject(:encoded) { described_class.strict_encode64('hello') }
+
+    it { is_expected.to eq('aGVsbG8=') }
+  end
+
+  describe '.strict_decode64' do
+    subject(:decoded) { described_class.strict_decode64('aGVsbG8=') }
+
+    it { is_expected.to eq('hello') }
+  end
+end

--- a/spec/datadog/data_streams/pathway_context_spec.rb
+++ b/spec/datadog/data_streams/pathway_context_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Datadog::DataStreams::PathwayContext do
 
     it 'returns nil for truncated data' do
       # Base64 encode only 4 bytes (need at least 8 for hash)
-      truncated = Datadog::Core::Utils::Base64.strict_encode64("\x01\x02\x03\x04")
+      truncated = Datadog::Core::Utils::Base64Codec.strict_encode64("\x01\x02\x03\x04")
       result = described_class.decode_b64(truncated)
       expect(result).to be_nil
     end

--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'datadog/core/utils/base64_codec'
+
 module DIHelpers
   class TestRemoteConfigGenerator
     def initialize(probe_configs)
@@ -81,7 +83,7 @@ module DIHelpers
     end
 
     def encode_str(v)
-      Datadog::Core::Utils::Base64.strict_encode64(v).chomp
+      Datadog::Core::Utils::Base64Codec.strict_encode64(v).chomp
     end
 
     def encode_obj(v)

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -1,4 +1,4 @@
-require 'datadog/core/utils/base64'
+require 'datadog/core/utils/base64_codec'
 require 'datadog/tracing/contrib/support/spec_helper'
 
 require 'datadog'
@@ -74,7 +74,7 @@ RSpec.describe 'contrib integration testing', :integration do
 
         target_files << {
           'path' => target,
-          'raw' => Datadog::Core::Utils::Base64.strict_encode64(raw),
+          'raw' => Datadog::Core::Utils::Base64Codec.strict_encode64(raw),
         }
 
         targets_targets[target] = {
@@ -87,7 +87,7 @@ RSpec.describe 'contrib integration testing', :integration do
 
       {
         'target_files' => target_files,
-        'targets' => Datadog::Core::Utils::Base64.strict_encode64(targets.to_json),
+        'targets' => Datadog::Core::Utils::Base64Codec.strict_encode64(targets.to_json),
         'client_configs' => client_configs,
       }.to_json
     end


### PR DESCRIPTION
**What does this PR do?**
Renames `Datadog::Core::Utils::Base64` to `Datadog::Core::Utils::Base64Codec`.

**Motivation:**
`Datadog::Core::Utils::Base64` collides with Ruby's standard `Base64` constant, when referenced through nested constant lookup.
This can cause you to reference `Base64`, normally wanting the std `Base64` module, but end up with `Datadog::Core::Utils::Base64`.

**Change log entry**
None. Internal.

**Additional Notes:**
Added coverage for (the newly renamed) `Base64Codec`.

**How to test the change?**
`bundle exec rspec spec/datadog/core/utils/base64_codec_spec.rb`