### PR TITLE
Disable shuffling of tasks to get consistent and deterministic batches in CI

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -29,6 +29,7 @@ runs:
     shell: bash
     env:
       COVERAGE_DIR: coverage/versions/${{ inputs.alias }}/${{ inputs.container-id }}
+      CI_TEST_SEED: "${{ github.run_id }}"
 
   - name: Display debug info
     if: ${{ !cancelled() }}

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -13,9 +13,6 @@ on: # yamllint disable-line rule:truthy
       alias:
         required: true
         type: string
-      seed:
-        required: false
-        type: number
     outputs:
       lockfile:
         description: "The lockfile artifact"
@@ -38,10 +35,6 @@ on: # yamllint disable-line rule:truthy
         description: "The alias of the engine (e.g. `ruby-34` for Ruby 3.4)"
         required: true
         type: string
-      seed:
-        description: "The seed to reproduce a CI run"
-        required: false
-        type: number
 
 permissions: {}
 
@@ -50,7 +43,6 @@ jobs:
     runs-on: ubuntu-24.04
     name: batch
     outputs:
-      seed: "${{ steps.set-batches.outputs.seed }}"
       batches: "${{ steps.set-batches.outputs.batches }}"
       misc: "${{ steps.set-batches.outputs.misc }}"
       cache-key: "${{ steps.bundle-cache.outputs.cache-key }}"
@@ -68,22 +60,18 @@ jobs:
 
       - id: set-batches
         name: Distribute tasks into batches
-        env:
-          CI_TEST_SEED: "${{ inputs.seed || '' }}"
         run: |
           data=$(bundle exec rake github:generate_batches)
           echo "$data" | ruby -rjson -e 'puts JSON.pretty_generate(JSON.parse(STDIN.read))'
 
           # Extract each key and set it as a separate output
-          seed_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["seed"]')
           batches_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["batches"].to_json')
           misc_data=$(echo "$data" | ruby -rjson -e 'puts JSON.parse(STDIN.read)["misc"].to_json')
 
-          { echo "seed=$seed_data"; echo "batches=$batches_data"; echo "misc=$misc_data"; } >> "$GITHUB_OUTPUT"
+          { echo "batches=$batches_data"; echo "misc=$misc_data"; } >> "$GITHUB_OUTPUT"
       - name: Generate batch summary
         env:
           batches_json: "${{ steps.set-batches.outputs.batches }}"
-          CI_TEST_SEED: "${{ steps.set-batches.outputs.seed }}"
         run: bundle exec rake github:generate_batch_summary
 
   # `Initialize containers` step becomes quite heavily when many services are used.
@@ -116,7 +104,6 @@ jobs:
     timeout-minutes: 30
     env:
       BATCHED_TASKS: "${{ toJSON(matrix.tasks) }}"
-      CI_TEST_SEED: "${{ needs.batch.outputs.seed }}"
     strategy:
       fail-fast: false
       matrix:
@@ -184,7 +171,6 @@ jobs:
     timeout-minutes: 30
     env:
       BATCHED_TASKS: "${{ toJSON(matrix.tasks) }}"
-      CI_TEST_SEED: "${{ needs.batch.outputs.seed }}"
     strategy:
       fail-fast: false
       matrix:

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -43,9 +43,6 @@ namespace :github do
     end
 
     # Seed
-    rng = (ENV['CI_TEST_SEED'] && ENV['CI_TEST_SEED'] != '') ? Random.new(ENV['CI_TEST_SEED'].to_i) : Random.new
-    matching_tasks.shuffle!(random: rng)
-
     batch_count = 7
 
     tasks_per_job = (matching_tasks.size.to_f / batch_count).ceil
@@ -57,7 +54,6 @@ namespace :github do
     end
 
     data = {
-      seed: rng.seed,
       batches: batched_matrix,
       misc: {'include' => [{'batch' => "0", 'tasks' => misc_tasks}]}
     }
@@ -74,7 +70,6 @@ namespace :github do
     summary = ENV['GITHUB_STEP_SUMMARY']
 
     File.open(summary, 'a') do |f|
-      f.puts "*__Seed__: #{ENV["CI_TEST_SEED"]}*"
       data['include'].each do |batch|
         rows = batch['tasks'].map do |t|
           "* #{t["task"]} (#{t["group"]})"


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
What the title says. The tasks are still shuffled but within a workflow run the seed is the same which means the batches for the various Ruby versions are consistent within a CI run.
So e.g. batch 2 on Ruby 3.3 and on Ruby 3.4 runs the same tasks.
This wasn't the case before [example](https://github.com/DataDog/dd-trace-rb/actions/runs/26566943565/job/78264034315?pr=5816) and meant even though the error there was always about compiling the native extension it failed different batches for different Ruby versions and even failed a different number of batches per Ruby version.
It's much easier to review CI failures if the batches are consistent, then we can easily guess if the failures on 3.2 are the same on 3.3 etc without looking at every failure.

**Motivation:**
^

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
