### PR TITLE
Minor: Fix outdated comment in `DirMonkeyPatches`

### DIFF
--- a/lib/datadog/profiling/ext/dir_monkey_patches.rb
+++ b/lib/datadog/profiling/ext/dir_monkey_patches.rb
@@ -4,9 +4,10 @@ module Datadog
   module Profiling
     # Monkey patches needed for profiler features and compatibility
     module Ext
-      # All Ruby versions as of this writing have bugs in the dir class implementation, causing issues such as
+      # Ruby versions before 3.4 have bugs in the `Dir` class implementation, causing issues such as
       # https://github.com/DataDog/dd-trace-rb/issues/3450 .
-      # See also https://bugs.ruby-lang.org/issues/20586 for more details.
+      # This was fixed upstream in https://bugs.ruby-lang.org/issues/20586 but we use this monkey patch to work around
+      # the issue on legacy versions (it gets applied by `Datadog::Profiling::Component`).
       #
       # This monkey patch for the Ruby `Dir` class works around these bugs for affected Ruby versions by temporarily
       # blocking the profiler from interrupting system calls.


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the outdated and misleading comment in `DirMonkeyPatches` that claimed that the monkey patches were needed on all Ruby versions.

This issue has been fixed upstream so in fact they are < 3.4 only and our logic (updated in
https://github.com/DataDog/dd-trace-rb/pull/3907 ) does not apply them on Rubies that don't need them.

**Motivation:**

Avoid confusing people with the outdated comment.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

N/A