### PR TITLE
[PROF-15076] Fix GC profiling being disabled on Ruby 3.2.10/3.2.11

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -8,9 +8,10 @@ target :datadog do
 
   check 'lib/'
 
-  # Profiling files that use inline RBS type annotations instead of sig/*.rbs.
+  # Files that use inline RBS type annotations instead of sig/*.rbs.
   # Inline checking requires Steep 2.0+. Some profiling files still need some
   # info that can't yet live on the .rb, so we keep the sig/*.rbs.
+  check 'lib/datadog/ruby_version.rb', inline: true
   check 'lib/datadog/profiling/encoded_profile.rb', inline: true
   check 'lib/datadog/profiling/exporter.rb', inline: true
   check 'lib/datadog/profiling/ext.rb', inline: true

--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'ruby_version'
 require_relative 'core/deprecations'
 require_relative 'core/configuration/config_helper'
 require_relative 'core/extensions'

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -141,15 +141,15 @@ module Datadog
         # that causes a segmentation fault during garbage collection of Ractors
         # (https://bugs.ruby-lang.org/issues/18464). We don't allow enabling gc profiling on such Rubies.
         # This bug is fixed on Ruby versions 3.1.4, 3.2.3 and 3.3.0.
-        if RUBY_VERSION.start_with?("3.0.") ||
-            (RUBY_VERSION.start_with?("3.1.") && RUBY_VERSION < "3.1.4") ||
-            (RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3")
+        if RubyVersion.is?("~> 3.0.0") ||
+            RubyVersion.is?("~> 3.1.0", "< 3.1.4") ||
+            RubyVersion.is?("~> 3.2.0", "< 3.2.3")
           logger.warn(
             "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling GC profiling would cause " \
             "crashes (https://bugs.ruby-lang.org/issues/18464). GC profiling has been disabled."
           )
           return false
-        elsif RUBY_VERSION.start_with?("3.")
+        elsif RubyVersion.is?("~> 3.0")
           logger.debug(
             "Using Ractors may result in GC profiling unexpectedly " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
@@ -177,7 +177,7 @@ module Datadog
         # Ruby 3.2.0 to 3.2.2 have a bug in the newobj tracepoint (https://bugs.ruby-lang.org/issues/19482,
         # https://github.com/ruby/ruby/pull/7464) that makes this crash in any configuration. This bug is
         # fixed on Ruby versions 3.2.3 and 3.3.0.
-        if RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3"
+        if RubyVersion.is?("~> 3.2.0", "< 3.2.3")
           logger.warn(
             "Allocation profiling is not supported in Ruby versions 3.2.0, 3.2.1 and 3.2.2 and will be forcibly " \
             "disabled. This is due to a VM bug that can lead to crashes (https://bugs.ruby-lang.org/issues/19482). " \
@@ -191,9 +191,9 @@ module Datadog
         # that causes a segmentation fault during garbage collection of Ractors
         # (https://bugs.ruby-lang.org/issues/18464). We don't recommend using this feature on such Rubies.
         # This bug is fixed on Ruby versions 3.1.4, 3.2.3 and 3.3.0.
-        if RUBY_VERSION.start_with?("3.0.") ||
-            (RUBY_VERSION.start_with?("3.1.") && RUBY_VERSION < "3.1.4") ||
-            (RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3")
+        if RubyVersion.is?("~> 3.0.0") ||
+            RubyVersion.is?("~> 3.1.0", "< 3.1.4") ||
+            RubyVersion.is?("~> 3.2.0", "< 3.2.3")
           logger.warn(
             "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling allocation profiling while using " \
             "Ractors may cause unexpected issues, including crashes (https://bugs.ruby-lang.org/issues/18464). " \
@@ -202,7 +202,7 @@ module Datadog
         # ANNOYANCE - Only with Ractors
         # On all known versions of Ruby 3.x, due to https://bugs.ruby-lang.org/issues/19112, when a ractor gets
         # garbage collected, Ruby will disable all active tracepoints, which this feature internally relies on.
-        elsif RUBY_VERSION.start_with?("3.")
+        elsif RubyVersion.is?("~> 3.0")
           logger.debug(
             "Using Ractors may result in allocation profiling " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
@@ -220,7 +220,7 @@ module Datadog
 
         return false unless heap_profiling_enabled
 
-        if RUBY_VERSION < "3.1"
+        if RubyVersion.is?("< 3.1")
           logger.warn(
             "Current Ruby version (#{RUBY_VERSION}) cannot support heap profiling due to VM limitations. " \
             "Please upgrade to Ruby >= 3.1 in order to use this feature. Heap profiling has been disabled."
@@ -262,7 +262,7 @@ module Datadog
         end
 
         if setting_value == false
-          if RUBY_VERSION.start_with?("2.5.")
+          if RubyVersion.is?("~> 2.5.0")
             logger.warn(
               'The profiling "no signals" workaround has been disabled via configuration on Ruby 2.5. ' \
               "This is not recommended " \
@@ -288,7 +288,7 @@ module Datadog
         # Setting is in auto mode. Let's probe to see if we should enable it:
 
         # We don't warn users in this situation because "upgrade your Ruby" is not a great warning
-        return true if RUBY_VERSION.start_with?("2.5.")
+        return true if RubyVersion.is?("~> 2.5.0")
 
         if Gem.loaded_specs["mysql2"] && incompatible_libmysqlclient_version?(settings, logger)
           logger.warn(
@@ -450,13 +450,13 @@ module Datadog
       end
 
       private_class_method def self.dir_interruption_workaround_enabled?(settings, no_signals_workaround_enabled)
-        return false if no_signals_workaround_enabled || RUBY_VERSION >= "3.4"
+        return false if no_signals_workaround_enabled || RubyVersion.is?(">= 3.4")
 
         settings.profiling.advanced.dir_interruption_workaround_enabled
       end
 
       private_class_method def self.can_apply_exec_monkey_patch?(settings)
-        return false if RUBY_VERSION < "2.7"
+        return false if RubyVersion.is?("< 2.7")
 
         # This file is 2.7+ only so we only require it here once we've checked the Ruby version
         require "datadog/profiling/ext/exec_monkey_patch"
@@ -465,7 +465,7 @@ module Datadog
       end
 
       private_class_method def self.enable_gvl_profiling?(settings, logger)
-        RUBY_VERSION >= "3.2" && settings.profiling.advanced.gvl_enabled
+        RubyVersion.is?(">= 3.2") && settings.profiling.advanced.gvl_enabled
       end
     end
   end

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -141,15 +141,14 @@ module Datadog
         # that causes a segmentation fault during garbage collection of Ractors
         # (https://bugs.ruby-lang.org/issues/18464). We don't allow enabling gc profiling on such Rubies.
         # This bug is fixed on Ruby versions 3.1.4, 3.2.3 and 3.3.0.
-        if RubyVersion.is?("~> 3.0.0") ||
-            RubyVersion.is?("~> 3.1.0", "< 3.1.4") ||
-            RubyVersion.is?("~> 3.2.0", "< 3.2.3")
+        if RubyVersion.is?(">= 3", "< 3.1.4") ||
+            RubyVersion.is?(">= 3.2", "< 3.2.3")
           logger.warn(
             "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling GC profiling would cause " \
             "crashes (https://bugs.ruby-lang.org/issues/18464). GC profiling has been disabled."
           )
           return false
-        elsif RubyVersion.is?("~> 3.0")
+        elsif RubyVersion.is?(">= 3", "< 4")
           logger.debug(
             "Using Ractors may result in GC profiling unexpectedly " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
@@ -177,7 +176,7 @@ module Datadog
         # Ruby 3.2.0 to 3.2.2 have a bug in the newobj tracepoint (https://bugs.ruby-lang.org/issues/19482,
         # https://github.com/ruby/ruby/pull/7464) that makes this crash in any configuration. This bug is
         # fixed on Ruby versions 3.2.3 and 3.3.0.
-        if RubyVersion.is?("~> 3.2.0", "< 3.2.3")
+        if RubyVersion.is?(">= 3.2", "< 3.2.3")
           logger.warn(
             "Allocation profiling is not supported in Ruby versions 3.2.0, 3.2.1 and 3.2.2 and will be forcibly " \
             "disabled. This is due to a VM bug that can lead to crashes (https://bugs.ruby-lang.org/issues/19482). " \
@@ -191,9 +190,8 @@ module Datadog
         # that causes a segmentation fault during garbage collection of Ractors
         # (https://bugs.ruby-lang.org/issues/18464). We don't recommend using this feature on such Rubies.
         # This bug is fixed on Ruby versions 3.1.4, 3.2.3 and 3.3.0.
-        if RubyVersion.is?("~> 3.0.0") ||
-            RubyVersion.is?("~> 3.1.0", "< 3.1.4") ||
-            RubyVersion.is?("~> 3.2.0", "< 3.2.3")
+        if RubyVersion.is?(">= 3", "< 3.1.4") ||
+            RubyVersion.is?(">= 3.2", "< 3.2.3")
           logger.warn(
             "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling allocation profiling while using " \
             "Ractors may cause unexpected issues, including crashes (https://bugs.ruby-lang.org/issues/18464). " \
@@ -202,7 +200,7 @@ module Datadog
         # ANNOYANCE - Only with Ractors
         # On all known versions of Ruby 3.x, due to https://bugs.ruby-lang.org/issues/19112, when a ractor gets
         # garbage collected, Ruby will disable all active tracepoints, which this feature internally relies on.
-        elsif RubyVersion.is?("~> 3.0")
+        elsif RubyVersion.is?(">= 3", "< 4")
           logger.debug(
             "Using Ractors may result in allocation profiling " \
             "stopping (https://bugs.ruby-lang.org/issues/19112). Note that this stop has no impact in your " \
@@ -262,7 +260,7 @@ module Datadog
         end
 
         if setting_value == false
-          if RubyVersion.is?("~> 2.5.0")
+          if RubyVersion.is?("< 2.6")
             logger.warn(
               'The profiling "no signals" workaround has been disabled via configuration on Ruby 2.5. ' \
               "This is not recommended " \
@@ -288,7 +286,7 @@ module Datadog
         # Setting is in auto mode. Let's probe to see if we should enable it:
 
         # We don't warn users in this situation because "upgrade your Ruby" is not a great warning
-        return true if RubyVersion.is?("~> 2.5.0")
+        return true if RubyVersion.is?("< 2.6")
 
         if Gem.loaded_specs["mysql2"] && incompatible_libmysqlclient_version?(settings, logger)
           logger.warn(

--- a/lib/datadog/profiling/ext/dir_monkey_patches.rb
+++ b/lib/datadog/profiling/ext/dir_monkey_patches.rb
@@ -28,7 +28,7 @@ module Datadog
         end
       end
 
-      if RUBY_VERSION.start_with?("2.")
+      if RubyVersion.is?("~> 2.0")
         # Monkey patches for Dir.singleton_class (Ruby 2 version). See DirMonkeyPatches above for more details.
         module DirClassMonkeyPatches
           # Steep: Workaround that defines args and block only for Ruby 2.x.
@@ -270,7 +270,7 @@ module Datadog
         end
       end
 
-      if RUBY_VERSION.start_with?("2.")
+      if RubyVersion.is?("~> 2.0")
         # Monkey patches for Dir (Ruby 2 version). See DirMonkeyPatches above for more details.
         module DirInstanceMonkeyPatches
           # Steep: Workaround that defines args and block only for Ruby 2.x.
@@ -300,7 +300,7 @@ module Datadog
             end
           end
 
-          unless RUBY_VERSION.start_with?("2.5.") # This is Ruby 2.6+
+          unless RubyVersion.is?("~> 2.5.0") # This is Ruby 2.6+
             # See note on methods that yield above.
             def each_child(*args, &block)
               if block

--- a/lib/datadog/profiling/ext/dir_monkey_patches.rb
+++ b/lib/datadog/profiling/ext/dir_monkey_patches.rb
@@ -300,7 +300,7 @@ module Datadog
             end
           end
 
-          unless RubyVersion.is?("~> 2.5.0") # This is Ruby 2.6+
+          if RubyVersion.is?(">= 2.6.0") # This is Ruby 2.6+
             # See note on methods that yield above.
             def each_child(*args, &block)
               if block

--- a/lib/datadog/profiling/ext/dir_monkey_patches.rb
+++ b/lib/datadog/profiling/ext/dir_monkey_patches.rb
@@ -28,7 +28,7 @@ module Datadog
         end
       end
 
-      if RubyVersion.is?("~> 2.0")
+      if RubyVersion.is?("< 3")
         # Monkey patches for Dir.singleton_class (Ruby 2 version). See DirMonkeyPatches above for more details.
         module DirClassMonkeyPatches
           # Steep: Workaround that defines args and block only for Ruby 2.x.
@@ -270,7 +270,7 @@ module Datadog
         end
       end
 
-      if RubyVersion.is?("~> 2.0")
+      if RubyVersion.is?("< 3")
         # Monkey patches for Dir (Ruby 2 version). See DirMonkeyPatches above for more details.
         module DirInstanceMonkeyPatches
           # Steep: Workaround that defines args and block only for Ruby 2.x.
@@ -300,7 +300,7 @@ module Datadog
             end
           end
 
-          if RubyVersion.is?(">= 2.6.0") # This is Ruby 2.6+
+          if RubyVersion.is?(">= 2.6.0") # This method is Ruby 2.6+
             # See note on methods that yield above.
             def each_child(*args, &block)
               if block

--- a/lib/datadog/ruby_version.rb
+++ b/lib/datadog/ruby_version.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Datadog
+  # Compares the running Ruby against version requirements.
+  #
+  # Lexical comparisons against `RUBY_VERSION` are subtly wrong: `RUBY_VERSION < "3.2.3"` is also
+  # `true` on 3.2.10 and 3.2.11, since those sort *before* "3.2.3" as strings.
+  #
+  # @example
+  #   RubyVersion.is?("~> 3.0.0")            # => true on Ruby 3.0.x only
+  #   RubyVersion.is?("~> 3.2.0", "< 3.2.3") # => true on Ruby 3.2.0, 3.2.1, 3.2.2 (NOT 3.2.3+, NOT 3.2.10+)
+  module RubyVersion
+    extend RubyVersion # steep currently needs this for the inline rbs to work
+
+    # Returns `true` when the running Ruby satisfies ALL of the given requirements. Each uses the
+    # same syntax as a gem dependency (e.g. `">= 3.1"`, `"~> 3.2.0"`, `"< 3.2.3"`).
+    #
+    # @rbs (*String requirements, ?ruby_version: String) -> bool
+    def is?(*requirements, ruby_version: RUBY_VERSION)
+      Gem::Requirement.new(*requirements).satisfied_by?(Gem::Version.new(ruby_version))
+    end
+  end
+end

--- a/lib/datadog/ruby_version.rb
+++ b/lib/datadog/ruby_version.rb
@@ -7,8 +7,7 @@ module Datadog
   # `true` on 3.2.10 and 3.2.11, since those sort *before* "3.2.3" as strings.
   #
   # @example
-  #   RubyVersion.is?("~> 3.0.0")            # => true on Ruby 3.0.x only
-  #   RubyVersion.is?("~> 3.2.0", "< 3.2.3") # => true on Ruby 3.2.0, 3.2.1, 3.2.2 (NOT 3.2.3+, NOT 3.2.10+)
+  #   RubyVersion.is?(">= 3.2", "< 3.2.3") # => true on Ruby 3.2.0, 3.2.1, 3.2.2 (NOT 3.2.3+, NOT 3.2.10+)
   module RubyVersion
     extend RubyVersion # steep currently needs this (instead of extend self or def self.is?) for the inline rbs to work
 
@@ -16,7 +15,7 @@ module Datadog
     private_constant :CURRENT_RUBY_VERSION
 
     # Returns `true` when the running Ruby satisfies ALL of the given requirements. Each uses the
-    # same syntax as a gem dependency (e.g. `">= 3.1"`, `"~> 3.2.0"`, `"< 3.2.3"`).
+    # same syntax as a gem dependency (e.g. `">= 3.1"`, `">= 3.2"`, `"< 3.2.3"`).
     #
     # @rbs (*String requirements, ?ruby_version: ::Gem::Version) -> bool
     def is?(*requirements, ruby_version: CURRENT_RUBY_VERSION)

--- a/lib/datadog/ruby_version.rb
+++ b/lib/datadog/ruby_version.rb
@@ -12,12 +12,15 @@ module Datadog
   module RubyVersion
     extend RubyVersion # steep currently needs this for the inline rbs to work
 
+    CURRENT_RUBY_VERSION = Gem::Version.new(RUBY_VERSION) #: ::Gem::Version
+    private_constant :CURRENT_RUBY_VERSION
+
     # Returns `true` when the running Ruby satisfies ALL of the given requirements. Each uses the
     # same syntax as a gem dependency (e.g. `">= 3.1"`, `"~> 3.2.0"`, `"< 3.2.3"`).
     #
-    # @rbs (*String requirements, ?ruby_version: String) -> bool
-    def is?(*requirements, ruby_version: RUBY_VERSION)
-      Gem::Requirement.new(*requirements).satisfied_by?(Gem::Version.new(ruby_version))
+    # @rbs (*String requirements, ?ruby_version: ::Gem::Version) -> bool
+    def is?(*requirements, ruby_version: CURRENT_RUBY_VERSION)
+      Gem::Requirement.new(*requirements).satisfied_by?(ruby_version)
     end
   end
 end

--- a/lib/datadog/ruby_version.rb
+++ b/lib/datadog/ruby_version.rb
@@ -10,7 +10,7 @@ module Datadog
   #   RubyVersion.is?("~> 3.0.0")            # => true on Ruby 3.0.x only
   #   RubyVersion.is?("~> 3.2.0", "< 3.2.3") # => true on Ruby 3.2.0, 3.2.1, 3.2.2 (NOT 3.2.3+, NOT 3.2.10+)
   module RubyVersion
-    extend RubyVersion # steep currently needs this for the inline rbs to work
+    extend RubyVersion # steep currently needs this (instead of extend self or def.self_is?) for the inline rbs to work
 
     CURRENT_RUBY_VERSION = Gem::Version.new(RUBY_VERSION) #: ::Gem::Version
     private_constant :CURRENT_RUBY_VERSION

--- a/lib/datadog/ruby_version.rb
+++ b/lib/datadog/ruby_version.rb
@@ -10,7 +10,7 @@ module Datadog
   #   RubyVersion.is?("~> 3.0.0")            # => true on Ruby 3.0.x only
   #   RubyVersion.is?("~> 3.2.0", "< 3.2.3") # => true on Ruby 3.2.0, 3.2.1, 3.2.2 (NOT 3.2.3+, NOT 3.2.10+)
   module RubyVersion
-    extend RubyVersion # steep currently needs this (instead of extend self or def.self_is?) for the inline rbs to work
+    extend RubyVersion # steep currently needs this (instead of extend self or def self.is?) for the inline rbs to work
 
     CURRENT_RUBY_VERSION = Gem::Version.new(RUBY_VERSION) #: ::Gem::Version
     private_constant :CURRENT_RUBY_VERSION

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     end
 
     context "when gvl_profiling_enabled is true on an unsupported Ruby" do
-      before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.2." }
+      before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 3.2") }
 
       let(:gvl_profiling_enabled) { true }
 
@@ -626,7 +626,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         #
         expect(sample_count).to be >= 8, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
 
-        if RUBY_VERSION >= "3.3.0"
+        if RubyVersion.is?(">= 3.3.0")
           expect(trigger_sample_attempts).to be >= sample_count
         else
           # @ivoanjo: We've seen this assertion become flaky once in CI for Ruby 3.1, where
@@ -720,7 +720,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         expect(allocation_sample.values).to include("alloc-samples": test_num_allocated_object)
         # For Ruby 4 onwards, new is inlined into the bytecode of the caller and there's no "new"
         # frame at the top of the stack, see https://github.com/ruby/ruby/pull/13080
-        expect((RUBY_VERSION >= "4.0.0") ? allocation_sample.locations[0] : allocation_sample.locations[1])
+        expect(RubyVersion.is?(">= 4.0.0") ? allocation_sample.locations[0] : allocation_sample.locations[1])
           .to match(have_attributes(base_label: "<top (required)>", path: __FILE__, lineno: allocation_line))
       end
 
@@ -815,7 +815,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         context "on Ruby 2.x" do
-          before { skip "Behavior only applies on Ruby 2.x" unless RUBY_VERSION.start_with?("2.") }
+          before { skip "Behavior only applies on Ruby 2.x" unless RubyVersion.is?("~> 2.0") }
 
           it "records internal VM objects, not including their specific kind" do
             start
@@ -833,7 +833,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         context "on Ruby 3.x" do
-          before { skip "Behavior only applies on Ruby 3.x" if RUBY_VERSION.start_with?("2.") }
+          before { skip "Behavior only applies on Ruby 3.x" if RubyVersion.is?("~> 2.0") }
 
           it "records internal VM objects, including their specific kind" do
             start
@@ -888,7 +888,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         allow(Datadog.logger).to receive(:warn)
         expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
 
-        skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
+        skip "Heap profiling is only supported on Ruby >= 2.7" if RubyVersion.is?("< 2.7")
       end
 
       after do |example|
@@ -925,7 +925,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         relevant_samples = samples_from_pprof(recorder.serialize!).select do |sample|
           # From Ruby 4 onwards, new is inlined into the bytecode of the caller and there's no "new"
           # frame at the top of the stack, see https://github.com/ruby/ruby/pull/13080
-          allocation_trigger_frame = (RUBY_VERSION >= "4.0.0") ? sample.locations[0] : sample.locations[1]
+          allocation_trigger_frame = RubyVersion.is?(">= 4.0.0") ? sample.locations[0] : sample.locations[1]
           next unless allocation_trigger_frame
 
           allocation_trigger_frame.lineno == allocation_line &&
@@ -1092,9 +1092,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       def skip_if_signal_handler_sampling_not_supported
         return unless sighandler_sampling_enabled
 
-        ruby_version = Gem::Version.new(RUBY_VERSION)
-        if ruby_version < Gem::Version.new("3.2.5") ||
-            (ruby_version >= Gem::Version.new("3.3.0") && ruby_version < Gem::Version.new("3.3.4"))
+        if RubyVersion.is?("< 3.2.5") ||
+            RubyVersion.is?(">= 3.3.0", "< 3.3.4")
           # In practice, many older Rubies are OK to sample from the signal handler, but for the purposes of testing
           # this is a safe simplification (these versions all include https://github.com/ruby/ruby/pull/11036)
           skip "Not safe to enable signal handler sampling on Ruby < 3.2.5 / Ruby < 3.3.4"
@@ -1152,10 +1151,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
   describe "Ractor safety" do
     before do
-      skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3."
+      skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3")
 
       # See native_extension_spec.rb for more details on the issues we saw on 3.0
-      skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.")
+      skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?("~> 3.0.0")
     end
 
     shared_examples_for "does not trigger a sample" do |run_ractor|
@@ -1190,7 +1189,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
               Ractor.new do
                 Thread.current.name = "background ractor"
                 Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_handle_sampling_signal
-              end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
+              end.yield_self { |r| RubyVersion.is?("< 4") ? r.take : r.value }
             end
           )
       end
@@ -1202,7 +1201,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
               Ractor.new do
                 Thread.current.name = "background ractor"
                 Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_simulate_sample_from_postponed_job
-              end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
+              end.yield_self { |r| RubyVersion.is?("< 4") ? r.take : r.value }
             end
           )
       end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         #
         expect(sample_count).to be >= 8, "sample_count: #{sample_count}, stats: #{stats}, debug_failures: #{debug_failures}"
 
-        if RubyVersion.is?(">= 3.3.0")
+        if RubyVersion.is?(">= 3.3")
           expect(trigger_sample_attempts).to be >= sample_count
         else
           # @ivoanjo: We've seen this assertion become flaky once in CI for Ruby 3.1, where
@@ -720,7 +720,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         expect(allocation_sample.values).to include("alloc-samples": test_num_allocated_object)
         # For Ruby 4 onwards, new is inlined into the bytecode of the caller and there's no "new"
         # frame at the top of the stack, see https://github.com/ruby/ruby/pull/13080
-        expect(RubyVersion.is?(">= 4.0.0") ? allocation_sample.locations[0] : allocation_sample.locations[1])
+        expect(RubyVersion.is?(">= 4") ? allocation_sample.locations[0] : allocation_sample.locations[1])
           .to match(have_attributes(base_label: "<top (required)>", path: __FILE__, lineno: allocation_line))
       end
 
@@ -815,7 +815,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         context "on Ruby 2.x" do
-          before { skip "Behavior only applies on Ruby 2.x" unless RubyVersion.is?("~> 2.0") }
+          before { skip "Behavior only applies on Ruby 2.x" unless RubyVersion.is?("< 3") }
 
           it "records internal VM objects, not including their specific kind" do
             start
@@ -833,7 +833,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         context "on Ruby 3.x" do
-          before { skip "Behavior only applies on Ruby 3.x" if RubyVersion.is?("~> 2.0") }
+          before { skip "Behavior only applies on Ruby 3.x" if RubyVersion.is?("< 3") }
 
           it "records internal VM objects, including their specific kind" do
             start
@@ -925,7 +925,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         relevant_samples = samples_from_pprof(recorder.serialize!).select do |sample|
           # From Ruby 4 onwards, new is inlined into the bytecode of the caller and there's no "new"
           # frame at the top of the stack, see https://github.com/ruby/ruby/pull/13080
-          allocation_trigger_frame = RubyVersion.is?(">= 4.0.0") ? sample.locations[0] : sample.locations[1]
+          allocation_trigger_frame = RubyVersion.is?(">= 4") ? sample.locations[0] : sample.locations[1]
           next unless allocation_trigger_frame
 
           allocation_trigger_frame.lineno == allocation_line &&
@@ -1093,7 +1093,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         return unless sighandler_sampling_enabled
 
         if RubyVersion.is?("< 3.2.5") ||
-            RubyVersion.is?(">= 3.3.0", "< 3.3.4")
+            RubyVersion.is?(">= 3.3", "< 3.3.4")
           # In practice, many older Rubies are OK to sample from the signal handler, but for the purposes of testing
           # this is a safe simplification (these versions all include https://github.com/ruby/ruby/pull/11036)
           skip "Not safe to enable signal handler sampling on Ruby < 3.2.5 / Ruby < 3.3.4"
@@ -1154,7 +1154,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3")
 
       # See native_extension_spec.rb for more details on the issues we saw on 3.0
-      skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?("~> 3.0.0")
+      skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?(">= 3", "< 3.1")
     end
 
     shared_examples_for "does not trigger a sample" do |run_ractor|

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -72,7 +72,7 @@ module IbhContainsRefinement
   module RefinesIbhClassG
     refine IbhClassG do
       def hello
-        if RUBY_VERSION >= "2.7.0"
+        if RubyVersion.is?(">= 2.7.0")
           IbhClassE.instance_method(:hello).bind_call(IbhClassF.new)
         else
           IbhClassE.instance_method(:hello).bind(IbhClassF.new).call

--- a/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
+++ b/spec/datadog/profiling/collectors/interesting_backtrace_helper.rb
@@ -72,7 +72,7 @@ module IbhContainsRefinement
   module RefinesIbhClassG
     refine IbhClassG do
       def hello
-        if RubyVersion.is?(">= 2.7.0")
+        if RubyVersion.is?(">= 2.7")
           IbhClassE.instance_method(:hello).bind_call(IbhClassF.new)
         else
           IbhClassE.instance_method(:hello).bind(IbhClassF.new).call

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     let(:background_thread) { Thread.new(ready_queue, &do_in_background_thread) }
     let(:expected_eval_path) do
       # Starting in Ruby 3.3, the path on evals went from being "(eval)" to being "(eval at some_file.rb:line)"
-      (RUBY_VERSION < "3.3.") ? "(eval)" : match(/\(eval at .+stack_spec.rb:\d+\)/)
+      RubyVersion.is?("< 3.3") ? "(eval)" : match(/\(eval at .+stack_spec.rb:\d+\)/)
     end
 
     before do
@@ -220,7 +220,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       # I opted to join these two expects to avoid running the `load` above more than once
       it "matches the Ruby backtrace API AND has a sleeping frame at the top of the stack" do
-        if RUBY_VERSION.start_with?("4.")
+        if RubyVersion.is?("~> 4.0")
           # In Ruby 4, due to https://bugs.ruby-lang.org/issues/20968 while internally Integer#times has the path
           # `<internal:numeric>` (and this is what the profiler observes), Ruby actually hides this and "blames" it
           # on the last ruby file/line that was on the stack.
@@ -533,7 +533,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       context "when sampling a thread blocked on Monitor#synchronize" do
         let(:expected_method_name) do
           # On older Rubies Monitor is implemented using Mutex instead of natively
-          if RUBY_VERSION.start_with?("2.5", "2.6")
+          if RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 2.6.0")
             "lock"
           else
             "synchronize"
@@ -626,7 +626,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       context "when sampling a thread waiting on a ConditionVariable object" do
         # In Ruby 4, we can directly match on ConditionVariable; for Ruby 2 & 3, wait delegates to sleep so we can't match as directly
-        let(:expected_method_name) { RUBY_VERSION.start_with?("4.") ? "wait" : "sleep" }
+        let(:expected_method_name) { RubyVersion.is?("~> 4.0") ? "wait" : "sleep" }
         let(:do_in_background_thread) do
           proc do |ready_queue|
             ready_queue << true

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       # I opted to join these two expects to avoid running the `load` above more than once
       it "matches the Ruby backtrace API AND has a sleeping frame at the top of the stack" do
-        if RubyVersion.is?("~> 4.0")
+        if RubyVersion.is?(">= 4")
           # In Ruby 4, due to https://bugs.ruby-lang.org/issues/20968 while internally Integer#times has the path
           # `<internal:numeric>` (and this is what the profiler observes), Ruby actually hides this and "blames" it
           # on the last ruby file/line that was on the stack.
@@ -533,7 +533,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       context "when sampling a thread blocked on Monitor#synchronize" do
         let(:expected_method_name) do
           # On older Rubies Monitor is implemented using Mutex instead of natively
-          if RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 2.6.0")
+          if RubyVersion.is?("< 2.7")
             "lock"
           else
             "synchronize"
@@ -626,7 +626,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       context "when sampling a thread waiting on a ConditionVariable object" do
         # In Ruby 4, we can directly match on ConditionVariable; for Ruby 2 & 3, wait delegates to sleep so we can't match as directly
-        let(:expected_method_name) { RubyVersion.is?("~> 4.0") ? "wait" : "sleep" }
+        let(:expected_method_name) { RubyVersion.is?(">= 4") ? "wait" : "sleep" }
         let(:do_in_background_thread) do
           proc do |ready_queue|
             ready_queue << true

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2024,7 +2024,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         context "on Ruby >= 3.1" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.1." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3.1") }
 
           # Thread#native_thread_id was added on 3.1
           it "contains the native thread ids of all sampled threads" do
@@ -2035,7 +2035,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         end
 
         context "on Ruby < 3.1" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.1." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 3.1") }
 
           it "contains a fallback native thread id" do
             per_thread_context.each do |_thread, context|

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Datadog::Profiling::Component do
             stub_const("RUBY_VERSION", testing_version)
           end
 
-          ["2.7.0", "3.1.4", "3.2.3", "3.3.0"].each do |fixed_ruby|
+          ["2.7.0", "3.1.4", "3.2.3", "3.2.10", "3.3.0"].each do |fixed_ruby|
             context "on a Ruby version not affected by https://bugs.ruby-lang.org/issues/18464 (#{fixed_ruby})" do
               let(:testing_version) { fixed_ruby }
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Datadog::Profiling::Component do
 
             # Since RUBY_VERSION is used to test if the ExecMonkeyPatch should be applied, mocking it below on an old
             # Ruby would cause it to wrongly be triggered, so we avoid running these specs there.
-            skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "2.7" && testing_version >= "3"
+            skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 2.7") && RubyVersion.is?(">= 3", ruby_version: testing_version)
 
             stub_const("RUBY_VERSION", testing_version)
           end
@@ -610,7 +610,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context "on Ruby >= 3.4" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.4." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3.4") }
 
           it "is never applied" do
             expect(Datadog::Profiling::Ext::DirMonkeyPatches).to_not receive(:apply!)
@@ -620,7 +620,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context "on Ruby < 3.4" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.4." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 3.4") }
 
           it "is applied by default" do
             expect(Datadog::Profiling::Ext::DirMonkeyPatches).to receive(:apply!)
@@ -695,7 +695,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context "on Ruby < 3.2" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3.2." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 3.2") }
 
           it "does not enable GVL profiling" do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
@@ -706,7 +706,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context "on Ruby >= 3.2" do
-          before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3.2." }
+          before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3.2") }
 
           it "enables GVL profiling" do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
@@ -723,7 +723,7 @@ RSpec.describe Datadog::Profiling::Component do
         end
 
         context "on Ruby >= 3.2" do
-          before { skip "On Ruby < 3.2 you can't enable the feature, it's always disabled" if RUBY_VERSION < "3.2." }
+          before { skip "On Ruby < 3.2 you can't enable the feature, it's always disabled" if RubyVersion.is?("< 3.2") }
 
           it "disables GVL profiling" do
             expect(Datadog::Profiling::Collectors::CpuAndWallTimeWorker)
@@ -832,7 +832,7 @@ RSpec.describe Datadog::Profiling::Component do
       it { is_expected.to be false }
 
       context "on Ruby 2.5 and below" do
-        before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "2.6." }
+        before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 2.6") }
 
         it "logs a warning message mentioning that this is is not recommended" do
           expect(logger).to receive(:warn).with(
@@ -844,7 +844,7 @@ RSpec.describe Datadog::Profiling::Component do
       end
 
       context "on Ruby 2.6 and above" do
-        before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "2.6." }
+        before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 2.6") }
 
         it "logs a warning message mentioning that the no signals mode has been disabled" do
           expect(logger).to receive(:warn).with('Profiling "no signals" workaround disabled via configuration')
@@ -871,13 +871,13 @@ RSpec.describe Datadog::Profiling::Component do
 
     shared_examples "no_signals_workaround_enabled :auto behavior" do
       context "on Ruby 2.5 and below" do
-        before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "2.6." }
+        before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 2.6") }
 
         it { is_expected.to be true }
       end
 
       context "on Ruby 2.6 and above" do
-        before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "2.6." }
+        before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 2.6") }
 
         context "when mysql2 gem is available" do
           include_context("loaded gems", mysql2: Gem::Version.new("0.5.5"), rugged: nil)

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe Datadog::Profiling::Component do
             settings.profiling.advanced.gc_enabled = true
 
             stub_const("RUBY_VERSION", testing_version)
+            stub_const("Datadog::RubyVersion::CURRENT_RUBY_VERSION", Gem::Version.new(RUBY_VERSION))
           end
 
           ["2.7.0", "3.1.4", "3.2.3", "3.2.10", "3.3.0"].each do |fixed_ruby|
@@ -240,6 +241,7 @@ RSpec.describe Datadog::Profiling::Component do
             end
 
             stub_const("RUBY_VERSION", testing_version)
+            stub_const("Datadog::RubyVersion::CURRENT_RUBY_VERSION", Gem::Version.new(RUBY_VERSION))
           end
 
           context "on Ruby 2.x" do
@@ -345,6 +347,7 @@ RSpec.describe Datadog::Profiling::Component do
             settings.profiling.advanced.experimental_heap_enabled = true
             settings.profiling.advanced.gc_enabled = false # Disable this to avoid any additional warnings coming from it
             stub_const("RUBY_VERSION", testing_version)
+            stub_const("Datadog::RubyVersion::CURRENT_RUBY_VERSION", Gem::Version.new(RUBY_VERSION))
           end
 
           context "on a Ruby older than 3.1" do
@@ -1128,7 +1131,10 @@ RSpec.describe Datadog::Profiling::Component do
     subject(:can_apply_exec_monkey_patch?) { described_class.send(:can_apply_exec_monkey_patch?, settings) }
 
     context "on Ruby < 2.7" do
-      before { stub_const("RUBY_VERSION", "2.6.9") }
+      before do
+        stub_const("RUBY_VERSION", "2.6.9")
+        stub_const("Datadog::RubyVersion::CURRENT_RUBY_VERSION", Gem::Version.new(RUBY_VERSION))
+      end
 
       it "returns false and does not require the monkey patch" do
         expect(described_class).to_not receive(:require)
@@ -1140,6 +1146,7 @@ RSpec.describe Datadog::Profiling::Component do
     context "on Ruby >= 2.7" do
       before do
         stub_const("RUBY_VERSION", "2.7.0")
+        stub_const("Datadog::RubyVersion::CURRENT_RUBY_VERSION", Gem::Version.new(RUBY_VERSION))
       end
 
       context "when exec workaround is disabled" do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -235,7 +235,9 @@ RSpec.describe Datadog::Profiling::Component do
 
             # Since RUBY_VERSION is used to test if the ExecMonkeyPatch should be applied, mocking it below on an old
             # Ruby would cause it to wrongly be triggered, so we avoid running these specs there.
-            skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 2.7") && RubyVersion.is?(">= 3", ruby_version: testing_version)
+            if RubyVersion.is?("< 2.7") && RubyVersion.is?(">= 3", ruby_version: Gem::Version.new(testing_version))
+              skip "Behavior does not apply to current Ruby version"
+            end
 
             stub_const("RUBY_VERSION", testing_version)
           end

--- a/spec/datadog/profiling/ext/dir_monkey_patches_spec.rb
+++ b/spec/datadog/profiling/ext/dir_monkey_patches_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Datadog::Profiling::Ext::DirMonkeyPatches do
     end
 
     describe "#each_child" do
-      before { skip("API not available on Ruby 2.5") if RUBY_VERSION.start_with?("2.5.") }
+      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("~> 2.5.0") }
 
       let(:expected_hold_resume_calls_count) { 1 + temporary_files_count }
 
@@ -278,7 +278,7 @@ RSpec.describe Datadog::Profiling::Ext::DirMonkeyPatches do
     end
 
     describe "#children" do
-      before { skip("API not available on Ruby 2.5") if RUBY_VERSION.start_with?("2.5.") }
+      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("~> 2.5.0") }
 
       it "matches the ruby behavior without monkey patching" do
         test_with_and_without_monkey_patch do

--- a/spec/datadog/profiling/ext/dir_monkey_patches_spec.rb
+++ b/spec/datadog/profiling/ext/dir_monkey_patches_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Datadog::Profiling::Ext::DirMonkeyPatches do
     end
 
     describe "#each_child" do
-      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("~> 2.5.0") }
+      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("< 2.6") }
 
       let(:expected_hold_resume_calls_count) { 1 + temporary_files_count }
 
@@ -278,7 +278,7 @@ RSpec.describe Datadog::Profiling::Ext::DirMonkeyPatches do
     end
 
     describe "#children" do
-      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("~> 2.5.0") }
+      before { skip("API not available on Ruby 2.5") if RubyVersion.is?("< 2.6") }
 
       it "matches the ruby behavior without monkey patching" do
         test_with_and_without_monkey_patch do

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -134,13 +134,13 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     subject(:ddtrace_rb_ractor_main_p) { described_class::Testing._native_ddtrace_rb_ractor_main_p }
 
     context "when Ruby has no support for Ractors" do
-      before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION >= "3" }
+      before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?(">= 3") }
 
       it { is_expected.to be true }
     end
 
     context "when Ruby has support for Ractors" do
-      before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION < "3" }
+      before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("< 3") }
 
       context "on the main Ractor" do
         it { is_expected.to be true }
@@ -157,13 +157,13 @@ RSpec.describe Datadog::Profiling::NativeExtension do
           # I was able to see this even on both Linux with 3.0.3 and macOS with 3.0.4. Thus, I decided to skip this
           # spec on Ruby 3.0. We can always run it manually if we change something around this helper; and we have
           # coverage on 3.1+ anyway.
-          skip "Ruby 3.0 Ractors are too buggy to run this spec" if RUBY_VERSION.start_with?("3.0.")
+          skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?("~> 3.0.0")
         end
 
         subject(:ddtrace_rb_ractor_main_p) do
           Ractor.new do
             Datadog::Profiling::NativeExtension::Testing._native_ddtrace_rb_ractor_main_p
-          end.yield_self { |r| (RUBY_VERSION < "4") ? r.take : r.value }
+          end.yield_self { |r| RubyVersion.is?("< 4") ? r.take : r.value }
         end
 
         it { is_expected.to be false }
@@ -258,7 +258,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     subject(:safe_object_info) { described_class::Testing._native_safe_object_info(object_to_inspect) }
 
     context "on a Ruby with rb_obj_info" do
-      before { skip "Behavior does not apply to current Ruby version" if RUBY_VERSION.start_with?("2.5", "3.3", "4.0") }
+      before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
 
       it "returns a string with information about the object" do
         expect(safe_object_info).to include("T_STRING")
@@ -266,7 +266,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     end
 
     context "on a Ruby without rb_obj_info" do
-      before { skip "Behavior does not apply to current Ruby version" unless RUBY_VERSION.start_with?("2.5", "3.3", "4.0") }
+      before { skip "Behavior does not apply to current Ruby version" unless RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
 
       it "returns a placeholder string and does not otherwise fail" do
         expect(safe_object_info).to eq "(No rb_obj_info for current Ruby)"

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
           # I was able to see this even on both Linux with 3.0.3 and macOS with 3.0.4. Thus, I decided to skip this
           # spec on Ruby 3.0. We can always run it manually if we change something around this helper; and we have
           # coverage on 3.1+ anyway.
-          skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?("~> 3.0.0")
+          skip "Ruby 3.0 Ractors are too buggy to run this spec" if RubyVersion.is?(">= 3", "< 3.1")
         end
 
         subject(:ddtrace_rb_ractor_main_p) do
@@ -260,7 +260,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     subject(:safe_object_info) { described_class::Testing._native_safe_object_info(object_to_inspect) }
 
     # Yes, 3.4 dropped it and it came back in 4.0, you're reading right ;)
-    let(:has_object_info) { RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
+    let(:has_object_info) { RubyVersion.is?("< 2.6") || RubyVersion.is?(">= 3.3", "< 3.4") || RubyVersion.is?(">= 4") }
 
     context "on a Ruby with rb_obj_info" do
       before { skip "Behavior does not apply to current Ruby version" if has_object_info }

--- a/spec/datadog/profiling/native_extension_spec.rb
+++ b/spec/datadog/profiling/native_extension_spec.rb
@@ -252,13 +252,18 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     end
   end
 
+  # `safe_object_info` is a helper used only for debugging, but we can't use it on every Ruby so we have a quick check
+  # here that we don't "oops" this, even though it's only for testing
   describe "safe_object_info" do
     let(:object_to_inspect) { "Hey, I'm a string!" }
 
     subject(:safe_object_info) { described_class::Testing._native_safe_object_info(object_to_inspect) }
 
+    # Yes, 3.4 dropped it and it came back in 4.0, you're reading right ;)
+    let(:has_object_info) { RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
+
     context "on a Ruby with rb_obj_info" do
-      before { skip "Behavior does not apply to current Ruby version" if RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
+      before { skip "Behavior does not apply to current Ruby version" if has_object_info }
 
       it "returns a string with information about the object" do
         expect(safe_object_info).to include("T_STRING")
@@ -266,7 +271,7 @@ RSpec.describe Datadog::Profiling::NativeExtension do
     end
 
     context "on a Ruby without rb_obj_info" do
-      before { skip "Behavior does not apply to current Ruby version" unless RubyVersion.is?("~> 2.5.0") || RubyVersion.is?("~> 3.3.0") || RubyVersion.is?("~> 4.0.0") }
+      before { skip "Behavior does not apply to current Ruby version" unless has_object_info }
 
       it "returns a placeholder string and does not otherwise fail" do
         expect(safe_object_info).to eq "(No rb_obj_info for current Ruby)"

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -4,6 +4,9 @@ if Datadog::Profiling.supported?
   require "zstd-ruby"
 end
 
+# Expose the version helper to profiling specs as a bare `RubyVersion` (alias for Datadog::RubyVersion).
+RubyVersion = Datadog::RubyVersion
+
 module ProfileHelpers
   Sample = Struct.new(:locations, :values, :labels) do |_sample_class| # rubocop:disable Lint/StructNewOverride
     def value?(type)
@@ -103,7 +106,7 @@ module ProfileHelpers
   end
 
   def skip_if_gvl_profiling_not_supported(testcase)
-    if RUBY_VERSION < "3.2."
+    if RubyVersion.is?("< 3.2")
       testcase.skip "GVL profiling is only supported on Ruby >= 3.2"
     end
   end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         end
 
         before do
-          skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
+          skip "Heap profiling is only supported on Ruby >= 2.7" if RubyVersion.is?("< 2.7")
         end
 
         it "include the stack and sample counts for the objects still left alive" do
@@ -1022,7 +1022,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       let(:heap_size_enabled) { true }
 
       before do
-        skip "Heap profiling is only supported on Ruby >= 2.7" if RUBY_VERSION < "2.7"
+        skip "Heap profiling is only supported on Ruby >= 2.7" if RubyVersion.is?("< 2.7")
       end
 
       def sample_allocation(obj)

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
     # Because the objective of this spec is making sure the benchmarks don't bitrot, and seeing as this flakiness seems
     # to especially affect 2.6 but we have no indication otherwise that we have issues in Ruby 2.6, I decided to skip
     # this for now and rely on this spec running on other Ruby versions to validate the benchmark is ok.
-    skip("Skipping on Ruby 2.6 as it's flaky and we couldn't figure out why yet") if RUBY_VERSION.start_with?("2.6")
+    skip("Skipping on Ruby 2.6 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?("~> 2.6.0")
 
     # Update: Because no good deed goes unpunished we also saw flakiness on 2.5 and actually that one provided NO
     # control frame information AND NO C level backtrace information -- so effectively no info.
     # For similar reasons as 2.6 above, I think this is at "let's keep an eye out on, and try to figure it out" level so
     # here's one more skip and let's hope that if/when this shows up on a modern Ruby we can get some actual interesting
     # info to debug.
-    skip("Skipping on Ruby 2.5 as it's flaky and we couldn't figure out why yet") if RUBY_VERSION.start_with?("2.5")
+    skip("Skipping on Ruby 2.5 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?("~> 2.5.0")
   end
 
   with_env "VALIDATE_BENCHMARK" => "true"

--- a/spec/datadog/profiling/validate_benchmarks_spec.rb
+++ b/spec/datadog/profiling/validate_benchmarks_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "Profiling benchmarks", :memcheck_valgrind_skip do
     # Because the objective of this spec is making sure the benchmarks don't bitrot, and seeing as this flakiness seems
     # to especially affect 2.6 but we have no indication otherwise that we have issues in Ruby 2.6, I decided to skip
     # this for now and rely on this spec running on other Ruby versions to validate the benchmark is ok.
-    skip("Skipping on Ruby 2.6 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?("~> 2.6.0")
+    skip("Skipping on Ruby 2.6 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?(">= 2.6", "< 2.7")
 
     # Update: Because no good deed goes unpunished we also saw flakiness on 2.5 and actually that one provided NO
     # control frame information AND NO C level backtrace information -- so effectively no info.
     # For similar reasons as 2.6 above, I think this is at "let's keep an eye out on, and try to figure it out" level so
     # here's one more skip and let's hope that if/when this shows up on a modern Ruby we can get some actual interesting
     # info to debug.
-    skip("Skipping on Ruby 2.5 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?("~> 2.5.0")
+    skip("Skipping on Ruby 2.5 as it's flaky and we couldn't figure out why yet") if RubyVersion.is?("< 2.6")
   end
 
   with_env "VALIDATE_BENCHMARK" => "true"

--- a/spec/datadog/ruby_version_spec.rb
+++ b/spec/datadog/ruby_version_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+require 'datadog/ruby_version'
+
+RSpec.describe Datadog::RubyVersion do
+  describe '.is' do
+    subject(:is) { described_class.is?(*requirements, ruby_version: ruby_version) }
+
+    context 'with a single requirement' do
+      let(:requirements) { ['~> 3.0.0'] }
+
+      context 'when the version matches' do
+        let(:ruby_version) { '3.0.5' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the version does not match' do
+        let(:ruby_version) { '3.1.0' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'with multiple requirements' do
+      let(:requirements) { ['~> 3.2.0', '< 3.2.3'] }
+
+      context 'when all requirements are satisfied' do
+        let(:ruby_version) { '3.2.2' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when only some requirements are satisfied' do
+        let(:ruby_version) { '3.3.0' }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    # These cases are the whole reason this helper exists: a naive lexical comparison such as
+    # `RUBY_VERSION < "3.2.3"` is wrongly `true` for "3.2.10" and "3.2.11" because they sort before
+    # "3.2.3" as plain strings.
+    context 'with versions that would break a lexical string comparison' do
+      let(:requirements) { ['< 3.2.3'] }
+
+      context 'on 3.2.10' do
+        let(:ruby_version) { '3.2.10' }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+end

--- a/spec/datadog/ruby_version_spec.rb
+++ b/spec/datadog/ruby_version_spec.rb
@@ -4,7 +4,7 @@ require 'datadog/ruby_version'
 
 RSpec.describe Datadog::RubyVersion do
   describe '.is' do
-    subject(:is) { described_class.is?(*requirements, ruby_version: ruby_version) }
+    subject(:is) { described_class.is?(*requirements, ruby_version: Gem::Version.new(ruby_version)) }
 
     context 'with a single requirement' do
       let(:requirements) { ['~> 3.0.0'] }

--- a/spec/datadog/ruby_version_spec.rb
+++ b/spec/datadog/ruby_version_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Datadog::RubyVersion do
     subject(:is) { described_class.is?(*requirements, ruby_version: Gem::Version.new(ruby_version)) }
 
     context 'with a single requirement' do
-      let(:requirements) { ['~> 3.0.0'] }
+      let(:requirements) { ['>= 3'] }
 
       context 'when the version matches' do
         let(:ruby_version) { '3.0.5' }
@@ -16,14 +16,14 @@ RSpec.describe Datadog::RubyVersion do
       end
 
       context 'when the version does not match' do
-        let(:ruby_version) { '3.1.0' }
+        let(:ruby_version) { '4.1.0' }
 
         it { is_expected.to be false }
       end
     end
 
     context 'with multiple requirements' do
-      let(:requirements) { ['~> 3.2.0', '< 3.2.3'] }
+      let(:requirements) { ['>= 3.2', '< 3.2.3'] }
 
       context 'when all requirements are satisfied' do
         let(:ruby_version) { '3.2.2' }

--- a/spec/datadog/ruby_version_spec.rb
+++ b/spec/datadog/ruby_version_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Datadog::RubyVersion do
     subject(:is) { described_class.is?(*requirements, ruby_version: Gem::Version.new(ruby_version)) }
 
     context 'with a single requirement' do
-      let(:requirements) { ['>= 3'] }
+      let(:requirements) { ['< 4'] }
 
       context 'when the version matches' do
         let(:ruby_version) { '3.0.5' }


### PR DESCRIPTION
**What does this PR do?**

This PR introduces a new `RubyVersion` helper and moves profiling code to use it.

This fixes a bug with our GC profiling logic testing using strings directly, and `3.2.10`/`3.2.11` are unfortunately `< "3.2.3"`, e.g.:

```ruby
if ...
    (RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3")
  logger.warn(
    "Current Ruby version (#{RUBY_VERSION}) has a VM bug where enabling GC profiling would cause " \
    "crashes (https://bugs.ruby-lang.org/issues/18464). GC profiling has been disabled."
  )
```

**Motivation:**

Fix feature being mistakenly broken on latest Ruby patch versions.

**Change log entry**

Yes. Fix GC profiling being disabled on Ruby 3.2.10/3.2.11

**Additional Notes:**

I admit I knew about this footgun, but there hadn't been .10 and above releases in a while and I kinda disliked the verboseness of doing the check using `Gem::Version` or the like.

With the addition of the helper, we can do it correctly and cleanly.

I've also changed every other use in profiling of `RUBY_VERSION`.

I'm preparing a follow-up PR to change this in more places in dd-trace-rb, but wanted to get this out as a smaller fix first.

Finally, I've split the change into step-by-step commits, and I recommend reviewing commit-by-commit.

**How to test the change?**

This change has test coverage.