### PR TITLE
[NO-TICKET] Skip a few more specs relating to GC under asan builds to avoid flakiness

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -792,6 +792,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             end
 
             it "enforces a minimum time between heap updates" do
+              skip_asan_flaky
+
               test_object_id_1 = sample_and_clear
 
               expect { recorder_after_gc_step }.to change { is_object_recorded?(test_object_id_1) }.from(true).to(false)
@@ -802,6 +804,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             end
 
             it "does not apply the minimum time between heap updates when serializing" do
+              skip_asan_flaky
+
               test_object_id_1 = sample_and_clear
 
               expect { recorder_after_gc_step }.to change { is_object_recorded?(test_object_id_1) }.from(true).to(false)


### PR DESCRIPTION
**What does this PR do?**

This PR skips two stack recorder specs when running on an ASAN ruby, as they were causing flakiness.

This fixes flakiness reported in
https://github.com/DataDog/ruby-guild/issues/301 from https://github.com/DataDog/dd-trace-rb/actions/runs/25787414475/job/75744086138?pr=5744:

```
Failures:

  1) Datadog::Profiling::StackRecorder#serialize heap samples and sizes when enabled #recorder_after_gc_step when heap_clean_after_gc_enabled is true does not apply the minimum time between heap updates when serializing
     Failure/Error: expect { recorder_after_gc_step }.to change { is_object_recorded?(test_object_id_1) }.from(true).to(false)
       expected `is_object_recorded?(test_object_id_1)` to have changed from true to false, but did not change
     # ./spec/datadog/profiling/stack_recorder_spec.rb:816:in 'block (7 levels) in <top (required)>'
     # ./spec/spec_helper.rb:275:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:155:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in 'block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in 'ForkableExample#run'

Finished in 1 minute 43.71 seconds (files took 3.55 seconds to load)
790 examples, 1 failure, 18 pending

Failed examples:

rspec ./spec/datadog/profiling/stack_recorder_spec.rb:813 # Datadog::Profiling::StackRecorder#serialize heap samples and sizes when enabled #recorder_after_gc_step when heap_clean_after_gc_enabled is true does not apply the minimum time between heap updates when serializing

Randomized with seed 13586
```

**Motivation:**

Zero flaky tests in profiling always!

**Change log entry**

None.

**Additional Notes:**

In https://github.com/DataDog/dd-trace-rb/pull/5666 we identified that the asan stack seems to sometimes keep objects alive for longer than they should be.

Our specs related to the heap profiler rely on us very precisely controlling when some Ruby objects are alive and get garbage collected, and asan keeping those objects alive wrecks those assumptions.

So, we just disable any such tests that prove flaky under asan.

**How to test the change?**

The affected tests no longer run in the `test-asan` CI check.