### PR TITLE
Remove unused private_raise_error_formatted()

### DIFF
--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.c
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.c
@@ -29,12 +29,6 @@ void private_raise_exception(VALUE exception, const char *static_message) {
   rb_exc_raise(exception);
 }
 
-// Helper for raising pre-formatted exceptions
-void private_raise_error_formatted(VALUE exception_class, const char *detailed_message, const char *static_message) {
-  VALUE exception = rb_exc_new_cstr(exception_class, detailed_message);
-  private_raise_exception(exception, static_message);
-}
-
 // Use `raise_error` the macro instead, as it provides additional argument checks.
 void private_raise_error(VALUE exception_class, const char *fmt, ...) {
   va_list args;

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -47,11 +47,6 @@ NORETURN(
   __attribute__ ((format (printf, 2, 3)));
 );
 
-// Internal helper for raising pre-formatted exceptions
-NORETURN(
-  void private_raise_error_formatted(VALUE exception_class, const char *detailed_message, const char *static_message)
-);
-
 // Raises an exception with separate telemetry-safe and detailed messages.
 // NOTE: Raising an exception always invokes Ruby code so it requires the GVL and is not compatible with "debug_enter_unsafe_context".
 // @see debug_enter_unsafe_context

--- a/ext/libdatadog_api/datadog_ruby_common.c
+++ b/ext/libdatadog_api/datadog_ruby_common.c
@@ -29,12 +29,6 @@ void private_raise_exception(VALUE exception, const char *static_message) {
   rb_exc_raise(exception);
 }
 
-// Helper for raising pre-formatted exceptions
-void private_raise_error_formatted(VALUE exception_class, const char *detailed_message, const char *static_message) {
-  VALUE exception = rb_exc_new_cstr(exception_class, detailed_message);
-  private_raise_exception(exception, static_message);
-}
-
 // Use `raise_error` the macro instead, as it provides additional argument checks.
 void private_raise_error(VALUE exception_class, const char *fmt, ...) {
   va_list args;

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -47,11 +47,6 @@ NORETURN(
   __attribute__ ((format (printf, 2, 3)));
 );
 
-// Internal helper for raising pre-formatted exceptions
-NORETURN(
-  void private_raise_error_formatted(VALUE exception_class, const char *detailed_message, const char *static_message)
-);
-
 // Raises an exception with separate telemetry-safe and detailed messages.
 // NOTE: Raising an exception always invokes Ruby code so it requires the GVL and is not compatible with "debug_enter_unsafe_context".
 // @see debug_enter_unsafe_context


### PR DESCRIPTION
No callers remain after grab_gvl_and_raise was changed to format with rb_vsprintf inside the GVL callback.
Follow-up of https://github.com/DataDog/dd-trace-rb/pull/5857
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Cleanup

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
