### PR TITLE
[APMSP-3061] Skip telemetry for DD_API_KEY and DD_APP_KEY

### DIFF
--- a/lib/datadog/ai_guard/configuration.rb
+++ b/lib/datadog/ai_guard/configuration.rb
@@ -71,6 +71,7 @@ module Datadog
               option :app_key do |o|
                 o.type :string, nilable: true
                 o.env Ext::ENV_APP_KEY
+                o.skip_telemetry true
               end
 
               # Request timeout in milliseconds.

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -107,6 +107,7 @@ module Datadog
         option :api_key do |o|
           o.type :string, nilable: true
           o.env Core::Environment::Ext::ENV_API_KEY
+          o.skip_telemetry true
         end
 
         # Datadog diagnostic settings.


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Skip telemetry for DD_API_KEY and DD_APP_KEY

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->
This does NOT constitute a critical security risk as these configs are dropped by the telemetry intake and none are stored. This is simply an easy-win for codex cloud security findings

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
