### PR TITLE
[NO-TICKET] Fix flaky asssertion that thread expected to be sleeping wasn't

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
     @clean_threads_required = true
     testing_threads.each { ready_queue.pop }
+    # Make sure all threads have reached the `sleep` before moving on
+    loop_until { testing_threads.all? { |t| t.status == "sleep" } }
     expect(Thread.list).to include(*testing_threads)
 
     testing_threads_and_current.each { |t| clear_per_thread_context_for(t) }


### PR DESCRIPTION
**What does this PR do?**

This PR is an attempt at fixing the flaky issue from test-memcheck runs (e.g. with valgrind) seen in
<https://github.com/DataDog/dd-trace-rb/actions/runs/27163185182/job/80183618479>:

```
Failures:

  1) Datadog::Profiling::Collectors::ThreadContext#sample timeline support when thread is Waiting for GVL when thread is ready to run again when Waiting for GVL duration < the threshold records a regular sample
     Failure/Error:
       expect(latest_sample.labels).to include(
         state: expected_state,
         end_timestamp_ns: be_between(time_before_sample, time_after_sample),
       )

       expected {end_timestamp_ns: 1780948784772095860, state: "had cpu", "thread id": "4043 (29584)", "thread name": "/home/runner/work/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:338"} to include {state: "sleeping"}
       Diff:
       @@ -1,2 +1,4 @@
       -:end_timestamp_ns => (be between 1780948784771880476 and 1780948784773149367 (inclusive)),
       -:state => "sleeping",
       +:end_timestamp_ns => 1780948784772095860,
       +:state => "had cpu",
       +:"thread id" => "4043 (29584)",
       +:"thread name" => "/home/runner/work/dd-trace-rb/dd-trace-rb/spec/spec_helper.rb:338",
     # ./spec/datadog/profiling/collectors/thread_context_spec.rb:1270:in 'RSpec::ExampleGroups::DatadogProfilingCollectorsThreadContext::Sample::TimelineSupport::WhenThreadIsWaitingForGVL#sample_and_check'
     # ./spec/datadog/profiling/collectors/thread_context_spec.rb:1358:in 'block (7 levels) in <top (required)>'
     # ./spec/spec_helper.rb:323:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:203:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.4.0/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in 'block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in 'ForkableExample#run'

Finished in 4 minutes 43.2 seconds (files took 22.96 seconds to load)
763 examples, 1 failure, 15 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/thread_context_spec.rb:1348 # Datadog::Profiling::Collectors::ThreadContext#sample timeline support when thread is Waiting for GVL when thread is ready to run again when Waiting for GVL duration < the threshold records a regular sample

Randomized with seed 54715
```

In this failure, a thread that is expected to be sleeping (`t1`) actually still has a bit of cpu-time use between two samples, which causes the assertion to fail.

In PR https://github.com/DataDog/dd-trace-rb/pull/5874 @p-datadog proposed that the root cause for this is

> Under valgrind, t1's per-thread CPU clock (CLOCK_THREAD_CPUTIME_ID) ticks between those two snapshots even when t1 is in Kernel.sleep, because valgrind serializes all threads onto a single OS thread and briefly schedules t1. A single nanosecond of delta is enough to flip the state.

My suspicion is that this root cause points the way but it's not quite right. That is, I suspect the issue here is that since valgrind is very slow + it forces single-threaded execution, what happened was that there's no actual atomicity between `ready_queue << true` and the call to `sleep`:

```ruby
  let(:t1) do
    Thread.new(ready_queue) do |ready_queue|
      inside_t1 do
        ready_queue << true
        # <--- Nothing guarantees that Ruby won't thread switch away exactly here
        sleep
      end
    end
```

and thus the test started while `t1` was still "moving", and that's why we see cpu-time assigned to `sleep`.

Thus, my proposed solution as an alternative to https://github.com/DataDog/dd-trace-rb/pull/5874 addresses this issue by actually waiting for the thread state to become "sleep" -- once this happens, the thread really should not have any more cpu-time spent.

**Motivation:**

Fix flaky spec!

**Change log entry**

None.

**Additional Notes:**

I could not reproduce the flake, but I did try forcing the hypothetical situation to happen with:

```ruby
  let(:t1) do
    Thread.new(ready_queue) do |ready_queue|
      inside_t1 do
        ready_queue << true
        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) + 1
        while Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) < deadline
          Thread.pass
        end
        sleep
      end
    end
  end
```

and indeed the test would fail under this situation.

So while I cannot _guarantee_ that this is indeed the source of the issue, it seems to me more likely than "valgrind made a sleeping thread spend cpu-time"...

**How to test the change?**

As I mentioned, since I can't reproduce this, I can't prove that this is the actual root cause, or if there are others. So we'll need to be on the watch out to see if this flakes again or not.