### PR TITLE
POC: Automatically set lockfile from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,18 @@
 # The gemspec is declared inside each per-Ruby base gemfile under gemfiles/
 # (as `gemspec path: '..'`). That allows those files to be loaded directly via
 # `BUNDLE_GEMFILE=gemfiles/ruby-X.Y.gemfile` and still resolve datadog.gemspec.
-eval_gemfile("gemfiles/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION.split(".").take(2).join(".")}.gemfile")
+
+versioned_gemfile = "gemfiles/#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION[0, 3]}.gemfile"
+versioned_lockfile = Pathname.new(File.expand_path("#{versioned_gemfile}.lock", __dir__))
+
+if respond_to?(:lockfile)
+  lockfile "#{versioned_gemfile}.lock"
+else
+  Bundler.define_singleton_method(:default_lockfile) { versioned_lockfile }
+
+  define_singleton_method(:to_definition) do |_lockfile, unlock|
+    super(versioned_lockfile, unlock)
+  end
+end
+
+eval_gemfile(versioned_gemfile)

--- a/gemfiles/ruby-2.7.gemfile.lock
+++ b/gemfiles/ruby-2.7.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ..
+  remote: .
   specs:
     datadog (2.35.0)
       cgi
@@ -35,10 +35,10 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux)
     google-protobuf (3.25.8-aarch64-linux)
     google-protobuf (3.25.8-arm64-darwin)
     google-protobuf (3.25.8-x86_64-darwin)

--- a/gemfiles/ruby-3.2.gemfile.lock
+++ b/gemfiles/ruby-3.2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ..
+  remote: .
   specs:
     datadog (2.35.0)
       cgi
@@ -291,4 +291,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.6

--- a/gemfiles/ruby-3.3.gemfile.lock
+++ b/gemfiles/ruby-3.3.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ..
+  remote: .
   specs:
     datadog (2.35.0)
       cgi
@@ -291,4 +291,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.13

--- a/gemfiles/ruby-3.4.gemfile.lock
+++ b/gemfiles/ruby-3.4.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ..
+  remote: .
   specs:
     datadog (2.35.0)
       cgi
@@ -295,4 +295,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.6

--- a/gemfiles/ruby-4.0.gemfile.lock
+++ b/gemfiles/ruby-4.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ..
+  remote: .
   specs:
     datadog (2.35.0)
       cgi
@@ -278,4 +278,4 @@ DEPENDENCIES
   zstd-ruby
 
 BUNDLED WITH
-   2.7.2
+  4.0.6


### PR DESCRIPTION
* Unfortunately it doesn't work so well as can be seen with the diff in gemfiles and also it doesn't install the correct Bundler version, which causes those diffs.
* A better way is: $ cat mise.toml [env] BUNDLE_GEMFILE = { value = "gemfiles/ruby-{{ tools.ruby.version | truncate(length=3, end='') }}.gemfile", tools = true }