### PR TITLE
Default DD_SYMBOL_DATABASE_UPLOAD_ENABLED to false

### DIFF
--- a/docs/DynamicInstrumentation.md
+++ b/docs/DynamicInstrumentation.md
@@ -324,13 +324,12 @@ names, method names, and method parameters when creating probes.
 
 ### Enabling the Symbol Database
 
-Symbol Database upload is enabled by default when Dynamic Instrumentation
-is enabled. No additional configuration is required. It activates using
-Remote Configuration when you open the DI UI for your service.
+Symbol Database upload is disabled by default. To enable it, set:
 
-To explicitly disable it:
+    export DD_SYMBOL_DATABASE_UPLOAD_ENABLED=true
 
-    export DD_SYMBOL_DATABASE_UPLOAD_ENABLED=false
+Once enabled, the upload activates via Remote Configuration when you open
+the DI UI for your service.
 
 ## Rate Limiting and Performance
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2970,15 +2970,15 @@ Alternatively, set DI parameters inside a `Datadog.configure` block:
 
 #### Symbol Database
 
-When Dynamic Instrumentation is enabled, the tracer can extract and upload symbol information (class names, method signatures, parameter names) from your application to enable auto-completion in the DI UI. Symbol Database upload is enabled by default and activates automatically using Remote Configuration.
+When Dynamic Instrumentation is enabled, the tracer can extract and upload symbol information (class names, method signatures, parameter names) from your application to enable auto-completion in the DI UI. Symbol Database upload is disabled by default; enable it to allow Remote Configuration to activate uploads.
 
 | Environment variable | Type | Description | Default |
 |---|---|---|---|
-| `DD_SYMBOL_DATABASE_UPLOAD_ENABLED` | `Boolean` | Enable or disable symbol database upload. | `true` |
+| `DD_SYMBOL_DATABASE_UPLOAD_ENABLED` | `Boolean` | Enable or disable symbol database upload. | `false` |
 
 | Setting | Type | Description | Default |
 |---|---|---|---|
-| `c.symbol_database.enabled` | `Boolean` | Enable or disable symbol database upload. | `true` |
+| `c.symbol_database.enabled` | `Boolean` | Enable or disable symbol database upload. | `false` |
 
 Symbol Database requires MRI Ruby 2.6+ and Remote Configuration (enabled by default). For details on what is extracted, which code is included, and behavior differences across Ruby versions, see [Dynamic Instrumentation — Symbol Database](DynamicInstrumentation.md#symbol-database).
 

--- a/lib/datadog/symbol_database/configuration.rb
+++ b/lib/datadog/symbol_database/configuration.rb
@@ -7,7 +7,7 @@ module Datadog
       # Configuration settings for symbol database upload feature.
       #
       # Public environment variable:
-      # - DD_SYMBOL_DATABASE_UPLOAD_ENABLED (default: true) - Feature gate
+      # - DD_SYMBOL_DATABASE_UPLOAD_ENABLED (default: false) - Feature gate
       #
       # Extended into: Core::Configuration::Settings (via extend)
       # Accessed as: Datadog.configuration.symbol_database.enabled
@@ -31,7 +31,7 @@ module Datadog
               option :enabled do |o|
                 o.type :bool
                 o.env 'DD_SYMBOL_DATABASE_UPLOAD_ENABLED'
-                o.default true
+                o.default false
               end
 
               # Settings in the 'internal' group are for internal Datadog

--- a/spec/datadog/symbol_database/configuration_spec.rb
+++ b/spec/datadog/symbol_database/configuration_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Symbol Database Configuration', :symdb_supported_platforms do
       [
         ['DD_SYMBOL_DATABASE_UPLOAD_ENABLED', 'true', nil, 'enabled', true],
         ['DD_SYMBOL_DATABASE_UPLOAD_ENABLED', 'false', nil, 'enabled', false],
-        ['DD_SYMBOL_DATABASE_UPLOAD_ENABLED', nil, nil, 'enabled', true],
+        ['DD_SYMBOL_DATABASE_UPLOAD_ENABLED', nil, nil, 'enabled', false],
         ['DD_INTERNAL_FORCE_SYMBOL_DATABASE_UPLOAD', 'true', 'internal', 'force_upload', true],
         ['DD_INTERNAL_FORCE_SYMBOL_DATABASE_UPLOAD', 'false', 'internal', 'force_upload', false],
         ['DD_INTERNAL_FORCE_SYMBOL_DATABASE_UPLOAD', nil, 'internal', 'force_upload', false],


### PR DESCRIPTION
**What does this PR do?**

Flips the default of `DD_SYMBOL_DATABASE_UPLOAD_ENABLED` / `c.symbol_database.enabled` from `true` to `false`, making Symbol Database upload opt-in. Updates the configuration default, the spec row that asserts the unset default, and the docs (DI guide and GettingStarted env-var/setting tables) to match.

**Motivation:**

Make Symbol Database upload an opt-in feature so customers explicitly enable it before any extraction or upload work runs.

**Change log entry**

Yes. `DD_SYMBOL_DATABASE_UPLOAD_ENABLED` now defaults to `false`; set it to `true` (or `c.symbol_database.enabled = true`) to opt in to Symbol Database upload.

**Additional Notes:**

Other specs that touch `symbol_database.enabled` (`components_spec.rb`, `capabilities_spec.rb`, `component_spec.rb`, `component_initialize_spec.rb`, `remote_config_integration_spec.rb`) all set the value explicitly and do not depend on the default.

**How to test the change?**

`bundle exec rspec spec/datadog/symbol_database/configuration_spec.rb` — the parameterized env-var row that exercises the unset default now asserts `false`.