### PR TITLE
Fix `NameError`: uninitialized constant `Datadog::Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE` 

### DIFF
--- a/lib/datadog/tracing/contrib/ext.rb
+++ b/lib/datadog/tracing/contrib/ext.rb
@@ -62,6 +62,9 @@ module Datadog
 
           # Value of tag from which peer.service value was remapped from
           TAG_PEER_SERVICE_REMAP = '_dd.peer.service.remapped_from'
+
+          # Set equal to the global service when contrib span.service is overriden
+          TAG_BASE_SERVICE = Tracing::Metadata::Ext::TAG_BASE_SERVICE
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

Reverts b806387607, restoring the `Datadog::Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE` constant as an alias to `Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE`.

**Motivation:**

A customer reported `NameError: uninitialized constant Datadog::Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE` after upgrading to v2.34.0. The constant was removed as part of internal cleanup after the prior commit moved base_service tagging into a centralized before-finish hook, but it was reachable from outside the gem and at least one customer was relying on it.

**Change log entry**

Yes. Restore `Datadog::Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE` constant that was unintentionally removed in v2.34.0.

**Additional Notes:**

The alias target `Datadog::Tracing::Metadata::Ext::TAG_BASE_SERVICE` is unchanged, so this is a pure restoration with no internal callsite impact.

**How to test the change?**

```ruby
require 'datadog'
Datadog::Tracing::Contrib::Ext::Metadata::TAG_BASE_SERVICE
# => "_dd.base_service"
```