### PR TITLE
Refine CLAUDE.md to use Docker as fallback and prefer locally-installed Rubies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,17 +95,27 @@ bundle exec rspec spec/path/file.rb     # ONLY for specs covered by test:main or
 
 The `test:main` task uses the default Gemfile and its specs can also be run individually with `bundle exec rspec`.
 
-### Docker requirement
+### Docker
 
-- Contrib/integration tests need Docker: `docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside
-- `test:main` can run locally on any Ruby for quick feedback
+- AppSec integration tests need Ruby 3.4, use Ruby 3.4 installed locally or if not available Docker (`docker compose run --rm tracer-3.4 /bin/bash`, then run the rake task inside)
+- `test:main` and `bundle exec rspec spec/datadog/profiling` can run locally on any Ruby for quick feedback
 - If Bundler fails inside the container (e.g. after a dependency update), run `bundle install` and retry the rake task once before investigating further
 
 ### Verifying across Ruby versions
 
-Before marking a task complete, run the relevant test task on both the earliest and latest supported Ruby versions. Regressions in older Rubies are easy to miss when only testing on the latest. Check the component's entry in `Matrixfile` for the supported range, then:
+Before marking a task complete, run the relevant test task on both the earliest and latest supported Ruby versions.
+Regressions in older Rubies are easy to miss when only testing on the latest.
+Check the component's entry in `Matrixfile` for the supported range, then:
 
 ```bash
+# If mise is available:
+# Use Ruby 2.6 if 2.5 is not available, Ruby 2.5 no longer builds on macOS
+mise exec ruby@2.6 -- bundle exec rake test:TASK_KEY
+mise exec ruby@4.0 -- bundle exec rake test:TASK_KEY
+```
+
+```bash
+# If no mise, use Docker:
 docker compose run --rm tracer-2.5 bundle exec rake test:TASK_KEY
 docker compose run --rm tracer-4.0 bundle exec rake test:TASK_KEY
 ```


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Using Docker for this is quite slow and can leave a bunch of containers running using quite a bit of CPU for nothing.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Locally with `Run profiling specs` + `Try also on the min & max Ruby versions` in Claude.
It works OK except the Gemfile.lock issue, that needs #5831 + https://github.com/DataDog/dd-trace-rb/pull/5831#discussion_r3333395995.
We could also instruct Claude to remove Gemfile.lock but that's suboptimal and doesn't work with parallel runs, so let's wait for those instead.

<!-- Unsure? Have a question? Request a review! -->
