### PR TITLE
Reproduce flaky: symdb extractor reopened-class test

### DIFF
--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
   # Helper to create test files in user code location
   def create_user_code_file(content)
-    filename = File.join(@test_dir, "test_#{Time.now.to_i}_#{rand(10000)}.rb")
+    # REPRODUCER: force the filename-collision flake (issue ruby-guild#303).
+    # Original returned "test_#{Time.now.to_i}_#{rand(10000)}.rb"; collisions
+    # within a single example occur with ~1/10000 probability per call pair.
+    # This constant filename triggers the failure deterministically.
+    filename = File.join(@test_dir, "test_collide.rb")
     File.write(filename, content)
     filename
   end


### PR DESCRIPTION
**What does this PR do?**

Reproduces the flaky test [`Datadog::SymbolDatabase::Extractor class/module defined across multiple files (reopening) class reopened across two files includes methods from both files in the extracted scope`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/symbol_database/extractor_spec.rb#L1514). Forces the underlying race so CI fails deterministically.

**Do not merge** — for CI validation only.

**Motivation:**

Reported in [DataDog/ruby-guild#303](https://github.com/DataDog/ruby-guild/issues/303). The failing CI job was [Ruby 3.3 / build & test (standard) [6]](https://github.com/DataDog/dd-trace-rb/actions/runs/26515551423/job/78091677570?pr=5815) attempt 1, which then succeeded on retry — same commit, pass/fail divergence = flaky.

**Failure (from CI):**

```
expected ["method_from_file2"] to include "method_from_file1"
```

**Hypothesis:**

The helper [`create_user_code_file`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/symbol_database/extractor_spec.rb#L27-L31) builds filenames as `"test_#{Time.now.to_i}_#{rand(10000)}.rb"`. Two consecutive calls within the same second collide with ~1/10000 probability per call pair. When they collide, the second `File.write` silently overwrites the first file, so both `@file1` and `@file2` point to a single file containing only file2's content. `load @file1; load @file2` then yields a `TestReopenedClass` with only `method_from_file2`.

**Reproducer technique:**

Replace the helper with a constant filename (`test_collide.rb`) so the collision happens 100% of the time. Companion fix PR uses an incrementing counter to guarantee uniqueness.

**Companion PRs:**
- Fix: #5823
- Validation: #5824

**Change log entry**

None.

**How to test the change?**

CI should show the targeted test fail deterministically with `expected ["method_from_file2"] to include "method_from_file1"`. Confirmed locally.