### PR TITLE
Use the per-Ruby gemfile in the Nix devshells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,10 @@
           # enable calling gem scripts without bundle exec
           export PATH="$GEM_HOME/bin:$PATH"
 
-          # enable implicitly resolving gems to bundled version
-          export RUBYGEMS_GEMDEPS="$(pwd)/Gemfile"
+          export BUNDLE_GEMFILE="$(pwd)/gemfiles/ruby-''${RUBY_VERSION%.0}.gemfile"
+
+          # enable implicitly resolving gems to the bundled version
+          export RUBYGEMS_GEMDEPS="$BUNDLE_GEMFILE"
 
           export SKIP_SIMPLECOV=1
         '';


### PR DESCRIPTION
**What does this PR do?**

Points each Nix devshell at the per-Ruby `gemfiles/ruby-X.Y.gemfile` (and its
committed lockfile) by exporting `BUNDLE_GEMFILE` (and `RUBYGEMS_GEMDEPS`) in the
shell hook, derived from the devshell's pinned Ruby version.

**Motivation:**

Each devshell already pins a known Ruby version, so it can use the same
gemfile/lockfile as CI directly, the same way `mise.toml` does (#5856). This
avoids the default `Gemfile` dispatch shim, which regenerates a stale root
`Gemfile.lock` when switching Ruby versions, and means gem resolution matches CI
without `rm Gemfile.lock`.

**Change log entry**

None.

**Additional Notes:**

- Relies on the per-Ruby base gemfiles (`gemfiles/ruby-X.Y.gemfile`) that exist
  on `master`; this branch is based off `origin/master` for that reason.
- AI was used to accelerate implementation; all code was reviewed and understood.

**How to test the change?**

`nix develop .#ruby34 --command sh -c 'echo $BUNDLE_GEMFILE'` prints
`.../gemfiles/ruby-3.4.gemfile`; same for the other version-specific shells.