### PR TITLE
Tracing: normalize tracestate encoding at propagator ingress

### DIFF
--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'trace/span'
+require_relative '../../tracing/distributed/helpers'
 require_relative '../../tracing/span_link'
 require_relative '../../tracing/span_event'
 require_relative '../../tracing/trace_digest'
@@ -106,7 +107,9 @@ module Datadog
                   trace_id: link.span_context.hex_trace_id.to_i(16),
                   span_id: link.span_context.hex_span_id.to_i(16),
                   trace_sampling_priority: (link.span_context.trace_flags&.sampled? ? 1 : 0),
-                  trace_state: link.span_context.tracestate&.to_s,
+                  trace_state: Tracing::Distributed::Helpers.normalize_tracestate_encoding(
+                    link.span_context.tracestate&.to_s
+                  ),
                   span_remote: link.span_context.remote?,
                 ),
                 attributes: link.attributes

--- a/lib/datadog/opentelemetry/sdk/span_processor.rb
+++ b/lib/datadog/opentelemetry/sdk/span_processor.rb
@@ -107,7 +107,7 @@ module Datadog
                   trace_id: link.span_context.hex_trace_id.to_i(16),
                   span_id: link.span_context.hex_span_id.to_i(16),
                   trace_sampling_priority: (link.span_context.trace_flags&.sampled? ? 1 : 0),
-                  trace_state: Tracing::Distributed::Helpers.normalize_tracestate_encoding(
+                  trace_state: Tracing::Distributed::Helpers.force_utf8_encoding(
                     link.span_context.tracestate&.to_s
                   ),
                   span_remote: link.span_context.remote?,

--- a/lib/datadog/tracing/distributed/helpers.rb
+++ b/lib/datadog/tracing/distributed/helpers.rb
@@ -42,15 +42,11 @@ module Datadog
         # Returns nil for nil input and for byte sequences that are not valid UTF-8
         # (e.g. a lone 0xFF). Bytes that form a valid UTF-8 sequence, including
         # non-ASCII multi-byte characters, are kept.
-        def self.normalize_tracestate_encoding(value)
+        def self.force_utf8_encoding(value)
           return unless value
 
-          if value.encoding == ::Encoding::UTF_8
-            return value.valid_encoding? ? value : nil
-          end
-
-          value = value.dup.force_encoding(::Encoding::UTF_8)
-          value if value.valid_encoding?
+          value = value.dup.force_encoding(::Encoding::UTF_8) if value.encoding != ::Encoding::UTF_8
+          value.valid_encoding? ? value : nil
         end
 
         def self.parse_hex_id(value)

--- a/lib/datadog/tracing/distributed/helpers.rb
+++ b/lib/datadog/tracing/distributed/helpers.rb
@@ -34,16 +34,14 @@ module Datadog
           num
         end
 
-        # Returns the input with UTF-8 encoding tagged, suitable for downstream
-        # consumers (msgpack, JSON, log encoders) that key behavior off `Encoding`.
+        # Returns the input retagged as UTF-8. HTTP frameworks hand header values to
+        # applications tagged as ASCII-8BIT; msgpack-ruby serializes those as `bin`
+        # rather than `str`, which the agent's wire schema rejects for fields like
+        # `SpanLinks[N].Tracestate`.
         #
-        # HTTP frameworks hand header values to applications tagged as ASCII-8BIT;
-        # msgpack-ruby serializes those as `bin` rather than `str`, which the agent's
-        # wire schema rejects for fields like `SpanLinks[N].Tracestate`.
-        #
-        # Returns nil for nil input, and for byte sequences that are not valid UTF-8 —
-        # W3C tracestate is restricted to printable ASCII, so non-ASCII bytes are spec
-        # violations and are dropped rather than propagated as corrupted data.
+        # Returns nil for nil input and for byte sequences that are not valid UTF-8
+        # (e.g. a lone 0xFF). Bytes that form a valid UTF-8 sequence, including
+        # non-ASCII multi-byte characters, are kept.
         def self.normalize_tracestate_encoding(value)
           return unless value
 

--- a/lib/datadog/tracing/distributed/helpers.rb
+++ b/lib/datadog/tracing/distributed/helpers.rb
@@ -34,6 +34,27 @@ module Datadog
           num
         end
 
+        # Returns the input with UTF-8 encoding tagged, suitable for downstream
+        # consumers (msgpack, JSON, log encoders) that key behavior off `Encoding`.
+        #
+        # HTTP frameworks hand header values to applications tagged as ASCII-8BIT;
+        # msgpack-ruby serializes those as `bin` rather than `str`, which the agent's
+        # wire schema rejects for fields like `SpanLinks[N].Tracestate`.
+        #
+        # Returns nil for nil input, and for byte sequences that are not valid UTF-8 —
+        # W3C tracestate is restricted to printable ASCII, so non-ASCII bytes are spec
+        # violations and are dropped rather than propagated as corrupted data.
+        def self.normalize_tracestate_encoding(value)
+          return unless value
+
+          if value.encoding == ::Encoding::UTF_8
+            return value.valid_encoding? ? value : nil
+          end
+
+          value = value.dup.force_encoding(::Encoding::UTF_8)
+          value if value.valid_encoding?
+        end
+
         def self.parse_hex_id(value)
           return unless value
 

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'helpers'
+
 module Datadog
   module Tracing
     module Distributed
@@ -285,6 +287,7 @@ module Datadog
         # @return [Array<String,Integer,String,String,Hash>] returns 4 values:
         # tracestate, sampling_priority, ts_parent_id, origin, tags.
         def extract_tracestate(tracestate)
+          tracestate = Helpers.normalize_tracestate_encoding(tracestate)
           vendors = split_tracestate(tracestate)
           return unless vendors && !vendors.empty?
 

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -290,7 +290,6 @@ module Datadog
         #   entry is present: [tracestate without `dd=`, sampling_priority, origin,
         #   ts_parent_id, tags, unknown_fields]. All elements past the first may be nil.
         def extract_tracestate(tracestate)
-          tracestate = Helpers.normalize_tracestate_encoding(tracestate)
           vendors = split_tracestate(tracestate)
           return unless vendors && !vendors.empty?
 
@@ -400,6 +399,9 @@ module Datadog
             tracestate = tracestate.byteslice(0, TRACESTATE_MAX_SIZE_LIMIT + 1) #: String
             tracestate = tracestate.chop
           end
+
+          tracestate = Helpers.normalize_tracestate_encoding(tracestate)
+          return unless tracestate
 
           vendors = tracestate.split(',', TRACESTATE_MAX_LIST_MEMBERS + 1)
           if vendors.length > TRACESTATE_MAX_LIST_MEMBERS || remove_last_member

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -284,8 +284,11 @@ module Datadog
           trace_flags & TRACE_FLAGS_SAMPLED
         end
 
-        # @return [Array<String,Integer,String,String,Hash>] returns 4 values:
-        # tracestate, sampling_priority, ts_parent_id, origin, tags.
+        # @return [nil] when the tracestate is absent or has no vendor entries.
+        # @return [String] when no `dd=` entry is present — the joined vendor list.
+        # @return [Array(String, Integer, String, String, Hash, String)] when a `dd=`
+        #   entry is present: [tracestate without `dd=`, sampling_priority, origin,
+        #   ts_parent_id, tags, unknown_fields]. All elements past the first may be nil.
         def extract_tracestate(tracestate)
           tracestate = Helpers.normalize_tracestate_encoding(tracestate)
           vendors = split_tracestate(tracestate)

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -400,7 +400,7 @@ module Datadog
             tracestate = tracestate.chop
           end
 
-          tracestate = Helpers.normalize_tracestate_encoding(tracestate)
+          tracestate = Helpers.force_utf8_encoding(tracestate)
           return unless tracestate
 
           vendors = tracestate.split(',', TRACESTATE_MAX_LIST_MEMBERS + 1)

--- a/sig/datadog/tracing/distributed/helpers.rbs
+++ b/sig/datadog/tracing/distributed/helpers.rbs
@@ -6,6 +6,8 @@ module Datadog
 
         def self.parse_decimal_id: (untyped value) -> (nil | untyped)
 
+        def self.normalize_tracestate_encoding: (String? value) -> String?
+
         def self.parse_hex_id: (untyped value) -> (nil | untyped)
       end
     end

--- a/sig/datadog/tracing/distributed/helpers.rbs
+++ b/sig/datadog/tracing/distributed/helpers.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         def self.parse_decimal_id: (untyped value) -> (nil | untyped)
 
-        def self.normalize_tracestate_encoding: (String? value) -> String?
+        def self.force_utf8_encoding: (String? value) -> String?
 
         def self.parse_hex_id: (untyped value) -> (nil | untyped)
       end

--- a/spec/datadog/tracing/distributed/helpers_spec.rb
+++ b/spec/datadog/tracing/distributed/helpers_spec.rb
@@ -39,6 +39,73 @@ RSpec.describe Datadog::Tracing::Distributed::Helpers do
     end
   end
 
+  describe '.normalize_tracestate_encoding' do
+    subject(:result) { described_class.normalize_tracestate_encoding(value) }
+
+    context 'with nil' do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an empty string tagged ASCII-8BIT' do
+      let(:value) { String.new('', encoding: Encoding::ASCII_8BIT) }
+
+      it 'returns an empty UTF-8 string' do
+        expect(result).to eq('')
+        expect(result.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context 'with an ASCII-8BIT string containing only ASCII bytes' do
+      let(:value) { String.new('vendor1=value1,vendor2=value2', encoding: Encoding::ASCII_8BIT) }
+
+      it 'retags as UTF-8 without modifying bytes' do
+        expect(result).to eq('vendor1=value1,vendor2=value2')
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.bytes).to eq(value.bytes)
+      end
+
+      it 'does not mutate the input' do
+        expect { result }.not_to(change { value.encoding })
+      end
+    end
+
+    context 'with a UTF-8 string that is already valid' do
+      let(:value) { 'vendor1=value1' }
+
+      it 'returns the input unchanged' do
+        expect(result).to equal(value)
+      end
+    end
+
+    context 'with an ASCII-8BIT string whose bytes form a valid UTF-8 sequence' do
+      # 'café' in UTF-8 is 63 61 66 c3 a9
+      let(:value) { String.new("caf\xC3\xA9", encoding: Encoding::ASCII_8BIT) }
+
+      it 'returns a UTF-8 string with the same bytes' do
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.bytes).to eq(value.bytes)
+      end
+    end
+
+    context 'with an ASCII-8BIT string containing invalid UTF-8 byte sequences' do
+      # Lone 0xFF is not a valid UTF-8 start byte.
+      let(:value) { String.new("foo\xFFbar", encoding: Encoding::ASCII_8BIT) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a frozen ASCII-8BIT string' do
+      let(:value) { String.new('vendor=value', encoding: Encoding::ASCII_8BIT).freeze }
+
+      it 'returns a UTF-8 string without raising' do
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result).to eq('vendor=value')
+      end
+    end
+  end
+
   describe '.parse_hex_id' do
     context 'when given with `length`' do
       [

--- a/spec/datadog/tracing/distributed/helpers_spec.rb
+++ b/spec/datadog/tracing/distributed/helpers_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Datadog::Tracing::Distributed::Helpers do
     end
   end
 
-  describe '.normalize_tracestate_encoding' do
-    subject(:result) { described_class.normalize_tracestate_encoding(value) }
+  describe '.force_utf8_encoding' do
+    subject(:result) { described_class.force_utf8_encoding(value) }
 
     context 'with nil' do
       let(:value) { nil }

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -550,6 +550,36 @@ RSpec.shared_examples 'Trace Context distributed format' do
         it { expect(digest.trace_origin).to eq('origin') }
       end
 
+      # HTTP frameworks (Rack and friends) hand header values to applications tagged
+      # as ASCII-8BIT. msgpack-ruby serializes those as `bin` rather than `str`,
+      # which the agent's wire schema rejects for `SpanLinks[N].Tracestate`.
+      context 'with an ASCII-8BIT-tagged tracestate header' do
+        let(:tracestate) do
+          String.new('dd=o:origin,v1=1,v2=2', encoding: Encoding::ASCII_8BIT)
+        end
+
+        it 'stores trace_state as UTF-8' do
+          expect(digest.trace_state).to eq('v1=1,v2=2')
+          expect(digest.trace_state.encoding).to eq(Encoding::UTF_8)
+        end
+
+        it 'still extracts Datadog fields from the dd= entry' do
+          expect(digest.trace_origin).to eq('origin')
+        end
+      end
+
+      context 'with an ASCII-8BIT tracestate containing invalid UTF-8 bytes' do
+        let(:tracestate) do
+          String.new("v1=1,vendor=foo\xFFbar", encoding: Encoding::ASCII_8BIT)
+        end
+
+        it 'drops the tracestate but keeps the traceparent' do
+          expect(digest.trace_id).to eq(0xC0FFEE)
+          expect(digest.span_id).to eq(0xBEE)
+          expect(digest.trace_state).to be_nil
+        end
+      end
+
       context 'with oversized tracestate vendors' do
         let(:tracestate) { Array.new(100) { |i| "v#{i}=#{'a' * 8}" }.join(',') }
 

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -583,6 +583,21 @@ RSpec.shared_examples 'Trace Context distributed format' do
         end
       end
 
+      # The size-limit truncation in split_tracestate runs before encoding
+      # validation, so an invalid byte that would be discarded by truncation
+      # does not poison the parseable prefix.
+      context 'with an oversized ASCII-8BIT tracestate where invalid bytes are only in the truncated tail' do
+        let(:tracestate) do
+          String.new("dd=o:origin,v=1,#{'a' * 600}\xFF", encoding: Encoding::ASCII_8BIT)
+        end
+
+        it 'preserves the parseable prefix instead of dropping the whole field' do
+          expect(digest.trace_origin).to eq('origin')
+          expect(digest.trace_state).to eq('v=1')
+          expect(digest.trace_state.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+
       # End-to-end: an ASCII-8BIT-tagged header must round-trip through
       # SpanLink#to_hash and msgpack as a `str`, not a `bin`. msgpack-ruby
       # uses encoding as a type signal — ASCII-8BIT serializes as `bin`,

--- a/spec/datadog/tracing/distributed/trace_context_spec.rb
+++ b/spec/datadog/tracing/distributed/trace_context_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
+require 'msgpack'
+
 require 'datadog/tracing/distributed/trace_context'
+require 'datadog/tracing/span_link'
 require 'datadog/tracing/trace_digest'
 
 RSpec.shared_examples 'Trace Context distributed format' do
@@ -577,6 +580,24 @@ RSpec.shared_examples 'Trace Context distributed format' do
           expect(digest.trace_id).to eq(0xC0FFEE)
           expect(digest.span_id).to eq(0xBEE)
           expect(digest.trace_state).to be_nil
+        end
+      end
+
+      # End-to-end: an ASCII-8BIT-tagged header must round-trip through
+      # SpanLink#to_hash and msgpack as a `str`, not a `bin`. msgpack-ruby
+      # uses encoding as a type signal — ASCII-8BIT serializes as `bin`,
+      # which the agent's wire schema rejects for `SpanLinks[N].Tracestate`.
+      context 'when the digest is serialized as a SpanLink through msgpack' do
+        let(:tracestate) do
+          String.new('dd=o:origin,v1=1,v2=2', encoding: Encoding::ASCII_8BIT)
+        end
+
+        let(:link_hash) { Datadog::Tracing::SpanLink.new(digest).to_hash }
+        let(:roundtripped) { MessagePack.unpack(MessagePack.pack(link_hash)) }
+
+        it 'encodes tracestate as a msgpack str (UTF-8 on unpack), not bin' do
+          expect(roundtripped['tracestate']).to eq('v1=1,v2=2')
+          expect(roundtripped['tracestate'].encoding).to eq(Encoding::UTF_8)
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

Routes the two ingress sites where W3C `tracestate` strings enter the tracer's domain — the `TraceContext` propagator's `split_tracestate` (called from `extract_tracestate`) and the OpenTelemetry `SpanProcessor` link bridge — through a new `Distributed::Helpers.force_utf8_encoding`. The helper retags ASCII-8BIT-encoded strings as UTF-8 (the bytes are unchanged since W3C tracestate is restricted to printable ASCII, a subset of UTF-8), and drops strings whose bytes do not form valid UTF-8 rather than propagating corrupted data.

The propagator-side call sits inside `split_tracestate`, after the pre-existing size-limit truncation, so an invalid byte that lands in the truncated tail is discarded by the size cap rather than dropping the whole field — the parseable prefix is preserved.

Also rewrites the `@return` doc comment on `extract_tracestate`, which previously described a 4-tuple but listed five values in the wrong order. The new comment documents the three actual return shapes (`nil`, `String`, or `Array(String, Integer, String, String, Hash, String)`).

**Motivation:**

This is preventive, not a fix for a confirmed customer-impacting bug — see the "Change log entry" section for why.

HTTP servers hand header values to Ruby applications tagged as ASCII-8BIT. The W3C propagator preserves that tag (Ruby's `Array#join` keeps the source encoding when separator and elements are compatible), so the binary tag flows onto `TraceDigest#trace_state`. msgpack-ruby uses string encoding as a type tag — UTF-8 serializes as `str`, ASCII-8BIT as `bin` — and the agent's wire schema specifies `str` for `SpanLinks[N].Tracestate`.

The fix could land in `SpanLink#initialize` instead, but the model layer isn't the right place to make wire-format decisions, and an earlier draft that did so used `Core::Utils.utf8_encode` — which silently swallows non-UTF-8 input into an empty string, replacing one kind of corruption with another. Doing the work at the propagator boundary surfaces malformed input as a dropped field with a single explicit code path.

**Change log entry**

None.

In shipping code today, the only path that msgpacks an extracted tracestate is `SpanLink#to_hash`, and the only place SpanLinks are constructed from a foreign tracestate is the OpenTelemetry bridge — which reads from `link.span_context.tracestate&.to_s`, an OTel SDK object whose encoding behavior I have not independently verified to be ASCII-8BIT. For the invalid-UTF-8-bytes path this PR adds an explicit drop-to-nil; pre-PR, those bytes would have reached the agent as `bin`-tagged opaque data, and whatever the agent did with that, the observable customer outcome (no usable tracestate) is the same. So I can't substantiate a customer-visible behavior change either way, and the changelog is `None.` rather than a speculative claim.

**Additional Notes:**

Audited the other distributed propagators (`B3`, `Datadog`, `Baggage`) — none touch `trace_state`. The intra-process re-use in `lib/datadog/tracing/distributed/propagation.rb` inherits its tracestate from the W3C digest and is fixed transitively.

**How to test the change?**

- `bundle exec rspec spec/datadog/tracing/distributed/helpers_spec.rb` — unit coverage for `Distributed::Helpers.force_utf8_encoding`: nil, empty ASCII-8BIT, ASCII-only ASCII-8BIT (retagged), already-valid UTF-8 (identity), ASCII-8BIT whose bytes form valid UTF-8 (retagged), ASCII-8BIT with invalid UTF-8 byte sequences (dropped), frozen input.
- `bundle exec rspec spec/datadog/tracing/distributed/trace_context_spec.rb` — propagator coverage: ASCII-8BIT header produces UTF-8 `digest.trace_state`; invalid UTF-8 drops the field while keeping the traceparent; oversized ASCII-8BIT tracestate with invalid bytes only in the truncated tail preserves the parseable prefix; end-to-end msgpack round-trip from `SpanLink#to_hash` returns the tracestate as `str` (UTF-8 on unpack), not `bin`.
- `bundle exec rake test:opentelemetry` — existing OTel link tests pass with the helper inserted.

