### PR TITLE
Validate Ivo's fix (#5879) against busy-wait reproducer (#5873)

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
     @clean_threads_required = true
     testing_threads.each { ready_queue.pop }
+    # Make sure all threads have reached the `sleep` before moving on
+    loop_until { testing_threads.all? { |t| t.status == "sleep" } }
     expect(Thread.list).to include(*testing_threads)
 
     testing_threads_and_current.each { |t| clear_per_thread_context_for(t) }

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1320,6 +1320,33 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
           context "when Waiting for GVL duration < the threshold" do
             let(:waiting_for_gvl_threshold_ns) { 1_000_000_000 }
 
+            # Reproducer for the CI flake observed in PR #5871's `test-memcheck` job
+            # (https://github.com/DataDog/dd-trace-rb/actions/runs/27163185182/job/80183618479).
+            # Tests the mechanism hypothesized by Ivo Anjo in PR #5879: there's no
+            # atomicity between `ready_queue << true` and `sleep` in the default `t1`.
+            # Under valgrind's slow, single-threaded scheduling, the test setup proceeds
+            # while `t1` is still on the path to `sleep`, so `t1` legitimately accrues
+            # cpu-time between the setup's last `sample` and the test body's `sample`.
+            # A positive `cpu_time_elapsed_ns` short-circuits state detection in
+            # collectors_stack.c:288-293 to "had cpu", bypassing the stack-based
+            # "sleeping" detection.
+            #
+            # This override forces the race deterministically by busy-waiting (instead
+            # of going straight to `sleep`) for long enough to cover the setup chain on
+            # any environment.
+            let(:t1) do
+              Thread.new(ready_queue) do |ready_queue|
+                inside_t1 do
+                  ready_queue << true
+                  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) + 0.5
+                  while Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second) < deadline
+                    Thread.pass
+                  end
+                  sleep
+                end
+              end
+            end
+
             it "records a regular sample" do
               expect(gvl_waiting_at_for(t1)).to eq 0
 


### PR DESCRIPTION
**What does this PR do?**

Validates @ivoanjo's fix from PR [#5879](https://github.com/DataDog/dd-trace-rb/pull/5879) against the deterministic mechanism reproducer from PR [#5873](https://github.com/DataDog/dd-trace-rb/pull/5873).

This branch = `origin/ivoanjo/fix-flaky-sleeping-assertion` + the busy-wait reproducer cherry from #5873.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Two PRs are open for the same flake (`thread_context_spec.rb` "records a regular sample"):
- [#5874](https://github.com/DataDog/dd-trace-rb/pull/5874) — AI fix, `INVALID_TIME` reset, mechanism-agnostic.
- [#5879](https://github.com/DataDog/dd-trace-rb/pull/5879) — Ivo's fix, `loop_until { … "sleep" }` wait, targets Ivo's race hypothesis (no atomicity between `ready_queue << true` and `sleep`).

Ivo notes he could not reproduce the original flake locally. The mechanism reproducer in #5873 (busy-wait between `ready_queue << true` and `sleep`) gives Ivo's fix a deterministic local validation target. This PR exercises that combination.

**Expected result:** test passes.

Mechanism: Ivo's `loop_until { testing_threads.all? { |t| t.status == "sleep" } }` in the outer `before` block waits for every testing thread (including `t1`) to actually reach `sleep` status before setup proceeds. With the reproducer's 500ms busy-wait between `ready_queue << true` and `sleep`, `loop_until` blocks for ~500ms until `t1` finishes busy-waiting and reaches `sleep`. After that, `t1`'s per-thread CPU clock stops advancing. Setup samples then snapshot `cpu_time_at_previous_sample_ns` while `t1` is genuinely sleeping; the test body's `sample` reads the same value; `cpu_time_elapsed_ns = 0`; state detection in `collectors_stack.c:288-293` falls through to the stack-based path; the `sleep` frame on `t1`'s stack labels the sample `"sleeping"`. Assertion passes.

**Local verification:**

- Targeted test (`records a regular sample`), 5 runs: 5/5 pass.
- Full file (`thread_context_spec.rb`): 178 examples, 0 failures, 2 unrelated pendings.

**What this PR proves and does not prove:**

- ✓ Proves: Ivo's fix neutralizes the failure mode his hypothesis describes (legitimate cpu-time accrual between `ready_queue << true` and `sleep`).
- ✗ Does NOT prove: Ivo's hypothesis is the actual upstream cause of the original CI flake. The AI's CPU-clock-tick-on-sleeping-thread hypothesis remains possible. Only repeated CI memcheck runs on the unmodified test, or a diagnostic capturing `t1.status` at sample time on a real failure, can arbitrate the two hypotheses.

**Change log entry**

None.

**How to test the change?**

CI is expected to pass on this PR across every job, including `test-memcheck` and `test-asan`.

**Companion PRs:**

- Mechanism reproducer: [#5873](https://github.com/DataDog/dd-trace-rb/pull/5873) (busy-wait, expected to fail on every job)
- Candidate fix: [#5879](https://github.com/DataDog/dd-trace-rb/pull/5879)
- Alternative fix: [#5874](https://github.com/DataDog/dd-trace-rb/pull/5874)
