### PR TITLE
Fix flaky thread_context_spec "records a regular sample" under valgrind

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       ._native_apply_delta_to_cpu_time_at_previous_sample_ns(thread, delta_ns)
   end
 
+  # Resets cpu_time_at_previous_sample_ns to INVALID_TIME (-1) so the next sample
+  # treats current_cpu_time_ns as the previous one (elapsed = 0). Used to neutralize
+  # per-thread CPU clock ticks that can otherwise flip a "sleeping" sample into
+  # "had cpu" under slow environments such as valgrind.
+  def invalidate_cpu_time_at_previous_sample_ns(thread)
+    current = per_thread_context.dig(thread, :cpu_time_at_previous_sample_ns)
+    apply_delta_to_cpu_time_at_previous_sample_ns(thread, -(current + 1))
+  end
+
   def prepare_sample_inside_signal_handler
     described_class::Testing._native_prepare_sample_inside_signal_handler
   end
@@ -1347,6 +1356,17 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
+
+              # Make the cpu-time delta deterministic. Under slow environments such as
+              # valgrind, t1's per-thread CPU clock can tick between the last setup
+              # `sample` (which updates cpu_time_at_previous_sample_ns in
+              # handle_gvl_waiting's situation-1 extra-sample path) and the test's
+              # `sample` call below — even though t1 is in `Kernel.sleep`. A non-zero
+              # cpu_time_elapsed_ns short-circuits state detection in collectors_stack.c
+              # to "had cpu", bypassing the stack-based "sleeping" detection this test
+              # is asserting. Resetting cpu_time_at_previous_sample_ns to INVALID_TIME
+              # forces the next sample's elapsed to 0 so the stack-based path runs.
+              invalidate_cpu_time_at_previous_sample_ns(t1)
 
               # This is a rare situation (but can still happen) -- the thread was Waiting for GVL on the previous sample,
               # but the overall duration of the Waiting for GVL was below the threshold. This means that on_gvl_running


### PR DESCRIPTION
**What does this PR do?**

Fixes the flaky test `spec/datadog/profiling/collectors/thread_context_spec.rb` `"records a regular sample"` (timeline support → Waiting for GVL → ready to run again → duration < threshold).

**Motivation:**

Original CI failure: [test-memcheck on PR #5871](https://github.com/DataDog/dd-trace-rb/actions/runs/27163185182/job/80183618479).

**Failure:** test under valgrind asserted `state: "sleeping"` but got `state: "had cpu"`.

**Root cause:** State detection in `collectors_stack.c:288-293` short-circuits to `"had cpu"` whenever `cpu_time_ns > 0`, bypassing the stack-based `"sleeping"` detection. The test's last update of `cpu_time_at_previous_sample_ns` happens in `handle_gvl_waiting`'s situation-1 extra-sample path during setup (`collectors_thread_context.c:2098`). Several calls later (`recorder.serialize!`, `on_gvl_running`, expectations), the test body takes another `sample` and computes the cpu-time delta from that earlier snapshot. Under valgrind, `t1`'s per-thread CPU clock (`CLOCK_THREAD_CPUTIME_ID`) ticks between those two snapshots even when `t1` is in `Kernel.sleep`, because valgrind serializes all threads onto a single OS thread and briefly schedules `t1`. A single nanosecond of delta is enough to flip the state.

**Fix:** introduces an `invalidate_cpu_time_at_previous_sample_ns(thread)` test helper that resets `cpu_time_at_previous_sample_ns` to `INVALID_TIME` via the existing `_native_apply_delta_to_cpu_time_at_previous_sample_ns` interface. Calling it just before `sample_and_check` makes the next sample's elapsed cpu-time deterministically 0, so the stack-based `"sleeping"` detection path runs. The assertion is unchanged.

**Change log entry**

None.

**How to test the change?**

- Run `bundle exec rspec spec/datadog/profiling/collectors/thread_context_spec.rb -e "records a regular sample"` — passes.
- Full file: `bundle exec rspec spec/datadog/profiling/collectors/thread_context_spec.rb` — 178 examples, 0 failures, 2 pending (unrelated).

**CI validation (companion PRs, now closed):**

A reproducer PR forced the same code path deterministically (without needing valgrind) by rewinding `cpu_time_at_previous_sample_ns`; a validation PR merged this fix into the reproducer to prove the fix neutralizes the forced failure.

- Reproducer (closed): #5873 — `test-memcheck` and `test-asan` both [failed on the target test](https://github.com/DataDog/dd-trace-rb/actions/runs/27171091307) (`expected "sleeping" got "had cpu"`), as did all standard build-and-test jobs, confirming the reproducer is deterministic everywhere.
- Validation (closed): #5875 — [`test-memcheck` and `test-asan` both pass](https://github.com/DataDog/dd-trace-rb/actions/runs/27171111899) with both the reproducer rewind and this fix applied. The `INVALID_TIME` reset wins because it runs after the rewind.
