### PR TITLE
SymDB: regression tests for extract_all enumeration coverage

### DIFF
--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2602,8 +2602,9 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       # ObjectSpace iterates by object identity, so private_constant'd
       # classes are reached regardless of name visibility. Any alternative
       # enumeration that relies on Module#constants must include private
-      # constants too — `Module#constants(false)` excludes them by default,
-      # which is the trap this regression test guards against.
+      # constants too — `Module#constants` never returns them regardless of
+      # the inherit argument (there is no public API to list private
+      # constants), which is the trap this regression test guards against.
       before do
         @file = create_test_file('private_constant_host.rb', <<~RUBY)
           class ExtractAllPrivateConstantHost

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2624,8 +2624,11 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
 
       it 'includes the private inner class in extract_all output' do
-        scopes = extract_all_clean
+        # Ensure this fixture is actually using a private constant (Module#constants(false) excludes it).
+        expect(ExtractAllPrivateConstantHost.constants(false)).not_to include(:Worker)
+        expect(ExtractAllPrivateConstantHost.private_constants(false)).to include(:Worker)
 
+        scopes = extract_all_clean
         file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @file }
         expect(file_scope).not_to be_nil
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2594,6 +2594,105 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
     end
 
+    context 'class marked with private_constant' do
+      # Coverage parity with ObjectSpace.each_object(Module). A class marked
+      # with `private_constant` is still a fully-loaded user class with
+      # methods; DI should still serve its methods to the autocomplete UI.
+      #
+      # ObjectSpace iterates by object identity, so private_constant'd
+      # classes are reached regardless of name visibility. Any alternative
+      # enumeration that relies on Module#constants must include private
+      # constants too — `Module#constants(false)` excludes them by default,
+      # which is the trap this regression test guards against.
+      before do
+        @file = create_test_file('private_constant_host.rb', <<~RUBY)
+          class ExtractAllPrivateConstantHost
+            class Worker
+              def do_work
+              end
+            end
+            private_constant :Worker
+          end
+        RUBY
+        load @file
+      end
+
+      after do
+        if Object.const_defined?(:ExtractAllPrivateConstantHost, false)
+          Object.send(:remove_const, :ExtractAllPrivateConstantHost)
+        end
+      end
+
+      it 'includes the private inner class in extract_all output' do
+        scopes = extract_all_clean
+
+        file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @file }
+        expect(file_scope).not_to be_nil
+
+        host = file_scope.scopes.find { |s| s.name == 'ExtractAllPrivateConstantHost' }
+        expect(host).not_to be_nil
+
+        worker = host.scopes.find { |s| s.name == 'ExtractAllPrivateConstantHost::Worker' }
+        expect(worker).not_to be_nil
+        expect(worker.scopes.map(&:name)).to include('do_work')
+      end
+    end
+
+    context 'class aliased to a second constant after the original constant is removed' do
+      # CRuby caches Module#name on first assignment and never invalidates it.
+      # If a class is assigned to constant :A, then aliased as :B, and then
+      # :A is removed, the class stays reachable via :B but `mod.name` still
+      # returns "A" — a name that no longer resolves.
+      #
+      # extract_all must not emit a scope under the stale name "A". The
+      # current implementation filters this via `resolves_to_same_module?`
+      # inside `build_per_file_index`, which segment-walks "A" from Object
+      # and finds the const removed. Any alternative enumeration that
+      # trusts Module#name without re-validating against the current
+      # binding regresses on this case.
+      before do
+        @file = create_test_file('aliased_after_remove_const.rb', <<~RUBY)
+          class ExtractAllAliasOriginal
+            def aliased_method
+            end
+          end
+        RUBY
+        load @file
+
+        # Alias under a second constant, then remove the original.
+        # The class object stays reachable via :ExtractAllAliasSurvivor,
+        # but `mod.name` continues to report the cached "ExtractAllAliasOriginal".
+        Object.const_set(:ExtractAllAliasSurvivor, ExtractAllAliasOriginal)
+        @survivor = ExtractAllAliasSurvivor
+        Object.send(:remove_const, :ExtractAllAliasOriginal)
+      end
+
+      after do
+        if Object.const_defined?(:ExtractAllAliasSurvivor, false)
+          Object.send(:remove_const, :ExtractAllAliasSurvivor)
+        end
+        if Object.const_defined?(:ExtractAllAliasOriginal, false)
+          Object.send(:remove_const, :ExtractAllAliasOriginal)
+        end
+      end
+
+      it 'does not emit a scope under the stale (removed) original name' do
+        scopes = extract_all_clean
+
+        # The original FQN must not appear anywhere because it no longer
+        # resolves. The surviving alias is a known limitation of the
+        # Module#name cache (mod.name still reports "ExtractAllAliasOriginal"),
+        # so neither name appearing in output is acceptable — what's not
+        # acceptable is emitting under the stale name.
+        stale_emitted = scopes.any? do |file_scope|
+          next false unless file_scope.scope_type == 'FILE'
+          file_scope.scopes.any? { |child| child.name == 'ExtractAllAliasOriginal' }
+        end
+
+        expect(stale_emitted).to be(false)
+      end
+    end
+
     context 'namespace-only module entry with empty method list' do
       # Regression guard for the Pass 1 → Pass 2 stale-method recheck in
       # build_file_scope. Pass 1 records namespace-only modules (no own

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2688,11 +2688,13 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       it 'does not emit a scope under the stale (removed) original name' do
         scopes = extract_all_clean
 
-        # The original FQN must not appear anywhere because it no longer
-        # resolves. The surviving alias is a known limitation of the
-        # Module#name cache (mod.name still reports "ExtractAllAliasOriginal"),
-        # so neither name appearing in output is acceptable — what's not
-        # acceptable is emitting under the stale name.
+        # The test forbids one outcome: emitting a scope under the stale
+        # (removed) name "ExtractAllAliasOriginal". Two outcomes are
+        # acceptable and both depend on the enumeration strategy:
+        #   - the class is absent entirely (Module#name's cache reports the
+        #     stale name, so an enumeration that filters by current binding
+        #     drops it); or
+        #   - the class surfaces under the surviving alias.
         stale_emitted = scopes.any? do |file_scope|
           next false unless file_scope.scope_type == 'FILE'
           file_scope.scopes.any? { |child| child.name == 'ExtractAllAliasOriginal' }

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2624,9 +2624,15 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
 
       it 'includes the private inner class in extract_all output' do
-        # Ensure this fixture is actually using a private constant (Module#constants(false) excludes it).
+        # Preconditions: verify the fixture is actually exercising private-constant
+        # visibility. Module#constants(false) excludes private constants; an attempt to
+        # access Worker via :: raises NameError with a "private constant" message. If
+        # either of these stops holding (typo in the fixture, Ruby semantics change),
+        # the test fails fast on the precondition rather than passing for the wrong
+        # reason. Module#private_constants is not a real method on any Ruby version, so
+        # the visibility-raise is the direct way to assert what private_constant does.
         expect(ExtractAllPrivateConstantHost.constants(false)).not_to include(:Worker)
-        expect(ExtractAllPrivateConstantHost.private_constants(false)).to include(:Worker)
+        expect { ExtractAllPrivateConstantHost::Worker }.to raise_error(NameError, /private constant/)
 
         scopes = extract_all_clean
         file_scope = scopes.find { |s| s.scope_type == 'FILE' && s.name == @file }

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2669,10 +2669,10 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         load @file
 
         # Alias under a second constant, then remove the original.
-        # The class object stays reachable via :ExtractAllAliasSurvivor,
-        # but `mod.name` continues to report the cached "ExtractAllAliasOriginal".
+        # The :ExtractAllAliasSurvivor binding on Object keeps the class
+        # alive through the after hook; no separate @ivar is needed.
+        # `mod.name` continues to report the cached "ExtractAllAliasOriginal".
         Object.const_set(:ExtractAllAliasSurvivor, ExtractAllAliasOriginal)
-        @survivor = ExtractAllAliasSurvivor
         Object.send(:remove_const, :ExtractAllAliasOriginal)
       end
 


### PR DESCRIPTION
**What does this PR do?**

Adds two regression tests for `Extractor#extract_all` enumeration coverage. No
production-code changes.

The new contexts sit alongside the existing autoload + `remove_const` + alias
leak-guard tests in `spec/datadog/symbol_database/extractor_spec.rb`, using the
same helpers (`create_test_file`, `extract_all_clean`) and the same FILE-scope
assertion shape.

The tests cover two enumeration cases that the existing suite did not exercise:

1. **Classes marked with `private_constant`.** A user class of the form
   `class Foo; class Worker; ...; end; private_constant :Worker; end` must
   continue to appear in `extract_all` output. `Module#constants(false)`
   excludes private constants; `ObjectSpace.each_object(Module)` reaches them
   by object identity.

2. **Class aliased to a second constant after the original is removed.** After
   `A = Module.new; B = A; Object.send(:remove_const, :A)`, the class stays
   reachable via `B` but `mod.name` still returns `"A"` (CRuby caches
   `Module#name` on first assignment and never invalidates it). `extract_all`
   output must not emit a scope under the stale name `"A"`.

**Motivation:**

These tests were not in the suite when #5889 (now closed) proposed replacing
`ObjectSpace.each_object(Module)` in `build_per_file_index` with a recursive
`Object.constants(false)` walk. That walk silently regressed on both cases
(see https://github.com/DataDog/dd-trace-rb/pull/5889#issuecomment-4712255280
for the verification trace). Adding the tests against master now means any
future replacement enumeration is forced to demonstrate coverage parity for
both categories before it can land.

The current implementation handles both cases because:
- `ObjectSpace.each_object(Module)` enumerates by identity and reaches private
  constants regardless of name visibility.
- `resolves_to_same_module?(mod_name, mod)` in `build_per_file_index`
  segment-walks the FQN from `Object`, finds the original constant removed,
  and rejects the stale-named module.

Both tests pass on master.

**Change log entry**

None.

**Additional Notes:**

I'm using AI assistance for this PR. The test bodies and the verification
trace below were produced by Claude under my direction; I reviewed the diff
and the local verification before pushing.

**How to test the change?**

```bash
bundle exec rspec spec/datadog/symbol_database/extractor_spec.rb \
  -e "class marked with private_constant" \
  -e "class aliased to a second constant after the original constant is removed"
```

Verified locally on Ruby 3.2.3 in three configurations:

| Configuration                                | Result      |
|----------------------------------------------|-------------|
| New tests against master (this branch)       | 2/2 passed  |
| New tests against #5889's `extractor.rb`     | 0/2 passed  |
| Failure modes on #5889's branch              | private inner class missing from output; stale `"A"` scope emitted |

The #5889-branch failures are the regressions these tests would have caught
at review time.
