### PR TITLE
[NO-TICKET] Clean old benchmark compatibility code

### DIFF
--- a/benchmarks/profiling_sample_gvl.rb
+++ b/benchmarks/profiling_sample_gvl.rb
@@ -56,15 +56,7 @@ class ProfilerSampleGvlBenchmark
       x.report("gvl benchmark samples") do
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gvl_waiting(@target_thread)
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gvl_running(@collector, @target_thread)
-
-        # Benchmark backwards compatibility
-        if Datadog::Profiling::Collectors::ThreadContext::Testing.method(:_native_sample_after_gvl_running).arity == 3
-          # New version since https://github.com/DataDog/dd-trace-rb/pull/5076
-          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gvl_running(@collector, @target_thread, false)
-        else
-          # Old version, this can be deleted after, say, 2026-02-01
-          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gvl_running(@collector, @target_thread)
-        end
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gvl_running(@collector, @target_thread, false)
       end
 
       x.save! "#{File.basename(__FILE__, '.rb')}-results.json" unless VALIDATE_BENCHMARK_MODE


### PR DESCRIPTION
**What does this PR do?**

This PR removes some leftover code needed to test out the `profiling_sample_gvl.rb` across two branches where the `_native_sample_after_gvl_running` had been refactored.

This is no longer needed.

**Motivation:**

Cleanup unused old code path.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

The `./spec/datadog/profiling/validate_benchmarks_spec.rb` can be used to validate that all benchmarks still run fine, so it validates that indeed the old code path is no longer in use.