### PR TITLE
SymDB: filter Class objects detached from their constant in extract_all

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -170,15 +170,29 @@ module Datadog
       # constant (via remove_const) but still carries the cached Module#name —
       # see collect_extractable_modules for the failure mode this protects.
       #
-      # Walks the namespace path segment-by-segment using Module#autoload? at
-      # each step. A pending autoload at any segment is treated as "does not
-      # resolve" without ever calling const_get on the autoload target — so
-      # symbol extraction never loads customer code as a side effect and a
-      # missing autoload target cannot raise LoadError (which is ScriptError,
-      # not StandardError, and would propagate past the outer rescue in
-      # collect_extractable_modules). const_defined?(sym, false) restricts the
-      # lookup to constants directly defined on the current namespace, matching
-      # the segment semantics of '::'.
+      # Walks the namespace path segment-by-segment. For each segment:
+      # 1. Check for a pending autoload directly on the current namespace.
+      #    If present, const_get would trigger it — loading customer code as
+      #    a side effect of symbol extraction and raising LoadError if the
+      #    target file is missing (LoadError is ScriptError, not StandardError,
+      #    and would propagate past the outer rescue in
+      #    collect_extractable_modules). Return false instead.
+      # 2. Otherwise, require the constant to be directly defined on this
+      #    namespace (const_defined?(sym, false)) and descend via
+      #    const_get(sym, false). The direct-only lookup means an ancestor's
+      #    pending autoload at the same name does not affect the result: a
+      #    subclass with its own binding resolves through the binding, an
+      #    inherited autoload triggers nothing.
+      #
+      # Ruby 2.7+ adds an inherit parameter to Module#autoload? —
+      # `current.autoload?(sym, false)` cleanly asks "is there an autoload
+      # registered directly on this namespace?". On Ruby 2.5 and 2.6 that
+      # parameter doesn't exist (per Ruby 2.7.0 NEWS), so the fallback
+      # branch uses `current.autoload?(sym)` which also reports inherited
+      # autoloads. The consequence on 2.5/2.6: a subclass binding whose
+      # name collides with an ancestor's pending autoload is conservatively
+      # treated as stale and dropped from extraction. The minimum supported
+      # Ruby is 2.5 per lib/datadog/version.rb, so this fallback ships.
       # @param mod_name [String]
       # @param mod [Module]
       # @return [Boolean]
@@ -186,9 +200,14 @@ module Datadog
         current = Object
         mod_name.split('::').each do |seg|
           sym = seg.to_sym
-          return false if current.autoload?(sym)
+          pending_autoload = if RUBY_VERSION >= '2.7'
+            current.autoload?(sym, false)
+          else
+            current.autoload?(sym)
+          end
+          return false if pending_autoload
           return false unless current.const_defined?(sym, false)
-          current = current.const_get(sym)
+          current = current.const_get(sym, false)
         end
         current.equal?(mod)
       rescue NameError, ArgumentError

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -191,8 +191,10 @@ module Datadog
           current = current.const_get(sym)
         end
         current.equal?(mod)
-      rescue NameError, ArgumentError => e
-        @logger.debug { "symdb: resolves_to_same_module?(#{mod_name}) failed: #{e.class}: #{e.message}" }
+      rescue NameError, ArgumentError
+        # Expected "no" outcome for stale/detached classes — the whole point
+        # of this predicate. Per the rescue convention in this file's header
+        # comment: inner per-item rescues are expected failures, no logging.
         false
       end
 

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -165,6 +165,26 @@ module Datadog
         nil
       end
 
+      # Verify that mod_name still resolves to mod through Ruby's constant
+      # table. Returns false when a Class/Module has been detached from its
+      # constant (via remove_const) but still carries the cached Module#name —
+      # see collect_extractable_modules for the failure mode this protects.
+      #
+      # Uses const_defined? before const_get so an unresolvable path
+      # short-circuits without triggering const_missing on the customer's
+      # Object class. const_get is only reached when the path resolves to a
+      # real binding, which avoids triggering autoload as a side effect.
+      # @param mod_name [String]
+      # @param mod [Module]
+      # @return [Boolean]
+      def resolves_to_same_module?(mod_name, mod)
+        return false unless Object.const_defined?(mod_name)
+        Object.const_get(mod_name).equal?(mod)
+      rescue NameError, ArgumentError => e
+        @logger.debug { "symdb: resolves_to_same_module?(#{mod_name}) failed: #{e.class}: #{e.message}" }
+        false
+      end
+
       # Check if module is from user code (not gems or stdlib)
       # @param mod [Module] The module to check
       # @return [Boolean] true if user code
@@ -650,6 +670,16 @@ module Datadog
 
           mod_name = safe_mod_name(mod)
           next unless mod_name
+
+          # Skip modules whose cached name no longer resolves to them. CRuby
+          # caches Module#name, so a Class whose constant was removed via
+          # remove_const stays in ObjectSpace and still reports its old FQN.
+          # Without this guard, a leaked Class from a prior remove_const +
+          # redefinition (test cleanup, customer hot-reload) collides with
+          # the current binding in the name-keyed `entries` hash below and
+          # the "winner" depends on ObjectSpace iteration order.
+          next unless resolves_to_same_module?(mod_name, mod)
+
           next unless user_code_module?(mod)
 
           methods_by_file = group_methods_by_file(mod)

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -170,16 +170,27 @@ module Datadog
       # constant (via remove_const) but still carries the cached Module#name —
       # see collect_extractable_modules for the failure mode this protects.
       #
-      # Uses const_defined? before const_get so an unresolvable path
-      # short-circuits without triggering const_missing on the customer's
-      # Object class. const_get is only reached when the path resolves to a
-      # real binding, which avoids triggering autoload as a side effect.
+      # Walks the namespace path segment-by-segment using Module#autoload? at
+      # each step. A pending autoload at any segment is treated as "does not
+      # resolve" without ever calling const_get on the autoload target — so
+      # symbol extraction never loads customer code as a side effect and a
+      # missing autoload target cannot raise LoadError (which is ScriptError,
+      # not StandardError, and would propagate past the outer rescue in
+      # collect_extractable_modules). const_defined?(sym, false) restricts the
+      # lookup to constants directly defined on the current namespace, matching
+      # the segment semantics of '::'.
       # @param mod_name [String]
       # @param mod [Module]
       # @return [Boolean]
       def resolves_to_same_module?(mod_name, mod)
-        return false unless Object.const_defined?(mod_name)
-        Object.const_get(mod_name).equal?(mod)
+        current = Object
+        mod_name.split('::').each do |seg|
+          sym = seg.to_sym
+          return false if current.autoload?(sym)
+          return false unless current.const_defined?(sym, false)
+          current = current.const_get(sym)
+        end
+        current.equal?(mod)
       rescue NameError, ArgumentError => e
         @logger.debug { "symdb: resolves_to_same_module?(#{mod_name}) failed: #{e.class}: #{e.message}" }
         false

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -22,6 +22,8 @@ module Datadog
 
       def safe_mod_name: (Module mod) -> String?
 
+      def resolves_to_same_module?: (String mod_name, Module mod) -> bool
+
       def user_code_module?: (Module mod) -> bool
 
       def user_code_path?: (String path) -> bool

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2329,6 +2329,50 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
     end
 
+    context 'autoload registered after remove_const' do
+      # Customer pattern (reloaders, plugin hot-load): a class is defined,
+      # removed via remove_const, then an autoload is registered at the same
+      # name. The leaked Class stays in ObjectSpace with the cached name.
+      # The earlier implementation called Object.const_get(mod_name) to verify
+      # the binding, which triggered the autoload (loading customer code as a
+      # side effect of extraction) and raised LoadError if the autoload target
+      # was missing. LoadError is ScriptError, not StandardError, so neither
+      # the local rescue (NameError, ArgumentError) nor the outer rescue in
+      # collect_extractable_modules (StandardError) caught it — extract_all
+      # aborted instead of skipping the leaked class.
+      before do
+        @leaked_file = create_test_file('autoload_leaked.rb', <<~RUBY)
+          class ExtractAllAutoloadDetached
+            def leaked_method; end
+          end
+        RUBY
+        load @leaked_file
+        # Keep a hard reference so GC.start cannot reclaim the leaked Class.
+        @leaked_class = ExtractAllAutoloadDetached
+        Object.send(:remove_const, :ExtractAllAutoloadDetached)
+        @autoload_target = '/nonexistent/symdb_autoload_target.rb'
+        Object.autoload(:ExtractAllAutoloadDetached, @autoload_target)
+      end
+
+      after do
+        if Object.const_defined?(:ExtractAllAutoloadDetached, false)
+          Object.send(:remove_const, :ExtractAllAutoloadDetached)
+        end
+      end
+
+      it 'skips the leaked class without triggering the autoload' do
+        scopes = nil
+        expect { scopes = extract_all_clean }.not_to raise_error
+
+        # Autoload registration is still pending — the target was not loaded.
+        expect(Object.autoload?(:ExtractAllAutoloadDetached)).to eq(@autoload_target)
+
+        # The leaked class's FILE scope is filtered out.
+        leaked_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @leaked_file }
+        expect(leaked_scope).to be_nil
+      end
+    end
+
     context 'class detached from its constant via remove_const' do
       # CRuby caches Module#name. After Object.send(:remove_const, :Foo) the
       # Class stays in ObjectSpace and `mod.name` still returns "Foo".

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2337,6 +2337,17 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       # The fix relies on the order of operations: const_defined?(sym, false)
       # detects the direct subclass binding first, and const_get(sym, false)
       # returns it without triggering the ancestor's autoload.
+      #
+      # Requires Module#autoload?(name, inherit) — the `inherit` parameter was
+      # added in Ruby 2.7 (Ruby 2.7.0 NEWS). On Ruby 2.5/2.6 the fallback in
+      # resolves_to_same_module? uses autoload?(name) which checks ancestors,
+      # so a subclass binding that collides with an ancestor's pending
+      # autoload is conservatively treated as stale and dropped. That is the
+      # documented fallback behavior and is unavoidable without the 2.7+ API.
+      before(:all) do
+        skip 'requires Module#autoload?(name, inherit) — Ruby 2.7+' if RUBY_VERSION < '2.7'
+      end
+
       before do
         @parent_file = create_test_file('autoload_parent.rb', <<~RUBY)
           class ExtractAllAutoloadParent

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2328,5 +2328,51 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(host.scopes.map(&:name)).to include('host_method')
       end
     end
+
+    context 'class detached from its constant via remove_const' do
+      # CRuby caches Module#name. After Object.send(:remove_const, :Foo) the
+      # Class stays in ObjectSpace and `mod.name` still returns "Foo".
+      # Without the resolves_to_same_module? filter in
+      # collect_extractable_modules, the leaked Class collides with a fresh
+      # binding of the same constant in the name-keyed entries hash, and the
+      # ObjectSpace-iteration-order winner can pair a MODULE from one binding
+      # with a CLASS from another — producing FILE scopes with empty children.
+      before do
+        @leaked_file = create_test_file('detached_old.rb', <<~RUBY)
+          class ExtractAllDetached
+            def old_method; end
+          end
+        RUBY
+        load @leaked_file
+        # Keep a hard reference so GC.start cannot reclaim the leaked Class.
+        @leaked_class = ExtractAllDetached
+        Object.send(:remove_const, :ExtractAllDetached)
+
+        @new_file = create_test_file('detached_new.rb', <<~RUBY)
+          class ExtractAllDetached
+            def new_method; end
+          end
+        RUBY
+        load @new_file
+      end
+
+      after do
+        Object.send(:remove_const, :ExtractAllDetached) if defined?(ExtractAllDetached)
+      end
+
+      it 'extracts the currently-bound class only, not the leaked one' do
+        scopes = extract_all_clean
+
+        leaked_file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @leaked_file }
+        expect(leaked_file_scope).to be_nil
+
+        new_file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @new_file }
+        expect(new_file_scope).not_to be_nil
+        host = new_file_scope.scopes.find { |s| s.name == 'ExtractAllDetached' }
+        expect(host).not_to be_nil
+        expect(host.scopes.map(&:name)).to include('new_method')
+        expect(host.scopes.map(&:name)).not_to include('old_method')
+      end
+    end
   end
 end

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2329,6 +2329,59 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
     end
 
+    context 'subclass with constant of same name as ancestor pending autoload' do
+      # Module#autoload? defaults to inherit=true, so when a subclass has a
+      # constant directly defined and an ancestor has a pending autoload at
+      # the same name, autoload? returns the ancestor's pending path. An
+      # autoload-first check would silently drop the real subclass binding.
+      # The fix relies on the order of operations: const_defined?(sym, false)
+      # detects the direct subclass binding first, and const_get(sym, false)
+      # returns it without triggering the ancestor's autoload.
+      before do
+        @parent_file = create_test_file('autoload_parent.rb', <<~RUBY)
+          class ExtractAllAutoloadParent
+            autoload :ExtractAllAutoloadChild, '/nonexistent/autoload_parent_child.rb'
+          end
+        RUBY
+        load @parent_file
+        @sub_file = create_test_file('autoload_sub.rb', <<~RUBY)
+          class ExtractAllAutoloadSub < ExtractAllAutoloadParent
+            class ExtractAllAutoloadChild
+              def real_method; end
+            end
+          end
+        RUBY
+        load @sub_file
+      end
+
+      after do
+        if Object.const_defined?(:ExtractAllAutoloadSub, false)
+          Object.send(:remove_const, :ExtractAllAutoloadSub)
+        end
+        if Object.const_defined?(:ExtractAllAutoloadParent, false)
+          Object.send(:remove_const, :ExtractAllAutoloadParent)
+        end
+      end
+
+      it 'extracts the subclass child without triggering the ancestor autoload' do
+        scopes = nil
+        expect { scopes = extract_all_clean }.not_to raise_error
+
+        # Ancestor's autoload remained pending — the lookup did not trigger it.
+        expect(ExtractAllAutoloadParent.autoload?(:ExtractAllAutoloadChild))
+          .to eq('/nonexistent/autoload_parent_child.rb')
+
+        # The subclass's directly-defined child is included in the payload.
+        file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @sub_file }
+        expect(file_scope).not_to be_nil
+        sub = file_scope.scopes.find { |s| s.name == 'ExtractAllAutoloadSub' }
+        expect(sub).not_to be_nil
+        child = sub.scopes.find { |s| s.name == 'ExtractAllAutoloadSub::ExtractAllAutoloadChild' }
+        expect(child).not_to be_nil
+        expect(child.scopes.map(&:name)).to include('real_method')
+      end
+    end
+
     context 'autoload registered after remove_const' do
       # Customer pattern (reloaders, plugin hot-load): a class is defined,
       # removed via remove_const, then an autoload is registered at the same


### PR DESCRIPTION
**What does this PR do?**

Filters out leaked `Class` and `Module` objects from symbol-database extraction so they don't get uploaded alongside the current bindings.

**Motivation:**

CRuby caches `Module#name`. When customer code calls `Object.send(:remove_const, :Foo)`, the `Foo` Class doesn't disappear — it stays alive in `ObjectSpace` and still answers `"Foo"` when asked for its name. If a new `class Foo` is then defined at a different file, the process has two distinct `Class` objects both claiming the name `"Foo"`.

Symbol-database extraction walks `ObjectSpace` and groups entries by `Module#name`. With two `Foo`s, the hash collision is broken by `ObjectSpace` iteration order — last-write-wins. The "winner" can pair a `MODULE` entry from one binding with a `CLASS` entry from a different binding, placing them in separate `FILE` trees. The resulting `MODULE` scope has no nested `CLASS`. `Scope#to_h` drops the empty `scopes` key via `h.compact!`, and downstream `.find` on it raises `NoMethodError: undefined method 'find' for nil:NilClass`.

Where this matters:

- **Customer impact:** Rails reloaders, hot-loaded plugins, and certain DSL idioms use `remove_const`-then-redefine. Without this fix, stale `Class` objects ship to the symbol database alongside the current bindings.
- **CI flakiness:** [PR #5525](https://github.com/DataDog/dd-trace-rb/pull/5525) CI run [`26135917255`](https://github.com/DataDog/dd-trace-rb/actions/runs/26135917255) failed `spec/datadog/symbol_database/remote_config_integration_spec.rb:76` on Ruby 3.2 [3] and Ruby 4.0 [0]. The same bug is on master but dormant — recent CI seeds happened to iterate `ObjectSpace` in an order that paired matching `MODULE`+`CLASS` entries.

The fix: `Extractor#collect_extractable_modules` now skips any `Class`/`Module` whose cached `Module#name` no longer resolves to the same object through Ruby's constant table. Stale entries are filtered before the name-keyed hash is built, so the collision never happens.

**Change log entry**

Yes. Symbol database: stale class definitions are no longer uploaded in applications that use `remove_const`-then-redefine patterns (Rails reloaders, hot-loaded plugins). Affects autocomplete accuracy in the Dynamic Instrumentation UI.

**Additional Notes:**

`resolves_to_same_module?` walks the namespace path segment-by-segment, calling `Module#autoload?` at each step. A pending autoload at any segment is treated as "does not resolve" without ever calling `const_get` on the autoload target.

This matters because extraction must not load customer code as a side effect: a naive `Object.const_get(mod_name)` triggers any autoload registered for `mod_name`, loading customer files and raising `LoadError` if the target file is missing. `LoadError` is `ScriptError`, not `StandardError`, so it isn't caught by the `rescue` blocks in `collect_extractable_modules` — without the segment walk, `extract_all` would abort instead of just skipping the leaked `Class`.

**How to test the change?**

Two new unit tests in `spec/datadog/symbol_database/extractor_spec.rb` under `describe '.extract_all'`:

1. **`'class detached from its constant via remove_const'`** — loads a class, captures a hard reference, `remove_const`s, redefines at a different path, then asserts `extract_all` produces only the new binding's `FILE` scope.
2. **`'autoload registered after remove_const'`** — loads a class, captures a reference, `remove_const`s, registers an autoload at the same name pointing at a non-existent file, then asserts `extract_all` runs without raising and the autoload remains pending (no `require` triggered).

Verified locally on Ruby 3.2.3:

- Both new unit tests pass.
- Re-running the original flaky scope (`spec/datadog/symbol_database/**/*_spec.rb,spec/datadog/core/**/*_spec.rb` with seed `32729`, which deterministically reproduced the symdb failure before this change) no longer reports the failure.
- All 351 examples in `spec/datadog/symbol_database/**/*_spec.rb` pass.
- `bundle exec steep check lib/datadog/symbol_database/extractor.rb` is clean.
