### PR TITLE
Update gems using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,23 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      gh-actions-packages:
+      github-actions:
         patterns:
           - "*"
     ignore:
       # Updated by .github/workflows/update-system-tests.yml, which keeps the workflow's `ref` input in sync.
       - dependency-name: "DataDog/system-tests/.github/workflows/system-tests.yml"
+    cooldown:
+      default-days: 2
+
+  - package-ecosystem: "bundler"
+    directories:
+      - "/gemfiles"
+    schedule:
+      interval: "daily"
+    groups:
+      gems:
+        patterns:
+          - "*"
     cooldown:
       default-days: 2


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

That way we can use a cooldown for all Ruby versions.

**Motivation:**
Easy way to support cooldown on all Ruby versions (Bundler built-in support is Ruby 3.2+ only).

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
By looking at the PR dependabot opens.
Initially scheduled daily to see if everything works as expected, then weekly if so.
If it doesn't work we can just revert this.

<!-- Unsure? Have a question? Request a review! -->
