### PR TITLE
SymDB: hot-load follow-ups — error boundary, race guard, deterministic tests, RBS type

### DIFF
--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -556,6 +556,13 @@ module Datadog
         @hot_load_buffer_mutex.synchronize { @hot_load_buffer << mod }
         @scheduler_mutex.synchronize do
           return if @shutdown
+          # TracePoint#disable does not wait for in-flight callbacks: a :class
+          # event firing concurrently with stop_upload can reach here after the
+          # hook has been torn down. Without this guard the stale event would
+          # re-arm the scheduler, contradicting stop_upload's contract. The
+          # buffer push above is harmless — the next start_upload runs
+          # extract_all, which clears the buffer before extracting.
+          return unless @hot_load_tracepoint
           @scheduled_at = Datadog::Core::Utils::Time.get_time + EXTRACT_DEBOUNCE_INTERVAL
           @scheduler_signaled = true
           @scheduler_cv.signal

--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -555,8 +555,17 @@ module Datadog
           next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
           component.send(:enqueue_hot_load, mod)
         rescue => e
-          logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
-          telemetry&.report(e, description: 'symdb: hot-load hook error')
+          # Logger or telemetry can themselves raise (custom logger
+          # implementation, telemetry worker in an unexpected state). The
+          # :class TracePoint fires inside customer class bodies, so the
+          # error boundary must hold even when error reporting fails;
+          # nothing useful to do if logging is broken.
+          begin
+            logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
+            telemetry&.report(e, description: 'symdb: hot-load hook error')
+          rescue
+            nil
+          end
         end
         @hot_load_tracepoint.enable # steep:ignore NoMethod
       end

--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -550,14 +550,13 @@ module Datadog
           # raise source (user-overridden singleton_class?); this rescue
           # closes the general case. Verified: a raise inside the callback
           # backtraces through `<class:CustomerClass>` in Ruby 3.x.
-          begin
-            mod = tp.self
-            next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
-            component.send(:enqueue_hot_load, mod)
-          rescue => e
-            logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
-            telemetry&.report(e, description: 'symdb: hot-load hook error')
-          end
+
+          mod = tp.self
+          next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
+          component.send(:enqueue_hot_load, mod)
+        rescue => e
+          logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
+          telemetry&.report(e, description: 'symdb: hot-load hook error')
         end
         @hot_load_tracepoint.enable # steep:ignore NoMethod
       end

--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -540,10 +540,24 @@ module Datadog
       def install_hot_load_hook
         return if @hot_load_tracepoint
         component = self
+        logger = @logger
+        telemetry = @telemetry
         @hot_load_tracepoint = TracePoint.new(:class) do |tp|
-          mod = tp.self
-          next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
-          component.send(:enqueue_hot_load, mod)
+          # The :class TracePoint fires inside the customer's class body —
+          # any exception that escapes this block surfaces at the customer's
+          # `class Foo; ... end` line and breaks their class load. The
+          # MODULE_SINGLETON_CLASS_PRED dispatch defends against one specific
+          # raise source (user-overridden singleton_class?); this rescue
+          # closes the general case. Verified: a raise inside the callback
+          # backtraces through `<class:CustomerClass>` in Ruby 3.x.
+          begin
+            mod = tp.self
+            next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
+            component.send(:enqueue_hot_load, mod)
+          rescue => e
+            logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
+            telemetry&.report(e, description: 'symdb: hot-load hook error')
+          end
         end
         @hot_load_tracepoint.enable # steep:ignore NoMethod
       end

--- a/sig/datadog/symbol_database/component.rbs
+++ b/sig/datadog/symbol_database/component.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module SymbolDatabase
     class Component
-      EXTRACT_DEBOUNCE_INTERVAL: Integer
+      EXTRACT_DEBOUNCE_INTERVAL: ::Numeric
       MODULE_SINGLETON_CLASS_PRED: ::UnboundMethod
 
       @settings: Datadog::Core::Configuration::Settings

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -643,6 +643,30 @@ RSpec.describe Datadog::Core::Configuration::Components do
     end
   end
 
+  describe '#after_fork' do
+    subject(:after_fork) { components.after_fork }
+
+    before do
+      allow(telemetry).to receive(:after_fork)
+      allow(remote).to receive(:after_fork)
+      allow(Datadog::Core::ProcessDiscovery).to receive(:after_fork)
+    end
+
+    it 'dispatches after_fork! to the symbol_database when present' do
+      symbol_database = instance_double(Datadog::SymbolDatabase::Component)
+      allow(components).to receive(:symbol_database).and_return(symbol_database)
+      expect(symbol_database).to receive(:after_fork!)
+
+      after_fork
+    end
+
+    it 'does not raise when symbol_database is nil' do
+      allow(components).to receive(:symbol_database).and_return(nil)
+
+      expect { after_fork }.not_to raise_error
+    end
+  end
+
   describe '#shutdown!' do
     before do
       allow(telemetry).to receive(:emit_closing!)

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -732,6 +732,28 @@ RSpec.describe Datadog::SymbolDatabase::Component do
         Object.send(:remove_const, :SymdbHotLoadRescueTestClass) if Object.const_defined?(:SymdbHotLoadRescueTestClass)
       end
     end
+
+    it 'does not propagate exceptions when logger.debug itself raises' do
+      # If the rescue handler's own logger call raises (custom logger
+      # implementation, IO error), it would escape the outer rescue and
+      # surface in the customer's class body. The inner rescue contains
+      # this case.
+      component = described_class.build(settings, agent_settings, logger)
+      component.wait_for_idle(timeout: 5)
+
+      allow(component).to receive(:enqueue_hot_load)
+        .and_raise(RuntimeError.new('simulated hot-load enqueue failure'))
+      allow(raw_logger).to receive(:debug).and_raise(RuntimeError.new('logger boom'))
+
+      begin
+        expect do
+          eval('class SymdbHotLoadLoggerRescueTestClass; end', binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
+        end.not_to raise_error
+      ensure
+        component.shutdown!
+        Object.send(:remove_const, :SymdbHotLoadLoggerRescueTestClass) if Object.const_defined?(:SymdbHotLoadLoggerRescueTestClass)
+      end
+    end
   end
 
   describe 'enable/disable upload (ported from Java SymDBEnablementTest.enableDisableSymDBThroughRC)' do

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -493,8 +493,10 @@ RSpec.describe Datadog::SymbolDatabase::Component do
     end
 
     it 'clears scheduler thread reference and pending schedule' do
+      # start_upload assigns @scheduler_thread synchronously inside
+      # @scheduler_mutex via ensure_scheduler_thread, so the ivar is non-nil
+      # by the time start_upload returns — no wait needed.
       component.start_upload
-      sleep 0.01 # let scheduler thread enter wait
       expect(component.instance_variable_get(:@scheduler_thread)).not_to be_nil
 
       component.after_fork!
@@ -592,7 +594,7 @@ RSpec.describe Datadog::SymbolDatabase::Component do
       expect(extractor).to receive(:extract_all).at_least(:once).and_return([])
 
       component.start_upload
-      sleep 0.2 # > EXTRACT_DEBOUNCE_INTERVAL
+      expect(component.wait_for_idle(timeout: 5)).to be true
 
       component.shutdown!
     end
@@ -787,14 +789,33 @@ RSpec.describe Datadog::SymbolDatabase::Component do
 
       begin
         # Define a class after stop_upload — with the TracePoint disabled this
-        # must not enqueue a hot-load event or re-arm the scheduler.
+        # must not enqueue a hot-load event or re-arm the scheduler. The
+        # @scheduled_at check is the structural proof: only enqueue_hot_load
+        # sets it after stop_upload, and enqueue_hot_load only runs if the
+        # TracePoint fired. extract_all cannot have been called because the
+        # scheduler thread cannot fire without @scheduled_at set.
         eval('class SymdbStopUploadSpecPostStopClass; def hello; end; end', binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
-        sleep 0.1
-        expect(extraction_count).to eq(1)
         expect(component.instance_variable_get(:@scheduled_at)).to be_nil
+        expect(extraction_count).to eq(1)
       ensure
         Object.send(:remove_const, :SymdbStopUploadSpecPostStopClass) if Object.const_defined?(:SymdbStopUploadSpecPostStopClass)
       end
+    end
+
+    it 'enqueue_hot_load called after stop_upload does not re-arm the scheduler' do
+      # Models the race where a :class TracePoint event fires concurrently
+      # with stop_upload: TracePoint#disable does not wait for in-flight
+      # callbacks, so the callback can reach enqueue_hot_load after the hook
+      # has been torn down. Without the @hot_load_tracepoint guard,
+      # enqueue_hot_load would re-arm the scheduler in this state.
+      allow(component.instance_variable_get(:@extractor)).to receive(:extract_all).and_return([])
+      component.start_upload
+      component.wait_for_idle(timeout: 5)
+      component.stop_upload
+
+      component.send(:enqueue_hot_load, Object)
+
+      expect(component.instance_variable_get(:@scheduled_at)).to be_nil
     end
   end
 

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -703,6 +703,35 @@ RSpec.describe Datadog::SymbolDatabase::Component do
       # bound Module#singleton_class? returns false and the module is enqueued.
       expect(buffered.map(&:name)).to include('SymdbHotLoadSpecSingletonOverride')
     end
+
+    it 'rescues exceptions raised inside the :class hook so customer class loads do not break' do
+      # The :class TracePoint fires inside the customer's `class Foo; ... end`
+      # body. If an exception escapes the callback, it propagates into the
+      # class definition and breaks the customer's class load (verified
+      # empirically: backtrace includes `<class:CustomerClass>`). The rescue
+      # in install_hot_load_hook contains the failure, logs at debug, and
+      # reports via telemetry.
+      component = described_class.build(settings, agent_settings, logger)
+      component.wait_for_idle(timeout: 5)
+
+      injected_error = RuntimeError.new('simulated hot-load enqueue failure')
+      allow(component).to receive(:enqueue_hot_load).and_raise(injected_error)
+
+      expect(raw_logger).to receive(:debug) do |&block|
+        expect(block.call).to include('hot-load hook error', 'RuntimeError', 'simulated hot-load enqueue failure')
+      end
+
+      begin
+        # With the rescue in place, defining a class while enqueue_hot_load is
+        # rigged to raise must not propagate the exception into the class body.
+        expect do
+          eval('class SymdbHotLoadRescueTestClass; end', binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
+        end.not_to raise_error
+      ensure
+        component.shutdown!
+        Object.send(:remove_const, :SymdbHotLoadRescueTestClass) if Object.const_defined?(:SymdbHotLoadRescueTestClass)
+      end
+    end
   end
 
   describe 'enable/disable upload (ported from Java SymDBEnablementTest.enableDisableSymDBThroughRC)' do

--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -226,42 +226,54 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
         symdb_logger
       )
 
-      # Step 1: initial load runs.
-      GC.start
-      component.start_upload
-      component.wait_for_idle(timeout: 5)
+      begin
+        # Step 1: initial load runs. Timeout matches the other e2e test in
+        # this file (line 84). On Ruby 2.6, extract_all is slow under heavy
+        # monkey-patching (see extractor.rb collect_extractable_modules
+        # comment about Module#name on singleton classes being O(ancestors)),
+        # so 5s is too short when an AppSec spec ran just before this one.
+        # Check the return value so a timeout fails the test loudly here
+        # instead of silently producing "captured_forms.size == 0" below.
+        GC.start
+        component.start_upload
+        expect(component.wait_for_idle(timeout: 30)).to be true
 
-      initial_form_count = captured_forms.size
-      expect(initial_form_count).to be >= 1
+        initial_form_count = captured_forms.size
+        expect(initial_form_count).to be >= 1
 
-      # Step 2: hot-load class is not in any initial upload.
-      expect(uploaded_class_names_across(captured_forms)).not_to include('HotLoadE2ETestClass')
+        # Step 2: hot-load class is not in any initial upload.
+        expect(uploaded_class_names_across(captured_forms)).not_to include('HotLoadE2ETestClass')
 
-      # Step 3: define the class via a real file so its source_location
-      # passes user_code_path? (eval-defined classes get `'(eval)'` and are
-      # filtered out by the extractor).
-      Dir.mktmpdir('hot_load_e2e') do |hot_dir|
-        hot_file = File.join(hot_dir, "hot_load_e2e_#{Time.now.to_i}_#{rand(10000)}.rb")
-        File.write(hot_file, "class HotLoadE2ETestClass; def hello; 42; end; end\n")
-        hot_file = File.realpath(hot_file)
+        # Step 3: define the class via a real file so its source_location
+        # passes user_code_path? (eval-defined classes get `'(eval)'` and are
+        # filtered out by the extractor).
+        Dir.mktmpdir('hot_load_e2e') do |hot_dir|
+          hot_file = File.join(hot_dir, "hot_load_e2e_#{Time.now.to_i}_#{rand(10000)}.rb")
+          File.write(hot_file, "class HotLoadE2ETestClass; def hello; 42; end; end\n")
+          hot_file = File.realpath(hot_file)
 
-        begin
-          load hot_file
+          begin
+            load hot_file
 
-          # Step 4: event-driven wait — wait_for_idle blocks on
-          # @last_upload_time_cv until @last_upload_time advances past the
-          # value captured at entry. No sleep.
-          expect(component.wait_for_idle(timeout: 5)).to be true
+            # Step 4: event-driven wait — wait_for_idle blocks on
+            # @last_upload_time_cv until @last_upload_time advances past the
+            # value captured at entry. No sleep.
+            expect(component.wait_for_idle(timeout: 30)).to be true
 
-          # Step 5: a new upload landed, and it contains the new class.
-          expect(captured_forms.size).to be > initial_form_count
-          expect(uploaded_class_names_across(captured_forms)).to include('HotLoadE2ETestClass')
-        ensure
-          Object.send(:remove_const, :HotLoadE2ETestClass) if defined?(HotLoadE2ETestClass)
+            # Step 5: a new upload landed, and it contains the new class.
+            expect(captured_forms.size).to be > initial_form_count
+            expect(uploaded_class_names_across(captured_forms)).to include('HotLoadE2ETestClass')
+          ensure
+            Object.send(:remove_const, :HotLoadE2ETestClass) if defined?(HotLoadE2ETestClass)
+          end
         end
+      ensure
+        # Always shut down — a mid-test failure must not leak the scheduler
+        # thread. A leaked thread continues running extract_all and can race
+        # ObjectSpace iteration with later specs in the same rspec process,
+        # producing cascading "file_scope is nil" failures in extractor_spec.
+        component.shutdown!
       end
-
-      component.shutdown!
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

Five follow-ups to PR #5697 (TracePoint :class hot-load hook for incremental class extraction):

1. **Error boundary around the hot-load TracePoint callback.** The `:class` TracePoint fires inside the customer's `class Foo; ... end` body. An exception escaping the callback propagates *into the class definition itself* — verified empirically: a `raise` inside a `:class` TracePoint backtraces through `<class:CustomerClass>` and surfaces at the customer's `class` keyword, breaking their class load. The earlier `MODULE_SINGLETON_CLASS_PRED` dispatch closed one specific raise source (user-overridden `singleton_class?`); this commit closes the general case with a rescue around the callback body that matches the sibling pattern in `start_upload`/`scheduler_loop`/`extract_and_upload`: log at debug, report via telemetry, allow the customer's class load to proceed.

2. **`enqueue_hot_load` race guard.** `TracePoint#disable` does not wait for in-flight callbacks. A `:class` event firing concurrently with `stop_upload` could reach `enqueue_hot_load` after the hook had been torn down and re-arm the scheduler — contradicting `stop_upload`'s contract. Now bails out when `@hot_load_tracepoint` is nil. The buffer push above the guard is harmless because the next `start_upload` runs `extract_all` (`@initial_extraction_done` was reset), which clears the buffer first.

3. **`Components#after_fork` spec.** Added a dedicated `#after_fork` describe block to `components_spec.rb` covering the `symbol_database&.after_fork!` wiring — both the dispatch path and the nil-safety case.

4. **Three sleeps replaced with deterministic waits in `component_spec.rb`:**
   - "clears scheduler thread reference and pending schedule" — `@scheduler_thread` is assigned synchronously inside `start_upload`'s mutex via `ensure_scheduler_thread`, so the sleep was never needed.
   - "leaves a child Component able to start_upload normally after fork-state reset" — replaced with `wait_for_idle`.
   - "stop_upload prevents a post-stop class definition from triggering extraction" — removed entirely; the `@scheduled_at` nil check is the structural proof (only `enqueue_hot_load` sets it after `stop_upload`, and `enqueue_hot_load` only runs if the TracePoint fired).

5. **RBS type fix.** `EXTRACT_DEBOUNCE_INTERVAL` is declared `Integer` but participates in arithmetic with `Float` clock values and is stubbed to `0.05` in tests. Changed to `::Numeric`.

**Motivation:**

Surfaced during review of #5697 after merge. Items 1 and 2 are behavioral; the rest are test/type hygiene.

Item 1 is the highest-impact: without the rescue, any unexpected raise inside the callback (mutex edge case, user-set `Time.now_provider` raising, future code change in `enqueue_hot_load`) propagates into customer code at `class Foo; ... end`. Item 2 closes a documented race window in which symdb can re-arm the scheduler after the customer disables it via remote config.

**Change log entry**

None.

**Additional Notes:**

- Item 1 verification (Ruby 3.2.3): raising `CustomerError` inside a `TracePoint :class` callback produced a backtrace of `block in <main>` → `<class:CustomerClass>` → `<main>`. The exception was caught by a `rescue` placed around the surrounding `class CustomerClass; end` block — confirming the callback's raise propagates through the class definition body and into customer scope.

**How to test the change?**

- `bundle exec rspec spec/datadog/symbol_database/component_spec.rb` — 51 examples, 0 failures. New specs:
  - `rescues exceptions raised inside the :class hook so customer class loads do not break` (item 1)
  - `enqueue_hot_load called after stop_upload does not re-arm the scheduler` (item 2)
- `bundle exec rspec spec/datadog/core/configuration/components_spec.rb` — passes including the two new `#after_fork` examples (item 3).
- `bundle exec steep check lib/datadog/symbol_database/component.rb` — clean.