### PR TITLE
DI benchmarks: decompose di_instrument by rate limit (firing vs skip path)

### DIFF
--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -58,22 +58,6 @@
 # production use; the skip-variant measurement is the floor cost that even
 # rate-limit-skipped traffic pays.
 #
-# After instrumentation is removed, performance returns to baseline within
-# measurement error: method-cleared was 2.6% below baseline, line-cleared was
-# 1.1% above baseline, no-instr-again was 0.8% above baseline -- all within the
-# +/- 1.6-2.2% error bands. A prior version of this header documented a 6-10%
-# residual loss with two candidate causes (lingering code overhead vs. CPU
-# thermal throttling); the throttling theory is consistent with what we see
-# now -- with turbo disabled the residual loss disappears.
-#
-# To reproduce stable measurements on a laptop, run as root:
-#   echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
-# then run the benchmark pinned to one P-core's SMT pair:
-#   taskset -c 2,3 bundle exec ruby benchmarks/di_instrument.rb
-# Without these, the default intel_pstate powersave governor swings P-core
-# frequency between 400 MHz and ~4.3 GHz under load, producing +/- 16-36%
-# per-report error bands that swamp the differences this benchmark measures.
-#
 
 # Used to quickly run benchmark under RSpec as part of the usual test suite, to validate it didn't bitrot
 VALIDATE_BENCHMARK_MODE = ENV['VALIDATE_BENCHMARK'] == 'true'

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -22,24 +22,24 @@
 # Typical result:
 #
 # Comparison:
-#                          method instrumentation - cleared:   556227.8 i/s
-#                            line instrumentation - cleared:   553976.4 i/s - same-ish: difference falls within error
-#                                        no instrumentation:   544419.0 i/s - same-ish: difference falls within error
-#                                no instrumentation - again:   499320.2 i/s - same-ish: difference falls within error
-#              method instrumentation - rate_limit=1 (skip):   295040.9 i/s - 1.89x  slower
-#     line instrumentation - targeted - rate_limit=1 (skip):   279164.6 i/s - 1.99x  slower
-#           method instrumentation - rate_limit=1M (firing):   122105.7 i/s - 4.56x  slower
-#  line instrumentation - targeted - rate_limit=1M (firing):   108801.5 i/s - 5.11x  slower
-#   line instrumentation - untargeted - rate_limit=1 (skip):    60316.8 i/s - 9.22x  slower
-# line instrumentation - untargeted - rate_limit=1M (firing):    44622.4 i/s - 12.47x  slower
+#                          method instrumentation - cleared:   170807.4 i/s
+#                                no instrumentation - again:   170507.2 i/s - same-ish: difference falls within error
+#                            line instrumentation - cleared:   169760.6 i/s - same-ish: difference falls within error
+#                                        no instrumentation:   165453.4 i/s - 1.03x  slower
+#              method instrumentation - rate_limit=1 (skip):    90687.8 i/s - 1.88x  slower
+#     line instrumentation - targeted - rate_limit=1 (skip):    81769.3 i/s - 2.09x  slower
+#           method instrumentation - rate_limit=1M (firing):    36179.6 i/s - 4.72x  slower
+#  line instrumentation - targeted - rate_limit=1M (firing):    33589.6 i/s - 5.09x  slower
+#   line instrumentation - untargeted - rate_limit=1 (skip):    29559.6 i/s - 5.78x  slower
+# line instrumentation - untargeted - rate_limit=1M (firing):    19262.5 i/s - 8.87x  slower
 #
 # Per-call wrapper overhead, computed as (1/instr_ips) - (1/baseline_ips)
 # from the numbers above:
 #
 #                                       skip path     firing path
-#   method probe                        ~1.55 us      ~6.35 us
-#   line probe - targeted               ~1.75 us      ~7.35 us
-#   line probe - untargeted             ~14.7 us      ~20.6 us
+#   method probe                        ~4.98 us      ~21.60 us
+#   line probe - targeted               ~6.19 us      ~23.73 us
+#   line probe - untargeted             ~27.79 us     ~45.87 us
 #
 # Method-probe firing is ~4x more expensive per call than skip. In
 # production, where the probe rate limit caps firing at 5000/sec per probe
@@ -52,7 +52,7 @@
 #
 # Untargeted line instrumentation is much slower than targeted because the
 # TracePoint fires for every line in the file rather than only the
-# instrumented line. The skip variant is still slow (~14.7 us) because the
+# instrumented line. The skip variant is still slow (~27.8 us) because the
 # per-line TracePoint callback runs even when the rate limiter rejects
 # snapshot delivery. Untargeted line probes remain unsuitable for
 # production use; the skip-variant measurement is the floor cost that even

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -85,11 +85,7 @@ require 'datadog'
 # Need to require datadog/di explicitly because dynamic instrumentation is not
 # currently integrated into the Ruby tracer due to being under development.
 require 'datadog/di'
-begin
-  require 'datadog/di/proc_responder'
-rescue LoadError
-  # Old tree
-end
+require 'datadog/di/proc_responder'
 
 class DIInstrumentBenchmark
   class Target
@@ -176,12 +172,8 @@ class DIInstrumentBenchmark
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method',
       rate_limit: 1_000_000,)
-    if defined?(Datadog::DI::ProcResponder)
-      responder = Datadog::DI::ProcResponder.new(executed_proc)
-      rv = instrumenter.hook_method(probe, responder)
-    else
-      rv = instrumenter.hook_method(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_method(probe, responder)
     unless rv
       raise "Method probe was not successfully installed (rate_limit=1M)"
     end
@@ -214,12 +206,8 @@ class DIInstrumentBenchmark
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method',
       rate_limit: 1,)
-    if defined?(Datadog::DI::ProcResponder)
-      responder = Datadog::DI::ProcResponder.new(executed_proc)
-      rv = instrumenter.hook_method(probe, responder)
-    else
-      rv = instrumenter.hook_method(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_method(probe, responder)
     unless rv
       raise "Method probe was not successfully installed (rate_limit=1)"
     end
@@ -263,12 +251,8 @@ class DIInstrumentBenchmark
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: file, line_no: line + 1, rate_limit: 1_000_000,)
-    if defined?(Datadog::DI::ProcResponder)
-      responder = Datadog::DI::ProcResponder.new(executed_proc)
-      rv = instrumenter.hook_line(probe, responder)
-    else
-      rv = instrumenter.hook_line(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
     unless rv
       raise "Line probe (untargeted, rate_limit=1M) was not successfully installed"
     end
@@ -299,12 +283,8 @@ class DIInstrumentBenchmark
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: file, line_no: line + 1, rate_limit: 1,)
-    if defined?(Datadog::DI::ProcResponder)
-      responder = Datadog::DI::ProcResponder.new(executed_proc)
-      rv = instrumenter.hook_line(probe, responder)
-    else
-      rv = instrumenter.hook_line(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
     unless rv
       raise "Line probe (untargeted, rate_limit=1) was not successfully installed"
     end
@@ -351,11 +331,8 @@ class DIInstrumentBenchmark
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,)
-    rv = if defined?(Datadog::DI::ProcResponder)
-      instrumenter.hook_line(probe, responder)
-    else
-      instrumenter.hook_line(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
     unless rv
       raise "Line probe (targeted, rate_limit=1M) was not successfully installed"
     end
@@ -387,11 +364,8 @@ class DIInstrumentBenchmark
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
       file: targeted_file, line_no: targeted_line + 1, rate_limit: 1,)
-    rv = if defined?(Datadog::DI::ProcResponder)
-      instrumenter.hook_line(probe, responder)
-    else
-      instrumenter.hook_line(probe, &executed_proc)
-    end
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
     unless rv
       raise "Line probe (targeted, rate_limit=1) was not successfully installed"
     end

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -1,30 +1,62 @@
 #
 # "Instrumentation" part of Dynamic Instrumentation benchmarks.
 #
-# Typical result (Intel Core Ultra 7 165U, Ruby 3.2.3, intel_pstate/no_turbo=1
-# locking P-cores at 1.7 GHz base, taskset -c 2,3 pinning to one P-core):
+# Each instrumented configuration is measured with two probe rate-limit
+# settings to decompose the wrapper's per-call cost:
 #
-# Reports in execution order, with i/s and slowdown vs. the initial baseline:
+#   rate_limit=1_000_000  - benchmark runs below the bucket ceiling, every
+#                           probe invocation fires the full path (firing).
+#   rate_limit=1          - one token initially + 1/sec refill. At the
+#                           benchmark's call rate, ~99.999% of invocations
+#                           hit the rate-limited skip branch (skip).
 #
-#               no instrumentation:   240234.8 i/s   1.00x  (baseline)
-#           method instrumentation:   138017.6 i/s   1.74x  slower
-# line instrumentation - untargeted:   25021.7 i/s   9.60x  slower
-#  line instrumentation - targeted:   117677.4 i/s   2.04x  slower
-# method instrumentation - cleared:   234189.2 i/s   1.03x  slower (within error)
-#   line instrumentation - cleared:   242757.1 i/s   0.99x  faster (within error)
-#       no instrumentation - again:   242268.1 i/s   0.99x  faster (within error)
+# The skip-path number is the dominant production overhead, since real
+# workloads vastly exceed any per-probe rate limit. The firing-path number
+# is what each delivered snapshot costs.
 #
-# Per-report error bands were +/- 1.4% to 2.2% on all configurations except
-# untargeted line (+/- 5.1%, which is intrinsic to its 40 us/iteration cost
-# yielding only ~2,500 iterations per 100 ms benchmark/ips sample).
+# capture_snapshot is not set on the probes (defaults to false), so the
+# firing path measured here exercises Context construction and responder
+# dispatch but not serialize_args. For probes with capture_snapshot=true,
+# the firing-path cost is higher than what this benchmark reports.
 #
-# Targeted line and method instrumentation have similar performance at about
-# 50-60% of baseline on this trivial target method. Real-world targets do more
-# per call, so the relative overhead of instrumentation will be lower in
-# practice than it is in this benchmark.
+# Typical result:
 #
-# Untargeted line instrumentation is the slowest configuration by ~4.7x over
-# the next-slowest, and remains too slow to be usable.
+# Comparison:
+#                          method instrumentation - cleared:   556227.8 i/s
+#                            line instrumentation - cleared:   553976.4 i/s - same-ish: difference falls within error
+#                                        no instrumentation:   544419.0 i/s - same-ish: difference falls within error
+#                                no instrumentation - again:   499320.2 i/s - same-ish: difference falls within error
+#              method instrumentation - rate_limit=1 (skip):   295040.9 i/s - 1.89x  slower
+#     line instrumentation - targeted - rate_limit=1 (skip):   279164.6 i/s - 1.99x  slower
+#           method instrumentation - rate_limit=1M (firing):   122105.7 i/s - 4.56x  slower
+#  line instrumentation - targeted - rate_limit=1M (firing):   108801.5 i/s - 5.11x  slower
+#   line instrumentation - untargeted - rate_limit=1 (skip):    60316.8 i/s - 9.22x  slower
+# line instrumentation - untargeted - rate_limit=1M (firing):    44622.4 i/s - 12.47x  slower
+#
+# Per-call wrapper overhead, computed as (1/instr_ips) - (1/baseline_ips)
+# from the numbers above:
+#
+#                                       skip path     firing path
+#   method probe                        ~1.55 us      ~6.35 us
+#   line probe - targeted               ~1.75 us      ~7.35 us
+#   line probe - untargeted             ~14.7 us      ~20.6 us
+#
+# Method-probe firing is ~4x more expensive per call than skip. In
+# production, where the probe rate limit caps firing at 5000/sec per probe
+# and the customer method runs at whatever the application produces, the
+# skip number is the per-call cost a customer pays on the overwhelming
+# majority of probed-method invocations.
+#
+# Targeted line instrumentation has similar per-call cost to method
+# instrumentation in both firing and skip variants.
+#
+# Untargeted line instrumentation is much slower than targeted because the
+# TracePoint fires for every line in the file rather than only the
+# instrumented line. The skip variant is still slow (~14.7 us) because the
+# per-line TracePoint callback runs even when the rate limiter rejects
+# snapshot delivery. Untargeted line probes remain unsuitable for
+# production use; the skip-variant measurement is the floor cost that even
+# rate-limit-skipped traffic pays.
 #
 # After instrumentation is removed, performance returns to baseline within
 # measurement error: method-cleared was 2.6% below baseline, line-cleared was
@@ -118,12 +150,32 @@ class DIInstrumentBenchmark
       x.compare!
     end
 
+    # Method instrumentation is run twice with deliberately extreme rate
+    # limits to decompose the wrapper's per-call cost:
+    #
+    #   rate_limit=1_000_000  - benchmark runs below the token-bucket
+    #                           ceiling, every call fires the full snapshot
+    #                           path. Measures firing-path cost.
+    #   rate_limit=1          - one token initially + one refill per second.
+    #                           At ~100k calls/sec, ~99.999% of calls hit
+    #                           the rate-limited skip branch. Measures
+    #                           skip-path cost (the dominant production
+    #                           overhead, since real workloads vastly exceed
+    #                           any per-probe rate limit).
+    #
+    # Note: this benchmark does not set capture_snapshot, so the firing
+    # variant exercises Context construction + responder dispatch but not
+    # serialize_args. For probes with capture_snapshot=true the firing-path
+    # cost is higher than what is measured here.
+
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method')
     executed_proc = lambda do |context|
       calls += 1
     end
+
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method',
+      rate_limit: 1_000_000,)
     if defined?(Datadog::DI::ProcResponder)
       responder = Datadog::DI::ProcResponder.new(executed_proc)
       rv = instrumenter.hook_method(probe, responder)
@@ -131,7 +183,7 @@ class DIInstrumentBenchmark
       rv = instrumenter.hook_method(probe, &executed_proc)
     end
     unless rv
-      raise "Method probe was not successfully installed"
+      raise "Method probe was not successfully installed (rate_limit=1M)"
     end
 
     Benchmark.ips do |x|
@@ -140,7 +192,7 @@ class DIInstrumentBenchmark
         **benchmark_time,
       )
 
-      x.report('method instrumentation') do
+      x.report('method instrumentation - rate_limit=1M (firing)') do
         Target.new.test_method
       end
 
@@ -149,11 +201,52 @@ class DIInstrumentBenchmark
     end
 
     if calls < 1
-      raise "Method instrumentation did not work - callback was never invoked"
+      raise "Method instrumentation (rate_limit=1M) did not work - callback was never invoked"
     end
 
     if calls < 1000 && !VALIDATE_BENCHMARK_MODE
-      raise "Expected at least 1000 calls to the method, got #{calls}"
+      raise "Method instrumentation (rate_limit=1M): expected at least 1000 firing calls, got #{calls}"
+    end
+
+    instrumenter.unhook(probe)
+
+    calls = 0
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      type_name: 'DIInstrumentBenchmark::Target', method_name: 'test_method',
+      rate_limit: 1,)
+    if defined?(Datadog::DI::ProcResponder)
+      responder = Datadog::DI::ProcResponder.new(executed_proc)
+      rv = instrumenter.hook_method(probe, responder)
+    else
+      rv = instrumenter.hook_method(probe, &executed_proc)
+    end
+    unless rv
+      raise "Method probe was not successfully installed (rate_limit=1)"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+
+      x.report('method instrumentation - rate_limit=1 (skip)') do
+        Target.new.test_method
+      end
+
+      x.save! "#{File.basename(__FILE__, '.rb')}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls < 1
+      raise "Method instrumentation (rate_limit=1) did not work - callback was never invoked"
+    end
+
+    # rate_limit=1 with ~12s of total time (2s warmup + 10s measure) should
+    # produce ~12 firing calls. Anything over 100 indicates the rate limiter
+    # is not enforcing.
+    if calls > 100 && !VALIDATE_BENCHMARK_MODE
+      raise "Method instrumentation (rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
     instrumenter.unhook(probe)
@@ -169,7 +262,7 @@ class DIInstrumentBenchmark
 
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: file, line_no: line + 1)
+      file: file, line_no: line + 1, rate_limit: 1_000_000,)
     if defined?(Datadog::DI::ProcResponder)
       responder = Datadog::DI::ProcResponder.new(executed_proc)
       rv = instrumenter.hook_line(probe, responder)
@@ -177,7 +270,7 @@ class DIInstrumentBenchmark
       rv = instrumenter.hook_line(probe, &executed_proc)
     end
     unless rv
-      raise "Line probe (in method) was not successfully installed"
+      raise "Line probe (untargeted, rate_limit=1M) was not successfully installed"
     end
 
     Benchmark.ips do |x|
@@ -185,7 +278,7 @@ class DIInstrumentBenchmark
       x.config(
         **benchmark_time,
       )
-      x.report('line instrumentation - untargeted') do
+      x.report('line instrumentation - untargeted - rate_limit=1M (firing)') do
         Target.new.test_method_for_line_probe
       end
 
@@ -194,11 +287,47 @@ class DIInstrumentBenchmark
     end
 
     if calls < 1
-      raise "Line instrumentation did not work - callback was never invoked"
+      raise "Line instrumentation (untargeted, rate_limit=1M) did not work - callback was never invoked"
     end
 
     if calls < 1000 && !VALIDATE_BENCHMARK_MODE
-      raise "Expected at least 1000 calls to the method, got #{calls}"
+      raise "Line instrumentation (untargeted, rate_limit=1M): expected at least 1000 firing calls, got #{calls}"
+    end
+
+    instrumenter.unhook(probe)
+
+    calls = 0
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      file: file, line_no: line + 1, rate_limit: 1,)
+    if defined?(Datadog::DI::ProcResponder)
+      responder = Datadog::DI::ProcResponder.new(executed_proc)
+      rv = instrumenter.hook_line(probe, responder)
+    else
+      rv = instrumenter.hook_line(probe, &executed_proc)
+    end
+    unless rv
+      raise "Line probe (untargeted, rate_limit=1) was not successfully installed"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+      x.report('line instrumentation - untargeted - rate_limit=1 (skip)') do
+        Target.new.test_method_for_line_probe
+      end
+
+      x.save! "#{File.basename(__FILE__, '.rb')}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls < 1
+      raise "Line instrumentation (untargeted, rate_limit=1) did not work - callback was never invoked"
+    end
+
+    if calls > 100 && !VALIDATE_BENCHMARK_MODE
+      raise "Line instrumentation (untargeted, rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
     instrumenter.unhook(probe)
@@ -221,14 +350,14 @@ class DIInstrumentBenchmark
 
     calls = 0
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: targeted_file, line_no: targeted_line + 1)
+      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,)
     rv = if defined?(Datadog::DI::ProcResponder)
       instrumenter.hook_line(probe, responder)
     else
       instrumenter.hook_line(probe, &executed_proc)
     end
     unless rv
-      raise "Line probe (targeted) was not successfully installed"
+      raise "Line probe (targeted, rate_limit=1M) was not successfully installed"
     end
 
     Benchmark.ips do |x|
@@ -237,7 +366,7 @@ class DIInstrumentBenchmark
         **benchmark_time,
       )
 
-      x.report('line instrumentation - targeted') do
+      x.report('line instrumentation - targeted - rate_limit=1M (firing)') do
         DITarget.new.test_method_for_line_probe
       end
 
@@ -246,11 +375,47 @@ class DIInstrumentBenchmark
     end
 
     if calls < 1
-      raise "Targeted line instrumentation did not work - callback was never invoked"
+      raise "Targeted line instrumentation (rate_limit=1M) did not work - callback was never invoked"
     end
 
     if calls < 1000 && !VALIDATE_BENCHMARK_MODE
-      raise "Expected at least 1000 calls to the method, got #{calls}"
+      raise "Targeted line instrumentation (rate_limit=1M): expected at least 1000 firing calls, got #{calls}"
+    end
+
+    instrumenter.unhook(probe)
+
+    calls = 0
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1,)
+    rv = if defined?(Datadog::DI::ProcResponder)
+      instrumenter.hook_line(probe, responder)
+    else
+      instrumenter.hook_line(probe, &executed_proc)
+    end
+    unless rv
+      raise "Line probe (targeted, rate_limit=1) was not successfully installed"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+
+      x.report('line instrumentation - targeted - rate_limit=1 (skip)') do
+        DITarget.new.test_method_for_line_probe
+      end
+
+      x.save! "#{File.basename(__FILE__, '.rb')}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls < 1
+      raise "Targeted line instrumentation (rate_limit=1) did not work - callback was never invoked"
+    end
+
+    if calls > 100 && !VALIDATE_BENCHMARK_MODE
+      raise "Targeted line instrumentation (rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
     # Now, remove all installed hooks and check that the performance of


### PR DESCRIPTION
**What does this PR do?**

Decomposes the three instrumented reports in `benchmarks/di_instrument.rb` (`method instrumentation`, `line instrumentation - untargeted`, `line instrumentation - targeted`) into firing-path and skip-path variants by running each twice with different probe `rate_limit` values:

- `rate_limit=1_000_000` — benchmark runs below the bucket ceiling, every invocation fires (firing path).
- `rate_limit=1` — one token initially + 1/sec refill, ~99.999% of calls hit the rate-limited skip branch (skip path).

10 reports total (was 7).

**Motivation:**

The pre-decomposition reports installed probes with no explicit `rate_limit`, defaulting to 5000/sec (`lib/datadog/di/probe.rb:87`). At the benchmark's call rate, ~96% of calls hit the rate-limited skip branch and ~4% fire the snapshot path. The reported per-call number was a blend of two paths with very different costs, and the report names did not signal that the blended measurement was dominated by the skip path.

**Measured numbers** (Ruby 3.2.3 / x86_64-linux, single E-core, single run on this branch's tip):

| Report | i/s | μs/iter | ±error |
|---|---:|---:|---:|
| no instrumentation | 165,453 | 6.04 | ±1.1% |
| method instrumentation - rate_limit=1M (firing) | 36,180 | 27.64 | ±1.6% |
| method instrumentation - rate_limit=1 (skip) | 90,688 | 11.03 | ±2.1% |
| line instrumentation - untargeted - rate_limit=1M (firing) | 19,263 | 51.91 | ±1.9% |
| line instrumentation - untargeted - rate_limit=1 (skip) | 29,560 | 33.83 | ±0.8% |
| line instrumentation - targeted - rate_limit=1M (firing) | 33,590 | 29.77 | ±1.6% |
| line instrumentation - targeted - rate_limit=1 (skip) | 81,769 | 12.23 | ±1.1% |
| method instrumentation - cleared | 170,807 | 5.85 | ±1.3% |
| line instrumentation - cleared | 169,761 | 5.89 | ±1.5% |
| no instrumentation - again | 170,507 | 5.86 | ±1.3% |

Ratios vs the same-run baseline, and per-call wrapper overhead computed as `(1/instr_ips) − (1/baseline_ips)`:

| Probe type | Skip ratio | Firing ratio | Skip overhead | Firing overhead | Firing / skip |
|---|---:|---:|---:|---:|---:|
| method | 1.82× | 4.57× | ~4.98 μs | ~21.60 μs | 4.34× |
| line - targeted | 2.02× | 4.93× | ~6.19 μs | ~23.73 μs | 3.83× |
| line - untargeted | 5.60× | 8.59× | ~27.79 μs | ~45.87 μs | 1.65× |

**Change log entry**

None.

**Additional Notes:**

- `capture_snapshot` is not set on the probes (defaults to false), so the firing variant exercises `Context` construction and responder dispatch but not `serialize_args`. Probes with `capture_snapshot: true` have a heavier firing path; this benchmark does not cover that and the header comment calls this out.

- Liveness check for the rate_limit=1 variants asserts `1 ≤ calls ≤ 100` (initial token plus ~12s worth of 1/sec refill across warmup + measure). Catches both "probe never fired" and "rate limiter not enforcing" regressions, which the original `calls ≥ 1000` assertion could not have detected for a rate-limited probe.

- The saved-results JSON file (`di_instrument-results.json`) report keys change. Cross-version comparisons against pre-decomposition results will not align.

- The `no instrumentation`, `method instrumentation - cleared`, `line instrumentation - cleared`, and `no instrumentation - again` reports are untouched — rate limit is irrelevant where no probe is active.

- Removed the `if defined?(Datadog::DI::ProcResponder)` guards (6 sites) and the matching `begin/rescue LoadError` around the require. `ProcResponder` shipped in v2.23.0 (#4979, 2025-10-29), so the old-tree fallback path is no longer needed. As a consequence the two targeted-line sections now construct `responder` locally instead of reusing the variable from earlier sections.

**How to test the change?**

```
bundle exec ruby benchmarks/di_instrument.rb
VALIDATE_BENCHMARK=true bundle exec ruby benchmarks/di_instrument.rb
bundle exec rake standard rubocop
```
