### PR TITLE
Validate fix for flaky thread_context_spec "records a regular sample"

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       ._native_apply_delta_to_cpu_time_at_previous_sample_ns(thread, delta_ns)
   end
 
+  # Resets cpu_time_at_previous_sample_ns to INVALID_TIME (-1) so the next sample
+  # treats current_cpu_time_ns as the previous one (elapsed = 0). Used to neutralize
+  # per-thread CPU clock ticks that can otherwise flip a "sleeping" sample into
+  # "had cpu" under slow environments such as valgrind.
+  def invalidate_cpu_time_at_previous_sample_ns(thread)
+    current = per_thread_context.dig(thread, :cpu_time_at_previous_sample_ns)
+    apply_delta_to_cpu_time_at_previous_sample_ns(thread, -(current + 1))
+  end
+
   def prepare_sample_inside_signal_handler
     described_class::Testing._native_prepare_sample_inside_signal_handler
   end
@@ -1347,6 +1356,17 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
+
+              # Make the cpu-time delta deterministic. Under slow environments such as
+              # valgrind, t1's per-thread CPU clock can tick between the last setup
+              # `sample` (which updates cpu_time_at_previous_sample_ns in
+              # handle_gvl_waiting's situation-1 extra-sample path) and the test's
+              # `sample` call below — even though t1 is in `Kernel.sleep`. A non-zero
+              # cpu_time_elapsed_ns short-circuits state detection in collectors_stack.c
+              # to "had cpu", bypassing the stack-based "sleeping" detection this test
+              # is asserting. Resetting cpu_time_at_previous_sample_ns to INVALID_TIME
+              # forces the next sample's elapsed to 0 so the stack-based path runs.
+              invalidate_cpu_time_at_previous_sample_ns(t1)
 
               # This is a rare situation (but can still happen) -- the thread was Waiting for GVL on the previous sample,
               # but the overall duration of the Waiting for GVL was below the threshold. This means that on_gvl_running

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1348,6 +1348,14 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
 
+              # Reproduce the CI failure mode: under valgrind, t1's per-thread CPU clock
+              # ticks between sample calls even when t1 is in Kernel.sleep. Rewinding
+              # cpu_time_at_previous_sample_ns by a small amount forces the next sample
+              # to compute cpu_time_elapsed_ns > 0, which makes state detection
+              # short-circuit to "had cpu" instead of running the stack-based detection
+              # that would label the sample "sleeping".
+              apply_delta_to_cpu_time_at_previous_sample_ns(t1, -12345)
+
               # This is a rare situation (but can still happen) -- the thread was Waiting for GVL on the previous sample,
               # but the overall duration of the Waiting for GVL was below the threshold. This means that on_gvl_running
               # clears the Waiting for GVL state, and the next sample is immediately back to being a regular sample.


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix in #5874 neutralizes the deterministic reproducer in #5873.

This branch merges:
- Reproducer PR: #5873 (forces the cpu_time delta > 0 condition)
- Fix PR: #5874 (resets cpu_time_at_previous_sample_ns to INVALID_TIME)

If CI passes, the fix addresses the exact failure mode the reproducer forces. If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for validation only.

**Change log entry**

None.

**How to test the change?**

CI passes = fix neutralizes the forced failure. CI fails = fix is insufficient.

Verified locally: `bundle exec rspec spec/datadog/profiling/collectors/thread_context_spec.rb -e "records a regular sample"` passes with both the rewind and the invalidate applied (the fix's `INVALID_TIME` reset wins over the reproducer's rewind).

**Companion PRs** (will be cross-linked once all three exist).

**Companion PRs:**
- Reproducer: #5873
- Fix: #5874