### PR TITLE
Fix typo in header name

### DIFF
--- a/lib/datadog/appsec/contrib/rack/ext.rb
+++ b/lib/datadog/appsec/contrib/rack/ext.rb
@@ -13,7 +13,7 @@ module Datadog
             'cloudfront-viewer-ja3-fingerprint',
             'content-type',
             'user-agent',
-            'x-amzn-trace-Id',
+            'x-amzn-trace-id',
             'x-appgw-trace-id',
             'x-cloud-trace-context',
             'x-sigsci-requestid',


### PR DESCRIPTION
It's checked case-sensitively here

https://github.com/DataDog/dd-trace-rb/blob/3d0ced6286b503a495f390bdb3698e0bdaa2bfd0/lib/datadog/appsec/contrib/rack/gateway/watcher.rb#L122

although Codex points out that fixing this doesn't actually matter because the same header is checked for with the correct case here

https://github.com/DataDog/dd-trace-rb/blob/3d0ced6286b503a495f390bdb3698e0bdaa2bfd0/lib/datadog/appsec/contrib/rack/request_middleware.rb#L30

https://github.com/DataDog/dd-trace-rb/blob/3d0ced6286b503a495f390bdb3698e0bdaa2bfd0/lib/datadog/appsec/contrib/rack/request_middleware.rb#L195

**Change log entry**

None.
