### PR TITLE
Reproducer: flaky thread_context_spec "records a regular sample" (busy-wait, mechanism)

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1348,6 +1348,14 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
 
+              # Reproduce the CI failure mode: under valgrind, t1's per-thread CPU clock
+              # ticks between sample calls even when t1 is in Kernel.sleep. Rewinding
+              # cpu_time_at_previous_sample_ns by a small amount forces the next sample
+              # to compute cpu_time_elapsed_ns > 0, which makes state detection
+              # short-circuit to "had cpu" instead of running the stack-based detection
+              # that would label the sample "sleeping".
+              apply_delta_to_cpu_time_at_previous_sample_ns(t1, -12345)
+
               # This is a rare situation (but can still happen) -- the thread was Waiting for GVL on the previous sample,
               # but the overall duration of the Waiting for GVL was below the threshold. This means that on_gvl_running
               # clears the Waiting for GVL state, and the next sample is immediately back to being a regular sample.

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1318,16 +1318,35 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           context "when Waiting for GVL duration < the threshold" do
             let(:waiting_for_gvl_threshold_ns) { 1_000_000_000 }
 
+            # Reproducer for the CI flake observed in PR #5871's `test-memcheck` job
+            # (https://github.com/DataDog/dd-trace-rb/actions/runs/27163185182/job/80183618479).
+            # Tests the mechanism hypothesized by Ivo Anjo in PR #5879: there's no
+            # atomicity between `ready_queue << true` and `sleep` in the default `t1`.
+            # Under valgrind's slow, single-threaded scheduling, the test setup proceeds
+            # while `t1` is still on the path to `sleep`, so `t1` legitimately accrues
+            # cpu-time between the setup's last `sample` and the test body's `sample`.
+            # A positive `cpu_time_elapsed_ns` short-circuits state detection in
+            # collectors_stack.c:288-293 to "had cpu", bypassing the stack-based
+            # "sleeping" detection.
+            #
+            # This override forces the race deterministically by busy-waiting (instead
+            # of going straight to `sleep`) for long enough to cover the setup chain on
+            # any environment.
+            let(:t1) do
+              Thread.new(ready_queue) do |ready_queue|
+                inside_t1 do
+                  ready_queue << true
+                  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) + 0.5
+                  while Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) < deadline
+                    Thread.pass
+                  end
+                  sleep
+                end
+              end
+            end
+
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
-
-              # Reproduce the CI failure mode: under valgrind, t1's per-thread CPU clock
-              # ticks between sample calls even when t1 is in Kernel.sleep. Rewinding
-              # cpu_time_at_previous_sample_ns by a small amount forces the next sample
-              # to compute cpu_time_elapsed_ns > 0, which makes state detection
-              # short-circuit to "had cpu" instead of running the stack-based detection
-              # that would label the sample "sleeping".
-              apply_delta_to_cpu_time_at_previous_sample_ns(t1, -12345)
 
               # This is a rare situation (but can still happen) -- the thread was Waiting for GVL on the previous sample,
               # but the overall duration of the Waiting for GVL was below the threshold. This means that on_gvl_running


### PR DESCRIPTION
**What does this PR do?**

Reproduces the flaky test `spec/datadog/profiling/collectors/thread_context_spec.rb` `"records a regular sample"` (under `timeline support` → `when thread is Waiting for GVL` → `when thread is ready to run again` → `when Waiting for GVL duration < the threshold`).

Tests the upstream **mechanism** hypothesized by @ivoanjo in [#5879](https://github.com/DataDog/dd-trace-rb/pull/5879): there is no atomicity between `ready_queue << true` and `sleep` in the default `t1`. Under valgrind's slow + single-threaded scheduling, the test setup proceeds while `t1` is still on the path to `sleep`, so `t1` legitimately accrues cpu-time between the setup's last `sample` and the test body's `sample`. A positive `cpu_time_elapsed_ns` short-circuits state detection in `collectors_stack.c:288-293` to `"had cpu"`, bypassing the stack-based `"sleeping"` detection.

The reproducer overrides `let(:t1)` only inside the failing context (no global effect) so `t1` busy-waits 500ms between `ready_queue << true` and `sleep` — long enough to cover the setup chain on any environment. The override produces the exact CI failure shape (`expected "sleeping" got "had cpu"`) deterministically, without requiring valgrind.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Original CI failure: [test-memcheck on PR #5871](https://github.com/DataDog/dd-trace-rb/actions/runs/27163185182/job/80183618479).

The test failed under valgrind (`spec:profiling:memcheck`) and passed under ASan (`spec:profiling:main`) on the same commit `c665434c` — the textbook flake signature (pass/fail divergence across jobs on the same commit).

**History — what changed from the prior version of this PR:**

The earlier version of this PR (commit `59fd54ab7c`, now superseded) used `apply_delta_to_cpu_time_at_previous_sample_ns(t1, -12345)` to mock the downstream symptom by directly mutating `cpu_time_at_previous_sample_ns`. That approach reproduced the failure shape but was mechanism-agnostic: it could not distinguish the AI's CPU-clock-tick-on-sleeping-thread hypothesis from Ivo's race hypothesis — both produce the same downstream effect (positive `cpu_time_elapsed_ns` at the test body's `sample`). The field-rewind was a symptom-shape reproducer, not a mechanism reproducer.

This version replaces the field-rewind with a busy-wait construction that exercises Ivo's hypothesized race directly. Ivo described the same construction (with a longer 1s wait) in #5879's "Additional Notes" to force the failure mode his fix addresses. This reproducer is therefore a deterministic local validation target for #5879's fix.

**Local verification:**

- Failing test, 5 runs: 5/5 failures with `expected "sleeping" got "had cpu"`.
- Full file (`spec/datadog/profiling/collectors/thread_context_spec.rb`): 178 examples, 1 failure (the targeted test), 2 unrelated pendings — confirming the override is correctly scoped.

**Change log entry**

None.

**How to test the change?**

CI is expected to fail on this PR with `state: "had cpu"` vs expected `"sleeping"` on `spec/datadog/profiling/collectors/thread_context_spec.rb` across **all** environments (memcheck, asan, and standard jobs) — not just valgrind. If CI passes, Ivo's hypothesis is wrong or this reproducer doesn't hit the same code path.

**Companion PRs**

- Candidate fix: [#5879](https://github.com/DataDog/dd-trace-rb/pull/5879) (`loop_until { … "sleep" }` wait in the setup helper). Expected to neutralize this reproducer.
- Alternative fix: [#5874](https://github.com/DataDog/dd-trace-rb/pull/5874) (`INVALID_TIME` reset before sample). Also expected to neutralize this reproducer, because the `INVALID_TIME` reset forces `cpu_time_elapsed_ns = 0` regardless of upstream cause.
