### PR TITLE
Fix flaky: symdb extractor reopened-class test

### DIFF
--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -23,9 +23,15 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     end
   end
 
-  # Helper to create test files in user code location
+  # Helper to create test files in user code location.
+  # Uses a per-example monotonic counter for filename uniqueness. Earlier
+  # implementation built names from "test_#{Time.now.to_i}_#{rand(10000)}.rb",
+  # which collided with ~1/10000 probability per consecutive call pair within
+  # the same second — see ruby-guild#303.
   def create_user_code_file(content)
-    filename = File.join(@test_dir, "test_#{Time.now.to_i}_#{rand(10000)}.rb")
+    @file_index ||= 0
+    @file_index += 1
+    filename = File.join(@test_dir, "test_#{@file_index}.rb")
     File.write(filename, content)
     filename
   end


### PR DESCRIPTION
**What does this PR do?**

Fixes the flaky test `Datadog::SymbolDatabase::Extractor class/module defined across multiple files (reopening) class reopened across two files includes methods from both files in the extracted scope` at [`spec/datadog/symbol_database/extractor_spec.rb:1514`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/symbol_database/extractor_spec.rb#L1514).

**Motivation:**

Reported in [DataDog/ruby-guild#303](https://github.com/DataDog/ruby-guild/issues/303). The failing CI job was [Ruby 3.3 / build & test (standard) [6]](https://github.com/DataDog/dd-trace-rb/actions/runs/26515551423/job/78091677570?pr=5815) attempt 1 — same commit passed on retry.

**Failure (from CI):**

```
expected ["method_from_file2"] to include "method_from_file1"
```

**Root cause:**

The test's `create_user_code_file` helper built filenames as `"test_#{Time.now.to_i}_#{rand(10000)}.rb"`. Two consecutive calls within the same second collide with ~1/10000 probability per call pair. On collision the second `File.write` silently overwrites the first file, so both `@file1` and `@file2` point to a single file containing only file2's content. `load @file1; load @file2` then produces a `TestReopenedClass` with only `method_from_file2`.

**Fix:**

Replace the name suffix with a per-example monotonic counter (`@file_index`). The counter starts at `0` per example (instance variable scope), increments on each call, and never collides. `Dir.mktmpdir` already isolates cross-example state.

**Companion PRs:**
- Reproducer: #5822 — forces 100% collision by hardcoding the filename
- Validation: #5824 — merges the reproducer onto this branch to prove the fix neutralizes the forced failure

**Change log entry**

None.

**How to test the change?**

Local verification on Ruby 3.2: 20/20 passes of the targeted test, full extractor spec passes (124 examples, 0 failures). The companion reproducer PR forces the collision and demonstrates the assertion failure with this fix absent.

**Validation results:**
- Reproducer PR #5822 — confirmed deterministic failure across Ruby 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0 on Linux + macOS (e.g. [Ruby 4.0 job](https://github.com/DataDog/dd-trace-rb/actions/runs/26533269048/job/78155421342) showed `expected ["method_from_file2"] to include "method_from_file1"`). Closed.
- Validation PR #5824 — CI green; fix neutralizes the forced failure. Closed.