### PR TITLE
[APPSEC-62377] Collect Datadog request attribution headers

### DIFF
--- a/.github/forced-tests-list.cfg
+++ b/.github/forced-tests-list.cfg
@@ -10,3 +10,5 @@
 
 # Example :
 # tests/parametric/test_config_consistency.py::Test_Stable_Config_Default::test_config_precedence
+
+tests/appsec/api_security_testing/test_headers_collection.py::Test_SecurityTestingHeaders

--- a/lib/datadog/tracing/contrib/rack/header_tagging.rb
+++ b/lib/datadog/tracing/contrib/rack/header_tagging.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
+require_relative 'header_collection'
+
 module Datadog
   module Tracing
     module Contrib
       module Rack
         # Matches Rack-style headers with a matcher and sets matching headers into a span.
         module HeaderTagging
+          DATADOG_REQUEST_ATTRIBUTION_HEADERS = [
+            'x-datadog-endpoint-scan',
+            'x-datadog-security-test'
+          ].freeze
+
           def self.tag_request_headers(span, env, configuration)
             # Wrap env in a case-insensitive Rack-style accessor.
             headers = env.is_a?(Header::RequestHeaderCollection) ? env : Header::RequestHeaderCollection.new(env)
@@ -25,6 +32,7 @@ module Datadog
             end
 
             span.set_tags(tags)
+            tag_datadog_request_attribution_headers(span, headers)
           end
 
           def self.tag_response_headers(span, headers, configuration)
@@ -55,6 +63,21 @@ module Datadog
             end
 
             span.set_tags(tags)
+          end
+
+          # Datadog-originated requests use these headers for request attribution.
+          # They are tagged independently of user-configured header tagging so
+          # downstream systems can distinguish them from regular application traffic.
+          #
+          # @api private
+          private_class_method def self.tag_datadog_request_attribution_headers(span, headers)
+            DATADOG_REQUEST_ATTRIBUTION_HEADERS.each do |header|
+              header_value = headers.get(header)
+              next unless header_value
+
+              header_tag = Tracing::Metadata::Ext::HTTP::RequestHeaders.to_tag(header)
+              span.set_tag(header_tag, header_value)
+            end
           end
         end
       end

--- a/sig/datadog/tracing/contrib/rack/header_collection.rbs
+++ b/sig/datadog/tracing/contrib/rack/header_collection.rbs
@@ -4,7 +4,7 @@ module Datadog
       module Rack
         module Header
           class RequestHeaderCollection < Datadog::Core::HeaderCollection
-            def initialize: (untyped env) -> void
+            def initialize: (::Rack::env env) -> void
             def get: (untyped header_name) -> untyped
             alias [] get
             def key?: (untyped header_name) -> untyped

--- a/sig/datadog/tracing/contrib/rack/header_tagging.rbs
+++ b/sig/datadog/tracing/contrib/rack/header_tagging.rbs
@@ -3,8 +3,13 @@ module Datadog
     module Contrib
       module Rack
         module HeaderTagging
-          def self.tag_request_headers: (SpanOperation span, Hash[String,String] env, Configuration configuration) -> untyped
-          def self.tag_response_headers: (SpanOperation span, Hash[String,String] headers, Configuration configuration) -> untyped
+          DATADOG_REQUEST_ATTRIBUTION_HEADERS: ::Array[::String]
+
+          def self.tag_request_headers: (SpanOperation span, ::Rack::env | Header::RequestHeaderCollection env, Configuration::Settings configuration) -> void
+
+          def self.tag_response_headers: (SpanOperation span, ::Rack::headers headers, Configuration::Settings configuration) -> void
+
+          def self.tag_datadog_request_attribution_headers: (SpanOperation span, Core::HeaderCollection headers) -> void
         end
       end
     end

--- a/spec/datadog/tracing/contrib/rack/header_tagging_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/header_tagging_spec.rb
@@ -3,6 +3,95 @@ require 'rack'
 require 'datadog/tracing/contrib/rack/header_tagging'
 
 RSpec.describe Datadog::Tracing::Contrib::Rack::HeaderTagging do
+  describe '.tag_request_headers' do
+    after do
+      Datadog.configuration.tracing.header_tags = []
+      Datadog.registry[:rack].reset_configuration!
+    end
+
+    let(:span_op) { Datadog::Tracing::SpanOperation.new('rack.request') }
+    let(:configuration) { Datadog.configuration.tracing[:rack] }
+    let(:env) do
+      {
+        'HTTP_X_DATADOG_ENDPOINT_SCAN' => 'scan-uuid',
+        'HTTP_X_DATADOG_SECURITY_TEST' => 'test-uuid',
+        'HTTP_X_OTHER_HEADER' => 'ignored'
+      }
+    end
+
+    context 'when no request headers are configured' do
+      before { described_class.tag_request_headers(span_op, env, configuration) }
+
+      it 'tags Datadog request attribution headers' do
+        aggregate_failures 'Datadog request attribution header tags' do
+          expect(span_op.get_tag('http.request.headers.x-datadog-endpoint-scan')).to eq('scan-uuid')
+          expect(span_op.get_tag('http.request.headers.x-datadog-security-test')).to eq('test-uuid')
+          expect(span_op.get_tag('http.request.headers.x-other-header')).to be_nil
+        end
+      end
+
+      context 'when Datadog request attribution headers are absent' do
+        let(:env) { {'HTTP_X_OTHER_HEADER' => 'ignored'} }
+
+        it 'does not tag Datadog request attribution headers' do
+          aggregate_failures 'Datadog request attribution header tags' do
+            expect(span_op.get_tag('http.request.headers.x-datadog-endpoint-scan')).to be_nil
+            expect(span_op.get_tag('http.request.headers.x-datadog-security-test')).to be_nil
+          end
+        end
+      end
+
+      context 'when Datadog request attribution headers have empty values' do
+        let(:env) do
+          {
+            'HTTP_X_DATADOG_ENDPOINT_SCAN' => '',
+            'HTTP_X_DATADOG_SECURITY_TEST' => ''
+          }
+        end
+
+        it 'tags Datadog request attribution headers' do
+          aggregate_failures 'Datadog request attribution header tags' do
+            expect(span_op.get_tag('http.request.headers.x-datadog-endpoint-scan')).to eq('')
+            expect(span_op.get_tag('http.request.headers.x-datadog-security-test')).to eq('')
+          end
+        end
+      end
+    end
+
+    context 'when global header tags are configured for unrelated headers' do
+      before do
+        Datadog.configuration.tracing.header_tags = ['x-other-header']
+        described_class.tag_request_headers(span_op, env, configuration)
+      end
+
+      it 'tags Datadog request attribution headers' do
+        aggregate_failures 'request header tags' do
+          expect(span_op.get_tag('http.request.headers.x-datadog-endpoint-scan')).to eq('scan-uuid')
+          expect(span_op.get_tag('http.request.headers.x-datadog-security-test')).to eq('test-uuid')
+          expect(span_op.get_tag('http.request.headers.x-other-header')).to eq('ignored')
+        end
+      end
+    end
+
+    context 'when integration header tags are configured for unrelated headers' do
+      before do
+        Datadog.configure do |c|
+          c.tracing.instrument :rack, headers: {request: ['x-other-header']}
+        end
+
+        described_class.tag_request_headers(span_op, env, configuration)
+      end
+
+      it 'tags Datadog request attribution headers' do
+        aggregate_failures 'request header tags' do
+          expect(span_op.get_tag('http.request.headers.x-datadog-endpoint-scan')).to eq('scan-uuid')
+          expect(span_op.get_tag('http.request.headers.x-datadog-security-test')).to eq('test-uuid')
+          expect(span_op.get_tag('http.request.headers.x-other-header')).to eq('ignored')
+        end
+      end
+    end
+  end
+
   describe '.tag_response_headers' do
     before do
       Datadog.configure do |c|

--- a/vendor/rbs/rack/0/rack.rbs
+++ b/vendor/rbs/rack/0/rack.rbs
@@ -1,6 +1,7 @@
 module Rack
   type env = ::Hash[::String, untyped]
-  type response = [::Integer, ::Hash[::String, ::String], ::Array[::String]]
+  type headers = ::Hash[::String, ::String | ::Array[::String]]
+  type response = [::Integer, headers, ::Array[::String]]
   type app = ^(env) -> response
 
   class Request
@@ -28,6 +29,6 @@ module Rack
       def to_ary: () -> ::Array[::String]?
     end
 
-    def initialize: (?untyped body, ?untyped status, ?untyped headers) -> void
+    def initialize: (?untyped body, ?untyped status, ?headers headers) -> void
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Add unconditional tagging for requests landing on customer application generated by Datadog, to distinguish them from real traffic.

**Motivation:**

[RFC-1105: Trace Attribution for Inventory Enrichment and Pollution Prevention](https://docs.google.com/document/d/1uR4QQvU8pItEV2zFqr3-L6jO2jxzmvLrFTX_yyvqIOA/edit?tab=t.0)

**Change log entry**

Yes. Prevent Datadog-generated traffic from interfering with application metrics.

**Additional Notes:**

I did it with generalization in mind simply because I can't decouple it now as it should work with AppSec being disabled or configuration missing. Hence - it lives in Tracer codebase.

I'm working on solution to have a better decoupling.

I've also fixed few overlooks with require statements and typing 🙌🏼 

Resolves APPSEC-62413

**How to test the change?**

CI + ST (enforced)