### PR TITLE
Clarify CLAUDE.md changelog rule: split internal vs product-facing telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@
 - Write for the developer performing code review; be concise
 - Use one sentence per relevant point in summary/motivation sections
 - Changelog entries are written for customers only; consider changes from user/customer POV
-- Internal changes (telemetry, CI, tooling) = "None" for changelog
+- Internal changes (CI, tooling, tracer-internal telemetry consumed only by Datadog engineering) = "None" for changelog
+- Telemetry that powers customer-facing Datadog product features (symbol database → DI autocomplete UI, profiling data → Profiler UI, AppSec events → AppSec UI, etc.) = "Yes" with a customer-facing summary, even though the data flow is tracer → Datadog backend
 - Changelog entry format: MUST start with "Yes." or "None."
   - If changes need CHANGELOG: `Yes. Brief customer-facing summary.`
   - If no CHANGELOG needed: `None.`


### PR DESCRIPTION
**What does this PR do?**

Splits the CLAUDE.md changelog rule for "telemetry" into two categories so future contributors (and AI agents reading CLAUDE.md) don't misclassify product-facing telemetry as internal.

**Motivation:**

The previous wording reads:

> Internal changes (telemetry, CI, tooling) = "None" for changelog

This lumps two categories with opposite customer visibility under the same word:

- **Tracer-internal telemetry** (health metrics, internal error counts) — consumed only by Datadog engineering, never surfaced to customers. Changelog: `None.`
- **Product telemetry** (symbol database → DI autocomplete UI, profiling data → Profiler UI, AppSec events → AppSec UI) — customers see and act on this data in the Datadog product. Changelog: `Yes.`

Both flow tracer → Datadog backend, so the structural similarity invited treating product telemetry as internal. This produced a real miscategorization on [PR #5872](https://github.com/DataDog/dd-trace-rb/pull/5872): a symbol-database bugfix was initially proposed with `None.` despite affecting DI autocomplete accuracy that customers see. The miscategorization was caught in review and the changelog was updated to `Yes.`, but the rule that misled it is still there.

The new wording names the disambiguator explicitly ("consumed only by Datadog engineering" vs "powers customer-facing Datadog product features") and gives concrete examples for each side.

**Change log entry**

None.

**Additional Notes:**

Documentation/instructions change. No code paths affected.

**How to test the change?**

N/A — instructions-only change.