### PR TITLE
DI: add method-probe wrapper dispatch-semantics coverage for fibers, Ractors, refinements

### DIFF
--- a/Matrixfile
+++ b/Matrixfile
@@ -19,6 +19,12 @@
   'di:di_with_ext' => {
     '' => '❌ 2.5 / ✅ 2.6 / ✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ 4.0',
   },
+  # DI Ractor dispatch-semantics spec, isolated from di:di_with_ext to keep the regular
+  # DI job from transitioning the VM into multi-ractor mode. Ruby 3.0 is excluded because
+  # of the same Ractor stability issues that the in-spec skip guard covers.
+  'di:ractors' => {
+    '' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ 4.0',
+  },
   'core_with_rails' => {
     # Run with Rails integration
     'rails8' => '❌ 2.5 / ❌ 2.6 / ❌ 2.7 / ❌ 3.0 / ❌ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ 4.0',

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ namespace :spec do
     :graphql, :graphql_unified_trace_patcher, :graphql_trace_patcher, :graphql_tracing_patcher,
     :rails, :railsredis, :railsredis_activesupport, :railsactivejob,
     :elasticsearch, :http, :redis, :sidekiq, :sinatra, :hanami, :hanami_autoinstrument,
-    :profiling, :core_with_libdatadog_api, :"di:di_with_ext", :error_tracking, :open_feature, :core_with_rails, :environment, :ai_guard]
+    :profiling, :core_with_libdatadog_api, :"di:di_with_ext", :"di:ractors", :error_tracking, :open_feature, :core_with_rails, :environment, :ai_guard]
 
   desc '' # "Explicitly hiding from `rake -T`"
   RSpec::Core::RakeTask.new(:main) do |t, args|
@@ -477,7 +477,19 @@ namespace :spec do
     RSpec::Core::RakeTask.new(:di_with_ext) do |t, args|
       t.pattern = DI_WITH_EXT.join(', ')
       t.exclude_pattern = 'spec/datadog/di/contrib/**/*_spec.rb'
-      t.rspec_opts = args.to_a.join(' ')
+      t.rspec_opts = [*args.to_a, '-t ~ractors'].join(' ')
+    end.tap do |t|
+      Rake::Task[t.name].enhance(["compile:libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"])
+    end
+
+    # Ractor creation transitions the entire Ruby VM into multi-ractor mode permanently
+    # and can introduce order-dependent side effects on later examples. Splitting these
+    # examples into a dedicated task mirrors spec:profiling:ractors (see Rakefile around
+    # spec:profiling:main / :ractors) and keeps the regular DI job from mutating VM mode.
+    RSpec::Core::RakeTask.new(:ractors) do |t, args|
+      t.pattern = DI_WITH_EXT.join(', ')
+      t.exclude_pattern = 'spec/datadog/di/contrib/**/*_spec.rb'
+      t.rspec_opts = [*args.to_a, '-t ractors'].join(' ')
     end.tap do |t|
       Rake::Task[t.name].enhance(["compile:libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"])
     end

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -1,0 +1,441 @@
+require "datadog/di/spec_helper"
+require 'datadog/di/instrumenter'
+require 'datadog/di/code_tracker'
+require 'datadog/di/serializer'
+require 'datadog/di/probe'
+require 'datadog/di/proc_responder'
+require 'logger'
+
+# Pins down method-probe wrapper behavior under three Ruby dispatch
+# scenarios that the existing test suite does not exercise:
+#
+#   1. Fiber switches inside a probed method body (Fiber.yield + resume)
+#   2. Ractor isolation when a probed method is invoked inside a Ractor
+#   3. Refinements visibility through the method-probe prepend chain
+#
+# Each scenario was a stated edge-case concern when comparing the
+# do_super-lambda form of the method-probe wrapper to a hypothetical
+# block + yield form. None of these scenarios had explicit test
+# coverage in spec/datadog/di/ before this file; this fixes that gap.
+#
+# The tests document the current behavior on master. Any future
+# refactor of the method-probe wrapper (PR #5560's re-entrancy guard,
+# alternative wrapper forms, C-implemented wrappers) should keep these
+# assertions green or update them deliberately with a rationale.
+
+# The fixture classes below are defined at top-level so #hook_method
+# can resolve them by name through ProbeManager-equivalent paths. They
+# are deliberately tiny: the tests are about wrapper-dispatch
+# semantics, not about snapshot content.
+
+begin
+  Object.send(:remove_const, :FiberDispatchFixture)
+rescue NameError
+end
+class FiberDispatchFixture
+  attr_reader :resumed_count
+
+  def initialize
+    @resumed_count = 0
+  end
+
+  # Yields control back to the fiber's resumer in the middle of the
+  # method body, then returns. The probe fires on this method, so
+  # the wrapper's enter/leave_probe (or any equivalent guard
+  # bracketing in future implementations) must survive the
+  # Fiber.yield/resume round trip.
+  def yield_then_return(label)
+    @resumed_count += 1
+    Fiber.yield(label)
+    "returned-#{label}"
+  end
+
+  # Bare method that does not yield. Used as the "outer" method when
+  # nesting probed calls across fiber switches.
+  def simple(value)
+    "simple-#{value}"
+  end
+end
+
+begin
+  Object.send(:remove_const, :RactorDispatchFixture)
+rescue NameError
+end
+class RactorDispatchFixture
+  def value(n)
+    n * 2
+  end
+end
+
+begin
+  Object.send(:remove_const, :RefinementFixture)
+rescue NameError
+end
+class RefinementFixture
+  def greet(name)
+    "hello-#{name}"
+  end
+end
+
+# Refinement defined at top-level so it can be `using`-ed from a
+# nested module scope inside the example below.
+module RefinementFixtureRefinement
+  refine RefinementFixture do
+    def greet(name)
+      "refined-#{name}"
+    end
+  end
+end
+
+RSpec.describe 'Method probe dispatch semantics' do
+  di_test
+
+  let(:observed) { [] }
+  let(:propagate_all_exceptions) { true }
+
+  mock_settings_for_di do |settings|
+    allow(settings.dynamic_instrumentation).to receive(:enabled).and_return(true)
+    allow(settings.dynamic_instrumentation.internal).to receive(:untargeted_trace_points).and_return(false)
+    allow(settings.dynamic_instrumentation).to receive(:max_capture_depth).and_return(2)
+    allow(settings.dynamic_instrumentation).to receive(:max_capture_attribute_count).and_return(2)
+    allow(settings.dynamic_instrumentation).to receive(:max_capture_string_length).and_return(100)
+    allow(settings.dynamic_instrumentation).to receive(:redacted_type_names).and_return([])
+    allow(settings.dynamic_instrumentation).to receive(:redacted_identifiers).and_return([])
+    allow(settings.dynamic_instrumentation).to receive(:redaction_excluded_identifiers).and_return([])
+    allow(settings.dynamic_instrumentation.internal).to receive(:propagate_all_exceptions).and_return(propagate_all_exceptions)
+    allow(settings.dynamic_instrumentation.internal).to receive(:max_processing_time).and_return(1)
+  end
+
+  let(:redactor) { Datadog::DI::Redactor.new(settings) }
+  let(:serializer) { Datadog::DI::Serializer.new(settings, redactor) }
+  let(:logger) { instance_double(Logger).tap { |l| allow(l).to receive(:debug) } }
+  let(:instrumenter) { Datadog::DI::Instrumenter.new(settings, serializer, logger, code_tracker: nil) }
+
+  def install_probe(type_name, method_name, &on_fire)
+    probe = Datadog::DI::Probe.new(
+      id: 'method-probe-dispatch-semantics-spec',
+      type: :log,
+      type_name: type_name,
+      method_name: method_name,
+      capture_snapshot: false,
+    )
+    responder = Datadog::DI::ProcResponder.new(on_fire)
+    instrumenter.hook_method(probe, responder)
+    probe
+  end
+
+  describe 'fiber switches inside the probed method body' do
+    # The method-probe wrapper is invoked on the fiber that calls the
+    # probed method. During the method's execution, that fiber may
+    # invoke Fiber.yield, which transfers control back to whichever
+    # fiber called Fiber#resume. When the original fiber is resumed
+    # the wrapper's post-super work runs (snapshot build, responder
+    # callback). The assertions below pin down what must hold across
+    # that round trip.
+
+    after { instrumenter.unhook(probe) if probe }
+
+    let!(:probe) do
+      install_probe('FiberDispatchFixture', 'yield_then_return') do |context|
+        observed << context
+      end
+    end
+
+    it 'fires the probe exactly once per call when the body yields and resumes' do
+      fixture = FiberDispatchFixture.new
+      fiber = Fiber.new { fixture.yield_then_return('A') }
+      yielded = fiber.resume
+      expect(yielded).to eq('A')
+      # At this point the probed method is paused mid-body. The wrapper
+      # has not run its post-super hook yet because super has not returned.
+      expect(observed.length).to eq 0
+
+      returned = fiber.resume
+      expect(returned).to eq('returned-A')
+      # Once the body returns, the wrapper's post-super hook runs.
+      expect(observed.length).to eq 1
+      expect(observed.first.return_value).to eq('returned-A')
+    end
+
+    it 'isolates probe firings between concurrently-paused fibers' do
+      fixture = FiberDispatchFixture.new
+      fiber_x = Fiber.new { fixture.yield_then_return('X') }
+      fiber_y = Fiber.new { fixture.yield_then_return('Y') }
+
+      # Resume fiber_x — it enters the probed method, yields 'X' back.
+      expect(fiber_x.resume).to eq('X')
+      # Resume fiber_y — it independently enters the probed method,
+      # yields 'Y' back. fiber_x's in-progress probe state must not
+      # interfere with fiber_y's probe state.
+      expect(fiber_y.resume).to eq('Y')
+
+      # No firings yet — neither method has returned.
+      expect(observed.length).to eq 0
+
+      # Resume each fiber to completion. Each returns from its own
+      # call; each fires the probe exactly once.
+      expect(fiber_x.resume).to eq('returned-X')
+      expect(fiber_y.resume).to eq('returned-Y')
+
+      expect(observed.length).to eq 2
+      return_values = observed.map(&:return_value)
+      expect(return_values).to contain_exactly('returned-X', 'returned-Y')
+
+      # The fixture method body increments resumed_count once on first
+      # entry of each fiber. Both fibers entered the body, so the count
+      # is 2. (Verifies that the wrapper did not re-enter the body on
+      # the resume.)
+      expect(fixture.resumed_count).to eq 2
+    end
+
+    it 'fires the probe for a non-yielding probed call made inside a fiber' do
+      # A probed method that does NOT yield, invoked inside a fiber,
+      # behaves identically to the same call on the main fiber. Pins
+      # that the wrapper does not have a fiber-specific code path
+      # that diverges for non-yielding methods.
+      simple_probe = install_probe('FiberDispatchFixture', 'simple') do |context|
+        observed << context
+      end
+      begin
+        fixture = FiberDispatchFixture.new
+        fiber = Fiber.new { fixture.simple(:inside) }
+        expect(fiber.resume).to eq('simple-inside')
+        expect(observed.map(&:return_value)).to include('simple-inside')
+      ensure
+        instrumenter.unhook(simple_probe)
+      end
+    end
+
+    it 'preserves the customer method return value across a yield/resume cycle' do
+      # Pins the contract that the wrapper's post-super hook does not
+      # corrupt the return value when the body yielded and resumed
+      # during execution.
+      fixture = FiberDispatchFixture.new
+      fiber = Fiber.new { fixture.yield_then_return('Z') }
+      fiber.resume # yield point — discards yielded value
+      final = fiber.resume
+      expect(final).to eq('returned-Z')
+      expect(observed.first.return_value).to eq('returned-Z')
+    end
+
+    it 'releases the fiber-local probe state when a fiber yields away mid-probe and is discarded' do
+      # The wrapper sets up state (timing, args, context) before super.
+      # If the fiber is abandoned while paused inside super, that state
+      # is held only by the fiber's locals — it must not leak into any
+      # later probe firing on the parent fiber.
+      fixture = FiberDispatchFixture.new
+      fiber = Fiber.new { fixture.yield_then_return('orphan') }
+      yielded = fiber.resume
+      expect(yielded).to eq('orphan')
+
+      # Abandon the fiber. It will not be resumed and will be GC'd.
+      fiber = nil
+      GC.start
+
+      # A subsequent firing on the parent fiber should produce a
+      # snapshot only for that call, not be polluted by the abandoned
+      # fiber's in-progress state.
+      observed.clear
+      complete_fiber = Fiber.new { fixture.yield_then_return('completing') }
+      expect(complete_fiber.resume).to eq('completing')
+      expect(complete_fiber.resume).to eq('returned-completing')
+      expect(observed.length).to eq 1
+      expect(observed.first.return_value).to eq('returned-completing')
+    end
+  end
+
+  describe 'Ractor isolation when invoking a probed method' do
+    # Ractors enforce that user-defined Ruby objects passed across
+    # Ractor boundaries are either shareable (frozen / built-in / Ractor::makeshare
+    # processed) or accessed via copy. The method-probe wrapper closes over
+    # an Instrumenter instance, which holds a Logger, settings, a serializer,
+    # and a code tracker — none of which are Ractor-shareable.
+    #
+    # This describe block pins the observable behavior of calling a
+    # probed method inside a non-main Ractor. The expectation is that
+    # the wrapper's reference to the captured Instrumenter raises a
+    # Ractor::IsolationError (or equivalent) when the closure body
+    # tries to invoke instrumenter.* from the Ractor. Tests below do
+    # not enforce a specific error class — they enforce that the
+    # process does not crash and the error is communicable to the
+    # main Ractor, so future changes either keep this property or
+    # update the test deliberately.
+
+    before do
+      skip "Ractor requires Ruby 3.0+" if RUBY_VERSION < "3.0"
+      skip "Ractor was removed/renamed in Ruby 4.0" if RUBY_VERSION >= "4.0"
+    end
+
+    after { instrumenter.unhook(probe) if probe }
+
+    let!(:probe) do
+      install_probe('RactorDispatchFixture', 'value') do |context|
+        observed << context
+      end
+    end
+
+    it 'does not crash the VM when a probed method is invoked from a non-main Ractor' do
+      # The Ractor body invokes the probed method. The wrapper closure
+      # captures non-shareable state; invoking it from inside the Ractor
+      # must produce a Ruby-level error (any kind), not a VM crash.
+      result = nil
+      error_class = nil
+      begin
+        # Suppress Ractor experimental-warning noise on Ruby 3.x.
+        verbose_was = $VERBOSE
+        $VERBOSE = nil
+        ractor = Ractor.new do
+          begin
+            RactorDispatchFixture.new.value(21)
+          rescue => e
+            [:error, e.class.name, e.message]
+          else
+            [:ok, nil, nil]
+          end
+        end
+        result = ractor.take
+        error_class = result[1]
+      ensure
+        $VERBOSE = verbose_was
+      end
+
+      # Either the Ractor returns a captured error (most likely
+      # Ractor::IsolationError or Ractor::UnsafeError around the
+      # captured Instrumenter / Logger), or it succeeds because Ruby
+      # decided the closure was shareable enough. Both outcomes are
+      # acceptable — what we pin is that the process did not crash
+      # and the outcome was communicable to the main Ractor.
+      expect([:ok, :error]).to include(result[0])
+      if result[0] == :error
+        expect(error_class).to be_a(String)
+        expect(error_class).not_to be_empty
+      end
+    end
+
+    it 'does not fire the probe on the main Ractor when the call is made inside a non-main Ractor' do
+      # If the wrapper raises before super, the responder callback
+      # should never run. If the wrapper succeeds (with shareable
+      # state somehow), the responder may run inside the Ractor —
+      # but it would not append to the main Ractor's `observed`
+      # array (which is not shareable into the Ractor). Either way,
+      # the main Ractor's `observed` is empty.
+      verbose_was = $VERBOSE
+      $VERBOSE = nil
+      begin
+        ractor = Ractor.new do
+          begin
+            RactorDispatchFixture.new.value(7)
+            :ok
+          rescue
+            :error
+          end
+        end
+        ractor.take
+      ensure
+        $VERBOSE = verbose_was
+      end
+
+      expect(observed).to be_empty
+    end
+
+    it 'fires the probe normally on the main Ractor after a non-main-Ractor call has been attempted' do
+      # A non-main-Ractor call may have left some intermediate wrapper
+      # state behind (e.g., the wrapper began before raising). The
+      # next call from the main Ractor must still be a complete probe
+      # firing — no residual short-circuit from the failed Ractor
+      # invocation.
+      verbose_was = $VERBOSE
+      $VERBOSE = nil
+      begin
+        ractor = Ractor.new do
+          begin
+            RactorDispatchFixture.new.value(7)
+          rescue
+            nil
+          end
+        end
+        ractor.take
+      ensure
+        $VERBOSE = verbose_was
+      end
+
+      RactorDispatchFixture.new.value(11)
+      expect(observed.length).to eq 1
+      expect(observed.first.return_value).to eq 22
+    end
+  end
+
+  describe 'refinements visibility through the probe wrapper' do
+    # A method-probe wrapper is installed via Module#prepend on the
+    # target class. Refinements live in a separate dispatch namespace:
+    # they are looked up on every method invocation inside a `using`
+    # scope, before normal method lookup. Prepended modules sit at
+    # the front of the class's ancestors chain, so:
+    #
+    #   - Outside `using`: customer call → wrapper (prepended) → original method.
+    #   - Inside `using`: customer call → refined method (refinement lookup wins).
+    #
+    # The expected consequence is that probes installed on a class
+    # method do NOT fire when the customer calls the method from inside
+    # a `using` scope that refines that method, because refinement
+    # dispatch bypasses the prepend chain. This describe block pins
+    # that contract; if a future wrapper redesign makes refinements
+    # interact with the probe wrapper differently, the test will
+    # surface it deliberately rather than as a silent regression.
+
+    after { instrumenter.unhook(probe) if probe }
+
+    let!(:probe) do
+      install_probe('RefinementFixture', 'greet') do |context|
+        observed << context
+      end
+    end
+
+    it 'fires the probe when the method is called outside any `using` scope' do
+      result = RefinementFixture.new.greet('world')
+      expect(result).to eq('hello-world')
+      expect(observed.length).to eq 1
+      expect(observed.first.return_value).to eq('hello-world')
+    end
+
+    it 'does not fire the probe when the method is called from inside a `using` scope that refines it' do
+      # Refinements must be activated lexically. Define a fresh module,
+      # `using` the refinement inside it, and call the method from a
+      # method on that module. Refinement dispatch wins over the
+      # prepended wrapper, so the probe does not fire.
+      mod = Module.new do
+        using RefinementFixtureRefinement
+
+        def self.call_refined(fixture)
+          fixture.greet('world')
+        end
+      end
+
+      result = mod.call_refined(RefinementFixture.new)
+      expect(result).to eq('refined-world')
+      expect(observed).to be_empty
+    end
+
+    it 'fires the probe for callers outside the `using` scope even after another caller inside the scope did not fire' do
+      # Pins the contract that an in-scope refinement call does not
+      # disable the wrapper for out-of-scope callers. The probe state
+      # is unchanged by the refined call (because the wrapper was
+      # never invoked).
+      mod = Module.new do
+        using RefinementFixtureRefinement
+
+        def self.call_refined(fixture)
+          fixture.greet('world')
+        end
+      end
+
+      mod.call_refined(RefinementFixture.new)
+      expect(observed).to be_empty
+
+      result = RefinementFixture.new.greet('world')
+      expect(result).to eq('hello-world')
+      expect(observed.length).to eq 1
+      expect(observed.first.return_value).to eq('hello-world')
+    end
+  end
+end

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Method probe dispatch semantics' do
 
   let(:redactor) { Datadog::DI::Redactor.new(settings) }
   let(:serializer) { Datadog::DI::Serializer.new(settings, redactor) }
-  let(:logger) { instance_double(Logger).tap { |l| allow(l).to receive(:debug) } }
+  let(:logger) { instance_double(Logger, debug: nil) }
   let(:instrumenter) { Datadog::DI::Instrumenter.new(settings, serializer, logger, code_tracker: nil) }
 
   def install_probe(type_name, method_name, &on_fire)

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -94,16 +94,20 @@ RSpec.describe 'Method probe dispatch semantics' do
   let(:propagate_all_exceptions) { true }
 
   mock_settings_for_di do |settings|
-    allow(settings.dynamic_instrumentation).to receive(:enabled).and_return(true)
-    allow(settings.dynamic_instrumentation.internal).to receive(:untargeted_trace_points).and_return(false)
-    allow(settings.dynamic_instrumentation).to receive(:max_capture_depth).and_return(2)
-    allow(settings.dynamic_instrumentation).to receive(:max_capture_attribute_count).and_return(2)
-    allow(settings.dynamic_instrumentation).to receive(:max_capture_string_length).and_return(100)
-    allow(settings.dynamic_instrumentation).to receive(:redacted_type_names).and_return([])
-    allow(settings.dynamic_instrumentation).to receive(:redacted_identifiers).and_return([])
-    allow(settings.dynamic_instrumentation).to receive(:redaction_excluded_identifiers).and_return([])
-    allow(settings.dynamic_instrumentation.internal).to receive(:propagate_all_exceptions).and_return(propagate_all_exceptions)
-    allow(settings.dynamic_instrumentation.internal).to receive(:max_processing_time).and_return(1)
+    allow(settings.dynamic_instrumentation).to receive_messages(
+      enabled: true,
+      max_capture_depth: 2,
+      max_capture_attribute_count: 2,
+      max_capture_string_length: 100,
+      redacted_type_names: [],
+      redacted_identifiers: [],
+      redaction_excluded_identifiers: [],
+    )
+    allow(settings.dynamic_instrumentation.internal).to receive_messages(
+      untargeted_trace_points: false,
+      propagate_all_exceptions: propagate_all_exceptions,
+      max_processing_time: 1,
+    )
   end
 
   let(:redactor) { Datadog::DI::Redactor.new(settings) }

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -228,8 +228,12 @@ RSpec.describe 'Method probe dispatch semantics' do
       yielded = fiber.resume
       expect(yielded).to eq('orphan')
 
-      # Abandon the fiber. It will not be resumed and will be GC'd.
-      fiber = nil
+      # Abandon the fiber by dropping the local-variable reference so the
+      # subsequent GC.start can actually collect it. StandardRB flags the
+      # assignment as useless because the variable is never read again,
+      # but the dead-store is the entire point — it's what makes the fiber
+      # collectable.
+      fiber = nil # standard:disable Lint/UselessAssignment
       GC.start
 
       # A subsequent firing on the parent fiber should produce a
@@ -285,13 +289,11 @@ RSpec.describe 'Method probe dispatch semantics' do
         verbose_was = $VERBOSE
         $VERBOSE = nil
         ractor = Ractor.new do
-          begin
-            RactorDispatchFixture.new.value(21)
-          rescue => e
-            [:error, e.class.name, e.message]
-          else
-            [:ok, nil, nil]
-          end
+          RactorDispatchFixture.new.value(21)
+        rescue => e
+          [:error, e.class.name, e.message]
+        else
+          [:ok, nil, nil]
         end
         result = ractor.take
         error_class = result[1]
@@ -323,12 +325,10 @@ RSpec.describe 'Method probe dispatch semantics' do
       $VERBOSE = nil
       begin
         ractor = Ractor.new do
-          begin
-            RactorDispatchFixture.new.value(7)
-            :ok
-          rescue
-            :error
-          end
+          RactorDispatchFixture.new.value(7)
+          :ok
+        rescue
+          :error
         end
         ractor.take
       ensure
@@ -348,11 +348,9 @@ RSpec.describe 'Method probe dispatch semantics' do
       $VERBOSE = nil
       begin
         ractor = Ractor.new do
-          begin
-            RactorDispatchFixture.new.value(7)
-          rescue
-            nil
-          end
+          RactorDispatchFixture.new.value(7)
+        rescue
+          nil
         end
         ractor.take
       ensure

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe 'Method probe dispatch semantics' do
 
   describe 'Ractor isolation when invoking a probed method' do
     # Ractors enforce that user-defined Ruby objects passed across
-    # Ractor boundaries are either shareable (frozen / built-in / Ractor::makeshare
+    # Ractor boundaries are either shareable (frozen / built-in / Ractor.make_shareable
     # processed) or accessed via copy. The method-probe wrapper closes over
     # an Instrumenter instance, which holds a Logger, settings, a serializer,
     # and a code tracker — none of which are Ractor-shareable.

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe 'Method probe dispatch semantics' do
     end
   end
 
-  describe 'Ractor isolation when invoking a probed method' do
+  describe 'Ractor isolation when invoking a probed method', ractors: true do
     # Ractors enforce that user-defined Ruby objects passed across
     # Ractor boundaries are either shareable (frozen / built-in / Ractor.make_shareable
     # processed) or accessed via copy. The method-probe wrapper closes over

--- a/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
+++ b/spec/datadog/di/method_probe_dispatch_semantics_spec.rb
@@ -267,7 +267,9 @@ RSpec.describe 'Method probe dispatch semantics' do
 
     before do
       skip "Ractor requires Ruby 3.0+" if RUBY_VERSION < "3.0"
-      skip "Ractor was removed/renamed in Ruby 4.0" if RUBY_VERSION >= "4.0"
+      # Ruby 3.0 Ractors have known bugs causing CI instability — matches the skip
+      # pattern used in spec/datadog/profiling/native_extension_spec.rb.
+      skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.")
     end
 
     after { instrumenter.unhook(probe) if probe }
@@ -295,7 +297,9 @@ RSpec.describe 'Method probe dispatch semantics' do
         else
           [:ok, nil, nil]
         end
-        result = ractor.take
+        # Ractor#take was replaced by Ractor#value in Ruby 4.0; matches the
+        # version-conditional pattern from spec/datadog/profiling/native_extension_spec.rb.
+        result = (RUBY_VERSION < "4") ? ractor.take : ractor.value
         error_class = result[1]
       ensure
         $VERBOSE = verbose_was
@@ -330,7 +334,7 @@ RSpec.describe 'Method probe dispatch semantics' do
         rescue
           :error
         end
-        ractor.take
+        (RUBY_VERSION < "4") ? ractor.take : ractor.value
       ensure
         $VERBOSE = verbose_was
       end
@@ -352,7 +356,7 @@ RSpec.describe 'Method probe dispatch semantics' do
         rescue
           nil
         end
-        ractor.take
+        (RUBY_VERSION < "4") ? ractor.take : ractor.value
       ensure
         $VERBOSE = verbose_was
       end


### PR DESCRIPTION
**What does this PR do?**

Adds `spec/datadog/di/method_probe_dispatch_semantics_spec.rb` covering three Ruby dispatch surfaces the existing DI test suite does not exercise against the method-probe wrapper:

- Fiber switches inside a probed method body (`Fiber.yield` + `resume`)
- Ractor isolation when a probed method is invoked inside a non-main Ractor
- Refinements visibility through the prepend chain that hosts the wrapper

No production code changes. 11 examples.

**Motivation:**

`spec/datadog/di/` has zero references to `Ractor` and zero `using SomeRefinement` directives. The existing fiber tests in `in_probe_spec.rb` cover the standalone re-entrancy guard primitives, not how the method-probe wrapper itself behaves when a probed method body yields to another fiber.

Ruby applications that use fibers (Async, Falcon), Ractors, or refinements can have method probes set on methods that interact with them. Without explicit coverage, a future wrapper refactor can silently change dispatch behavior for any of them.

This spec pins the observable contract so future changes either keep it green or update the assertions deliberately.

**Change log entry**

None.

**Additional Notes:**

Placement: the spec sits alongside `instrumenter_spec.rb` (not under `integration/`) because it uses `Instrumenter` directly with `ProcResponder` — same pattern as `instrumenter_spec.rb` — and does not require the `ProbeManager` / `Component` / notifier-worker stack the `integration/` specs use. Happy to move it if reviewers prefer.

Ractor assertions are deliberately broad ("does not crash; outcome is communicable") rather than pinning a specific error class. Ruby 3.0 → 3.3 Ractor semantics have shifted across point releases; asserting a specific error would couple the test to a Ruby version. The intent is to catch a regression where calling a probed method inside a Ractor crashes the VM or silently corrupts main-Ractor state.

Fiber assertions check ordering between `Fiber.resume` calls and responder callback invocations, which catches regressions where the wrapper fires its post-super hook at the wrong fiber-control point (e.g. on the first `resume` instead of on completion).

Verified against:
- `master` at `b75cf221d3` (current wrapper, no re-entrancy guard) — 11/11 green
- PR #5560 head at `34d0e62fd2` (lambda + `do_super` + guard wrapper) — 11/11 green

**How to test the change?**

Fiber + refinement examples (8 examples, runs on Ruby 2.5+):

```
bundle exec rake spec:di:di_with_ext
# or directly:
bundle exec rspec spec/datadog/di/method_probe_dispatch_semantics_spec.rb
```

Ractor examples (3 examples, runs on Ruby 3.1+):

```
bundle exec rake spec:di:ractors
# or directly:
bundle exec rspec spec/datadog/di/method_probe_dispatch_semantics_spec.rb -t ractors
```

Ractor examples are tagged `ractors: true` and isolated into a dedicated rake task so the regular `spec:di:di_with_ext` job does not transition the VM into multi-ractor mode — mirroring `spec:profiling:ractors`. The Ractor `describe` is skipped on Ruby 3.0.x by an in-spec guard (matching the pattern in `spec/datadog/profiling/native_extension_spec.rb`) because of known Ractor stability bugs on 3.0; on Ruby 2.5–2.7 it is skipped at the Matrixfile level because `Ractor` does not exist there.

**Skips:**

- `spec/datadog/di/method_probe_dispatch_semantics_spec.rb`
  - Skip 1 (line 273): `skip "Ractor requires Ruby 3.0+" if RUBY_VERSION < "3.0"`
  - Skip 2 (line 276): `skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.")`

  Both skips guard the `Ractor isolation when invoking a probed method` describe block (tagged `ractors: true`).

  **CI jobs that ran this spec file** (all batch [0] of the standard suite, all ✅ PASS):
  - `Ruby 2.6 / build & test (standard) [0]` — runs `di:di_with_ext` (8 fiber + refinement examples; Ractor describe excluded by `-t ~ractors`)
  - `Ruby 2.7 / build & test (standard) [0]` — same as 2.6
  - `Ruby 3.0 / build & test (standard) [0]` — same as 2.6
  - `Ruby 3.1 / build & test (standard) [0]` — runs both `di:di_with_ext` and `di:ractors` (11 examples total)
  - `Ruby 3.2 / build & test (standard) [0]` — same as 3.1
  - `Ruby 3.3 / build & test (standard) [0]` — same as 3.1
  - `Ruby 3.4 / build & test (standard) [0]` — same as 3.1
  - `Ruby 4.0 / build & test (standard) [0]` — same as 3.1

  Ruby 2.5 does not run this spec at all (Matrixfile excludes `di:di_with_ext` on Ruby 2.5).

  **Where each in-spec skip actually fires:** in zero CI jobs.
  - Under `di:di_with_ext` (Ruby 2.6, 2.7, 3.0): the `-t ~ractors` filter excludes the Ractor describe block before any `before` hook runs, so the in-spec skips are never reached.
  - Under `di:ractors` (Ruby 3.1+): the in-spec skip conditions (`RUBY_VERSION < "3.0"`, `start_with?("3.0.")`) are false, so the skips are not triggered.

  The in-spec skips are defensive guards for developers who run `bundle exec rspec spec/datadog/di/method_probe_dispatch_semantics_spec.rb -t ractors` directly on Ruby 2.6 / 2.7 / 3.0. They are kept so the spec degrades gracefully under manual invocation on an unsupported runtime.


