### PR TITLE
Fix transient in spec expecting exactly 100 allocations to not count the per_thread_context TypedData

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       **options
     }
   end
+  let(:sample) {
+    Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(worker_settings[:thread_context_collector], Thread.current, false)
+  }
 
   subject(:cpu_and_wall_time_worker) { described_class.new(**worker_settings, **options) }
 
@@ -292,19 +295,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     context "with allocation profiling enabled" do
       # We need this otherwise allocations_during_sample will never change
       let(:allocation_profiling_enabled) { true }
-      let(:sample) {
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample(worker_settings[:thread_context_collector], Thread.current, false)
-      }
 
       it "does not allocate Ruby objects during the regular operation of sampling" do
-        # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path"
-        # sampling.
+        # The intention of this test is to warn us if we accidentally trigger object allocations during "happy path" sampling.
         # Note that when something does go wrong during sampling, we do allocate exceptions (and then raise them).
-        #
-        # The first sample of each thread allocates a TypedData wrapper for per_thread_context, so we wait for that
-        # initial burst to pass and then check that no further allocations occur.
 
         start
+        # Ensure the per_thread_context TypedData wrapper is already allocated for the current Thread
         sample
         allocations_after_initial = cpu_and_wall_time_worker.stats.fetch(:allocations_during_sample)
 
@@ -1425,8 +1422,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # there's a small chance that a GC gets triggered in between the two
           # `_native_allocation_count` calls and contributes with unexpected Array allocations to
           # the allocation count. To prevent this, we'll explicitly disable GC around these checks.
-
           GC.disable
+
+          # Ensure the per_thread_context TypedData wrapper is already allocated for the current Thread
+          sample
+
           # To get the exact expected number of allocations, we run through the ropes once so
           # Ruby can create and cache all it needs to and hopefully flush any pending finalizer
           # executions that could affect our expectations
@@ -1440,7 +1440,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           100.times(&new_object)
           after_allocations = described_class._native_allocation_count
 
-          expect(after_allocations - before_allocations).to be 100
+          expect(after_allocations - before_allocations).to eq 100
         ensure
           GC.enable
         end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Green reliable CI

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
