### PR TITLE
APMSP-3553 DI: redactor normalize Rack CGI header prefix

### DIFF
--- a/lib/datadog/di/redactor.rb
+++ b/lib/datadog/di/redactor.rb
@@ -196,10 +196,11 @@ module Datadog
       # the prefix here, those keys normalize to `httpauthorization`,
       # `httpcookie`, `httpxapikey`, etc., none of which appear in the default
       # identifier list — so the values would not be matched against entries
-      # like `authorization`, `cookie`, or `xapikey`. The prefix strip runs
-      # before the punctuation gsub so it only matches the literal CGI form
-      # (a leading `http_` after downcase) and not arbitrary identifiers that
-      # happen to begin with the letters `http`.
+      # like `authorization`, `cookie`, or `xapikey`. The `\Ahttp_` anchor
+      # limits the strip to the literal CGI form, so identifiers that merely
+      # begin with the letters `http` (e.g. `httpinfo`) are unaffected. The
+      # strip must run before the punctuation gsub: the gsub removes the
+      # underscore, after which `\Ahttp_` could never match.
       def normalize(str)
         str.to_s.strip.downcase.sub(/\Ahttp_/, "").gsub(/[-_$@]/, "")
       end

--- a/lib/datadog/di/redactor.rb
+++ b/lib/datadog/di/redactor.rb
@@ -202,7 +202,7 @@ module Datadog
       # strip must run before the punctuation gsub: the gsub removes the
       # underscore, after which `\Ahttp_` could never match.
       def normalize(str)
-        str.to_s.strip.downcase.sub(/\Ahttp_/, "").gsub(/[-_$@]/, "")
+        str.to_s.strip.downcase.sub(/\Ahttp_/, "").tr("-_$@", "")
       end
     end
   end

--- a/lib/datadog/di/redactor.rb
+++ b/lib/datadog/di/redactor.rb
@@ -186,8 +186,22 @@ module Datadog
       ]
 
       # Input can be a string or a symbol.
+      #
+      # Hash keys captured in snapshots often originate from a Rack environment
+      # (Rack/Rails/Sinatra middleware and controllers all keep `env` in scope).
+      # Rack rewrites incoming HTTP header names to the CGI form
+      # `HTTP_<HEADER>` with dashes converted to underscores — for example,
+      # `Authorization` becomes `HTTP_AUTHORIZATION`, `Cookie` becomes
+      # `HTTP_COOKIE`, `X-API-Key` becomes `HTTP_X_API_KEY`. Without stripping
+      # the prefix here, those keys normalize to `httpauthorization`,
+      # `httpcookie`, `httpxapikey`, etc., none of which appear in the default
+      # identifier list — so the values would not be matched against entries
+      # like `authorization`, `cookie`, or `xapikey`. The prefix strip runs
+      # before the punctuation gsub so it only matches the literal CGI form
+      # (a leading `http_` after downcase) and not arbitrary identifiers that
+      # happen to begin with the letters `http`.
       def normalize(str)
-        str.to_s.strip.downcase.gsub(/[-_$@]/, "")
+        str.to_s.strip.downcase.sub(/\Ahttp_/, "").gsub(/[-_$@]/, "")
       end
     end
   end

--- a/spec/datadog/di/redactor_spec.rb
+++ b/spec/datadog/di/redactor_spec.rb
@@ -123,6 +123,10 @@ RSpec.describe Datadog::DI::Redactor do
         ["excluded identifier with different case", "PASSWORD", false],
         ["excluded identifier with punctuation", "pass_word", false],
         ["non-excluded default identifier", "secret", true],
+        # The HTTP_ prefix strip applies to the excluded list too, so
+        # excluding the bare name also suppresses redaction of the Rack
+        # CGI form.
+        ["excluded default identifier in Rack CGI form", "HTTP_PASSWORD", false],
       ]
 
       define_cases(cases)

--- a/spec/datadog/di/redactor_spec.rb
+++ b/spec/datadog/di/redactor_spec.rb
@@ -68,13 +68,27 @@ RSpec.describe Datadog::DI::Redactor do
       ["uppercase", "PASSWORD", true],
       ["with removed punctiation", "pass_word", true],
       ["with non-removed punctuation", "pass/word", false],
+      # Rack rewrites incoming HTTP headers to CGI form (HTTP_<HEADER>);
+      # the CGI-prefixed key must normalize to the same identifier as the
+      # bare header name, otherwise hash captures of a Rack env emit
+      # bearer tokens, session cookies and API keys in plaintext.
+      ["rack CGI authorization header", "HTTP_AUTHORIZATION", true],
+      ["rack CGI cookie header", "HTTP_COOKIE", true],
+      ["rack CGI X-API-Key header", "HTTP_X_API_KEY", true],
+      ["rack CGI X-Auth-Token header", "HTTP_X_AUTH_TOKEN", true],
+      ["rack CGI Set-Cookie header", "HTTP_SET_COOKIE", true],
+      ["rack CGI non-sensitive header", "HTTP_REFERER", false],
+      ["rack CGI Host header", "HTTP_HOST", false],
+      # The strip only matches the literal CGI form (leading `http_`),
+      # not arbitrary identifiers that happen to begin with `http`.
+      ["identifier starting with http but no underscore", "httpinfo", false],
     ]
 
     define_cases(cases)
 
     context "when user-defined redacted identifiers exist" do
       before do
-        expect(di_settings).to receive(:redacted_identifiers).and_return(%w[foo пароль Ключ @var])
+        expect(di_settings).to receive(:redacted_identifiers).and_return(%w[foo пароль Ключ @var http_custom])
       end
 
       cases = [
@@ -90,6 +104,10 @@ RSpec.describe Datadog::DI::Redactor do
         ["@ in definition but name does not match", "var1", false],
         ["@ in target identifier", "@foo", true],
         ["@ in target identifier but name does not match", "@foo1", false],
+        # User-defined identifiers go through the same normalization, so a
+        # user-provided name starting with `http_` collapses to its tail.
+        ["user-defined identifier with http_ prefix matches CGI form", "HTTP_CUSTOM", true],
+        ["user-defined identifier with http_ prefix matches bare form", "custom", true],
       ]
 
       define_cases(cases)


### PR DESCRIPTION
**What does this PR do?**

Makes `Redactor#normalize` strip a leading `http_` so that Rack CGI
header keys (`HTTP_AUTHORIZATION`, `HTTP_COOKIE`, `HTTP_X_API_KEY`,
…) collapse to the same identifier as the bare header name and are
matched against `DEFAULT_REDACTED_IDENTIFIERS` (`authorization`,
`cookie`, `xapikey`, …).

**Motivation**

Rack rewrites incoming HTTP header names to the CGI form `HTTP_<HEADER>`
(dashes to underscores, `HTTP_` prefix). The previous `normalize`
implementation stripped only `[-_$@]`, so Rack-shaped keys collapsed to
`httpauthorization`, `httpcookie`, `httpxapikey`, etc., and no entry in
the default identifier list matched them. Any hash capture that
included a Rack `env` (every Rack-based middleware, Rails controller,
or Sinatra handler keeps it in lexical scope) ended up emitting those
values verbatim into the snapshot, while the same headers under their
bare names (`Authorization`, `Cookie`, `X-API-Key`) were redacted.
Snapshots should not distinguish between `env["HTTP_AUTHORIZATION"]`
and a local `authorization` — both name the same thing.

The change is in `normalize` rather than `DEFAULT_REDACTED_IDENTIFIERS`
because the list is shared across tracers and the gap is structural:
every entry in the list has an `HTTP_`-prefixed twin under Rack, and
maintaining the twin in lockstep is more error-prone than collapsing
the prefix at normalization time. The strip runs after `downcase` and
is anchored to `\Ahttp_`, so identifiers that simply start with the
letters `http` without a following underscore (e.g. `httpinfo`) are
unaffected. User-supplied identifiers go through the same path, so a
user-defined `http_custom` entry now also matches the bare `custom`
form — the same collapsing already applies to the punctuation gsub
(`pass_word` matches `password`), and this extends the principle to
the Rack prefix.

**Change log entry**

Yes. Dynamic Instrumentation: redactor normalizes the Rack CGI header
prefix (`HTTP_<HEADER>`), so snapshot captures of a Rack environment
redact sensitive header values under the same defaults as their bare
header names.

**Implementation**

`Redactor#normalize` becomes:

```ruby
str.to_s.strip.downcase.sub(/\Ahttp_/, "").gsub(/[-_$@]/, "")
```

The `sub` runs once at normalization time; there is no per-lookup
cost beyond a single anchored regex check on already-downcased input.
Both the default list and the user-defined / excluded lists are
normalized with the same function (see the `redacted_identifiers`
private method), so the prefix strip applies symmetrically — a name
excluded via `redaction_excluded_identifiers` continues to suppress
redaction regardless of whether the captured key is the bare form or
the `HTTP_`-prefixed form.

**How to test the change?**

```
bundle exec rspec spec/datadog/di/redactor_spec.rb
```

49 examples, 0 failures.

```
bundle exec rake test:di:di_with_ext
```

808 examples, 0 failures, 8 pending (same 8 Ruby-version-gated pending
tests as on master).

New spec cases live under `describe '#redact_identifier?'` and cover:

- `HTTP_AUTHORIZATION`, `HTTP_COOKIE`, `HTTP_X_API_KEY`,
  `HTTP_X_AUTH_TOKEN`, `HTTP_SET_COOKIE` — all match their bare
  counterparts in `DEFAULT_REDACTED_IDENTIFIERS`
- `HTTP_REFERER`, `HTTP_HOST` — Rack-shaped but not in the list;
  pass through unredacted as controls
- `httpinfo` — boundary case proving the prefix strip is anchored to
  the literal CGI form (leading `http_`), not arbitrary identifiers
  that begin with the letters `http`
- `HTTP_CUSTOM` and `custom` against a user-defined `http_custom`
  entry — confirms the user-defined list normalizes through the same
  function
