### PR TITLE
SymDB: walk Object.constants in build_per_file_index

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -261,6 +261,74 @@ module Datadog
         false
       end
 
+      # Yield every named Module reachable from `Object` via const lookup,
+      # once per Module identity. Used by `build_per_file_index` in place of
+      # `ObjectSpace.each_object(Module)`.
+      #
+      # Coverage equivalence vs `ObjectSpace.each_object(Module)`:
+      #   - Modules reachable via const lookup: yielded by both.
+      #   - Anonymous modules (no `Module#name`): not yielded here, but
+      #     `safe_mod_name` in the previous traversal returned nil for these
+      #     and they were filtered out anyway.
+      #   - Singleton classes: not yielded here (not const-referenced), and
+      #     the previous traversal skipped them via MODULE_SINGLETON_CLASS_PRED.
+      #   - "Leaked" classes whose constant was removed via `remove_const` but
+      #     are still held by ObjectSpace: not yielded here (unreachable via
+      #     const lookup), and `resolves_to_same_module?` in the previous
+      #     traversal filtered them out. The const-walk provides the same
+      #     guarantee by construction — anything reached IS the binding at
+      #     that name.
+      #
+      # Autoload safety: a const_get on an autoload-pending name triggers
+      # the autoload (loads customer code, raises LoadError on missing
+      # target). Each segment is guarded with `autoload?` first; pending
+      # autoloads abort descent into that subtree without triggering.
+      #
+      # Order is DFS, parent-before-child. The seen set is keyed on
+      # `object_id` so a Module assigned to multiple constants
+      # (`Alias = SomeMod`) is yielded once — `Module#name` returns the
+      # canonical (first-assigned) name regardless of the traversal path.
+      def each_named_module
+        seen = {}
+        # Stack holds Object (the root, a Class<Module>) plus Modules pushed
+        # during traversal. The runtime invariant is "every element responds
+        # to `constants`, `autoload?`, `const_get`"; Module satisfies that
+        # contract for both Object (a Class<Module>) and any pushed element.
+        stack = [Object]
+        while (parent = stack.pop)
+          begin
+            parent.constants(false).each do |sym|
+              pending_autoload = if RUBY_VERSION >= '2.7'
+                parent.autoload?(sym, false)
+              else
+                parent.autoload?(sym)
+              end
+              next if pending_autoload
+              val = begin
+                parent.const_get(sym, false)
+              rescue NameError, ScriptError
+                # const_get can race with concurrent remove_const, or hit a
+                # loader that surfaces a load error even off the autoload
+                # path. ScriptError covers LoadError (its subclass). Skip
+                # the subtree rather than abort the walk.
+                next
+              end
+              next unless val.is_a?(Module)
+              oid = val.object_id
+              next if seen[oid]
+              seen[oid] = true
+              yield val
+              stack << val # steep:ignore
+            end
+          rescue => e
+            @logger.debug do
+              "symdb: error walking constants under #{safe_mod_name(parent) || '<unknown>'}: " \
+                "#{e.class}: #{e.message}"
+            end
+          end
+        end
+      end
+
       # Check if module is from user code (not gems or stdlib)
       # @param mod [Module] The module to check
       # @return [Boolean] true if user code
@@ -740,22 +808,21 @@ module Datadog
         index = {}
         seen = 0
 
-        ObjectSpace.each_object(Module) do |mod|
-          # Singleton classes (per-object metaclasses) are never user-code classes.
-          # They're not const-referenced, DI cannot instrument methods on a singular
-          # object instance, and on Ruby 2.6 specifically, Module#name on unnamed
-          # singleton classes with long ancestor chains (e.g. through monkey-patches
-          # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
-          # — measured ~20ms per call, which dominates extract_all on heavily-loaded
-          # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
-          next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
-
+        # Const-walk reachability is the leak filter: anything reached IS the
+        # binding at that name, so `resolves_to_same_module?` is not needed
+        # here (vs. the legacy `collect_extractable_modules`, which iterates
+        # `ObjectSpace.each_object(Module)` and must filter post-hoc).
+        # Anonymous and singleton modules are excluded by construction.
+        each_named_module do |mod|
+          # See collect_extractable_modules for the rationale behind the
+          # periodic sleep.
           seen += 1
           sleep SLEEP_SECONDS if (seen % SLEEP_EVERY_N_MODULES).zero?
 
           mod_name = safe_mod_name(mod)
+          # Const-reachable modules normally have a name, but a recently
+          # remove_const'd module could be reached transiently — skip it.
           next unless mod_name
-          next unless resolves_to_same_module?(mod_name, mod)
           next unless user_code_module?(mod)
 
           file_to_names = collect_method_names_by_file(mod)

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -34,6 +34,8 @@ module Datadog
 
       def resolves_to_same_module?: (String mod_name, Module mod) -> bool
 
+      def each_named_module: () { (Module) -> void } -> void
+
       def user_code_module?: (Module mod) -> bool
 
       def user_code_path?: (String path) -> bool

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -1638,6 +1638,62 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     end
   end
 
+  describe '#each_named_module' do
+    def collect_walked
+      walked = []
+      extractor.send(:each_named_module) { |m| walked << m }
+      walked
+    end
+
+    it 'yields each const-reachable Module once even when assigned to multiple constants' do
+      stub_const('EachNamedModuleAliasHost', Module.new)
+      shared = Module.new
+      EachNamedModuleAliasHost.const_set(:First, shared)
+      EachNamedModuleAliasHost.const_set(:Second, shared)
+
+      walked = collect_walked
+
+      expect(walked.count(shared)).to eq(1)
+    end
+
+    it 'does not yield a class that has been remove_const-ed but is still in ObjectSpace' do
+      stub_const('EachNamedModuleLeakHost', Module.new)
+      leaked = Class.new do
+        def alpha
+        end
+      end
+      EachNamedModuleLeakHost.const_set(:Leaked, leaked)
+      # Keep a hard reference so GC cannot reclaim the leaked Class.
+      keep_alive = leaked
+      EachNamedModuleLeakHost.send(:remove_const, :Leaked)
+
+      walked = collect_walked
+
+      expect(walked).not_to include(leaked)
+      expect(keep_alive).to be(leaked)
+    end
+
+    it 'does not trigger an autoload-pending constant' do
+      stub_const('EachNamedModuleAutoloadHost', Module.new)
+      autoload_target = '/nonexistent/each_named_module_autoload_target.rb'
+      EachNamedModuleAutoloadHost.autoload(:Pending, autoload_target)
+
+      expect { collect_walked }.not_to raise_error
+      expect(EachNamedModuleAutoloadHost.autoload?(:Pending)).to eq(autoload_target)
+    end
+
+    it 'skips non-Module constants' do
+      stub_const('EachNamedModuleConstantHost', Module.new)
+      EachNamedModuleConstantHost.const_set(:NUMBER, 42)
+      EachNamedModuleConstantHost.const_set(:STRING, 'hello')
+
+      walked = collect_walked
+
+      expect(walked).not_to include(42)
+      expect(walked).not_to include('hello')
+    end
+  end
+
   # ── extract_all tests ──────────────────────────────────────────────
   # These test the production path: two-pass extraction with FQN-based nesting
   # and per-file method grouping.


### PR DESCRIPTION
**What does this PR do?**

Replaces `ObjectSpace.each_object(Module)` in `Extractor#build_per_file_index` with a `Object.constants` recursive walk. The walk descends via `Module#constants(false)` + `const_get(sym, false)` with a per-segment `autoload?` guard so it never triggers customer autoloads (same pattern #5872 introduced in `resolves_to_same_module?`).

The legacy `collect_extractable_modules` (still used while the non-block `extract_all` API exists) keeps `ObjectSpace.each_object`. Only the memory-bounded path moves to the const-walk.

**Motivation:**

Per @eregon's review comment on #5872 ([link](https://github.com/DataDog/dd-trace-rb/pull/5872#discussion_r3387930251)): walking `Object.constants` recursively makes `resolves_to_same_module?` redundant by construction — anything reached through the const tree *is* the binding at that name, so the leak filter is the traversal itself. Also avoids iterating every loaded `Module` object.

**Coverage equivalence vs `ObjectSpace.each_object(Module)`:**

| Category | ObjectSpace walk | Const walk |
|---|---|---|
| Const-reachable named modules | yielded | yielded |
| Anonymous modules (`Module#name == nil`) | yielded → filtered by `safe_mod_name` | not yielded |
| Singleton classes (per-object metaclasses) | yielded → filtered by `MODULE_SINGLETON_CLASS_PRED` | not yielded |
| Leaked classes (`remove_const`-ed, still in ObjectSpace) | yielded → filtered by `resolves_to_same_module?` | not yielded |
| Module assigned to multiple constants | yielded once | yielded once (`object_id` seen-set) |

The categories the legacy walk filtered out are excluded by construction in the const walk. The categories both yield are identical.

**Autoload safety:**

`const_get(sym, false)` still triggers autoload on a pending name (the bug #5872 fixed). Each segment is guarded with `autoload?` first — Ruby 2.7+ uses `autoload?(sym, false)` for direct-only semantics; 2.5/2.6 falls back to `autoload?(sym)` (this matches the version branch in `resolves_to_same_module?`). Pending autoloads abort descent into that subtree without loading customer code or raising `LoadError`.

**Change log entry**

None.

**Benchmarks:**

Ran the three SymDB benchmarks from #5798 (`symbol_database_extraction.rb`, `symbol_database_background_impact.rb`, `symbol_database_baseline_matrix.rb`) on a laptop with a 2500-class workload, comparing `master` (`f9044e8cea`) against this PR (`fc0342d357`).

Setup: Intel Core Ultra 7 165U, Ruby 3.2.3, `taskset` pinning, turbo enabled. SymDB benchmarks are documented as ±5-10% precision (see [`ruby-di-benchmarks/SETUP.md`](https://github.com/p-datadog/claude-projects/blob/master/projects/ruby-di-benchmarks/SETUP.md) in the laptop project for the host recipe).

`symbol_database_extraction.rb` (per-iteration `extract_all`, 12s window), 4 runs per branch on each core type, medians:

| Metric | P-core master | P-core 5889 | E-core master | E-core 5889 |
|---|---:|---:|---:|---:|
| Per-iter wall mean (s) | 0.606 | 0.613 | 1.538 | 1.557 |
| Per-iter CPU mean (s)  | 0.572 | 0.581 | 0.906 | 0.914 |
| Memory peak (KB)       | 88,704 | 88,338 | 88,710 | 88,342 |

The const walk lands within ~1-2% of master on per-iteration wall and CPU, in the *opposite* direction from eregon's predicted speedup — both ratios sit inside the benchmark's documented noise envelope, so it feels like the two approaches are statistically indistinguishable on this workload. Memory peak is consistently ~370 KB (~0.4%) lower on 5889, which lines up with the const walk not enumerating singleton classes, anonymous modules, or `remove_const`-leaked classes that the legacy walk filters post-hoc.

`symbol_database_background_impact.rb` and `symbol_database_baseline_matrix.rb` show the same picture: throughput-drop magnitudes and frequency-scaling artifacts match between the two branches.

Reading: both walks spend most of `extract_all`'s time in per-module work (method-names extraction, scope building), so module enumeration isn't the hot path at this scale. The change stands on the coverage-equivalence + by-construction leak-filter argument, not on a speedup.

**How to test the change?**

```bash
bundle exec rspec spec/datadog/symbol_database/extractor_spec.rb
bundle exec rspec spec/datadog/symbol_database/
bundle exec steep check lib/datadog/symbol_database/extractor.rb
```

All green locally. The existing leak tests (`autoload registered after remove_const`, `class detached from its constant via remove_const`, `subclass with constant of same name as ancestor pending autoload`) now exercise the const-walk path through `extract_all` and continue to pass — confirming end-to-end coverage equivalence.

Four new unit tests for `each_named_module` directly:
- yields a module assigned to multiple constants once
- does not yield a `remove_const`-ed class still in ObjectSpace
- does not trigger an autoload-pending constant
- skips non-Module constants

