### PR TITLE
Automatically use the correct gemfile and lockfile when using mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[env]
+BUNDLE_GEMFILE = { value = "{{ config_root }}/gemfiles/ruby-{{ tools.ruby.version | truncate(length=3, end='') }}.gemfile", tools = true }

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'gem release process' do
            |Steepfile
            |datadog\.gemspec
            |docker-compose\.yml
+           |mise\.toml
            |shell\.nix
            |default\.nix
            |flake\.nix


### PR DESCRIPTION
* e.g. gemfiles/ruby-3.4.gemfile and gemfiles/ruby-3.4.gemfile.lock on Ruby 3.4

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Not having to `rm -f Gemfile.lock`, resolving the same gem versions as CI and things just working when switching Ruby versions, both for local workflows and for agents.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Tested locally with many versions, including 2.6, 2.7, 3.2, 3.3, 3.4, 4.0.

<!-- Unsure? Have a question? Request a review! -->
