### PR TITLE
DI benchmarks: fix di_snapshot URL, refresh di_instrument header

### DIFF
--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -4,14 +4,15 @@
 # Typical result (Intel Core Ultra 7 165U, Ruby 3.2.3, intel_pstate/no_turbo=1
 # locking P-cores at 1.7 GHz base, taskset -c 2,3 pinning to one P-core):
 #
-# Comparison:
-#       no instrumentation - again:   242268.1 i/s
-#   line instrumentation - cleared:   242757.1 i/s - same-ish: within error
-#               no instrumentation:   240234.8 i/s - same-ish: within error
-# method instrumentation - cleared:   234189.2 i/s - same-ish: within error
-#           method instrumentation:   138017.6 i/s - 1.74x  slower
-#  line instrumentation - targeted:   117677.4 i/s - 2.04x  slower
-# line instrumentation - untargeted:   25021.7 i/s - 9.60x  slower
+# Reports in execution order, with i/s and slowdown vs. the initial baseline:
+#
+#               no instrumentation:   240234.8 i/s   1.00x  (baseline)
+#           method instrumentation:   138017.6 i/s   1.74x  slower
+# line instrumentation - untargeted:   25021.7 i/s   9.60x  slower
+#  line instrumentation - targeted:   117677.4 i/s   2.04x  slower
+# method instrumentation - cleared:   234189.2 i/s   1.03x  slower (within error)
+#   line instrumentation - cleared:   242757.1 i/s   0.99x  faster (within error)
+#       no instrumentation - again:   242268.1 i/s   0.99x  faster (within error)
 #
 # Per-report error bands were +/- 1.4% to 2.2% on all configurations except
 # untargeted line (+/- 5.1%, which is intrinsic to its 40 us/iteration cost

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -1,36 +1,45 @@
 #
 # "Instrumentation" part of Dynamic Instrumentation benchmarks.
 #
-# Typical result:
+# Typical result (Intel Core Ultra 7 165U, Ruby 3.2.3, intel_pstate/no_turbo=1
+# locking P-cores at 1.7 GHz base, taskset -c 2,3 pinning to one P-core):
 #
 # Comparison:
-#   no instrumentation:   589490.0 i/s
-# method instrumentation - cleared:   545807.2 i/s - 1.08x  slower
-# line instrumentation - cleared:   539686.5 i/s - 1.09x  slower
-# no instrumentation - again:   535761.0 i/s - 1.10x  slower
-# method instrumentation:   129159.5 i/s - 4.56x  slower
-# line instrumentation - targeted:   128848.6 i/s - 4.58x  slower
-# line instrumentation:    10771.7 i/s - 54.73x  slower
+#       no instrumentation - again:   242268.1 i/s
+#   line instrumentation - cleared:   242757.1 i/s - same-ish: within error
+#               no instrumentation:   240234.8 i/s - same-ish: within error
+# method instrumentation - cleared:   234189.2 i/s - same-ish: within error
+#           method instrumentation:   138017.6 i/s - 1.74x  slower
+#  line instrumentation - targeted:   117677.4 i/s - 2.04x  slower
+# line instrumentation - untargeted:   25021.7 i/s - 9.60x  slower
 #
-# Targeted line and method instrumentations have similar performance at
-# about 25% of baseline. Note that the instrumented method is fairly
-# small and probably runs very quickly by itself, so while this is not the
-# worst possible case for instrumentation (that would be an empty method),
-# likely the vast majority of real world uses of DI would have way expensive
-# target code and the relative overhead of instrumentation will be significantly
-# lower than it is in this benchmark.
+# Per-report error bands were +/- 1.4% to 2.2% on all configurations except
+# untargeted line (+/- 5.1%, which is intrinsic to its 40 us/iteration cost
+# yielding only ~2,500 iterations per 100 ms benchmark/ips sample).
 #
-# Untargeted line instrumentation is extremely slow, too slow to be usable.
+# Targeted line and method instrumentation have similar performance at about
+# 50-60% of baseline on this trivial target method. Real-world targets do more
+# per call, so the relative overhead of instrumentation will be lower in
+# practice than it is in this benchmark.
 #
-# In theory, after instrumentation is removed, performance should return to
-# the baseline. We are currently observing about a 6-10% performance loss.
-# Two theories for why this is so:
-# 1. Some overhead remains in the code - to be investigated.
-# 2. The benchmarks were run on a laptop, and during the benchmarking
-# process the CPU is heating up and it can't turbo to the same speeds at
-# the end of the run as it can at the beginning. Meaning the observed 6-10%
-# slowdown at the end is an environmental issue and not an implementation
-# problem.
+# Untargeted line instrumentation is the slowest configuration by ~4.7x over
+# the next-slowest, and remains too slow to be usable.
+#
+# After instrumentation is removed, performance returns to baseline within
+# measurement error: method-cleared was 2.6% below baseline, line-cleared was
+# 1.1% above baseline, no-instr-again was 0.8% above baseline -- all within the
+# +/- 1.6-2.2% error bands. A prior version of this header documented a 6-10%
+# residual loss with two candidate causes (lingering code overhead vs. CPU
+# thermal throttling); the throttling theory is consistent with what we see
+# now -- with turbo disabled the residual loss disappears.
+#
+# To reproduce stable measurements on a laptop, run as root:
+#   echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+# then run the benchmark pinned to one P-core's SMT pair:
+#   taskset -c 2,3 bundle exec ruby benchmarks/di_instrument.rb
+# Without these, the default intel_pstate powersave governor swings P-core
+# frequency between 400 MHz and ~4.3 GHz under load, producing +/- 16-36%
+# per-report error bands that swamp the differences this benchmark measures.
 #
 
 # Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot

--- a/benchmarks/di_snapshot.rb
+++ b/benchmarks/di_snapshot.rb
@@ -234,7 +234,7 @@ class DISnapshotBenchmark
         # This request is a multipart form post
       end
 
-      server.mount_proc('/debugger/v1/input') do |req, res|
+      server.mount_proc('/debugger/v2/input') do |req, res|
         payload = JSON.parse(req.body)
         @received_snapshot_count += payload.length
         @received_snapshot_bytes += req.body.length


### PR DESCRIPTION
**What does this PR do?**

Two fixes to the Dynamic Instrumentation benchmarks under `benchmarks/`:

1. `di_snapshot.rb` — the fake WEBrick server mounts `/debugger/v2/input` so it actually receives snapshot uploads. The DI transport at `lib/datadog/di/transport/http.rb:19` was switched from v1 to v2 input previously, but the benchmark's mock endpoint kept the old path, so the "Received N snapshots" diagnostic line always printed 0.
2. `di_instrument.rb` — the "Typical result" header block is refreshed with measurements taken under reproducible conditions, and the reproduction recipe is included in the comment.

**Motivation:**

`di_snapshot.rb`: it feels like the snapshot-count diagnostic was silently broken because nobody hit the v1/v2 transport mismatch. With the fix, all four reports return non-zero snapshot counts and the benchmark's secondary check (size of snapshots flushed) is meaningful again.

`di_instrument.rb`: the previous header numbers couldn't be reproduced without knowing the original measurement conditions. The new header records numbers taken with `intel_pstate/no_turbo=1` and `taskset -c 2,3` pinning, error bands ±1.4–2.2% on most reports, plus the recipe for reproducing the setup. The 6-10% post-unhook residual loss the old header documented does not appear under these conditions — consistent with the original header's second hypothesis that the effect was CPU thermal throttling, not lingering instrumentation overhead.

**Change log entry**

None.

**Additional Notes:**

The `di_instrument` header change is comments only — no code change. The numbers were taken from a laptop run on master (commit b75cf221d3) under Ruby 3.2.3 with the configuration documented in the new header. We should expect different absolute numbers on different hardware; the slowdown ratios and the post-unhook return-to-baseline behavior are what matter.

**How to test the change?**

Validate mode (what the existing `spec/datadog/di/validate_benchmarks_spec.rb` runs):

```
VALIDATE_BENCHMARK=true bundle exec ruby benchmarks/di_instrument.rb
VALIDATE_BENCHMARK=true bundle exec ruby benchmarks/di_snapshot.rb
```

Both should complete without raising. The existing validate spec exercises this path.

To confirm the `di_snapshot` URL fix delivers snapshots end-to-end, a real run shows non-zero counts for all four reports:

```
taskset -c 2,3 bundle exec ruby benchmarks/di_snapshot.rb
# Sample output after fix:
# Received 67948 snapshots, 174203253 bytes total   (method probe - basic)
# Received 12 snapshots, 237661 bytes total         (method probe - enriched)
# Received 67778 snapshots, 177216549 bytes total   (line probe - basic)
# Received 12 snapshots, 1876224 bytes total        (line probe - enriched)
```

Before the fix the same counters reported 0 across all four reports.
