### PR TITLE
[APPSEC-68196] Infer route from path when request has no env

### DIFF
--- a/lib/datadog/appsec/api_security/route_extractor.rb
+++ b/lib/datadog/appsec/api_security/route_extractor.rb
@@ -50,6 +50,12 @@ module Datadog
         #          In Rails < 7.1 it also will not be set even if a route was found,
         #          but in this case `action_dispatch.request.path_parameters` won't be empty.
         def self.route_pattern(request)
+          # NOTE: Requests from contribs like AWS Lambda don't provide a usable
+          #       `::Rack::Request#env`, so infer the route from the path instead
+          unless request.respond_to?(:env)
+            return Tracing::Contrib::Rack::RouteInference.infer(request.path.to_s)
+          end
+
           if request.env.key?(GRAPE_ROUTE_KEY)
             pattern = request.env[GRAPE_ROUTE_KEY][:route_info]&.pattern&.origin
             "#{request.script_name}#{pattern}"

--- a/sig/datadog/appsec/api_security.rbs
+++ b/sig/datadog/appsec/api_security.rbs
@@ -2,6 +2,7 @@ module Datadog
   module AppSec
     module APISecurity
       interface _Request
+        def respond_to?: (Symbol) -> bool
         def env: () -> Hash[String, untyped]
         def script_name: () -> String?
         def request_method: () -> String

--- a/spec/datadog/appsec/api_security/route_extractor_spec.rb
+++ b/spec/datadog/appsec/api_security/route_extractor_spec.rb
@@ -278,6 +278,26 @@ RSpec.describe Datadog::AppSec::APISecurity::RouteExtractor do
       end
     end
 
+    context 'when request does not respond to env' do
+      context 'when path has a dynamic segment' do
+        let(:request) { double('Lambda::Request', path: '/users/1') }
+
+        it { expect(described_class.route_pattern(request)).to eq('/users/{param:int}') }
+      end
+
+      context 'when path is root' do
+        let(:request) { double('Lambda::Request', path: '/') }
+
+        it { expect(described_class.route_pattern(request)).to eq('/') }
+      end
+
+      context 'when path is nil' do
+        let(:request) { double('Lambda::Request', path: nil) }
+
+        it { expect(described_class.route_pattern(request)).to eq('/') }
+      end
+    end
+
     context 'when multiple framework routes are present' do
       context 'when Sinatra and Grape routes are present' do
         let(:route_info) do


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**

Introduces shortcut for requests that doesn't have ENV by nature

**Motivation:**

This is a needed change for AWS Lambda contrib to use the same extraction module.

**Change log entry**

None.

**Additional Notes:**

None.

**How to test the change?**

CI + ST