### PR TITLE
Store per_thread_context in each Ruby Thread

### DIFF
--- a/docs/ProfilingDevelopment.md
+++ b/docs/ProfilingDevelopment.md
@@ -149,9 +149,7 @@ See comments at the top of `collectors_thread_context.c` for an explanation on h
 
 ## How GVL profiling works
 
-Profiling the Ruby Global VM Lock (GVL) works by using the [GVL instrumentation API](https://github.com/ruby/ruby/pull/5500).
-
-This API currently only works on Ruby 3.2+.
+Profiling the Ruby Global VM Lock (GVL) works by using the [GVL instrumentation API](https://github.com/ruby/ruby/pull/5500) (Ruby 3.2+).
 
 These blog posts are good starting points to understand this API:
 
@@ -237,28 +235,32 @@ The weirdest piece of this puzzle is done in the `ThreadContext` collector. Beca
 `on_gvl_waiting` and `on_gvl_running` can get called outside the GVL/in other Ractors, we avoid touching the current
 `ThreadContext` instance state in these methods.
 
-Instead, we ask Ruby to hold the data we need for us using the `rb_internal_thread_specific` API. This API provides
-an extremely low-level and limited thread-local storage mechanism, but one that's thread-safe and thus a good match
-for our needs. (This API is only available on Ruby 3.3+; to support Ruby 3.2 we use an alternative implementation.)
+Instead, we use Ruby's `rb_internal_thread_specific` API to hold a `per_thread_context` struct
+for each Ruby thread. This API provides an extremely low-level and limited thread-local storage mechanism, but
+one that's thread-safe and thus a good match for our needs. (This API is only available on Ruby 3.3+; to support
+Ruby 3.2 we use an alternative implementation — see "Supporting Ruby 3.2" below.)
 
-So, here's how this works: the first time the `ThreadContext` collector sees a thread (e.g. when it creates a context
-for it), it uses this API to tag this thread as a thread we want to know about:
+The first time the `ThreadContext` collector sees a thread, it allocates a `per_thread_context` for it and stores a
+pointer to that struct in the Ruby thread's storage:
 
 ```c
-rb_internal_thread_specific_set(thread, per_thread_gvl_waiting_timestamp_key, (void *) GVL_WAITING_ENABLED_EMPTY);
+set_per_thread_context(thread, thread_context); // wraps rb_internal_thread_specific_set on 3.3+
 ```
 
-From here on out, `on_gvl_waiting` and `on_gvl_running` know that if a thread has the `per_thread_gvl_waiting_timestamp`
-variable set (to any other value than the default of `NULL`/0), it means this thread is known by the `ThreadContext`
-collector and thus we should record data about it.
-(And threads not in the main Ractor don't get this marker so this is one way we filter them out.)
+The GVL-waiting timestamp lives as a field on that struct (`thread_context->gvl_waiting_at`). `on_gvl_waiting`
+and `on_gvl_running` look up the context from thread-local storage and read/write that field directly. If
+`get_per_thread_context(thread)` returns `NULL`, the thread isn't tracked by us (e.g. a background thread we
+haven't sampled yet, or a thread in a non-main Ractor) and we skip it.
 
-Could we have stored a pointer to the thread context directly on the thread? Potentially, yes, but we'd need to be
-extremely careful when accessing thread contexts and when cleaning them up. (Maybe we'll evolve in this direction in
-the future?)
+This also means there are two complementary APIs for looking up the context for a thread:
+
+* `get_per_thread_context(thread)` — TLS-only lookup, signal-handler-safe. Returns `NULL` if the thread isn't tracked.
+  Used from places that may be called outside the GVL (signal handler, GVL events, GC events).
+* `get_or_create_context_for(thread, state)` — TLS fast path, falling through to allocating + tracking a new context
+  if the thread isn't yet known. Requires the GVL.
 
 With the storage problem solved, here's what happens: the first part is that `on_gvl_waiting` records a timestamp for
-when waiting started in the thread in `per_thread_gvl_waiting_timestamp`.
+when waiting started in the thread's `per_thread_context->gvl_waiting_at`.
 
 Then, `on_gvl_running` checks the duration of the waiting (e.g. time between waiting started and current time). This
 is a mechanism for reducing overhead: we'll produce at least two samples for every "Waiting for GVL" event that
@@ -290,53 +292,31 @@ There's some (lovely?) ASCII art in `handle_gvl_waiting` to explain how we creat
 
 Once a thread is in the "Waiting for GVL" state, then all regular cpu/wall-time samples triggered by the `CpuAndWallTimeWorker`
 will continue to mark the thread as being in this state, until `on_gvl_running` + `sample_after_gvl_running` happen and
-clear the `per_thread_gvl_waiting_timestamp`, which will make samples revert back to the regular behavior.
+reset `thread_context->gvl_waiting_at`, which will make samples revert back to the regular behavior.
 
 ### Supporting Ruby 3.2
 
-Supporting GVL profiling on Ruby 3.2 needs special additional work. That's because while in Ruby 3.2 we have the GVL
-instrumentation API giving us the events we need to profile the GVL, we're missing:
+Supporting GVL profiling on Ruby 3.2 needs special additional work. That's because while Ruby 3.2 has the GVL
+instrumentation API giving us the events we need to profile the GVL, two things were only introduced in Ruby 3.3:
 
-1. Getting the Ruby thread `VALUE` as an argument in GVL instrumentation API events
-2. The `rb_internal_thread_specific` API that allows us to attach in a thread-safe way data to Ruby thread objects
+1. Getting the Ruby thread `VALUE` as an argument in GVL instrumentation API events.
+2. The `rb_internal_thread_specific` API that allows us to attach data to Ruby thread objects in a thread-safe way.
 
-Both 1 and 2 were only introduced in Ruby 3.3, and our implementation of GVL profiling relies on them.
+We bridge each gap with a small alternative implementation:
 
-We bridge this gap with alternative implementations for Ruby 3.2:
+**To solve 1**, we rely on the fact that the `RUBY_INTERNAL_THREAD_EVENT_READY` and `RUBY_INTERNAL_THREAD_EVENT_RESUMED`
+events always fire on the OS thread of the Ruby thread they are about — so `rb_thread_current()` returns the event
+thread even though the event payload doesn't carry it.
 
-To solve 1, we're using native level thread-locals (GCC's `__thread`) to keep a pointer to the underlying Ruby `rb_thread_t` structure.
+**To solve 2**, we rely on an important observation: there's a `VALUE stat_insn_usage` field inside `rb_thread_t`
+that's unused and seems to have effectively been forgotten about — there's nowhere in the VM code that writes or
+reads it (other than marking it for GC). We use this field to store our per-thread pointer, FIXNUM-encoded, as a
+replacement for `rb_internal_thread_specific`. See `get_per_thread_context`/`set_per_thread_context` in
+`private_vm_api_access.c`. This is used on all Ruby versions < 3.3 so we can consistently and quickly access the
+`per_thread_context` from the Ruby `Thread` object.
 
-This is more complex than than "just keep it on a thread-local" because:
-
-a) Ruby reuses native threads. When a Ruby thread dies, Ruby keeps the underlying native thread around for a bit,
-and if another Ruby thread is born very quickly after the previous one, Ruby will reuse the native thread and attach it
-to the new Ruby thread.
-
-   To avoid incorrectly reusing the thread-locals, we install an event hook on Ruby thread start, and make sure to
-   clean any native thread-locals when a new thread stats.
-
-b) Some of the GVL instrumentation API events are emitted while the thread does not have the GVL and so we need to be
-careful when we can and cannot read VM information.
-
-   Thus, we only initialize the thread-local during the `RUBY_INTERNAL_THREAD_EVENT_RESUMED` which is emitted while the
-   thread owns the GVL.
-
-c) Since we don't get the current thread in events, we need to get a bit... creative. Thus, what we do is in
-`RUBY_INTERNAL_THREAD_EVENT_RESUMED`, because we know the current thread MUST own the GVL, we read from the internal
-Ruby VM state which thread is the GVL owner to find the info we need.
-
-With a + b + c together we are able to keep a pointer to the underlying `rb_thread_t` up-to-date in a native thread
-local, thus replacing the need to get a `VALUE thread` as an argument.
-
-To solve 2, we rely on an important observation: there's a `VALUE stat_insn_usage` field inside `rb_thread_t` that's
-unused and seems to have effectively been forgotten about.
-
-There's nowhere in the VM code that's writing or reading it (other than marking it for GC), and not even git history
-reveals a time where this field was used. I could not find any other references to this field anywhere else. Thus, we
-make use of this field to store the information we need, as a replacement for `rb_internal_thread_specific`.
-
-Since presumably Ruby 3.2 will never see this field either removed or used during its remaining maintenance release
-period this should work fine, and we have a nice clean solution for 3.3+.
+Since Ruby versions < 3.3 are EOL they will never see this field either removed or repurposed,
+this should work fine, and we have a nice clean solution for 3.3+.
 
 ## Measuring the performance of profiler sampling
 

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -659,7 +659,7 @@ static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
   if (sample_from_signal_handler) {
     // Buffer current stack trace. Note that this will not actually record the sample, for that we still need to wait
     // until the postponed job below gets run.
-    bool prepared = thread_context_collector_prepare_sample_inside_signal_handler(state->thread_context_collector_instance);
+    bool prepared = thread_context_collector_prepare_sample_inside_signal_handler();
 
     if (prepared) state->stats.signal_handler_prepared_sample++;
   }
@@ -865,10 +865,6 @@ static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
 
   if (state->gvl_profiling_enabled) {
     #ifndef NO_GVL_INSTRUMENTATION
-      #ifdef USE_GVL_PROFILING_3_2_WORKAROUNDS
-        gvl_profiling_state_thread_tracking_workaround();
-      #endif
-
       state->gvl_profiling_hook = rb_internal_thread_add_event_hook(
         on_gvl_event,
         (
@@ -1245,13 +1241,23 @@ static void on_newobj_event(DDTRACE_UNUSED VALUE unused1, DDTRACE_UNUSED void *u
     return;
   }
 
+  VALUE current_thread = rb_thread_current();
+
   // If Ruby is in the middle of raising an exception, we don't want to try to sample. This is because if we accidentally
   // trigger an exception inside the profiler code, bad things will happen (specifically, Ruby will try to kill off the
   // thread even though we may try to catch the exception).
   //
   // Note that "in the middle of raising an exception" means the exception itself has already been allocated.
   // What's getting allocated now is probably the backtrace objects (@ivoanjo or at least that's what I've observed)
-  if (is_raised_flag_set(rb_thread_current())) {
+  if (is_raised_flag_set(current_thread)) {
+    return;
+  }
+
+  per_thread_context *thread_context = get_per_thread_context(current_thread);
+  if (!thread_context) {
+    // No per_thread_context yet on this Thread, we can't use get_or_create_context_for() as that allocates,
+    // and we are inside on_newobj_event where we MUST NOT allocate.
+    // So we don't sample allocations until another hook allocates the per_thread_context.
     return;
   }
 
@@ -1286,7 +1292,7 @@ static void on_newobj_event(DDTRACE_UNUSED VALUE unused1, DDTRACE_UNUSED void *u
   // Rescue against any exceptions that happen during sampling
   safely_call(
     rescued_sample_allocation,
-    Qnil,
+    (VALUE) thread_context,
     state->self_instance,
     handle_sampling_failure_rescued_sample_allocation
   );
@@ -1338,7 +1344,8 @@ static VALUE _native_with_blocked_sigprof(DDTRACE_UNUSED VALUE self) {
   }
 }
 
-static VALUE rescued_sample_allocation(DDTRACE_UNUSED VALUE unused) {
+static VALUE rescued_sample_allocation(VALUE arg) {
+  per_thread_context *thread_context = (per_thread_context*) arg;
   cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
 
   // This should not happen in a normal situation because on_newobj_event already checked for this, but just in case...
@@ -1357,7 +1364,7 @@ static VALUE rescued_sample_allocation(DDTRACE_UNUSED VALUE unused) {
   // To control bias from sampling, we clamp the maximum weight attributed to a single allocation sample. This avoids
   // assigning a very large number to a sample, if for instance the dynamic sampling mechanism chose a really big interval.
   unsigned int weight = allocations_since_last_sample > MAX_ALLOC_WEIGHT ? MAX_ALLOC_WEIGHT : (unsigned int) allocations_since_last_sample;
-  bool needs_after_allocation = thread_context_collector_sample_allocation(state->thread_context_collector_instance, weight, new_object);
+  bool needs_after_allocation = thread_context_collector_sample_allocation(state->thread_context_collector_instance, thread_context, weight, new_object);
   // ...but we still represent the skipped samples in the profile, thus the data will account for all allocations.
   if (weight < allocations_since_last_sample) {
     uint32_t skipped_samples = (uint32_t) uint64_min_of(allocations_since_last_sample - weight, UINT32_MAX);
@@ -1416,23 +1423,28 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
     // Be very careful about touching the `state` here or doing anything at all:
     // This function gets called without the GVL, and potentially from background Ractors!
     //
-    // In fact, the `target_thread` that this event is about may not even be the current thread. (So be careful with thread locals that
-    // are not directly tied to the `target_thread` object and the like)
-    gvl_profiling_thread target_thread = thread_from_event(event_data);
+    // In fact, the thread that this event is about may not even be the current thread. (So be careful with thread locals that
+    // are not directly tied to the thread object and the like)
+
+    // On Ruby 3.2 the event does not carry the thread, but it always fires on the OS thread of the Ruby thread
+    // it is about, so `rb_thread_current()` returns the event thread for both READY and RESUMED.
+    // However, during early thread startup `rb_thread_current()` can crash because the execution context isn't
+    // stored in TLS yet; `ruby_native_thread_p()` guards against this.
+    #ifdef HAVE_RUBY_THREAD_STORAGE_API
+      VALUE target_thread = event_data->thread;
+    #else
+      if (!ruby_native_thread_p()) return;
+      VALUE target_thread = rb_thread_current();
+    #endif
 
     if (event_id == RUBY_INTERNAL_THREAD_EVENT_READY) { /* waiting for gvl */
       thread_context_collector_on_gvl_waiting(target_thread);
     } else if (event_id == RUBY_INTERNAL_THREAD_EVENT_RESUMED) { /* running/runnable */
       // Interesting note: A RUBY_INTERNAL_THREAD_EVENT_RESUMED is guaranteed to be called with the GVL being acquired.
-      // (And... I think target_thread will be == rb_thread_current()?)
       //
       // But we're not sure if we're on the main Ractor yet. The thread context collector can actually help here:
       // it tags threads it's tracking, so if a thread is tagged then by definition we know that thread belongs to the main
       // Ractor. Thus, if we get a ON_GVL_RUNNING_UNKNOWN result we shouldn't touch any state, but otherwise we're good to go.
-
-      #ifdef USE_GVL_PROFILING_3_2_WORKAROUNDS
-        target_thread = gvl_profiling_state_maybe_initialize();
-      #endif
 
       cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
       if (state == NULL) return; // This should not happen, but just in case...

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1051,6 +1051,9 @@ static VALUE _native_simulate_sample_from_postponed_job(DDTRACE_UNUSED VALUE sel
 //
 // In the future, if we add more other components with tracepoints, we will need to coordinate stopping all such
 // tracepoints before doing the other cleaning steps.
+//
+// Note that tests call this method directly in the same process without forking,
+// and in such a case non-current Threads keep running.
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE instance) {
   cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(instance, cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -40,7 +40,7 @@ static void set_file_info_for_cfunc(
   st_table *native_filenames_cache
 );
 static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache);
-static void add_truncated_frames_placeholder(sampling_buffer* buffer);
+static void add_truncated_frames_placeholder(ddog_prof_Location *locations);
 static void record_placeholder_stack_in_native_code(VALUE recorder_instance, sample_values values, sample_labels labels);
 static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_CharSlice *filename_slice);
 
@@ -175,7 +175,7 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
 
   ddog_prof_Location *locations = ruby_xcalloc(max_frames_requested, sizeof(ddog_prof_Location));
   sampling_buffer buffer;
-  sampling_buffer_initialize(&buffer, max_frames_requested, locations);
+  sampling_buffer_initialize(&buffer, max_frames_requested);
 
   ddog_prof_Slice_Label slice_labels = {.ptr = labels, .len = labels_count};
 
@@ -208,6 +208,7 @@ static VALUE native_sample_do(VALUE args) {
     sample_thread(
       args_struct->thread,
       args_struct->buffer,
+      args_struct->locations,
       args_struct->recorder_instance,
       args_struct->values,
       args_struct->labels,
@@ -243,6 +244,7 @@ static VALUE native_sample_ensure(VALUE args) {
 void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
+  ddog_prof_Location *locations,
   VALUE recorder_instance,
   sample_values values,
   sample_labels labels,
@@ -389,7 +391,7 @@ void sample_thread(
 
     int libdatadog_stores_stacks_flipped_from_rb_profile_frames_index = top_of_stack_position - i;
 
-    buffer->locations[libdatadog_stores_stacks_flipped_from_rb_profile_frames_index] = (ddog_prof_Location) {
+    locations[libdatadog_stores_stacks_flipped_from_rb_profile_frames_index] = (ddog_prof_Location) {
       .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C(""), .build_id_id = {}},
       .function = (ddog_prof_Function) {.name = name_slice, .filename = filename_slice},
       .line = line,
@@ -399,12 +401,12 @@ void sample_thread(
   // If we filled up the buffer, some frames may have been omitted. In that case, we'll add a placeholder frame
   // with that info.
   if (captured_frames == (long) buffer->max_frames) {
-    add_truncated_frames_placeholder(buffer);
+    add_truncated_frames_placeholder(locations);
   }
 
   record_sample(
     recorder_instance,
-    (ddog_prof_Slice_Location) {.ptr = buffer->locations, .len = captured_frames},
+    (ddog_prof_Slice_Location) {.ptr = locations, .len = captured_frames},
     values,
     labels
   );
@@ -538,10 +540,10 @@ static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_Char
   name_slice->len = pos;
 }
 
-static void add_truncated_frames_placeholder(sampling_buffer* buffer) {
+static void add_truncated_frames_placeholder(ddog_prof_Location *locations) {
   // Important note: The strings below are static so we don't need to worry about their lifetime. If we ever want to change
   // this to non-static strings, don't forget to check that lifetimes are properly respected.
-  buffer->locations[0] = (ddog_prof_Location) {
+  locations[0] = (ddog_prof_Location) {
     .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C(""), .build_id_id = {}},
     .function = {.name = DDOG_CHARSLICE_C("Truncated Frames"), .filename = DDOG_CHARSLICE_C(""), .filename_id = {}},
     .line = 0,
@@ -618,11 +620,10 @@ uint16_t sampling_buffer_check_max_frames(int max_frames) {
   return max_frames;
 }
 
-void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames, ddog_prof_Location *locations) {
+void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames) {
   sampling_buffer_check_max_frames(max_frames);
 
   buffer->max_frames = max_frames;
-  buffer->locations = locations;
   buffer->stack_buffer = ruby_xcalloc(max_frames, sizeof(frame_info));
   buffer->pending_sample = false;
   buffer->is_marking = false;
@@ -630,15 +631,13 @@ void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames, dd
 }
 
 void sampling_buffer_free(sampling_buffer *buffer) {
-  if (buffer->max_frames == 0 || buffer->locations == NULL || buffer->stack_buffer == NULL) {
+  if (buffer->max_frames == 0 || buffer->stack_buffer == NULL) {
     raise_error(rb_eArgError, "sampling_buffer_free called with invalid buffer");
   }
 
   ruby_xfree(buffer->stack_buffer);
-  // Note: buffer->locations are owned by whoever called sampling_buffer_initialize, not by the buffer itself
 
   buffer->max_frames = 0;
-  buffer->locations = NULL;
   buffer->stack_buffer = NULL;
   buffer->pending_sample = false;
   buffer->is_marking = false;

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -98,7 +98,7 @@ typedef struct {
   sample_values values;
   sample_labels labels;
   VALUE thread;
-  ddog_prof_Location *locations;
+  sample_locations locations;
   sampling_buffer *buffer;
   bool native_filenames_enabled;
   st_table *native_filenames_cache;
@@ -185,7 +185,7 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
     .values = values,
     .labels = (sample_labels) {.labels = slice_labels, .state_label = state_label, .is_gvl_waiting_state = is_gvl_waiting_state == Qtrue},
     .thread = thread,
-    .locations = locations,
+    .locations = (sample_locations) {.ptr = locations, .len = max_frames_requested},
     .buffer = &buffer,
     .native_filenames_enabled = native_filenames_enabled == Qtrue,
     .native_filenames_cache = st_init_numtable(),
@@ -223,7 +223,7 @@ static VALUE native_sample_do(VALUE args) {
 static VALUE native_sample_ensure(VALUE args) {
   native_sample_args *args_struct = (native_sample_args *) args;
 
-  ruby_xfree(args_struct->locations);
+  ruby_xfree(args_struct->locations.ptr);
   sampling_buffer_free(args_struct->buffer);
   st_free_table(args_struct->native_filenames_cache);
 
@@ -244,7 +244,7 @@ static VALUE native_sample_ensure(VALUE args) {
 void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
-  ddog_prof_Location *locations,
+  sample_locations locations,
   VALUE recorder_instance,
   sample_values values,
   sample_labels labels,
@@ -252,10 +252,20 @@ void sample_thread(
   st_table *native_filenames_cache
 ) {
   // If we already prepared a sample, we use it below; if not, we prepare it now.
-  if (!buffer->pending_sample) prepare_sample_thread(thread, buffer);
+  if (!buffer->pending_sample) {
+    // Reconcile the sampling_buffer's max_frames with the locations size
+    if (buffer->max_frames != locations.len) {
+      sampling_buffer_reinitialize(buffer, locations.len);
+    }
+    prepare_sample_thread(thread, buffer);
+  }
 
   buffer->pending_sample = false;
   int captured_frames = buffer->pending_sample_result;
+
+  // The per_thread_context's sampling_buffer may have been created by a previous collector with a
+  // different (larger) max_frames. Cap to the locations array size to prevent out-of-bounds writes.
+  if (captured_frames > (int) locations.len) captured_frames = (int) locations.len;
 
   if (captured_frames == PLACEHOLDER_STACK_IN_NATIVE_CODE) {
     record_placeholder_stack_in_native_code(recorder_instance, values, labels);
@@ -391,25 +401,30 @@ void sample_thread(
 
     int libdatadog_stores_stacks_flipped_from_rb_profile_frames_index = top_of_stack_position - i;
 
-    locations[libdatadog_stores_stacks_flipped_from_rb_profile_frames_index] = (ddog_prof_Location) {
+    locations.ptr[libdatadog_stores_stacks_flipped_from_rb_profile_frames_index] = (ddog_prof_Location) {
       .mapping = {.filename = DDOG_CHARSLICE_C(""), .build_id = DDOG_CHARSLICE_C(""), .build_id_id = {}},
       .function = (ddog_prof_Function) {.name = name_slice, .filename = filename_slice},
       .line = line,
     };
   }
 
-  // If we filled up the buffer, some frames may have been omitted. In that case, we'll add a placeholder frame
+  // If we filled up the locations, some frames may have been omitted. In that case, we'll add a placeholder frame
   // with that info.
-  if (captured_frames == (long) buffer->max_frames) {
-    add_truncated_frames_placeholder(locations);
+  if (captured_frames == (long) locations.len) {
+    add_truncated_frames_placeholder(locations.ptr);
   }
 
   record_sample(
     recorder_instance,
-    (ddog_prof_Slice_Location) {.ptr = locations, .len = captured_frames},
+    (ddog_prof_Slice_Location) {.ptr = locations.ptr, .len = captured_frames},
     values,
     labels
   );
+
+  // Reconcile the sampling_buffer's max_frames with the locations size for future samples
+  if (buffer->max_frames != locations.len) {
+    sampling_buffer_reinitialize(buffer, locations.len);
+  }
 }
 
 #if (defined(HAVE_DLADDR1) && HAVE_DLADDR1) || (defined(HAVE_DLADDR) && HAVE_DLADDR)
@@ -628,6 +643,11 @@ void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames) {
   buffer->pending_sample = false;
   buffer->is_marking = false;
   buffer->pending_sample_result = 0;
+}
+
+void sampling_buffer_reinitialize(sampling_buffer *buffer, uint16_t max_frames) {
+  sampling_buffer_free(buffer);
+  sampling_buffer_initialize(buffer, max_frames);
 }
 
 void sampling_buffer_free(sampling_buffer *buffer) {

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -17,10 +17,15 @@ typedef struct {
   int pending_sample_result;
 } sampling_buffer;
 
+typedef struct {
+  ddog_prof_Location *ptr;
+  uint16_t len;
+} sample_locations;
+
 void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
-  ddog_prof_Location *locations,
+  sample_locations locations,
   VALUE recorder_instance,
   sample_values values,
   sample_labels labels,
@@ -37,6 +42,7 @@ bool prepare_sample_thread(VALUE thread, sampling_buffer *buffer);
 
 uint16_t sampling_buffer_check_max_frames(int max_frames);
 void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames);
+void sampling_buffer_reinitialize(sampling_buffer *buffer, uint16_t max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);
 void sampling_buffer_mark(sampling_buffer *buffer);
 static inline bool sampling_buffer_needs_marking(sampling_buffer *buffer) {

--- a/ext/datadog_profiling_native_extension/collectors_stack.h
+++ b/ext/datadog_profiling_native_extension/collectors_stack.h
@@ -11,7 +11,6 @@
 // Used as scratch space during sampling
 typedef struct {
   uint16_t max_frames;
-  ddog_prof_Location *locations;
   frame_info *stack_buffer;
   bool pending_sample;
   bool is_marking; // Used to avoid recording a sample when marking
@@ -21,6 +20,7 @@ typedef struct {
 void sample_thread(
   VALUE thread,
   sampling_buffer* buffer,
+  ddog_prof_Location *locations,
   VALUE recorder_instance,
   sample_values values,
   sample_labels labels,
@@ -36,7 +36,7 @@ void record_placeholder_stack(
 bool prepare_sample_thread(VALUE thread, sampling_buffer *buffer);
 
 uint16_t sampling_buffer_check_max_frames(int max_frames);
-void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames, ddog_prof_Location *locations);
+void sampling_buffer_initialize(sampling_buffer *buffer, uint16_t max_frames);
 void sampling_buffer_free(sampling_buffer *buffer);
 void sampling_buffer_mark(sampling_buffer *buffer);
 static inline bool sampling_buffer_needs_marking(sampling_buffer *buffer) {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1564,7 +1564,10 @@ static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collecto
   return needs_after_allocation ? Qtrue : Qfalse;
 }
 
-static VALUE new_empty_thread_inner(DDTRACE_UNUSED void *arg) { return Qnil; }
+static VALUE new_empty_thread_inner(DDTRACE_UNUSED void *arg) {
+  rb_thread_sleep(INT_MAX);
+  return Qnil;
+}
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
 // It SHOULD NOT be used for other purposes.

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -124,9 +124,8 @@ typedef struct {
   // Note: Places in this file that usually need to be changed when this struct is changed are tagged with
   // "Update this when modifying state struct"
 
-  // Required by Datadog::Profiling::Collectors::Stack as a scratch buffer during sampling
-  ddog_prof_Location *locations;
-  uint16_t max_frames;
+  // Output buffer for stack traces, passed to sample_thread()
+  sample_locations locations;
   // Datadog::Profiling::StackRecorder instance
   VALUE recorder_instance;
   // If the tracer is available and enabled, this will be the fiber-local symbol for accessing its running context,
@@ -401,7 +400,7 @@ static void thread_context_collector_typed_data_free(void *state_ptr) {
 
   // Important: Remember that we're only guaranteed to see here what's been set in _native_new, aka
   // pointers that have been set NULL there may still be NULL here.
-  if (state->locations != NULL) ruby_xfree(state->locations);
+  if (state->locations.ptr != NULL) ruby_xfree(state->locations.ptr);
 
   st_free_table(state->native_filenames_cache);
 
@@ -451,8 +450,8 @@ static VALUE _native_new(VALUE klass) {
   // being leaked.
 
   // Update this when modifying state struct
-  state->locations = NULL;
-  state->max_frames = 0;
+  state->locations.ptr = NULL;
+  state->locations.len = 0;
   state->recorder_instance = Qnil;
   state->tracer_context_key = MISSING_TRACER_CONTEXT_KEY;
   VALUE thread_list_buffer = rb_ary_new();
@@ -504,8 +503,8 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   // Update this when modifying state struct
-  state->max_frames = sampling_buffer_check_max_frames(NUM2INT(max_frames));
-  state->locations = ruby_xcalloc(state->max_frames, sizeof(ddog_prof_Location));
+  state->locations.len = sampling_buffer_check_max_frames(NUM2INT(max_frames));
+  state->locations.ptr = ruby_xcalloc(state->locations.len, sizeof(ddog_prof_Location));
   state->recorder_instance = enforce_recorder_instance(recorder_instance);
   state->endpoint_collection_enabled = (endpoint_collection_enabled == Qtrue);
   state->native_filenames_enabled = (native_filenames_enabled == Qtrue);
@@ -1071,7 +1070,7 @@ static bool is_logging_gem_monkey_patch(VALUE invoke_file_location) {
 }
 
 static void initialize_context(VALUE thread, per_thread_context *thread_context, thread_context_collector_state *state) {
-  sampling_buffer_initialize(&thread_context->sampling_buffer, state->max_frames);
+  sampling_buffer_initialize(&thread_context->sampling_buffer, state->locations.len);
 
   snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%"PRIu64" (%lu)", native_thread_id_for(thread), (unsigned long) thread_id_for(thread));
   thread_context->thread_id_char_slice = (ddog_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
@@ -1132,7 +1131,7 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
   VALUE result = rb_str_new2(" (native state)");
 
   // Update this when modifying state struct
-  rb_str_concat(result, rb_sprintf(" max_frames=%d", state->max_frames));
+  rb_str_concat(result, rb_sprintf(" max_frames=%d", state->locations.len));
   rb_str_concat(result, rb_sprintf(" recorder_instance=%"PRIsVALUE, state->recorder_instance));
   VALUE tracer_context_key = state->tracer_context_key == MISSING_TRACER_CONTEXT_KEY ? Qnil : ID2SYM(state->tracer_context_key);
   rb_str_concat(result, rb_sprintf(" tracer_context_key=%+"PRIsVALUE, tracer_context_key));

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -85,6 +85,8 @@
 // and for which there's no data yet
 #define GVL_WAITING_ENABLED_EMPTY RUBY_FIXNUM_MAX
 
+static ID dd_per_thread_context_id; // Hidden ivar (no @ prefix, inaccessible from Ruby)
+
 static ID at_active_span_id;  // id of :@active_span in Ruby
 static ID at_active_trace_id; // id of :@active_trace in Ruby
 static ID at_id_id;           // id of :@id in Ruby
@@ -125,19 +127,12 @@ typedef struct {
   // Required by Datadog::Profiling::Collectors::Stack as a scratch buffer during sampling
   ddog_prof_Location *locations;
   uint16_t max_frames;
-  // Hashmap <Thread Object, per_thread_context>
-  // Note: Be very careful when mutating this map, as it gets read e.g. in the middle of GC and signal handlers.
-  st_table *hash_map_per_thread_context;
   // Datadog::Profiling::StackRecorder instance
   VALUE recorder_instance;
   // If the tracer is available and enabled, this will be the fiber-local symbol for accessing its running context,
   // to enable code hotspots and endpoint aggregation.
   // When not available, this is set to MISSING_TRACER_CONTEXT_KEY.
   ID tracer_context_key;
-  // Track how many regular samples we've taken. Does not include garbage collection samples.
-  // Currently **outside** of stats struct because we also use it to decide when to clean the contexts, and thus this
-  // is not (just) a stat.
-  unsigned int sample_count;
   // Reusable array to get list of threads
   VALUE thread_list_buffer;
   // Used to omit endpoint names (retrieved from tracer) from collected data
@@ -160,6 +155,8 @@ typedef struct {
   st_table *native_filenames_cache;
 
   struct stats {
+    // Track how many regular samples we've taken. Does not include garbage collection samples.
+    unsigned int sample_count;
     // Track how many garbage collection samples we've taken.
     unsigned int gc_samples;
     // See thread_context_collector_on_gc_start for details
@@ -176,7 +173,7 @@ typedef struct {
 } thread_context_collector_state;
 
 // Tracks per-thread state
-typedef struct {
+struct per_thread_context {
   sampling_buffer sampling_buffer;
   char thread_id[THREAD_ID_LIMIT_CHARS];
   ddog_CharSlice thread_id_char_slice;
@@ -185,6 +182,7 @@ typedef struct {
   thread_cpu_time_id thread_cpu_time_id;
   long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
   long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
+  long gvl_waiting_at;
 
   struct {
     // Both of these fields are set by on_gc_start and kept until on_gc_finish is called.
@@ -192,7 +190,7 @@ typedef struct {
     long cpu_time_at_start_ns;
     long wall_time_at_start_ns;
   } gc_tracking;
-} per_thread_context;
+};
 
 // Used to correlate profiles with traces
 typedef struct {
@@ -210,8 +208,8 @@ typedef struct {
 
 static void thread_context_collector_typed_data_mark(void *state_ptr);
 static void thread_context_collector_typed_data_free(void *state_ptr);
-static int hash_map_per_thread_context_mark(st_data_t key_thread, st_data_t value_thread_context, DDTRACE_UNUSED st_data_t _argument);
-static int hash_map_per_thread_context_free_values(st_data_t _thread, st_data_t value_per_thread_context, st_data_t _argument);
+static void per_thread_context_typed_data_mark(void *ctx_ptr);
+static void per_thread_context_typed_data_free(void *ctx_ptr);
 static VALUE _native_new(VALUE klass);
 static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static VALUE _native_sample(VALUE self, VALUE collector_instance, VALUE profiler_overhead_stack_thread, VALUE allow_exception);
@@ -242,16 +240,11 @@ static void trigger_sample_for_thread(
 );
 static VALUE _native_thread_list(VALUE self);
 static per_thread_context *get_or_create_context_for(VALUE thread, thread_context_collector_state *state);
-static per_thread_context *get_context_for(VALUE thread, thread_context_collector_state *state);
 static void initialize_context(VALUE thread, per_thread_context *thread_context, thread_context_collector_state *state);
-static void free_context(per_thread_context* thread_context);
 static VALUE _native_inspect(VALUE self, VALUE collector_instance);
-static VALUE per_thread_context_st_table_as_ruby_hash(thread_context_collector_state *state);
-static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value_context, st_data_t result_hash);
+static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context);
 static VALUE stats_as_ruby_hash(thread_context_collector_state *state);
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state);
-static void remove_context_for_dead_threads(thread_context_collector_state *state);
-static int remove_if_dead_thread(st_data_t key_thread, st_data_t value_context, st_data_t _argument);
 static VALUE _native_per_thread_context(VALUE self, VALUE collector_instance);
 static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, long gc_start_time_ns, bool is_wall_time);
 static long cpu_time_now_ns(per_thread_context *thread_context);
@@ -293,7 +286,7 @@ static bool handle_gvl_waiting(
   static VALUE _native_gvl_waiting_at_for(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception);
-  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE delta_ns);
+  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 #endif
 static void otel_without_ddtrace_trace_identifiers_for(
   thread_context_collector_state *state,
@@ -305,7 +298,8 @@ static otel_span otel_span_from(VALUE otel_context, VALUE otel_current_span_key)
 static uint64_t otel_span_id_to_uint(VALUE otel_span_id);
 static VALUE safely_lookup_hash_without_going_into_ruby_code(VALUE hash, VALUE key);
 static VALUE _native_system_epoch_time_now_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
-static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
+static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self);
+static VALUE _native_clear_per_thread_context_for(DDTRACE_UNUSED VALUE self, VALUE thread);
 
 void collectors_thread_context_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -338,13 +332,14 @@ void collectors_thread_context_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_new_empty_thread", _native_new_empty_thread, 0);
   rb_define_singleton_method(testing_module, "_native_sample_skipped_allocation_samples", _native_sample_skipped_allocation_samples, 2);
   rb_define_singleton_method(testing_module, "_native_system_epoch_time_now_ns", _native_system_epoch_time_now_ns, 1);
-  rb_define_singleton_method(testing_module, "_native_prepare_sample_inside_signal_handler", _native_prepare_sample_inside_signal_handler, 1);
+  rb_define_singleton_method(testing_module, "_native_prepare_sample_inside_signal_handler", _native_prepare_sample_inside_signal_handler, 0);
+  rb_define_singleton_method(testing_module, "_native_clear_per_thread_context_for", _native_clear_per_thread_context_for, 1);
   #ifndef NO_GVL_INSTRUMENTATION
     rb_define_singleton_method(testing_module, "_native_on_gvl_waiting", _native_on_gvl_waiting, 1);
     rb_define_singleton_method(testing_module, "_native_gvl_waiting_at_for", _native_gvl_waiting_at_for, 1);
     rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 1);
     rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 3);
-    rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 3);
+    rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
   #endif
 
   at_active_span_id = rb_intern_const("@active_span");
@@ -366,10 +361,10 @@ void collectors_thread_context_init(VALUE profiling_module) {
   otel_context_storage_id = rb_intern_const("__opentelemetry_context_storage__");
   otel_fiber_context_storage_id = rb_intern_const("@opentelemetry_context");
 
-  #ifndef NO_GVL_INSTRUMENTATION
-    // This will raise if Ruby already ran out of thread-local keys
-    gvl_profiling_init();
-  #endif
+  dd_per_thread_context_id = rb_intern_const("dd_per_thread_context");
+
+  // This will raise if Ruby already ran out of thread-local keys
+  per_thread_context_tls_init();
 
   gc_profiling_init();
 }
@@ -394,7 +389,6 @@ static void thread_context_collector_typed_data_mark(void *state_ptr) {
 
   // Update this when modifying state struct
   rb_gc_mark(state->recorder_instance);
-  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_mark, 0 /* unused */);
   rb_gc_mark(state->thread_list_buffer);
   rb_gc_mark(state->main_thread);
   rb_gc_mark(state->otel_current_span_key);
@@ -409,34 +403,43 @@ static void thread_context_collector_typed_data_free(void *state_ptr) {
   // pointers that have been set NULL there may still be NULL here.
   if (state->locations != NULL) ruby_xfree(state->locations);
 
-  // Free each entry in the map
-  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_free_values, 0 /* unused */);
-  // ...and then the map
-  st_free_table(state->hash_map_per_thread_context);
-
   st_free_table(state->native_filenames_cache);
 
   ruby_xfree(state);
 }
 
-// Mark Ruby thread references we keep as keys in hash_map_per_thread_context
-static int hash_map_per_thread_context_mark(st_data_t key_thread, st_data_t value_thread_context, DDTRACE_UNUSED st_data_t _argument) {
-  VALUE thread = (VALUE) key_thread;
-  per_thread_context *thread_context = (per_thread_context *) value_thread_context;
+// per_thread_context is wrapped in a TypedData Ruby object stored as an ivar on each Ruby Thread.
+// This gives us automatic GC marking (for sampling_buffer iseq VALUEs) and lifecycle management.
+static const rb_data_type_t per_thread_context_typed_data = {
+  .wrap_struct_name = "Datadog::Profiling::PerThreadContext",
+  .function = {
+    .dmark = per_thread_context_typed_data_mark,
+    .dfree = per_thread_context_typed_data_free,
+    .dsize = NULL,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
 
-  rb_gc_mark(thread);
-  if (sampling_buffer_needs_marking(&thread_context->sampling_buffer)) {
-    sampling_buffer_mark(&thread_context->sampling_buffer);
+static void per_thread_context_typed_data_mark(void *ctx_ptr) {
+  per_thread_context *ctx = (per_thread_context *) ctx_ptr;
+  if (sampling_buffer_needs_marking(&ctx->sampling_buffer)) {
+    sampling_buffer_mark(&ctx->sampling_buffer);
   }
-
-  return ST_CONTINUE;
 }
 
-// Used to clear each of the per_thread_contexts inside the hash_map_per_thread_context
-static int hash_map_per_thread_context_free_values(DDTRACE_UNUSED st_data_t _thread, st_data_t value_per_thread_context, DDTRACE_UNUSED st_data_t _argument) {
-  per_thread_context *thread_context = (per_thread_context*) value_per_thread_context;
-  free_context(thread_context);
-  return ST_CONTINUE;
+static void per_thread_context_typed_data_free(void *ctx_ptr) {
+  per_thread_context *ctx = (per_thread_context *) ctx_ptr;
+  sampling_buffer_free(&ctx->sampling_buffer);
+  free(ctx);
+}
+
+static VALUE _native_clear_per_thread_context_for(DDTRACE_UNUSED VALUE self, VALUE thread) {
+  per_thread_context *ctx = get_per_thread_context(thread);
+  if (ctx != NULL) {
+    set_per_thread_context(thread, NULL);
+    if (!RB_OBJ_FROZEN(thread)) rb_ivar_set(thread, dd_per_thread_context_id, Qnil);
+  }
+  return Qnil;
 }
 
 static VALUE _native_new(VALUE klass) {
@@ -448,9 +451,6 @@ static VALUE _native_new(VALUE klass) {
   // Update this when modifying state struct
   state->locations = NULL;
   state->max_frames = 0;
-  state->hash_map_per_thread_context =
-   // "numtable" is an awful name, but TL;DR it's what should be used when keys are `VALUE`s.
-    st_init_numtable();
   state->recorder_instance = Qnil;
   state->tracer_context_key = MISSING_TRACER_CONTEXT_KEY;
   VALUE thread_list_buffer = rb_ary_new();
@@ -504,7 +504,6 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
   // Update this when modifying state struct
   state->max_frames = sampling_buffer_check_max_frames(NUM2INT(max_frames));
   state->locations = ruby_xcalloc(state->max_frames, sizeof(ddog_prof_Location));
-  // hash_map_per_thread_context is already initialized, nothing to do here
   state->recorder_instance = enforce_recorder_instance(recorder_instance);
   state->endpoint_collection_enabled = (endpoint_collection_enabled == Qtrue);
   state->native_filenames_enabled = (native_filenames_enabled == Qtrue);
@@ -599,6 +598,7 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
 
   VALUE current_thread = rb_thread_current();
   per_thread_context *current_thread_context = get_or_create_context_for(current_thread, state);
+  if (current_thread_context == NULL) return;
   long cpu_time_at_sample_start_for_current_thread = cpu_time_now_ns(current_thread_context);
 
   VALUE threads = thread_list(state);
@@ -623,11 +623,7 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
     );
   }
 
-  state->sample_count++;
-
-  // TODO: This seems somewhat overkill and inefficient to do often; right now we just do it every few samples
-  // but there's probably a better way to do this if we actually track when threads finish
-  if (state->sample_count % 100 == 0) remove_context_for_dead_threads(state);
+  state->stats.sample_count++;
 
   update_metrics_and_sample(
     state,
@@ -718,7 +714,7 @@ void thread_context_collector_on_gc_start(VALUE self_instance) {
   // This should never fail the the above check passes
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  per_thread_context *thread_context = get_context_for(rb_thread_current(), state);
+  per_thread_context *thread_context = get_per_thread_context(rb_thread_current());
 
   // If there was no previously-existing context for this thread, we won't allocate one (see safety). For now we just drop
   // the GC sample, under the assumption that "a thread that is so new that we never sampled it even once before it triggers
@@ -751,7 +747,7 @@ bool thread_context_collector_on_gc_finish(VALUE self_instance) {
   // This should never fail the the above check passes
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  per_thread_context *thread_context = get_context_for(rb_thread_current(), state);
+  per_thread_context *thread_context = get_per_thread_context(rb_thread_current());
 
   // If there was no previously-existing context for this thread, we won't allocate one (see safety). We keep a metric for
   // how often this happens -- see on_gc_start.
@@ -1005,6 +1001,7 @@ static void trigger_sample_for_thread(
   sample_thread(
     stack_from_thread,
     sampling_buffer,
+    state->locations,
     state->recorder_instance,
     values,
     (sample_labels) {
@@ -1032,29 +1029,20 @@ static VALUE _native_thread_list(DDTRACE_UNUSED VALUE _self) {
   return result;
 }
 
+// This allocates a Ruby object and therefore needs the GVL and is not safe to call from RUBY_INTERNAL_EVENT_* hooks.
 static per_thread_context *get_or_create_context_for(VALUE thread, thread_context_collector_state *state) {
-  per_thread_context* thread_context = NULL;
-  st_data_t value_context = 0;
+  per_thread_context *thread_context = get_per_thread_context(thread);
+  if (thread_context != NULL) return thread_context;
 
-  if (st_lookup(state->hash_map_per_thread_context, (st_data_t) thread, &value_context)) {
-    thread_context = (per_thread_context*) value_context;
-  } else {
-    thread_context = calloc(1, sizeof(per_thread_context)); // See "note on calloc vs ruby_xcalloc use" in heap_recorder.c
-    initialize_context(thread, thread_context, state);
-    st_insert(state->hash_map_per_thread_context, (st_data_t) thread, (st_data_t) thread_context);
-  }
+  if (RB_OBJ_FROZEN(thread)) return NULL;
 
-  return thread_context;
-}
+  thread_context = calloc(1, sizeof(per_thread_context)); // See "note on calloc vs ruby_xcalloc use" in heap_recorder.c
+  initialize_context(thread, thread_context, state);
 
-static per_thread_context *get_context_for(VALUE thread, thread_context_collector_state *state) {
-  per_thread_context* thread_context = NULL;
-  st_data_t value_context = 0;
+  VALUE wrapper = TypedData_Wrap_Struct(rb_cObject, &per_thread_context_typed_data, thread_context);
+  rb_ivar_set(thread, dd_per_thread_context_id, wrapper);
 
-  if (st_lookup(state->hash_map_per_thread_context, (st_data_t) thread, &value_context)) {
-    thread_context = (per_thread_context*) value_context;
-  }
-
+  set_per_thread_context(thread, thread_context);
   return thread_context;
 }
 
@@ -1080,7 +1068,7 @@ static bool is_logging_gem_monkey_patch(VALUE invoke_file_location) {
 }
 
 static void initialize_context(VALUE thread, per_thread_context *thread_context, thread_context_collector_state *state) {
-  sampling_buffer_initialize(&thread_context->sampling_buffer, state->max_frames, state->locations);
+  sampling_buffer_initialize(&thread_context->sampling_buffer, state->max_frames);
 
   snprintf(thread_context->thread_id, THREAD_ID_LIMIT_CHARS, "%"PRIu64" (%lu)", native_thread_id_for(thread), (unsigned long) thread_id_for(thread));
   thread_context->thread_id_char_slice = (ddog_CharSlice) {.ptr = thread_context->thread_id, .len = strlen(thread_context->thread_id)};
@@ -1121,24 +1109,17 @@ static void initialize_context(VALUE thread, per_thread_context *thread_context,
   thread_context->gc_tracking.cpu_time_at_start_ns = INVALID_TIME;
   thread_context->gc_tracking.wall_time_at_start_ns = INVALID_TIME;
 
-  #ifndef NO_GVL_INSTRUMENTATION
-    // We use this special location to store data that can be accessed without any
-    // kind of synchronization (e.g. by threads without the GVL).
-    //
-    // We set this marker here for two purposes:
-    // * To make sure there's no stale data from a previous execution of the profiler.
-    // * To mark threads that are actually being profiled
-    //
-    // (Setting this is potentially a race, but what we want is to avoid _stale_ data, so
-    // if this gets set concurrently with context initialization, then such a value will belong
-    // to the current profiler instance, so that's OK)
-    gvl_profiling_state_thread_object_set(thread, GVL_WAITING_ENABLED_EMPTY);
-  #endif
-}
-
-static void free_context(per_thread_context* thread_context) {
-  sampling_buffer_free(&thread_context->sampling_buffer);
-  free(thread_context); // See "note on calloc vs ruby_xcalloc use" in heap_recorder.c
+  // We use this special location to store data that can be accessed without any
+  // kind of synchronization (e.g. by threads without the GVL).
+  //
+  // We set this marker here for two purposes:
+  // * To make sure there's no stale data from a previous execution of the profiler.
+  // * To mark threads that are actually being profiled
+  //
+  // (Setting this is potentially a race, but what we want is to avoid _stale_ data, so
+  // if this gets set concurrently with context initialization, then such a value will belong
+  // to the current profiler instance, so that's OK)
+  thread_context->gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY;
 }
 
 static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {
@@ -1149,11 +1130,9 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
 
   // Update this when modifying state struct
   rb_str_concat(result, rb_sprintf(" max_frames=%d", state->max_frames));
-  rb_str_concat(result, rb_sprintf(" hash_map_per_thread_context=%"PRIsVALUE, per_thread_context_st_table_as_ruby_hash(state)));
   rb_str_concat(result, rb_sprintf(" recorder_instance=%"PRIsVALUE, state->recorder_instance));
   VALUE tracer_context_key = state->tracer_context_key == MISSING_TRACER_CONTEXT_KEY ? Qnil : ID2SYM(state->tracer_context_key);
   rb_str_concat(result, rb_sprintf(" tracer_context_key=%+"PRIsVALUE, tracer_context_key));
-  rb_str_concat(result, rb_sprintf(" sample_count=%u", state->sample_count));
   rb_str_concat(result, rb_sprintf(" stats=%"PRIsVALUE, stats_as_ruby_hash(state)));
   rb_str_concat(result, rb_sprintf(" endpoint_collection_enabled=%"PRIsVALUE, state->endpoint_collection_enabled ? Qtrue : Qfalse));
   rb_str_concat(result, rb_sprintf(" native_filenames_enabled=%"PRIsVALUE, state->native_filenames_enabled ? Qtrue : Qfalse));
@@ -1173,18 +1152,8 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
   return result;
 }
 
-static VALUE per_thread_context_st_table_as_ruby_hash(thread_context_collector_state *state) {
-  VALUE result = rb_hash_new();
-  st_foreach(state->hash_map_per_thread_context, per_thread_context_as_ruby_hash, result);
-  return result;
-}
-
-static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value_context, st_data_t result_hash) {
-  VALUE thread = (VALUE) key_thread;
-  per_thread_context *thread_context = (per_thread_context*) value_context;
-  VALUE result = (VALUE) result_hash;
+static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context) {
   VALUE context_as_hash = rb_hash_new();
-  rb_hash_aset(result, thread, context_as_hash);
 
   VALUE arguments[] = {
     ID2SYM(rb_intern("thread_id")),                       /* => */ rb_str_new2(thread_context->thread_id),
@@ -1201,19 +1170,18 @@ static int per_thread_context_as_ruby_hash(st_data_t key_thread, st_data_t value
     ID2SYM(rb_intern("gc_tracking.cpu_time_at_start_ns")),   /* => */ LONG2NUM(thread_context->gc_tracking.cpu_time_at_start_ns),
     ID2SYM(rb_intern("gc_tracking.wall_time_at_start_ns")),  /* => */ LONG2NUM(thread_context->gc_tracking.wall_time_at_start_ns),
 
-    #ifndef NO_GVL_INSTRUMENTATION
-      ID2SYM(rb_intern("gvl_waiting_at")), /* => */ LONG2NUM(gvl_profiling_state_thread_object_get(thread)),
-    #endif
+    ID2SYM(rb_intern("gvl_waiting_at")), /* => */ LONG2NUM(thread_context->gvl_waiting_at),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 
-  return ST_CONTINUE;
+  return context_as_hash;
 }
 
 static VALUE stats_as_ruby_hash(thread_context_collector_state *state) {
   // Update this when modifying state struct (stats inner struct)
   VALUE stats_as_hash = rb_hash_new();
   VALUE arguments[] = {
+    ID2SYM(rb_intern("sample_count")),                             /* => */ UINT2NUM(state->stats.sample_count),
     ID2SYM(rb_intern("gc_samples")),                               /* => */ UINT2NUM(state->stats.gc_samples),
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
   };
@@ -1234,29 +1202,25 @@ static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state) {
   return result;
 }
 
-static void remove_context_for_dead_threads(thread_context_collector_state *state) {
-  st_foreach(state->hash_map_per_thread_context, remove_if_dead_thread, 0 /* unused */);
-}
-
-static int remove_if_dead_thread(st_data_t key_thread, st_data_t value_context, DDTRACE_UNUSED st_data_t _argument) {
-  VALUE thread = (VALUE) key_thread;
-  per_thread_context* thread_context = (per_thread_context*) value_context;
-
-  if (is_thread_alive(thread)) return ST_CONTINUE;
-
-  free_context(thread_context);
-  return ST_DELETE;
-}
-
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 //
-// Returns the whole contents of the per_thread_context structs being tracked.
+// Returns the whole contents of the per_thread_context structs being tracked, by iterating all live threads.
 static VALUE _native_per_thread_context(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  return per_thread_context_st_table_as_ruby_hash(state);
+  VALUE result = rb_hash_new();
+  VALUE threads = thread_list(state);
+  const long thread_count = RARRAY_LEN(threads);
+  for (long i = 0; i < thread_count; i++) {
+    VALUE thread = RARRAY_AREF(threads, i);
+    per_thread_context *thread_context = get_per_thread_context(thread);
+    if (thread_context != NULL) {
+      rb_hash_aset(result, thread, per_thread_context_to_ruby_hash(thread_context));
+    }
+  }
+  return result;
 }
 
 static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, long gc_start_time_ns, bool is_wall_time) {
@@ -1449,12 +1413,18 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  // Release all context memory before clearing the existing context
-  st_foreach(state->hash_map_per_thread_context, hash_map_per_thread_context_free_values, 0 /* unused */);
-
-  st_clear(state->hash_map_per_thread_context);
-
   state->stats = (struct stats) {}; // Resets all stats back to zero
+
+  VALUE threads = thread_list(state);
+  const long thread_count = RARRAY_LEN(threads);
+  for (long i = 0; i < thread_count; i++) {
+    VALUE thread = RARRAY_AREF(threads, i);
+    per_thread_context *ctx = get_per_thread_context(thread);
+    if (ctx != NULL) {
+      set_per_thread_context(thread, NULL);
+      if (!RB_OBJ_FROZEN(thread)) rb_ivar_set(thread, dd_per_thread_context_id, Qnil);
+    }
+  }
 
   rb_funcall(state->recorder_instance, rb_intern("reset_after_fork"), 0);
 
@@ -1475,14 +1445,9 @@ static VALUE thread_list(thread_context_collector_state *state) {
 // expected to be called from a signal handler and to be async-signal-safe.
 //
 // Also, no allocation (Ruby or malloc) can happen.
-bool thread_context_collector_prepare_sample_inside_signal_handler(VALUE self_instance) {
-  thread_context_collector_state *state;
-  if (!rb_typeddata_is_kind_of(self_instance, &thread_context_collector_typed_data)) return false;
-  // This should never fail if the above check passes
-  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
-
+bool thread_context_collector_prepare_sample_inside_signal_handler(void) {
   VALUE current_thread = rb_thread_current();
-  per_thread_context *thread_context = get_context_for(current_thread, state);
+  per_thread_context *thread_context = get_per_thread_context(current_thread);
   if (thread_context == NULL) return false;
 
   return prepare_sample_thread(current_thread, &thread_context->sampling_buffer);
@@ -1493,11 +1458,11 @@ bool thread_context_collector_prepare_sample_inside_signal_handler(VALUE self_in
 //
 // Returns true if the after_allocation needs to be called (to do work that can't be done from inside the
 // tracepoint, such as allocate new objects), and false if it doesn't
-bool thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight, VALUE new_object) {
+//
+// The callers must ensure thread_context is non-NULL.
+bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_context *thread_context, unsigned int sample_weight, VALUE new_object) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
-
-  VALUE current_thread = rb_thread_current();
 
   enum ruby_value_type type = rb_type(new_object);
 
@@ -1565,7 +1530,7 @@ bool thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
 
   bool needs_after_allocation = track_object(state->recorder_instance, new_object, sample_weight, class_name);
 
-  per_thread_context *thread_context = get_or_create_context_for(current_thread, state);
+  VALUE current_thread = rb_thread_current();
 
   trigger_sample_for_thread(
     state,
@@ -1587,9 +1552,16 @@ bool thread_context_collector_sample_allocation(VALUE self_instance, unsigned in
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
 // It SHOULD NOT be used for other purposes.
 static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE sample_weight, VALUE new_object) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+  per_thread_context *thread_context = get_or_create_context_for(rb_thread_current(), state);
+  if (thread_context == NULL) {
+    return Qnil;
+  }
+
   debug_enter_unsafe_context();
 
-  bool needs_after_allocation = thread_context_collector_sample_allocation(collector_instance, NUM2UINT(sample_weight), new_object);
+  bool needs_after_allocation = thread_context_collector_sample_allocation(collector_instance, thread_context, NUM2UINT(sample_weight), new_object);
 
   debug_leave_unsafe_context();
 
@@ -1893,7 +1865,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
 #ifndef NO_GVL_INSTRUMENTATION
   // This function can get called from outside the GVL and even on non-main Ractors
-  void thread_context_collector_on_gvl_waiting(gvl_profiling_thread thread) {
+  void thread_context_collector_on_gvl_waiting(VALUE thread) {
     // Because this function gets called from a thread that is NOT holding the GVL, we avoid touching the
     // per-thread context directly.
     //
@@ -1902,19 +1874,26 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     //
     // Also, this function can get called on the non-main Ractor. We deal with this by checking if the value in the context
     // is non-zero, since only `initialize_context` ever sets the value from 0 to non-zero for threads it sees.
-    intptr_t thread_being_profiled = gvl_profiling_state_get(thread);
+    per_thread_context* thread_being_profiled = get_per_thread_context(thread);
     if (!thread_being_profiled) return;
 
     long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE);
     if (current_monotonic_wall_time_ns <= 0 || current_monotonic_wall_time_ns > GVL_WAITING_ENABLED_EMPTY) return;
 
-    gvl_profiling_state_set(thread, current_monotonic_wall_time_ns);
+    thread_being_profiled->gvl_waiting_at = current_monotonic_wall_time_ns;
   }
 
   // This function can get called from outside the GVL and even on non-main Ractors
   __attribute__((warn_unused_result))
-  on_gvl_running_result thread_context_collector_on_gvl_running_with_threshold(gvl_profiling_thread thread, uint32_t waiting_for_gvl_threshold_ns) {
-    intptr_t gvl_waiting_at = gvl_profiling_state_get(thread);
+  on_gvl_running_result thread_context_collector_on_gvl_running_with_threshold(VALUE thread, uint32_t waiting_for_gvl_threshold_ns) {
+    per_thread_context* thread_being_profiled = get_per_thread_context(thread);
+
+    // Thread was not being profiled
+    if (!thread_being_profiled) {
+      return (on_gvl_running_result) {.action = ON_GVL_RUNNING_UNKNOWN, .waiting_for_gvl_duration_ns = 0};
+    }
+
+    long gvl_waiting_at = thread_being_profiled->gvl_waiting_at;
 
     // Thread was not being profiled / not waiting on gvl
     if (gvl_waiting_at == 0 || gvl_waiting_at == GVL_WAITING_ENABLED_EMPTY) {
@@ -1932,12 +1911,12 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     if (should_sample) {
       // We flip the gvl_waiting_at to negative to mark that the thread is now running and no longer waiting
-      intptr_t gvl_waiting_at_is_now_running = -gvl_waiting_at;
+      long gvl_waiting_at_is_now_running = -gvl_waiting_at;
 
-      gvl_profiling_state_set(thread, gvl_waiting_at_is_now_running);
+      thread_being_profiled->gvl_waiting_at = gvl_waiting_at_is_now_running;
     } else {
       // We decided not to sample. Let's mark the thread back to the initial "enabled but empty" state
-      gvl_profiling_state_set(thread, GVL_WAITING_ENABLED_EMPTY);
+      thread_being_profiled->gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY;
     }
 
     return (on_gvl_running_result) {
@@ -1947,7 +1926,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
   }
 
   __attribute__((warn_unused_result))
-  on_gvl_running_result thread_context_collector_on_gvl_running(gvl_profiling_thread thread) {
+  on_gvl_running_result thread_context_collector_on_gvl_running(VALUE thread) {
     return thread_context_collector_on_gvl_running_with_threshold(thread, global_waiting_for_gvl_threshold_ns);
   }
 
@@ -1977,13 +1956,18 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
   //
   // ---
   //
+  // Always called with the GVL, either from a postponed_job or from tests.
+  //
   // NOTE: In normal use, current_thread is expected to be == rb_thread_current(); the `current_thread` parameter only
   // exists to enable testing.
   VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance, VALUE current_thread, long current_monotonic_wall_time_ns) {
     thread_context_collector_state *state;
     TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-    intptr_t gvl_waiting_at = gvl_profiling_state_thread_object_get(current_thread);
+    per_thread_context *thread_context = get_or_create_context_for(current_thread, state);
+    if (thread_context == NULL) return Qfalse;
+
+    long gvl_waiting_at = thread_context->gvl_waiting_at;
 
     if (gvl_waiting_at >= 0) {
       // @ivoanjo: I'm not sure if this can ever happen. This means that we're not on the same thread
@@ -1992,8 +1976,6 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
       // We do nothing in this case.
       return Qfalse;
     }
-
-    per_thread_context *thread_context = get_or_create_context_for(current_thread, state);
 
     // We don't actually account for cpu-time during Waiting for GVL. BUT, we may chose to push an
     // extra sample to represent the period prior to Waiting for GVL. To support that, we retrieve the current
@@ -2026,7 +2008,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     sampling_buffer* sampling_buffer,
     long current_cpu_time_ns
   ) {
-    intptr_t gvl_waiting_at = gvl_profiling_state_thread_object_get(thread_being_sampled);
+    long gvl_waiting_at = thread_context->gvl_waiting_at;
 
     bool is_gvl_waiting_state = gvl_waiting_at != 0 && gvl_waiting_at != GVL_WAITING_ENABLED_EMPTY;
 
@@ -2076,7 +2058,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     if (gvl_waiting_at < 0) {
       // Negative means the waiting for GVL just ended, so we clear the state, so next samples no longer represent waiting
-      gvl_profiling_state_thread_object_set(thread_being_sampled, GVL_WAITING_ENABLED_EMPTY);
+      thread_context->gvl_waiting_at = GVL_WAITING_ENABLED_EMPTY;
     }
 
     long gvl_waiting_started_wall_time_ns = labs(gvl_waiting_at);
@@ -2120,7 +2102,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     debug_enter_unsafe_context();
 
-    thread_context_collector_on_gvl_waiting(thread_from_thread_object(thread));
+    thread_context_collector_on_gvl_waiting(thread);
 
     debug_leave_unsafe_context();
 
@@ -2132,11 +2114,12 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     debug_enter_unsafe_context();
 
-    intptr_t gvl_waiting_at = gvl_profiling_state_thread_object_get(thread);
+    per_thread_context *thread_context = get_per_thread_context(thread);
+    VALUE result = thread_context ? LONG2NUM(thread_context->gvl_waiting_at) : Qnil;
 
     debug_leave_unsafe_context();
 
-    return LONG2NUM(gvl_waiting_at);
+    return result;
   }
 
   static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE thread) {
@@ -2144,7 +2127,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     debug_enter_unsafe_context();
 
-    VALUE result = thread_context_collector_on_gvl_running(thread_from_thread_object(thread)).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
+    VALUE result = thread_context_collector_on_gvl_running(thread).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
 
     debug_leave_unsafe_context();
 
@@ -2154,8 +2137,6 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception) {
     ENFORCE_THREAD(thread);
     ENFORCE_BOOLEAN(allow_exception);
-
-
 
     if (allow_exception == Qfalse) debug_enter_unsafe_context();
 
@@ -2170,13 +2151,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     return result;
   }
 
-  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE delta_ns) {
+  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns) {
     ENFORCE_THREAD(thread);
 
-    thread_context_collector_state *state;
-    TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
-
-    per_thread_context *thread_context = get_context_for(thread, state);
+    per_thread_context *thread_context = get_per_thread_context(thread);
     if (thread_context == NULL) raise_error(rb_eArgError, "Unexpected: This method cannot be used unless the per-thread context for the thread already exists");
 
     thread_context->cpu_time_at_previous_sample_ns += NUM2LONG(delta_ns);
@@ -2239,6 +2217,6 @@ static VALUE _native_system_epoch_time_now_ns(DDTRACE_UNUSED VALUE self, VALUE c
   return LONG2NUM(system_epoch_time_ns);
 }
 
-static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self, VALUE collector_instance) {
-  return thread_context_collector_prepare_sample_inside_signal_handler(collector_instance) ? Qtrue : Qfalse;
+static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self) {
+  return thread_context_collector_prepare_sample_inside_signal_handler() ? Qtrue : Qfalse;
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -2041,17 +2041,17 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     //  ...──────────────┬───────────────────...
     //       Other state │ Waiting for GVL
     //  ...──────────────┴───────────────────...
-    //     ▲                              ▲
+    //     ▲                               ▲
     //     └─ Previous sample              └─ Regular sample (caller)
     //
     //   In this case, we'll want to push two samples: a) one for the current time (handled by the caller), b) an extra sample
-    //   to represent the remaining cpu/wall time before the "Waiting for GVL" started:
+    //   to represent the remaining cpu/wall time before the "Waiting for GVL" started (for timeline purposes):
     //
     //                             time ─────►
     //  ...──────────────┬───────────────────...
     //       Other state │ Waiting for GVL
     //  ...──────────────┴───────────────────...
-    //     ▲            ▲                ▲
+    //     ▲             ▲                 ▲
     //     └─ Prev...    └─ Extra sample   └─ Regular sample (caller)
     //
     // 2. The current sample is the n-th one after we entered the "Waiting for GVL" state
@@ -2061,7 +2061,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     //  ...──────────────┬───────────────────────────────────────────────...
     //       Other state │ Waiting for GVL
     //  ...──────────────┴───────────────────────────────────────────────...
-    //     ▲                              ▲                          ▲
+    //     ▲                               ▲                          ▲
     //     └─ Previous sample              └─ Previous sample         └─ Regular sample (caller)
     //
     //   In this case, we just report back to the caller that the thread is in the "Waiting for GVL" state.

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -437,7 +437,9 @@ static VALUE _native_clear_per_thread_context_for(DDTRACE_UNUSED VALUE self, VAL
   per_thread_context *ctx = get_per_thread_context(thread);
   if (ctx != NULL) {
     set_per_thread_context(thread, NULL);
-    if (!RB_OBJ_FROZEN(thread)) rb_ivar_set(thread, dd_per_thread_context_id, Qnil);
+    if (!RB_OBJ_FROZEN(thread)) {
+      rb_ivar_set(thread, dd_per_thread_context_id, Qnil);
+    }
   }
   return Qnil;
 }
@@ -598,7 +600,6 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
 
   VALUE current_thread = rb_thread_current();
   per_thread_context *current_thread_context = get_or_create_context_for(current_thread, state);
-  if (current_thread_context == NULL) return;
   long cpu_time_at_sample_start_for_current_thread = cpu_time_now_ns(current_thread_context);
 
   VALUE threads = thread_list(state);
@@ -1034,7 +1035,9 @@ static per_thread_context *get_or_create_context_for(VALUE thread, thread_contex
   per_thread_context *thread_context = get_per_thread_context(thread);
   if (thread_context != NULL) return thread_context;
 
-  if (RB_OBJ_FROZEN(thread)) return NULL;
+  if (RB_OBJ_FROZEN(thread)) {
+    raise_error(rb_eFrozenError, "Cannot setup profiler state for Thread %"PRIsVALUE" because it is frozen. Please avoid freezing Thread instances and/or report the issue to dd-trace-rb", thread);
+  }
 
   thread_context = calloc(1, sizeof(per_thread_context)); // See "note on calloc vs ruby_xcalloc use" in heap_recorder.c
   initialize_context(thread, thread_context, state);
@@ -1550,9 +1553,6 @@ static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collecto
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
   per_thread_context *thread_context = get_or_create_context_for(rb_thread_current(), state);
-  if (thread_context == NULL) {
-    return Qnil;
-  }
 
   debug_enter_unsafe_context();
 
@@ -1960,7 +1960,6 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
     per_thread_context *thread_context = get_or_create_context_for(current_thread, state);
-    if (thread_context == NULL) return Qfalse;
 
     long gvl_waiting_at = thread_context->gvl_waiting_at;
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1409,22 +1409,17 @@ static bool should_collect_resource(VALUE root_span) {
 //
 // Assumption: This method gets called BEFORE restarting profiling -- e.g. there are no components attempting to
 // trigger samples at the same time.
+//
+// Note that tests call this method directly in the same process without forking,
+// and in such a case non-current Threads keep running.
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector_instance) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(collector_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   state->stats = (struct stats) {}; // Resets all stats back to zero
 
-  VALUE threads = thread_list(state);
-  const long thread_count = RARRAY_LEN(threads);
-  for (long i = 0; i < thread_count; i++) {
-    VALUE thread = RARRAY_AREF(threads, i);
-    per_thread_context *ctx = get_per_thread_context(thread);
-    if (ctx != NULL) {
-      set_per_thread_context(thread, NULL);
-      if (!RB_OBJ_FROZEN(thread)) rb_ivar_set(thread, dd_per_thread_context_id, Qnil);
-    }
-  }
+  // Clear any leftover state from parent process in the current thread; all other threads are assumed dead
+  _native_clear_per_thread_context_for(Qnil, rb_thread_current());
 
   rb_funcall(state->recorder_instance, rb_intern("reset_after_fork"), 0);
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -11,8 +11,8 @@ void thread_context_collector_sample(
   long current_monotonic_wall_time_ns,
   VALUE profiler_overhead_stack_thread
 );
-__attribute__((warn_unused_result)) bool thread_context_collector_prepare_sample_inside_signal_handler(VALUE self_instance);
-__attribute__((warn_unused_result)) bool thread_context_collector_sample_allocation(VALUE self_instance, unsigned int sample_weight, VALUE new_object);
+__attribute__((warn_unused_result)) bool thread_context_collector_prepare_sample_inside_signal_handler(void);
+__attribute__((warn_unused_result)) bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_context *thread_context, unsigned int sample_weight, VALUE new_object);
 void thread_context_collector_after_allocation(VALUE self_instance);
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
@@ -33,7 +33,7 @@ VALUE enforce_thread_context_collector_instance(VALUE object);
     long waiting_for_gvl_duration_ns;
   } on_gvl_running_result;
 
-  void thread_context_collector_on_gvl_waiting(gvl_profiling_thread thread);
-  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(gvl_profiling_thread thread);
+  void thread_context_collector_on_gvl_waiting(VALUE thread);
+  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(VALUE thread);
   VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance, VALUE current_thread, long current_monotonic_wall_time_ns);
 #endif

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -174,8 +174,8 @@ $defs << "-DUSE_RACTOR_INTERNAL_APIS_DIRECTLY" if RUBY_VERSION < "3.3"
 # On older Rubies, there was no GVL instrumentation API and APIs created to support it
 $defs << "-DNO_GVL_INSTRUMENTATION" if RUBY_VERSION < "3.2"
 
-# Supporting GVL instrumentation on 3.2 needs some workarounds
-$defs << "-DUSE_GVL_PROFILING_3_2_WORKAROUNDS" if RUBY_VERSION.start_with?("3.2")
+# rb_internal_thread_specific_*()
+$defs << "-DHAVE_RUBY_THREAD_STORAGE_API" if RUBY_VERSION >= "3.3"
 
 # On older Rubies, there was no struct rb_native_thread. See private_vm_api_acccess.c for details.
 $defs << "-DNO_RB_NATIVE_THREAD" if RUBY_VERSION < "3.2"

--- a/ext/datadog_profiling_native_extension/gvl_profiling_helper.c
+++ b/ext/datadog_profiling_native_extension/gvl_profiling_helper.c
@@ -4,49 +4,10 @@
 #include "datadog_ruby_common.h"
 #include "gvl_profiling_helper.h"
 
-#if !defined(NO_GVL_INSTRUMENTATION) && !defined(USE_GVL_PROFILING_3_2_WORKAROUNDS) // Ruby 3.3+
-  rb_internal_thread_specific_key_t gvl_waiting_tls_key;
+#ifdef HAVE_RUBY_THREAD_STORAGE_API
+  rb_internal_thread_specific_key_t per_thread_context_key;
 
-  void gvl_profiling_init(void) {
-    gvl_waiting_tls_key = rb_internal_thread_specific_key_create();
-  }
-
-#endif
-
-#ifdef USE_GVL_PROFILING_3_2_WORKAROUNDS // Ruby 3.2
-  __thread gvl_profiling_thread gvl_waiting_tls;
-  static bool gvl_profiling_state_thread_tracking_workaround_installed = false;
-
-  static void on_thread_start(
-    DDTRACE_UNUSED rb_event_flag_t _unused1,
-    DDTRACE_UNUSED const rb_internal_thread_event_data_t *_unused2,
-    DDTRACE_UNUSED void *_unused3
-  ) {
-    gvl_waiting_tls = (gvl_profiling_thread) {.thread = NULL};
-  }
-
-  // Hack: We're using the gvl_waiting_tls native thread-local to store per-thread information. Unfortunately, Ruby puts a big hole
-  // in our plan because it reuses native threads -- specifically, in Ruby 3.2, native threads are still 1:1 to Ruby
-  // threads (M:N wasn't a thing yet) BUT once a Ruby thread dies, the VM will keep the native thread around for a
-  // bit, and if another Ruby thread starts right after, Ruby will reuse the native thread, rather than create a new one.
-  //
-  // This will mean that the new Ruby thread will still have the same native thread-local data that we set on the
-  // old thread. For the purposes of our tracking, where we're keeping a pointer to the current thread object in
-  // thread-local storage **this is disastrous** since it means we'll be pointing at the wrong thread (and its
-  // memory may have been freed or reused since!)
-  //
-  // To work around this issue, once GVL profiling is enabled, we install an event hook on thread start
-  // events that clears the thread-local data. This guarantees that there will be no stale data -- any existing
-  // data will be cleared at thread start.
-  //
-  // Note that once installed, this event hook becomes permanent -- stopping the profiler does not stop this event
-  // hook, unlike all others. This is because we can't afford to miss any thread start events while the
-  // profiler is stopped (e.g. during reconfiguration) as that would mean stale data once the profiler starts again.
-  void gvl_profiling_state_thread_tracking_workaround(void) {
-    if (gvl_profiling_state_thread_tracking_workaround_installed) return;
-
-    rb_internal_thread_add_event_hook(on_thread_start, RUBY_INTERNAL_THREAD_EVENT_STARTED, NULL);
-
-    gvl_profiling_state_thread_tracking_workaround_installed = true;
+  void per_thread_context_tls_init(void) {
+    per_thread_context_key = rb_internal_thread_specific_key_create();
   }
 #endif

--- a/ext/datadog_profiling_native_extension/gvl_profiling_helper.h
+++ b/ext/datadog_profiling_native_extension/gvl_profiling_helper.h
@@ -6,62 +6,30 @@
 
 #include "extconf.h"
 
-#if !defined(NO_GVL_INSTRUMENTATION) && !defined(USE_GVL_PROFILING_3_2_WORKAROUNDS) // Ruby 3.3+
-  #include <ruby.h>
+#include <ruby.h>
+
+// Opaque to this header; the full definition lives in collectors_thread_context.c.
+typedef struct per_thread_context per_thread_context;
+
+#ifdef HAVE_RUBY_THREAD_STORAGE_API
   #include <ruby/thread.h>
-  #include "datadog_ruby_common.h"
 
-  typedef struct { VALUE thread; } gvl_profiling_thread;
-  extern rb_internal_thread_specific_key_t gvl_waiting_tls_key;
+  extern rb_internal_thread_specific_key_t per_thread_context_key;
 
-  void gvl_profiling_init(void);
+  void per_thread_context_tls_init(void);
 
-  static inline gvl_profiling_thread thread_from_thread_object(VALUE thread) {
-    return (gvl_profiling_thread) {.thread = thread};
+  static inline per_thread_context* get_per_thread_context(VALUE thread) {
+    return rb_internal_thread_specific_get(thread, per_thread_context_key);
   }
 
-  static inline gvl_profiling_thread thread_from_event(const rb_internal_thread_event_data_t *event_data) {
-    return thread_from_thread_object(event_data->thread);
+  static inline void set_per_thread_context(VALUE thread, per_thread_context* value) {
+    rb_internal_thread_specific_set(thread, per_thread_context_key, value);
   }
-
-  static inline intptr_t gvl_profiling_state_get(gvl_profiling_thread thread) {
-    return (intptr_t) rb_internal_thread_specific_get(thread.thread, gvl_waiting_tls_key);
-  }
-
-  static inline void gvl_profiling_state_set(gvl_profiling_thread thread, intptr_t value) {
-    rb_internal_thread_specific_set(thread.thread, gvl_waiting_tls_key, (void *) value);
-  }
-#endif
-
-#ifdef USE_GVL_PROFILING_3_2_WORKAROUNDS // Ruby 3.2
-  typedef struct { void *thread; } gvl_profiling_thread;
-  extern __thread gvl_profiling_thread gvl_waiting_tls;
-
-  static inline void gvl_profiling_init(void) { }
-
-  // NOTE: This is a hack that relies on the knowledge that on Ruby 3.2 the
-  // RUBY_INTERNAL_THREAD_EVENT_READY and RUBY_INTERNAL_THREAD_EVENT_RESUMED events always get called on the thread they
-  // are about. Thus, we can use our thread local storage hack to get this data, even though the event doesn't include it.
-  static inline gvl_profiling_thread thread_from_event(DDTRACE_UNUSED const void *event_data) {
-    return gvl_waiting_tls;
-  }
-
-  void gvl_profiling_state_thread_tracking_workaround(void);
-  gvl_profiling_thread gvl_profiling_state_maybe_initialize(void);
+#else
+  static inline void per_thread_context_tls_init(void) { }
 
   // Implementing these on Ruby 3.2 requires access to private VM things, so the following methods are
   // implemented in `private_vm_api_access.c`
-  gvl_profiling_thread thread_from_thread_object(VALUE thread);
-  intptr_t gvl_profiling_state_get(gvl_profiling_thread thread);
-  void gvl_profiling_state_set(gvl_profiling_thread thread, intptr_t value);
-#endif
-
-#ifndef NO_GVL_INSTRUMENTATION // For all Rubies supporting GVL profiling (3.2+)
-  static inline intptr_t gvl_profiling_state_thread_object_get(VALUE thread) {
-    return gvl_profiling_state_get(thread_from_thread_object(thread));
-  }
-
-  static inline void gvl_profiling_state_thread_object_set(VALUE thread, intptr_t value) {
-    gvl_profiling_state_set(thread_from_thread_object(thread), value);
-  }
+  per_thread_context* get_per_thread_context(VALUE thread);
+  void set_per_thread_context(VALUE thread, per_thread_context* value);
 #endif

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -5,7 +5,7 @@
 #include "libdatadog_helpers.h"
 #include "time_helpers.h"
 
-// Note on calloc vs ruby_xcalloc use:
+// note on calloc vs ruby_xcalloc use:
 // * Whenever we're allocating memory after being called by the Ruby VM in a "regular" situation (e.g. initializer)
 //   we should use `ruby_xcalloc` to give the VM visibility into what we're doing + give it a chance to manage GC
 // * BUT, when we're being called during a sample, being in the middle of an object allocation is a very special

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -790,15 +790,11 @@ static inline int ddtrace_imemo_type(VALUE imemo) {
   }
 #endif
 
-#ifdef USE_GVL_PROFILING_3_2_WORKAROUNDS // Ruby 3.2
+#ifndef HAVE_RUBY_THREAD_STORAGE_API
   #include "gvl_profiling_helper.h"
 
-  gvl_profiling_thread thread_from_thread_object(VALUE thread) {
-    return (gvl_profiling_thread) {.thread = thread_struct_from_object(thread)};
-  }
-
   // Hack: In Ruby 3.3+ we attach gvl profiling state to Ruby threads using the
-  // rb_internal_thread_specific_* APIs. These APIs did not exist on Ruby 3.2. On Ruby 3.2 we instead store the
+  // rb_internal_thread_specific_* APIs. These APIs did not exist on Ruby <= 3.2. On Ruby <= 3.2 we instead store the
   // needed data inside the `rb_thread_t` structure, specifically in `stat_insn_usage` as a Ruby FIXNUM.
   //
   // Why `stat_insn_usage`? We needed some per-thread storage, and while looking at the Ruby VM sources I noticed
@@ -806,38 +802,21 @@ static inline int ddtrace_imemo_type(VALUE imemo) {
   // code. There's a comment attached to it "/* statistics data for profiler */" but other than marking this
   // field for GC, I could not find any place in the VM commit history or on GitHub where this has ever been used.
   //
-  // Thus, since this hack is only for 3.2, which presumably will never see this field either removed or used
-  // during its remaining maintenance release period we... kinda take it for our own usage. It's ugly, I know...
-  intptr_t gvl_profiling_state_get(gvl_profiling_thread thread) {
-    if (thread.thread == NULL) return 0;
-
-    VALUE current_value = ((rb_thread_t *)thread.thread)->stat_insn_usage;
-    intptr_t result = current_value == Qnil ? 0 : FIX2LONG(current_value);
-    return result;
-  }
-
-  void gvl_profiling_state_set(gvl_profiling_thread thread, intptr_t value) {
-    if (thread.thread == NULL) return;
-    ((rb_thread_t *)thread.thread)->stat_insn_usage = LONG2FIX(value);
-  }
-
-  // Because Ruby 3.2 does not give us the current thread when calling the RUBY_INTERNAL_THREAD_EVENT_READY and
-  // RUBY_INTERNAL_THREAD_EVENT_RESUMED APIs, we need to figure out this info ourselves.
+  // Thus, since this hack is only for Ruby <= 3.2, which presumably will never see this field either removed or used
+  // we... kinda take it for our own usage. It's ugly, I know...
   //
-  // Specifically, this method was created to be called from a RUBY_INTERNAL_THREAD_EVENT_RESUMED callback --
-  // when it's triggered, we know the thread the code gets executed on is holding the GVL, so we use this
-  // opportunity to initialize our thread-local value.
-  gvl_profiling_thread gvl_profiling_state_maybe_initialize(void) {
-    gvl_profiling_thread current_thread = gvl_waiting_tls;
+  // 64-bit pointers actually use 48-bit virtual addresses (https://muxup.com/2023q4/storing-data-in-pointers),
+  // so we are sure the addresses fit in Fixnums.
+  per_thread_context *get_per_thread_context(VALUE thread) {
+    VALUE current_value = thread_struct_from_object(thread)->stat_insn_usage;
+    return RB_FIXNUM_P(current_value) ? (per_thread_context *) FIX2LONG(current_value) : NULL;
+  }
 
-    if (current_thread.thread == NULL) {
-      // threads.sched.running is the thread currently holding the GVL, which when this gets executed is the
-      // current thread!
-      current_thread = (gvl_profiling_thread) {.thread = (void *) rb_current_ractor()->threads.sched.running};
-      gvl_waiting_tls = current_thread;
+  void set_per_thread_context(VALUE thread, per_thread_context *value) {
+    if (!RB_FIXABLE((intptr_t) value)) {
+      rb_bug("per_thread_context pointer does not fit in a Fixnum: %p", value);
     }
-
-    return current_thread;
+    thread_struct_from_object(thread)->stat_insn_usage = value ? LONG2FIX((intptr_t) value) : Qfalse;
   }
 #endif
 

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -894,6 +894,9 @@ static ddog_Timespec system_epoch_now_timespec(void) {
 //
 // Assumption: This method gets called BEFORE restarting profiling -- e.g. there are no components attempting to
 // trigger samples at the same time.
+//
+// Note that tests call this method directly in the same process without forking,
+// and in such a case non-current Threads keep running.
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);

--- a/ext/datadog_profiling_native_extension/unsafe_api_calls_check.h
+++ b/ext/datadog_profiling_native_extension/unsafe_api_calls_check.h
@@ -18,7 +18,7 @@
 // in most (all?) thread switch points, Ruby will check for interrupts and run the postponed jobs.
 //
 // Thus, if we set a flag while we're sampling (inside_unsafe_context), trigger the postponed job, and then only unset
-// the flag after sampling, he correct thing to happen is that the postponed job should never see the flag.
+// the flag after sampling, the correct thing to happen is that the postponed job should never see the flag.
 //
 // If, however, we have a bug and there's a thread switch point, our postponed job will see the flag and immediately
 // stop the Ruby VM before further damage happens (and hopefully giving us a stack trace clearly pointing to the culprit).

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -297,8 +297,18 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path"
         # sampling.
         # Note that when something does go wrong during sampling, we do allocate exceptions (and then raise them).
+        #
+        # The first sample of each thread allocates a TypedData wrapper for per_thread_context, so we wait for that
+        # initial burst to pass and then check that no further allocations occur.
 
         start
+
+        try_wait_until do
+          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+          samples if samples.any?
+        end
+
+        allocations_after_initial = cpu_and_wall_time_worker.stats.fetch(:allocations_during_sample)
 
         try_wait_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
@@ -309,7 +319,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         stats = cpu_and_wall_time_worker.stats
 
-        expect(stats).to include(allocations_during_sample: 0)
+        expect(stats.fetch(:allocations_during_sample)).to be(allocations_after_initial)
       end
     end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -292,6 +292,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     context "with allocation profiling enabled" do
       # We need this otherwise allocations_during_sample will never change
       let(:allocation_profiling_enabled) { true }
+      let(:sample) {
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(worker_settings[:thread_context_collector], Thread.current, false)
+      }
 
       it "does not allocate Ruby objects during the regular operation of sampling" do
         # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path"
@@ -302,12 +305,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         # initial burst to pass and then check that no further allocations occur.
 
         start
-
-        try_wait_until do
-          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples.any?
-        end
-
+        sample
         allocations_after_initial = cpu_and_wall_time_worker.stats.fetch(:allocations_during_sample)
 
         try_wait_until do

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2226,4 +2226,41 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       reset_after_fork
     end
   end
+
+  describe "when a new collector is created with a smaller max_frames" do
+    it "caps the number of frames to the new max_frames" do
+      large_max_frames = 400
+      first_collector = described_class.new(
+        recorder: recorder,
+        max_frames: large_max_frames,
+        tracer: tracer,
+        endpoint_collection_enabled: endpoint_collection_enabled,
+        waiting_for_gvl_threshold_ns: waiting_for_gvl_threshold_ns,
+        otel_context_enabled: otel_context_enabled,
+        native_filenames_enabled: native_filenames_enabled,
+      )
+      described_class::Testing._native_sample(first_collector, profiler_overhead_thread_placeholder, false)
+
+      # Second collector with much smaller max_frames — its locations array is smaller,
+      # but the existing per_thread_context still has a sampling_buffer sized for large_max_frames.
+      small_max_frames = 5
+      second_recorder = Datadog::Profiling::StackRecorder.for_testing(alloc_samples_enabled: true)
+      second_collector = described_class.new(
+        recorder: second_recorder,
+        max_frames: small_max_frames,
+        tracer: tracer,
+        endpoint_collection_enabled: endpoint_collection_enabled,
+        waiting_for_gvl_threshold_ns: waiting_for_gvl_threshold_ns,
+        otel_context_enabled: otel_context_enabled,
+        native_filenames_enabled: native_filenames_enabled,
+      )
+      described_class::Testing._native_sample(second_collector, profiler_overhead_thread_placeholder, false)
+
+      second_samples = samples_from_pprof(second_recorder.serialize!)
+      current_thread_samples = samples_for_thread(second_samples, Thread.current)
+      main_sample = current_thread_samples.find { |s| !s.labels.key?(:"profiler overhead") }
+
+      expect(main_sample.locations.size).to be <= small_max_frames
+    end
+  end
 end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     @clean_threads_required = true
     testing_threads.each { ready_queue.pop }
     expect(Thread.list).to include(*testing_threads)
+
+    testing_threads_and_current.each { |t| clear_per_thread_context_for(t) }
   end
 
   let(:recorder) do
@@ -37,15 +39,16 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
   let(:profiler_overhead_thread_placeholder) do
     Thread.new(ready_queue) do |ready_queue|
-      def self.overhead_placeholder(queue)
+      overhead_placeholder = ->(queue) do
         queue << true
         sleep
       end
 
-      overhead_placeholder(ready_queue)
+      overhead_placeholder.call(ready_queue)
     end
   end
   let(:testing_threads) { [t1, t2, t3, profiler_overhead_thread_placeholder] }
+  let(:testing_threads_and_current) { [*testing_threads, Thread.current] }
   let(:max_frames) { 123 }
 
   let(:pprof_result) { recorder.serialize! }
@@ -83,6 +86,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
   def sample(profiler_overhead_stack_thread: profiler_overhead_thread_placeholder, allow_exception: false)
     described_class::Testing._native_sample(thread_context_collector, profiler_overhead_stack_thread, allow_exception)
+  end
+
+  def clear_per_thread_context_for(thread)
+    described_class::Testing._native_clear_per_thread_context_for(thread)
   end
 
   def on_gc_start
@@ -139,11 +146,11 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
   def apply_delta_to_cpu_time_at_previous_sample_ns(thread, delta_ns)
     described_class::Testing
-      ._native_apply_delta_to_cpu_time_at_previous_sample_ns(thread_context_collector, thread, delta_ns)
+      ._native_apply_delta_to_cpu_time_at_previous_sample_ns(thread, delta_ns)
   end
 
   def prepare_sample_inside_signal_handler
-    described_class::Testing._native_prepare_sample_inside_signal_handler(thread_context_collector)
+    described_class::Testing._native_prepare_sample_inside_signal_handler
   end
 
   # What's the deal with the `profiler_system_epoch_time_now_ns`? Internally the profiler uses a monotonic clock
@@ -323,22 +330,18 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
     context "cpu-time behavior" do
       it "includes the cpu-time for the samples" do
-        rspec_thread_spent_time = Datadog::Core::Utils::Time.measure(:nanosecond) do
-          5.times { sample }
-          samples # to trigger serialization
-        end
+        t0 = Process.clock_gettime(Process::CLOCK_THREAD_CPUTIME_ID, :nanosecond)
+        5.times { sample }
+        samples # to trigger serialization
+        t1 = Process.clock_gettime(Process::CLOCK_THREAD_CPUTIME_ID, :nanosecond)
+        rspec_thread_spent_cpu_time = t1 - t0
 
-        # The only thread we're guaranteed has spent some time on cpu is the rspec thread, so let's check we have
-        # some data for it
         total_cpu_for_rspec_thread =
           samples_for_thread(samples, Thread.current)
             .map { |it| it.values.fetch(:"cpu-time") }
             .reduce(:+)
 
-        # The **wall-clock time** spent by the rspec thread is going to be an upper bound for the cpu time spent,
-        # e.g. if it took 5 real world seconds to run the test, then at most the rspec thread spent those 5 seconds
-        # running on CPU, but possibly it spent slightly less.
-        expect(total_cpu_for_rspec_thread).to be_between(1, rspec_thread_spent_time)
+        expect(total_cpu_for_rspec_thread).to be_between(1, rspec_thread_spent_cpu_time)
       end
 
       context "when a thread is marked as being in garbage collection by on_gc_start" do
@@ -1360,6 +1363,17 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
       end
     end
+
+    context "when a thread is frozen" do
+      it "does not raise and skips the frozen thread" do
+        t1.freeze
+
+        sample
+
+        expect(samples_for_thread(samples, t1)).to be_empty
+        expect(per_thread_context.keys).to_not include(t1)
+      end
+    end
   end
 
   describe "#on_gc_start" do
@@ -1786,10 +1800,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     before { skip_if_gvl_profiling_not_supported(self) }
 
     context "if thread has not been sampled before" do
-      it "does not record anything in the internal_thread_specific value" do
+      it "does not trigger the creation of the thread context" do
         on_gvl_waiting(t1)
 
-        expect(gvl_waiting_at_for(t1)).to be 0
+        expect(gvl_waiting_at_for(t1)).to be_nil
       end
     end
 
@@ -1812,10 +1826,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     before { skip_if_gvl_profiling_not_supported(self) }
 
     context "if thread has not been sampled before" do
-      it "does not record anything in the internal_thread_specific value" do
+      it "does not trigger the creation of the thread context" do
         on_gvl_running(t1)
 
-        expect(gvl_waiting_at_for(t1)).to be 0
+        expect(gvl_waiting_at_for(t1)).to be_nil
       end
     end
 
@@ -1891,9 +1905,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   describe "#sample_after_gvl_running" do
     before { skip_if_gvl_profiling_not_supported(self) }
 
-    context "when thread is not at the end of a Waiting for GVL period" do
+    context "if thread has not been sampled before" do
       before do
-        expect(gvl_waiting_at_for(t1)).to be 0
+        expect(gvl_waiting_at_for(t1)).to be_nil
       end
 
       it do
@@ -2019,12 +2033,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   describe "#per_thread_context" do
-    context "before sampling" do
-      it do
-        expect(per_thread_context).to be_empty
-      end
-    end
-
     context "after sampling" do
       before do
         @wall_time_before_sample_ns = Datadog::Core::Utils::Time.get_time(:nanosecond)
@@ -2123,11 +2131,11 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
           sample
 
-          native_thread.kill
-          native_thread.join
-
           invoke_location = per_thread_context.fetch(native_thread).fetch(:thread_invoke_location)
           expect(invoke_location).to eq "(Unnamed thread from native code)"
+
+          native_thread.kill
+          native_thread.join
         end
 
         context "when the `logging` gem has monkey patched thread creation" do
@@ -2162,22 +2170,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       end
 
       describe ":gvl_waiting_at" do
-        context "on supported Rubies" do
-          before { skip_if_gvl_profiling_not_supported(self) }
-
-          it "is initialized to GVL_WAITING_ENABLED_EMPTY (INTPTR_MAX)" do
-            expect(per_thread_context.values).to all(
-              include(gvl_waiting_at: gvl_waiting_enabled_empty_magic_value)
-            )
-          end
-        end
-
-        context "on legacy Rubies" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.2." }
-
-          it "is not set" do
-            per_thread_context.each do |_thread, context|
-              expect(context.key?(:gvl_waiting_at)).to be false
+        it "is initialized to GVL_WAITING_ENABLED_EMPTY (INTPTR_MAX)" do
+          per_thread_context.each do |thread, context|
+            if testing_threads_and_current.include?(thread)
+              expect(context[:gvl_waiting_at]).to eq gvl_waiting_enabled_empty_magic_value
             end
           end
         end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2208,8 +2208,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       sample
     end
 
-    it "clears the per_thread_context" do
-      expect { reset_after_fork }.to change { per_thread_context.empty? }.from(false).to(true)
+    it "clears the current Thread per_thread_context" do
+      expect { reset_after_fork }.to change { per_thread_context.key?(Thread.current) }.from(true).to(false)
     end
 
     it "clears the stats" do

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1368,10 +1368,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       it "does not raise and skips the frozen thread" do
         t1.freeze
 
-        sample
-
-        expect(samples_for_thread(samples, t1)).to be_empty
-        expect(per_thread_context.keys).to_not include(t1)
+        expect {
+          sample(allow_exception: true)
+        }.to raise_error(FrozenError, "Cannot setup profiler state for Thread #{t1} because it is frozen. Please avoid freezing Thread instances and/or report the issue to dd-trace-rb")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -173,6 +173,22 @@ RSpec.configure do |config|
     end
   end
 
+  # Repeat each example N times to flush out transient failures.
+  # Usage: RSPEC_REPEAT=100 bundle exec rspec spec/path/to_spec.rb:123
+  if (repeat_count = Integer(ENV['RSPEC_REPEAT'] || 1)) > 1
+    config.around do |example|
+      repeat_count.times do |i|
+        example.run
+        if example.exception
+          warn "Failed on repetition #{i + 1}/#{repeat_count}"
+          break
+        end
+        example.example_group_instance.send(:__init_memoized)
+        example.instance_variable_set(:@exception, nil)
+      end
+    end
+  end
+
   # Check for leaky test resources.
   #
   # Execute this after the test has finished


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Store the per_thread_context in the Ruby Thread TLS (rb_internal_thread_specific_set()) so all the state is in one struct and not a struct + a single field in the TLS. Also we'll need more place in TLS for https://github.com/DataDog/dd-trace-rb/pull/5777#issuecomment-4543027193 but there is a hard limit on TLS, so this avoids that problem.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Much simpler and more consistent, the state is together vs spread in different places.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Remove overhead related to cleaning up profiler state for dead threads.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
