### PR TITLE
Sample directly from the on_gvl_running hook instead of deferring via postponed job

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -90,7 +90,6 @@ unsigned int MAX_ALLOC_WEIGHT = 10000;
   // `collectors_cpu_and_wall_time_worker_init` below and always get reused after that.
   static rb_postponed_job_handle_t sample_from_postponed_job_handle;
   static rb_postponed_job_handle_t after_gc_from_postponed_job_handle;
-  static rb_postponed_job_handle_t after_gvl_running_from_postponed_job_handle;
   static rb_postponed_job_handle_t after_allocation_from_postponed_job_handle;
 #endif
 
@@ -250,9 +249,8 @@ static VALUE _native_hold_signals(DDTRACE_UNUSED VALUE self);
 static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self);
 #ifndef NO_GVL_INSTRUMENTATION
   static void on_gvl_event(rb_event_flag_t event_id, const rb_internal_thread_event_data_t *event_data, DDTRACE_UNUSED void *_unused);
-  static void after_gvl_running_from_postponed_job(DDTRACE_UNUSED void *_unused);
-  static VALUE rescued_after_gvl_running_from_postponed_job(VALUE self_instance);
-  static VALUE handle_sampling_failure_rescued_after_gvl_running_from_postponed_job(VALUE self_instance, VALUE exception);
+  static VALUE rescued_sample_after_gvl_running(VALUE self_instance);
+  static VALUE handle_sampling_failure_rescued_sample_after_gvl_running(VALUE self_instance, VALUE exception);
 #endif
 static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE handle_sampling_failure_rescued_sample_from_postponed_job(VALUE self_instance, VALUE exception);
@@ -308,13 +306,11 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
     int unused_flags = 0;
     sample_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, sample_from_postponed_job, NULL);
     after_gc_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_gc_from_postponed_job, NULL);
-    after_gvl_running_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_gvl_running_from_postponed_job, NULL);
     after_allocation_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_allocation_from_postponed_job, NULL);
 
     if (
       sample_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
       after_gc_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
-      after_gvl_running_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
       after_allocation_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID
     ) {
       raise_error(rb_eRuntimeError, "Failed to register profiler postponed jobs (got POSTPONED_JOB_HANDLE_INVALID)");
@@ -1459,11 +1455,16 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
       }
 
       if (result.action == ON_GVL_RUNNING_SAMPLE) {
-        #ifndef NO_POSTPONED_TRIGGER
-          rb_postponed_job_trigger(after_gvl_running_from_postponed_job_handle);
-        #else
-          rb_postponed_job_register_one(0, after_gvl_running_from_postponed_job, NULL);
-        #endif
+        during_sample_enter(state);
+
+        safely_call(
+          rescued_sample_after_gvl_running,
+          state->self_instance,
+          state->self_instance,
+          handle_sampling_failure_rescued_sample_after_gvl_running
+        );
+
+        during_sample_exit(state);
       } else if (result.action == ON_GVL_RUNNING_DONT_SAMPLE) {
         state->stats.gvl_dont_sample++;
       }
@@ -1473,26 +1474,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
     }
   }
 
-  static void after_gvl_running_from_postponed_job(DDTRACE_UNUSED void *_unused) {
-    cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
-
-    // This can potentially happen if the CpuAndWallTimeWorker was stopped while the postponed job was waiting to be executed; nothing to do
-    if (state == NULL) return;
-
-    during_sample_enter(state);
-
-    // Rescue against any exceptions that happen during sampling
-    safely_call(
-      rescued_after_gvl_running_from_postponed_job,
-      state->self_instance,
-      state->self_instance,
-      handle_sampling_failure_rescued_after_gvl_running_from_postponed_job
-    );
-
-    during_sample_exit(state);
-  }
-
-  static VALUE rescued_after_gvl_running_from_postponed_job(VALUE self_instance) {
+  static VALUE rescued_sample_after_gvl_running(VALUE self_instance) {
     cpu_and_wall_time_worker_state *state;
     TypedData_Get_Struct(self_instance, cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
 
@@ -1521,8 +1503,8 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
     return state->gvl_profiling_hook != NULL ? Qtrue : Qfalse;
   }
 
-  static VALUE handle_sampling_failure_rescued_after_gvl_running_from_postponed_job(VALUE self_instance, VALUE exception) {
-    stop(self_instance, exception, "rescued_after_gvl_running_from_postponed_job");
+  static VALUE handle_sampling_failure_rescued_sample_after_gvl_running(VALUE self_instance, VALUE exception) {
+    stop(self_instance, exception, "rescued_sample_after_gvl_running");
     return Qnil;
   }
 #else

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1448,7 +1448,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self) {
       cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
       if (state == NULL) return; // This should not happen, but just in case...
 
-      on_gvl_running_result result = thread_context_collector_on_gvl_running(target_thread);
+      on_gvl_running_result result = thread_context_collector_on_gvl_running(state->thread_context_collector_instance, target_thread);
 
       if (result.waiting_for_gvl_duration_ns > 0) {
         state->stats.vm_metrics.gvl_waiting_time_ns_total += (uint64_t) result.waiting_for_gvl_duration_ns;

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -105,12 +105,6 @@ static ID server_id;      // id of :server in Ruby
 static ID otel_context_storage_id; // id of :__opentelemetry_context_storage__ in Ruby
 static ID otel_fiber_context_storage_id; // id of :@opentelemetry_context in Ruby
 
-// This is used by `thread_context_collector_on_gvl_running`. Because when that method gets called we're not sure if
-// it's safe to access the state of the thread context collector, we store this setting as a global value. This does
-// mean this setting is shared among all thread context collectors, and thus it's "last writer wins".
-// In production this should not be a problem: there should only be one profiler, which is the last one created,
-// and that'll be the one that last wrote this setting.
-static uint32_t global_waiting_for_gvl_threshold_ns = MILLIS_AS_NS(10);
 
 typedef enum { OTEL_CONTEXT_ENABLED_FALSE, OTEL_CONTEXT_ENABLED_ONLY, OTEL_CONTEXT_ENABLED_BOTH } otel_context_enabled;
 typedef enum { OTEL_CONTEXT_SOURCE_UNKNOWN, OTEL_CONTEXT_SOURCE_FIBER_IVAR, OTEL_CONTEXT_SOURCE_FIBER_LOCAL } otel_context_source;
@@ -148,6 +142,8 @@ typedef struct {
   bool native_filenames_enabled;
   // Used to cache native filename lookup results (Map[void *function_pointer, char *filename])
   st_table *native_filenames_cache;
+  // Minimum duration of "Waiting for GVL" to trigger a sample
+  uint32_t waiting_for_gvl_threshold_ns;
 
   struct stats {
     // Track how many regular samples we've taken. Does not include garbage collection samples.
@@ -310,7 +306,7 @@ static bool handle_gvl_waiting(
 #ifndef NO_GVL_INSTRUMENTATION
   static VALUE _native_on_gvl_waiting(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_gvl_waiting_at_for(DDTRACE_UNUSED VALUE self, VALUE thread);
-  static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE thread);
+  static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread);
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception);
   static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 #endif
@@ -363,7 +359,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
   #ifndef NO_GVL_INSTRUMENTATION
     rb_define_singleton_method(testing_module, "_native_on_gvl_waiting", _native_on_gvl_waiting, 1);
     rb_define_singleton_method(testing_module, "_native_gvl_waiting_at_for", _native_gvl_waiting_at_for, 1);
-    rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 1);
+    rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 2);
     rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 3);
     rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
   #endif
@@ -545,7 +541,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
     raise_error(rb_eArgError, "Unexpected value for otel_context_enabled: %+" PRIsVALUE, otel_context_enabled);
   }
 
-  global_waiting_for_gvl_threshold_ns = NUM2UINT(waiting_for_gvl_threshold_ns);
+  state->waiting_for_gvl_threshold_ns = NUM2UINT(waiting_for_gvl_threshold_ns);
 
   if (RTEST(tracer_context_key)) {
     ENFORCE_TYPE(tracer_context_key, T_SYMBOL);
@@ -1166,7 +1162,7 @@ static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instanc
   rb_str_concat(result, rb_sprintf(" main_thread=%"PRIsVALUE, state->main_thread));
   rb_str_concat(result, rb_sprintf(" gc_tracking=%"PRIsVALUE, gc_tracking_as_ruby_hash(state)));
   rb_str_concat(result, rb_sprintf(" otel_current_span_key=%"PRIsVALUE, state->otel_current_span_key));
-  rb_str_concat(result, rb_sprintf(" global_waiting_for_gvl_threshold_ns=%u", global_waiting_for_gvl_threshold_ns));
+  rb_str_concat(result, rb_sprintf(" waiting_for_gvl_threshold_ns=%u", state->waiting_for_gvl_threshold_ns));
 
   return result;
 }
@@ -1892,7 +1888,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
   // This function runs on the passed thread and has the GVL because it gets called just after the Ruby thread acquired the GVL
   __attribute__((warn_unused_result))
-  on_gvl_running_result thread_context_collector_on_gvl_running(VALUE thread) {
+  on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread) {
+    thread_context_collector_state *state;
+    TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
     per_thread_context* thread_being_profiled = get_per_thread_context(thread);
 
     // Thread was not being profiled
@@ -1914,7 +1913,7 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
 
     long waiting_for_gvl_duration_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - gvl_waiting_at;
 
-    bool should_sample = waiting_for_gvl_duration_ns >= global_waiting_for_gvl_threshold_ns;
+    bool should_sample = waiting_for_gvl_duration_ns >= state->waiting_for_gvl_threshold_ns;
 
     if (should_sample) {
       // We flip the gvl_waiting_at to negative to mark that the thread is now running and no longer waiting
@@ -2122,14 +2121,10 @@ static uint64_t otel_span_id_to_uint(VALUE otel_span_id) {
     return result;
   }
 
-  static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE thread) {
+  static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread) {
     ENFORCE_THREAD(thread);
 
-    debug_enter_unsafe_context();
-
-    VALUE result = thread_context_collector_on_gvl_running(thread).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
-
-    debug_leave_unsafe_context();
+    VALUE result = thread_context_collector_on_gvl_running(collector_instance, thread).action == ON_GVL_RUNNING_SAMPLE ? Qtrue : Qfalse;
 
     return result;
   }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -34,6 +34,6 @@ VALUE enforce_thread_context_collector_instance(VALUE object);
   } on_gvl_running_result;
 
   void thread_context_collector_on_gvl_waiting(VALUE thread);
-  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(VALUE thread);
+  __attribute__((warn_unused_result)) on_gvl_running_result thread_context_collector_on_gvl_running(VALUE self_instance, VALUE thread);
   VALUE thread_context_collector_sample_after_gvl_running(VALUE self_instance, VALUE current_thread, long current_monotonic_wall_time_ns);
 #endif

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   end
 
   def on_gvl_running(thread)
-    described_class::Testing._native_on_gvl_running(thread)
+    described_class::Testing._native_on_gvl_running(thread_context_collector, thread)
   end
 
   def sample_after_gvl_running(thread, allow_exception: false)
@@ -189,7 +189,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
   describe ".new" do
     it "sets the waiting_for_gvl_threshold_ns to the provided value" do
       # This is a bit ugly but it saves us from having to introduce yet another way to poke at the native state
-      expect(thread_context_collector.inspect).to include("global_waiting_for_gvl_threshold_ns=222333444")
+      expect(thread_context_collector.inspect).to include("waiting_for_gvl_threshold_ns=222333444")
     end
 
     context "when otel_context_enabled has an invalid value" do


### PR DESCRIPTION
The RUBY_INTERNAL_THREAD_EVENT_RESUMED hook already runs with the GVL held
on the current thread, so it is safe to sample directly without going
through rb_postponed_job. This removes unnecessary latency and indirection.

Also:
Replace global_waiting_for_gvl_threshold_ns with a field on the collector state
* Now that on_gvl_running runs in a context where the collector state is
  accessible, the global variable workaround is no longer needed.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Simplicity

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
