### PR TITLE
Fix raise_error() and grab_gvl_and_raise() to use rb_vsprintf() so PRIsVALUE works

### DIFF
--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.c
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.c
@@ -37,8 +37,13 @@ void private_raise_error_formatted(VALUE exception_class, const char *detailed_m
 
 // Use `raise_error` the macro instead, as it provides additional argument checks.
 void private_raise_error(VALUE exception_class, const char *fmt, ...) {
-  FORMAT_VA_ERROR_MESSAGE(detailed_message, fmt);
-  private_raise_error_formatted(exception_class, detailed_message, fmt);
+  va_list args;
+  va_start(args, fmt);
+  VALUE detailed_message = rb_vsprintf(fmt, args);
+  va_end(args);
+
+  VALUE exception = rb_exc_new_str(exception_class, detailed_message);
+  private_raise_exception(exception, fmt);
 }
 
 VALUE datadog_gem_version(void) {

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -61,13 +61,6 @@ NORETURN(
 
 #define MAX_RAISE_MESSAGE_SIZE 256
 
-#define FORMAT_VA_ERROR_MESSAGE(buf, fmt) \
-  char buf[MAX_RAISE_MESSAGE_SIZE]; \
-  va_list buf##_args; \
-  va_start(buf##_args, fmt); \
-  vsnprintf(buf, MAX_RAISE_MESSAGE_SIZE, fmt, buf##_args); \
-  va_end(buf##_args);
-
 // Helper to retrieve Datadog::VERSION::STRING
 VALUE datadog_gem_version(void);
 

--- a/ext/datadog_profiling_native_extension/profiling.c
+++ b/ext/datadog_profiling_native_extension/profiling.c
@@ -28,8 +28,11 @@ void crashtracking_runtime_stacks_init(void);
 void setup_signal_handler_init(VALUE profiling_module);
 
 static VALUE native_working_p(VALUE self);
-static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg, VALUE release_gvl);
+static VALUE _native_raise_error_value_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message_value_arg);
+static VALUE _native_grab_gvl_and_raise_cstr_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg, VALUE release_gvl);
 static void *trigger_grab_gvl_and_raise(void *trigger_args);
+static VALUE _native_grab_gvl_and_raise_value_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message_value_arg, VALUE release_gvl);
+static void *trigger_grab_gvl_and_raise_value_arg(void *trigger_args);
 static VALUE _native_grab_gvl_and_raise_syserr(DDTRACE_UNUSED VALUE _self, VALUE syserr_errno, VALUE test_message, VALUE test_message_arg, VALUE release_gvl);
 static void *trigger_grab_gvl_and_raise_syserr(void *trigger_args);
 static VALUE _native_ddtrace_rb_ractor_main_p(DDTRACE_UNUSED VALUE _self);
@@ -78,7 +81,9 @@ void DDTRACE_EXPORT Init_datadog_profiling_native_extension(void) {
 
   // Hosts methods used for testing the native code using RSpec
   VALUE testing_module = rb_define_module_under(native_extension_module, "Testing");
-  rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise", _native_grab_gvl_and_raise, 4);
+  rb_define_singleton_method(testing_module, "_native_raise_error_value_arg", _native_raise_error_value_arg, 2);
+  rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise_cstr_arg", _native_grab_gvl_and_raise_cstr_arg, 4);
+  rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise_value_arg", _native_grab_gvl_and_raise_value_arg, 3);
   rb_define_singleton_method(testing_module, "_native_grab_gvl_and_raise_syserr", _native_grab_gvl_and_raise_syserr, 4);
   rb_define_singleton_method(testing_module, "_native_ddtrace_rb_ractor_main_p", _native_ddtrace_rb_ractor_main_p, 0);
   rb_define_singleton_method(testing_module, "_native_is_current_thread_holding_the_gvl", _native_is_current_thread_holding_the_gvl, 0);
@@ -103,13 +108,17 @@ static VALUE native_working_p(DDTRACE_UNUSED VALUE _self) {
   return Qtrue;
 }
 
+static VALUE _native_raise_error_value_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message_value_arg) {
+  raise_error(exception_class, ">%"PRIsVALUE"<", test_message_value_arg);
+}
+
 typedef struct {
   VALUE exception_class;
   char *test_message;
   char *test_message_arg;
 } trigger_grab_gvl_and_raise_arguments;
 
-static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg, VALUE release_gvl) {
+static VALUE _native_grab_gvl_and_raise_cstr_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message, VALUE test_message_arg, VALUE release_gvl) {
   ENFORCE_TYPE(test_message, T_STRING);
 
   trigger_grab_gvl_and_raise_arguments args;
@@ -124,7 +133,7 @@ static VALUE _native_grab_gvl_and_raise(DDTRACE_UNUSED VALUE _self, VALUE except
     private_grab_gvl_and_raise(args.exception_class, 0, args.test_message, args.test_message_arg);
   }
 
-  raise_error(rb_eRuntimeError, "Failed to raise exception in _native_grab_gvl_and_raise; this should never happen");
+  raise_error(rb_eRuntimeError, "Failed to raise exception in _native_grab_gvl_and_raise_cstr_arg; this should never happen");
 }
 
 static void *trigger_grab_gvl_and_raise(void *trigger_args) {
@@ -135,6 +144,34 @@ static void *trigger_grab_gvl_and_raise(void *trigger_args) {
   } else {
     private_grab_gvl_and_raise(args->exception_class, 0, args->test_message, NULL);
   }
+
+  return NULL;
+}
+
+typedef struct {
+  VALUE exception_class;
+  VALUE test_message_value_arg;
+} trigger_grab_gvl_and_raise_value_arguments;
+
+static VALUE _native_grab_gvl_and_raise_value_arg(DDTRACE_UNUSED VALUE _self, VALUE exception_class, VALUE test_message_value_arg, VALUE release_gvl) {
+  trigger_grab_gvl_and_raise_value_arguments args;
+
+  args.exception_class = exception_class;
+  args.test_message_value_arg = test_message_value_arg;
+
+  if (RTEST(release_gvl)) {
+    rb_thread_call_without_gvl(trigger_grab_gvl_and_raise_value_arg, &args, NULL, NULL);
+  } else {
+    private_grab_gvl_and_raise(args.exception_class, 0, ">%"PRIsVALUE"<", args.test_message_value_arg);
+  }
+
+  raise_error(rb_eRuntimeError, "Failed to raise exception in _native_grab_gvl_and_raise_value_arg; this should never happen");
+}
+
+static void *trigger_grab_gvl_and_raise_value_arg(void *trigger_args) {
+  trigger_grab_gvl_and_raise_value_arguments *args = (trigger_grab_gvl_and_raise_value_arguments *) trigger_args;
+
+  private_grab_gvl_and_raise(args->exception_class, 0, ">%"PRIsVALUE"<", args->test_message_value_arg);
 
   return NULL;
 }

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -45,12 +45,6 @@ static void *trigger_raise(void *raise_arguments) {
   raise_args *args = (raise_args *) raise_arguments;
 
   VALUE detailed_message = rb_vsprintf(args->format_string, args->va_args);
-  if (RSTRING_LEN(detailed_message) >= MAX_RAISE_MESSAGE_SIZE) {
-    detailed_message = rb_str_substr(detailed_message, 0, MAX_RAISE_MESSAGE_SIZE - 1);
-  }
-
-  char telemetry_message[MAX_RAISE_MESSAGE_SIZE];
-  snprintf(telemetry_message, MAX_RAISE_MESSAGE_SIZE, "%s", args->format_string);
 
   VALUE exception;
   if (args->syserr_errno) {
@@ -59,7 +53,7 @@ static void *trigger_raise(void *raise_arguments) {
     exception = rb_exc_new_str(args->exception_class, detailed_message);
   }
 
-  private_raise_exception(exception, telemetry_message);
+  private_raise_exception(exception, args->format_string);
 
   return NULL;
 }

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -107,10 +107,11 @@ void private_raise_enforce_syserr(
   int line,
   const char *function_name
 ) {
+  const char *format = "Failure returned by '%s' at %s:%d:in `%s'";
   if (have_gvl) {
-    rb_exc_raise(rb_syserr_new_str(syserr_errno, rb_sprintf("Failure returned by '%s' at %s:%d:in `%s'", expression, file, line, function_name)));
+    private_raise_exception(rb_syserr_new_str(syserr_errno, rb_sprintf(format, expression, file, line, function_name)), format);
   } else {
-    private_grab_gvl_and_raise(Qnil, syserr_errno, "Failure returned by '%s' at %s:%d:in `%s'", expression, file, line, function_name);
+    private_grab_gvl_and_raise(Qnil, syserr_errno, format, expression, file, line, function_name);
   }
 }
 

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -21,41 +21,45 @@ void ruby_helpers_init(void) {
   to_s_id = rb_intern("to_s");
 }
 
-// Internal helper for raising pre-formatted syserr exceptions
-static NORETURN(void private_raise_syserr_formatted(int syserr_errno, const char *detailed_message, const char *static_message)) {
-  VALUE exception = rb_syserr_new(syserr_errno, detailed_message);
-  private_raise_exception(exception, static_message);
-}
-
 // Use `raise_syserr` the macro instead, as it provides additional argument checks.
 void private_raise_syserr(int syserr_errno, const char *fmt, ...) {
-  FORMAT_VA_ERROR_MESSAGE(detailed_message, fmt);
-  private_raise_syserr_formatted(syserr_errno, detailed_message, fmt);
+  va_list args;
+  va_start(args, fmt);
+  VALUE detailed_message = rb_vsprintf(fmt, args);
+  va_end(args);
+
+  VALUE exception = rb_syserr_new_str(syserr_errno, detailed_message);
+  private_raise_exception(exception, fmt);
 }
 
 typedef struct {
   VALUE exception_class;
   int syserr_errno;
-  char exception_message[MAX_RAISE_MESSAGE_SIZE];
-  char telemetry_message[MAX_RAISE_MESSAGE_SIZE];
+  const char *format_string;
+  va_list va_args;
 } raise_args;
 
+// Called via rb_thread_call_with_gvl from private_grab_gvl_and_raise.
+// Formats the message with rb_vsprintf (which requires the GVL) and raises.
 static void *trigger_raise(void *raise_arguments) {
   raise_args *args = (raise_args *) raise_arguments;
 
-  if (args->syserr_errno) {
-    private_raise_syserr_formatted(
-      args->syserr_errno,
-      args->exception_message,
-      args->telemetry_message
-    );
-  } else {
-    private_raise_error_formatted(
-      args->exception_class,
-      args->exception_message,
-      args->telemetry_message
-    );
+  VALUE detailed_message = rb_vsprintf(args->format_string, args->va_args);
+  if (RSTRING_LEN(detailed_message) >= MAX_RAISE_MESSAGE_SIZE) {
+    detailed_message = rb_str_substr(detailed_message, 0, MAX_RAISE_MESSAGE_SIZE - 1);
   }
+
+  char telemetry_message[MAX_RAISE_MESSAGE_SIZE];
+  snprintf(telemetry_message, MAX_RAISE_MESSAGE_SIZE, "%s", args->format_string);
+
+  VALUE exception;
+  if (args->syserr_errno) {
+    exception = rb_syserr_new_str(args->syserr_errno, detailed_message);
+  } else {
+    exception = rb_exc_new_str(args->exception_class, detailed_message);
+  }
+
+  private_raise_exception(exception, telemetry_message);
 
   return NULL;
 }
@@ -71,11 +75,17 @@ void private_grab_gvl_and_raise(VALUE exception_class, int syserr_errno, const c
     args.syserr_errno = 0;
   }
 
-  FORMAT_VA_ERROR_MESSAGE(formatted_exception_message, format_string);
-  snprintf(args.exception_message, MAX_RAISE_MESSAGE_SIZE, "%s", formatted_exception_message);
-  snprintf(args.telemetry_message, MAX_RAISE_MESSAGE_SIZE, "%s", format_string);
+  args.format_string = format_string;
+  va_start(args.va_args, format_string);
 
   if (is_current_thread_holding_the_gvl()) {
+    VALUE detailed_message = rb_vsprintf(format_string, args.va_args);
+    va_end(args.va_args);
+
+    VALUE wrapped_message = rb_sprintf(
+      "grab_gvl_and_raise called by thread holding the global VM lock: %"PRIsVALUE,
+      detailed_message
+    );
     char telemetry_message[MAX_RAISE_MESSAGE_SIZE];
     snprintf(
       telemetry_message,
@@ -83,20 +93,14 @@ void private_grab_gvl_and_raise(VALUE exception_class, int syserr_errno, const c
       "grab_gvl_and_raise called by thread holding the global VM lock: %s",
       format_string
     );
-    char exception_message[MAX_RAISE_MESSAGE_SIZE];
-    snprintf(
-      exception_message,
-      MAX_RAISE_MESSAGE_SIZE,
-      "grab_gvl_and_raise called by thread holding the global VM lock: %s",
-      args.exception_message
-    );
-    VALUE exception = rb_exc_new_cstr(rb_eRuntimeError, exception_message);
+    VALUE exception = rb_exc_new_str(rb_eRuntimeError, wrapped_message);
     private_raise_exception(exception, telemetry_message);
   }
 
   rb_thread_call_with_gvl(trigger_raise, &args);
 
-  rb_bug("[ddtrace] Unexpected: Reached the end of grab_gvl_and_raise while raising '%s'\n", args.exception_message);
+  va_end(args.va_args);
+  rb_bug("[ddtrace] Unexpected: Reached the end of grab_gvl_and_raise while raising '%s'\n", format_string);
 }
 
 void private_raise_enforce_syserr(

--- a/ext/libdatadog_api/datadog_ruby_common.c
+++ b/ext/libdatadog_api/datadog_ruby_common.c
@@ -37,8 +37,13 @@ void private_raise_error_formatted(VALUE exception_class, const char *detailed_m
 
 // Use `raise_error` the macro instead, as it provides additional argument checks.
 void private_raise_error(VALUE exception_class, const char *fmt, ...) {
-  FORMAT_VA_ERROR_MESSAGE(detailed_message, fmt);
-  private_raise_error_formatted(exception_class, detailed_message, fmt);
+  va_list args;
+  va_start(args, fmt);
+  VALUE detailed_message = rb_vsprintf(fmt, args);
+  va_end(args);
+
+  VALUE exception = rb_exc_new_str(exception_class, detailed_message);
+  private_raise_exception(exception, fmt);
 }
 
 VALUE datadog_gem_version(void) {

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -61,13 +61,6 @@ NORETURN(
 
 #define MAX_RAISE_MESSAGE_SIZE 256
 
-#define FORMAT_VA_ERROR_MESSAGE(buf, fmt) \
-  char buf[MAX_RAISE_MESSAGE_SIZE]; \
-  va_list buf##_args; \
-  va_start(buf##_args, fmt); \
-  vsnprintf(buf, MAX_RAISE_MESSAGE_SIZE, fmt, buf##_args); \
-  va_end(buf##_args);
-
 // Helper to retrieve Datadog::VERSION::STRING
 VALUE datadog_gem_version(void);
 

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -187,6 +187,14 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       expect(thread_context_collector.inspect).to include("global_waiting_for_gvl_threshold_ns=222333444")
     end
 
+    context "when otel_context_enabled has an invalid value" do
+      it "raises an ArgumentError with the value formatted via PRIsVALUE" do
+        expect {
+          described_class.for_testing(recorder: recorder, otel_context_enabled: :invalid)
+        }.to raise_error(ArgumentError, "Unexpected value for otel_context_enabled: :invalid")
+      end
+    end
+
     context "when native filenames are enabled but feature is not available" do
       let(:native_filenames_enabled) { true }
 

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -12,15 +12,23 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
   describe "grab_gvl_and_raise" do
     it "raises the requested exception with the passed in message" do
-      expect { described_class::Testing._native_grab_gvl_and_raise(::RuntimeError, "this is a test", nil, true) }
+      expect { described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::RuntimeError, "this is a test", nil, true) }
         .to raise_error(::RuntimeError) do |error|
           expect(error.message).to eq("this is a test")
           expect(error.instance_variable_get(:@telemetry_message)).to eq("this is a test")
         end
     end
 
+    it "formats correctly with %PRIsVALUE" do
+      expect {
+        described_class::Testing._native_grab_gvl_and_raise_value_arg(::RuntimeError, String, true)
+      }.to raise_error(::RuntimeError) do |error|
+        expect(error.message).to eq(">String<")
+      end
+    end
+
     it "on printf-style, only report the fixed string for telemetry" do
-      expect { described_class::Testing._native_grab_gvl_and_raise(::RuntimeError, "message %s", "oops", true) }
+      expect { described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::RuntimeError, "message %s", "oops", true) }
         .to raise_error(::RuntimeError) do |error|
           expect(error.message).to eq("message oops")
           expect(error.instance_variable_get(:@telemetry_message)).to eq("message %s")
@@ -30,7 +38,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     it "limits the exception message to 255 characters" do
       big_message = "a" * 500
 
-      expect { described_class::Testing._native_grab_gvl_and_raise(::RuntimeError, big_message, nil, true) }
+      expect { described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::RuntimeError, big_message, nil, true) }
         .to raise_error(::RuntimeError) do |error|
           expect(error.message).to match(/a{255}\z/)
           expect(error.instance_variable_get(:@telemetry_message)).to match(/a{255}\z/)
@@ -40,7 +48,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     context "when called without releasing the gvl" do
       it "raises a RuntimeError with appropriate error handling when called without GVL" do
         expect do
-          described_class::Testing._native_grab_gvl_and_raise(ZeroDivisionError, "message %s", 'oops', false)
+          described_class::Testing._native_grab_gvl_and_raise_cstr_arg(ZeroDivisionError, "message %s", 'oops', false)
         end.to raise_error(::RuntimeError) do |error|
           expect(error.message).to include('grab_gvl_and_raise called by thread holding the global VM lock: message oops')
           expect(error.instance_variable_get(:@telemetry_message)).to include('grab_gvl_and_raise called by thread holding the global VM lock: message %s')
@@ -50,7 +58,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
     context "when raising RuntimeError" do
       subject(:raise_native_runtime_error) do
-        described_class::Testing._native_grab_gvl_and_raise(::RuntimeError, "runtime error test", nil, true)
+        described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::RuntimeError, "runtime error test", nil, true)
       end
 
       it "raises a RuntimeError" do
@@ -63,7 +71,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
     context "when raising ArgumentError" do
       subject(:raise_native_argument_error) do
-        described_class::Testing._native_grab_gvl_and_raise(::ArgumentError, "argument error test", nil, true)
+        described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::ArgumentError, "argument error test", nil, true)
       end
 
       it "raises an ArgumentError" do
@@ -76,7 +84,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
 
     context "when raising TypeError" do
       subject(:raise_native_type_error) do
-        described_class::Testing._native_grab_gvl_and_raise(::TypeError, "type error test", nil, true)
+        described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::TypeError, "type error test", nil, true)
       end
 
       it "raises a TypeError" do
@@ -84,6 +92,16 @@ RSpec.describe Datadog::Profiling::NativeExtension do
           expect(error.message).to eq("type error test")
           expect(error.instance_variable_get(:@telemetry_message)).to eq("type error test")
         end
+      end
+    end
+  end
+
+  describe "raise_error" do
+    it "formats correctly with %PRIsVALUE" do
+      expect {
+        described_class::Testing._native_raise_error_value_arg(::RuntimeError, String)
+      }.to raise_error(::RuntimeError) do |error|
+        expect(error.message).to eq(">String<")
       end
     end
   end

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -35,16 +35,6 @@ RSpec.describe Datadog::Profiling::NativeExtension do
         end
     end
 
-    it "limits the exception message to 255 characters" do
-      big_message = "a" * 500
-
-      expect { described_class::Testing._native_grab_gvl_and_raise_cstr_arg(::RuntimeError, big_message, nil, true) }
-        .to raise_error(::RuntimeError) do |error|
-          expect(error.message).to match(/a{255}\z/)
-          expect(error.instance_variable_get(:@telemetry_message)).to match(/a{255}\z/)
-        end
-    end
-
     context "when called without releasing the gvl" do
       it "raises a RuntimeError with appropriate error handling when called without GVL" do
         expect do
@@ -126,14 +116,6 @@ RSpec.describe Datadog::Profiling::NativeExtension do
         expect(error.message).to include("message oops")
         expect(error.instance_variable_get(:@telemetry_message)).to eq("message %s")
       end
-    end
-
-    it "limits the caller-provided exception message to 255 characters" do
-      big_message = "a" * 500
-
-      expect do
-        described_class::Testing._native_grab_gvl_and_raise_syserr(Errno::EINTR::Errno, big_message, nil, true)
-      end.to raise_exception(Errno::EINTR, /.+a{255}\z/)
     end
 
     context "when called without releasing the gvl" do


### PR DESCRIPTION
* So `raise_error(rb_eRuntimeError, "foo %"PRIsVALUE" bar", some_ruby_object)` calls #to_s and doesn't print an integer.
  (or `"%+"PRIsVALUE` which calls #inspect and not print "+123")
* Pass the va_list through rb_thread_call_with_gvl and call rb_vsprintf()
  inside the callback where the GVL is held (rb_vsprintf allocates Ruby
  objects). This is safe because rb_thread_call_with_gvl is synchronous so
  the parent stack frame (where the va_list lives) is still alive.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Correctness and useful error messages.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Fix some exception messages which were not formatted correctly.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
