### PR TITLE
Fix `set_endpoint_tag` Rack middleware method

### DIFF
--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -268,7 +268,7 @@ module Datadog
             #   1. resource renaming is enabled
             #   2. AppSec is enabled and resource renaming is disabled (by default, not explicitly)
             if Datadog.configuration.tracing.resource_renaming.enabled ||
-                Datadog.configuration.appsec.enabled && Datadog.configuration.tracing.resource_renaming.options[:enabled].default_precedence?
+                Datadog.configuration.appsec&.enabled && Datadog.configuration.tracing.resource_renaming.options[:enabled].default_precedence?
               request_span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_ENDPOINT, value)
             end
           end

--- a/lib/datadog/tracing/contrib/rack/middlewares.rb
+++ b/lib/datadog/tracing/contrib/rack/middlewares.rb
@@ -268,7 +268,9 @@ module Datadog
             #   1. resource renaming is enabled
             #   2. AppSec is enabled and resource renaming is disabled (by default, not explicitly)
             if Datadog.configuration.tracing.resource_renaming.enabled ||
-                Datadog.configuration.appsec&.enabled && Datadog.configuration.tracing.resource_renaming.options[:enabled].default_precedence?
+                Datadog.configuration.respond_to?(:appsec) &&
+                    Datadog.configuration.appsec&.enabled &&
+                    Datadog.configuration.tracing.resource_renaming.options[:enabled].default_precedence?
               request_span.set_tag(Tracing::Metadata::Ext::HTTP::TAG_ENDPOINT, value)
             end
           end

--- a/spec/datadog/tracing/contrib/rack/http_endpoint_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/http_endpoint_spec.rb
@@ -67,9 +67,11 @@ RSpec.describe 'Rack testing for http.endpoint tag' do
     end
   end
 
-  context 'when appsec configuration is unavailable' do
+  context 'when appsec settings extension is not loaded' do
     before do
-      allow(Datadog.configuration).to receive(:appsec).and_return(nil)
+      allow(Datadog.configuration).to receive(:respond_to?).and_call_original
+      allow(Datadog.configuration).to receive(:respond_to?).with(:appsec).and_return(false)
+      allow(Datadog.configuration).to receive(:appsec).and_raise(NoMethodError)
       Datadog.configuration.tracing.resource_renaming.reset!
     end
 

--- a/spec/datadog/tracing/contrib/rack/http_endpoint_spec.rb
+++ b/spec/datadog/tracing/contrib/rack/http_endpoint_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe 'Rack testing for http.endpoint tag' do
     end
   end
 
+  context 'when appsec configuration is unavailable' do
+    before do
+      allow(Datadog.configuration).to receive(:appsec).and_return(nil)
+      Datadog.configuration.tracing.resource_renaming.reset!
+    end
+
+    it 'does not report http.endpoint' do
+      response = get('/hello/world')
+
+      expect(response).to be_ok
+      expect(request_span.tags).not_to have_key('http.endpoint')
+    end
+  end
+
   context 'when resource_renaming.enabled is explicitly set to false and appsec is enabled' do
     before do
       Datadog.configuration.appsec.enabled = true


### PR DESCRIPTION
**What does this PR do?**
This PR fixes a possible `NoMethodError` in the `set_endpoint_tag` Tracing Rack Middleware method when `Datadog.configuration.appsec` is not loaded.

**Motivation:**
This is a fix for an issue reported by Codex.

**Change log entry**
None.

**Additional Notes:**
APMSP-3134

**How to test the change?**
CI is enough.
