### PR TITLE
Fix uninitialized instance variable warning for @rails_application_name

### DIFF
--- a/lib/datadog/core/environment/process.rb
+++ b/lib/datadog/core/environment/process.rb
@@ -34,8 +34,10 @@ module Datadog
 
           tags << "#{Environment::Ext::TAG_ENTRYPOINT_TYPE}:#{TagNormalizer.normalize(entrypoint_type, remove_digit_start_char: false)}"
 
-          rails_name = TagNormalizer.normalize_process_value(@rails_application_name.to_s)
-          tags << "#{Environment::Ext::TAG_RAILS_APPLICATION}:#{rails_name}" unless rails_name.empty?
+          if defined?(@rails_application_name)
+            rails_name = TagNormalizer.normalize_process_value(@rails_application_name.to_s)
+            tags << "#{Environment::Ext::TAG_RAILS_APPLICATION}:#{rails_name}" unless rails_name.empty?
+          end
 
           if defined?(@service_user_configured)
             if @service_user_configured


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

See title.

**Motivation:**

Lots of noisy warnings on Ruby 2.6 when running specs:
```
./dd-trace-rb/lib/datadog/core/environment/process.rb:37: warning: instance variable @rails_application_name not initialized
./dd-trace-rb/lib/datadog/core/environment/process.rb:37: warning: instance variable @rails_application_name not initialized
```

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
