### PR TITLE
Validate fix for flaky: symdb extractor reopened-class test

### DIFF
--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
   # Helper to create test files in user code location
   def create_user_code_file(content)
-    filename = File.join(@test_dir, "test_#{Time.now.to_i}_#{rand(10000)}.rb")
+    # REPRODUCER: force the filename-collision flake (issue ruby-guild#303).
+    # Original returned "test_#{Time.now.to_i}_#{rand(10000)}.rb"; collisions
+    # within a single example occur with ~1/10000 probability per call pair.
+    # This constant filename triggers the failure deterministically.
+    filename = File.join(@test_dir, "test_collide.rb")
     File.write(filename, content)
     filename
   end

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -23,9 +23,15 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     end
   end
 
-  # Helper to create test files in user code location
+  # Helper to create test files in user code location.
+  # Uses a per-example monotonic counter for filename uniqueness. Earlier
+  # implementation built names from "test_#{Time.now.to_i}_#{rand(10000)}.rb",
+  # which collided with ~1/10000 probability per consecutive call pair within
+  # the same second — see ruby-guild#303.
   def create_user_code_file(content)
-    filename = File.join(@test_dir, "test_#{Time.now.to_i}_#{rand(10000)}.rb")
+    @file_index ||= 0
+    @file_index += 1
+    filename = File.join(@test_dir, "test_#{@file_index}.rb")
     File.write(filename, content)
     filename
   end


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix neutralizes the forced failure for the flaky symdb extractor reopened-class test ([ruby-guild#303](https://github.com/DataDog/ruby-guild/issues/303)).

This branch merges:
- Reproducer PR #5822 — forces 100% filename collision in `create_user_code_file`
- Fix PR #5823 — replaces the helper with a per-example monotonic counter

The merge conflict (both branches touch the helper body) is resolved by taking the fix's version. CI passing on this branch demonstrates that with the fix in place, the reproducer's failure mode is no longer reachable.

**Do not merge** — for validation only.

**Companion PRs:**
- Reproducer: #5822
- Fix: #5823

**Change log entry**

None.

**How to test the change?**

CI passes = fix neutralizes the forced failure. CI fails = fix is insufficient. Verified locally on Ruby 3.2: target test passes (1 example, 0 failures).