### PR TITLE
[APPSEC-62723] Add Rails fast path for RouteExtractor

### DIFF
--- a/lib/datadog/appsec/api_security/route_extractor.rb
+++ b/lib/datadog/appsec/api_security/route_extractor.rb
@@ -15,6 +15,7 @@ module Datadog
         RAILS_ROUTES_KEY = 'action_dispatch.routes'
         RAILS_PATH_PARAMS_KEY = 'action_dispatch.request.path_parameters'
         RAILS_FORMAT_SUFFIX = '(.:format)'
+        DATADOG_RAILS_ROUTE_KEY = 'datadog.action_dispatch.route'
 
         # HACK: We rely on the fact that each contrib will modify `request.env`
         #       and store information sufficient to compute the canonical
@@ -55,6 +56,8 @@ module Datadog
           elsif request.env.key?(SINATRA_ROUTE_KEY)
             pattern = request.env[SINATRA_ROUTE_KEY].split(SINATRA_ROUTE_SEPARATOR, 2)[1]
             "#{request.script_name}#{pattern}"
+          elsif request.env.key?(DATADOG_RAILS_ROUTE_KEY)
+            request.env[DATADOG_RAILS_ROUTE_KEY].path.spec.to_s.delete_suffix(RAILS_FORMAT_SUFFIX)
           elsif request.env.key?(RAILS_ROUTE_KEY)
             request.env[RAILS_ROUTE_KEY].path.spec.to_s.delete_suffix(RAILS_FORMAT_SUFFIX)
           elsif request.env.key?(RAILS_ROUTE_URI_PATTERN_KEY)

--- a/sig/datadog/appsec/api_security/route_extractor.rbs
+++ b/sig/datadog/appsec/api_security/route_extractor.rbs
@@ -18,6 +18,8 @@ module Datadog
 
         RAILS_FORMAT_SUFFIX: String
 
+        DATADOG_RAILS_ROUTE_KEY: String
+
         def self.route_pattern: (APISecurity::_Request request) -> String?
       end
     end

--- a/spec/datadog/appsec/api_security/route_extractor_spec.rb
+++ b/spec/datadog/appsec/api_security/route_extractor_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe Datadog::AppSec::APISecurity::RouteExtractor do
     end
 
     context 'when Rails routing is present' do
+      context 'when datadog.action_dispatch.route is set' do
+        before { allow(request).to receive(:env).and_return({'datadog.action_dispatch.route' => datadog_route}) }
+
+        let(:datadog_route) do
+          spec = instance_double('ActionDispatch::Journey::Nodes::Cat', to_s: '/users/:id(.:format)')
+          path_pattern = instance_double('ActionDispatch::Journey::Path::Pattern', spec: spec)
+
+          instance_double('ActionDispatch::Journey::Route', path: path_pattern)
+        end
+
+        it { expect(described_class.route_pattern(request)).to eq('/users/:id') }
+      end
+
       context 'when action_dispatch.route_uri_pattern is set' do
         context 'when route has format suffix' do
           before do
@@ -119,6 +132,32 @@ RSpec.describe Datadog::AppSec::APISecurity::RouteExtractor do
           before { allow(request).to receive(:env).and_return({'action_dispatch.route' => route_double}) }
 
           it { expect(described_class.route_pattern(request)).to eq('/users/:id') }
+        end
+      end
+
+      context 'when both datadog and native rails route keys are present' do
+        before do
+          allow(request).to receive(:env).and_return(
+            {'datadog.action_dispatch.route' => datadog_route, 'action_dispatch.route' => native_route}
+          )
+        end
+
+        let(:datadog_route) do
+          spec = instance_double('ActionDispatch::Journey::Nodes::Cat', to_s: '/tracer/:id(.:format)')
+          path_pattern = instance_double('ActionDispatch::Journey::Path::Pattern', spec: spec)
+
+          instance_double('ActionDispatch::Journey::Route', path: path_pattern)
+        end
+
+        let(:native_route) do
+          spec = instance_double('ActionDispatch::Journey::Nodes::Cat', to_s: '/native/:id(.:format)')
+          path_pattern = instance_double('ActionDispatch::Journey::Path::Pattern', spec: spec)
+
+          instance_double('ActionDispatch::Journey::Route', path: path_pattern)
+        end
+
+        it 'chooses the datadog key' do
+          expect(described_class.route_pattern(request)).to eq('/tracer/:id')
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

Utilize prior improvement https://github.com/DataDog/dd-trace-rb/pull/5744

**Motivation:**

This gives us a fast path like in Rails 8.1+ reducing footprint

**Change log entry**

Yes. Improve route extraction for Rails applications

**Additional Notes:**

None.

**How to test the change?**

CI