### PR TITLE
SymDB: fix test-only thread leaks in component_spec and integration_spec

### DIFF
--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -495,15 +495,31 @@ RSpec.describe Datadog::SymbolDatabase::Component do
     it 'clears scheduler thread reference and pending schedule' do
       # start_upload assigns @scheduler_thread synchronously inside
       # @scheduler_mutex via ensure_scheduler_thread, so the ivar is non-nil
-      # by the time start_upload returns — no wait needed.
+      # by the time start_upload returns — no wait needed. Capture the
+      # thread reference before after_fork! nils it so we can terminate it
+      # in the ensure block below.
       component.start_upload
-      expect(component.instance_variable_get(:@scheduler_thread)).not_to be_nil
+      scheduler_thread = component.instance_variable_get(:@scheduler_thread)
+      expect(scheduler_thread).not_to be_nil
 
       component.after_fork!
 
       expect(component.instance_variable_get(:@scheduler_thread)).to be_nil
       expect(component.instance_variable_get(:@scheduled_at)).to be_nil
       expect(component.instance_variable_get(:@scheduler_signaled)).to be false
+    ensure
+      # In a real fork, the kernel destroys the parent's scheduler thread in
+      # the child, so the after_fork! contract assumes the underlying thread
+      # is already gone. Simulating fork by calling after_fork! on the parent
+      # in-process leaves the scheduler thread alive and orphaned: it's
+      # bound by closure to the pre-after_fork! @scheduler_mutex /
+      # @scheduler_cv, which nothing else references — it would block in
+      # scheduler_loop's @scheduler_cv.wait forever. shutdown! cannot clean
+      # it up (it acts on the post-after_fork! mutex/cv and the now-nil
+      # @scheduler_thread). Kill the captured reference directly so the
+      # leak detector doesn't report it across subsequent examples.
+      scheduler_thread&.kill
+      scheduler_thread&.join(5)
     end
 
     it 'clears the hot-load buffer and the initial-extraction flag' do

--- a/spec/datadog/symbol_database/integration_spec.rb
+++ b/spec/datadog/symbol_database/integration_spec.rb
@@ -122,6 +122,12 @@ RSpec.describe 'Symbol Database Integration' do
         expect(parsed_method['injectible_lines']).to be_an(Array)
         expect(parsed_method['injectible_lines']).not_to be_empty
       ensure
+        # add_scope spawns the ScopeBatcher timer thread via ensure_timer_running
+        # (scope_batcher.rb:228). flush uploads the current batch but leaves the
+        # timer thread running — only shutdown signals @timer_stopped and joins
+        # the thread. Without this, the timer thread outlives the example and the
+        # spec_helper leak detector reports it across subsequent examples.
+        context&.shutdown
         Object.send(:remove_const, :IntegrationTestModule) if defined?(IntegrationTestModule)
       end
     end


### PR DESCRIPTION
**What does this PR do?**

Fixes two pre-existing test-only thread leaks under `spec/datadog/symbol_database/`. After this change, `bundle exec rspec spec/datadog/symbol_database/` reports `0` leaked threads instead of `3` (verified across seeds 1, 42, 99999, 31415).

1. `spec/datadog/symbol_database/component_spec.rb` — the `Component#after_fork!` example `clears scheduler thread reference and pending schedule` leaks the scheduler thread.
2. `spec/datadog/symbol_database/integration_spec.rb` — the `extracts, batches, and uploads symbols from user code` example leaks the `ScopeBatcher` timer thread.

The spec_helper leak detector only `warn`s — it does not fail the build — so master CI passes today despite the noise. The leak count caps at 3 reports per process ([`spec/spec_helper.rb:208`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/spec_helper.rb#L208)), so each leak is attributed across several adjacent examples.

**Motivation:**

*Leak 1 — Component scheduler thread.* The example calls `component.start_upload` (which spawns the scheduler thread via `ensure_scheduler_thread` at [`component.rb:402`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/symbol_database/component.rb#L402)) and then `component.after_fork!`. `after_fork!` is designed for the post-`Process.fork` child path where the kernel has already destroyed the parent's scheduler thread, so it only nils `@scheduler_thread` and replaces `@scheduler_mutex` / `@scheduler_cv` with fresh instances — it does not set `@shutdown`, signal the old cv, or join the thread ([`component.rb:345-372`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/symbol_database/component.rb#L345-L372)). When the example simulates fork in-process, the scheduler thread survives, orphaned on the pre-`after_fork!` mutex/cv that nothing else references. It blocks forever in `scheduler_loop`'s `@scheduler_cv.wait`.

A blanket `after { component.shutdown! }` does not work: by the time it runs, `after_fork!` has already replaced the mutex/cv and nulled `@scheduler_thread`. `shutdown!` operates on the post-`after_fork!` instances, signals the new cv (which the orphan thread cannot see), and the `@scheduler_thread&.join(5)` no-ops on the nil ref. Fix: capture `@scheduler_thread` into a local before `after_fork!`, then in an `ensure` block call `Thread#kill` followed by `Thread#join(5)` (same timeout `shutdown!` uses at [`component.rb:273`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/symbol_database/component.rb#L273)).

Only the one example at `component_spec.rb:495` is the leak source. The other `start_upload` site in `#after_fork!` (line 596) is already paired with `component.shutdown!` and does not leak.

*Leak 2 — ScopeBatcher timer thread.* The integration example creates a `ScopeBatcher` and calls `context.add_scope(file_scope)`, which spawns the timer thread via `ensure_timer_running` at [`scope_batcher.rb:228`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/symbol_database/scope_batcher.rb#L228). It then calls `context.flush` (uploads the current batch but leaves the timer running) and exits. Only `shutdown` signals `@timer_stopped` and joins the thread ([`scope_batcher.rb:148-174`](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/symbol_database/scope_batcher.rb#L148-L174)). Fix: call `context&.shutdown` in the existing `ensure` block of the `Dir.mktmpdir` body.

The `wire format` example does not itself create threads; it was reported as leaking only because the orphan from the first example was still alive when the second example's leak check ran.

**Change log entry**

None.

**Additional Notes:**

Two commits, one per logical fix.

**How to test the change?**

Before:
```
$ bundle exec rspec spec/datadog/symbol_database/ 2>&1 | grep -E 'Spec leaked|examples,'
Spec leaked 1 threads in "Symbol Database Integration extracts, batches, and uploads symbols from user code".
Spec leaked 1 threads in "Symbol Database Integration wire format builds multipart form with event.json and gzipped symbols file".
Spec leaked 1 threads in "Datadog::SymbolDatabase::ServiceVersion#to_h passes empty env through to hash".
360 examples, 0 failures
```

(`Datadog::SymbolDatabase::Component#after_fork!` leaks visible separately when running `component_spec.rb` alone — the 3-report cap suppresses overlap when running the full directory.)

After:
```
$ bundle exec rspec spec/datadog/symbol_database/ 2>&1 | grep -E 'Spec leaked|examples,'
360 examples, 0 failures
```

Verified deterministic across seeds 1, 42, 99999, 31415. `bundle exec rake typecheck` passes.
