### PR TITLE
Refuse to publish prerelease versions to RubyGems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,18 @@ jobs:
       - id: version
         run: echo "version=$(ruby -e 'puts Gem::Specification::load(Dir.glob("*.gemspec").first).version')" >> "$GITHUB_OUTPUT"
 
+      # Reject prerelease versions (e.g. X.Y.Z.dev). The in-repo version.rb keeps
+      # PRE='dev' between releases; publishing without flipping PRE to nil would
+      # push a .dev gem to RubyGems, which cannot be reused once yanked.
+      - name: Verify version is not a prerelease
+        env:
+          GEM_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ruby -e "exit Gem::Version.new(ENV['GEM_VERSION']).prerelease? ? 0 : 1"; then
+            echo "::error::Version $GEM_VERSION is a prerelease (e.g. .dev) - refusing to publish"
+            exit 1
+          fi
+
       # Check if the gem version is already published
       - name: Verify gem version
         continue-on-error: ${{ inputs.force }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GEM_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if ruby -e "exit Gem::Version.new(ENV['GEM_VERSION']).prerelease? ? 0 : 1"; then
+          if ruby -e "exit Gem::Version.new(ENV['GEM_VERSION']).prerelease?"; then
             echo "::error::Version $GEM_VERSION is a prerelease (e.g. .dev) - refusing to publish"
             exit 1
           fi


### PR DESCRIPTION
**What does this PR do?**

Adds a step to the `verify-checks` job in `.github/workflows/publish.yml` that refuses to publish if the gemspec version is a prerelease (e.g. `X.Y.Z.dev`, `.rc1`, `.beta1`). Placed first in the job so it fails before any other release work runs.

**Motivation:**

`lib/datadog/version.rb` keeps `PRE = 'dev'` between releases, so the in-repo gemspec version is always `X.Y.Z.dev`. The publish pipeline builds from `version.rb` as-is and relies on the human-driven `bump-gem-version` step to flip `PRE` to `nil` before publishing. If that step is skipped or fails silently, a `.dev` gem would be pushed to RubyGems. Yanking does not free the version number for reuse, so the mistake is hard to undo.

Existing checks would catch the failure only for the wrong reason (the draft release / milestone named `vX.Y.Z.dev` doesn't exist), and `force: true` would bypass them entirely. The new check has no `continue-on-error` and is not bypassable by `force` — accidentally publishing a prerelease isn't worth a force-override path.

`Gem::Version#prerelease?` is the same API already used by `version:next` in `tasks/version.rake`. It covers `.dev`, `.rc1`, `.beta`, `.pre` and any future suffix.

**Change log entry**

None.

**Additional Notes:**

Diverges from the surrounding `verify-checks` steps in one way: no `continue-on-error: ${{ inputs.force }}`. Happy to make it bypassable if the team prefers consistency over safety here.

**How to test the change?**

Local logic check (already run):

```
['2.35.0.dev', '2.35.0', '2.35.0.rc1', '2.35.0.beta1'].each do |v|
  puts "#{v}: prerelease?=#{Gem::Version.new(v).prerelease?}"
end
# 2.35.0.dev: prerelease?=true
# 2.35.0: prerelease?=false
# 2.35.0.rc1: prerelease?=true
# 2.35.0.beta1: prerelease?=true
```

End-to-end check via workflow dispatch:

1. From the GitHub UI, run `Actions → Publish gem → Run workflow` against this branch (`ci/refuse-prerelease-publish`) with `force` unchecked.
2. The new `Verify version is not a prerelease` step must fail with `::error::Version 2.35.0.dev is a prerelease (e.g. .dev) - refusing to publish`.
3. The `rubygems-release` job must not run (gated on `verify-checks`).

A positive case (stable version passes) can only be exercised by an actual release; that path is covered by `Gem::Version#prerelease?` returning `false` for `2.35.0` in the local check above.
