### PR TITLE
Revert "Temporary workaround for benchmark analyzer expecting at least one benchmark to not be change per file"

### DIFF
--- a/benchmarks/profiling_sample_serialize.rb
+++ b/benchmarks/profiling_sample_serialize.rb
@@ -27,9 +27,6 @@ class ProfilerSampleSerializeBenchmark
       benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 60, warmup: 2}
       x.config(**benchmark_time)
 
-      # Temporary workaround for benchmark analyzer expecting at least one benchmark to not be change per file
-      x.report("sample  timeline=false") {}
-
       x.report("sample and serialize #{ENV["CONFIG"]}") do
         samples_per_second = 100
         simulate_seconds = 60


### PR DESCRIPTION
This reverts commit 2b1ec6fd99fdd1e6a2e981c13fd961ca6cc58492.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Reverts a workaround for benchmark analyzer added in #5750.

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
