### PR TITLE
Add support for inline GraphQL fragments for AppSec

### DIFF
--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -50,28 +50,53 @@ module Datadog
                 selected_operation = query.selected_operation
                 next unless selected_operation
 
-                arguments_from_selections(selected_operation.selections, query.variables, args_hash)
+                arguments_from_selections(selected_operation.selections, query.variables, args_hash, query.fragments)
               end
             end
 
-            def arguments_from_selections(selections, query_variables, args_hash)
+            def arguments_from_selections(selections, query_variables, args_hash, fragments, visited_fragments = {})
               selections.each do |selection|
-                # rubocop:disable Style/ClassEqualityComparison
-                next unless selection.class.name == Integration::AST_NODE_CLASS_NAMES[:field]
-                # rubocop:enable Style/ClassEqualityComparison
+                case selection
+                when ::GraphQL::Language::Nodes::FragmentSpread
+                  fragment_name = selection.name
+                  next if visited_fragments[fragment_name]
 
-                selection_name = selection.alias || selection.name
+                  fragment = fragments[fragment_name]
+                  next unless fragment
 
-                if !selection.arguments.empty? || !selection.directives.empty?
-                  args_hash[selection_name] ||= []
-                  args_hash[selection_name] <<
-                    arguments_hash(selection.arguments, query_variables).merge!(
-                      arguments_from_directives(selection.directives, query_variables)
-                    )
+                  visited_fragments[fragment_name] = true
+                  arguments_from_selections(
+                    fragment.selections, query_variables, args_hash, fragments, visited_fragments
+                  )
+                  visited_fragments.delete(fragment_name)
+                  next
+                when ::GraphQL::Language::Nodes::Field
+                  selection_name = selection.alias || selection.name
+
+                  if selection.arguments.any? || selection.directives.any?
+                    args_hash[selection_name] ||= []
+                    args_hash[selection_name] <<
+                      arguments_hash(selection.arguments, query_variables).merge!(
+                        arguments_from_directives(selection.directives, query_variables)
+                      )
+                  end
+
+                  arguments_from_selections(
+                    node_selections(selection), query_variables, args_hash, fragments, visited_fragments
+                  )
+                else
+                  arguments_from_selections(
+                    node_selections(selection), query_variables, args_hash, fragments, visited_fragments
+                  )
                 end
-
-                arguments_from_selections(selection.selections, query_variables, args_hash)
               end
+            end
+
+            def node_selections(node)
+              return [] unless node.respond_to?(:selections)
+
+              # @type var node: untyped
+              node.selections
             end
 
             def arguments_from_directives(directives, query_variables)

--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -59,54 +59,74 @@ module Datadog
                 case selection
                 when ::GraphQL::Language::Nodes::FragmentSpread
                   fragment_name = selection.name
+                  append_arguments(
+                    args_hash, fragment_name, nil, arguments_from_directives(selection.directives, query_variables)
+                  )
+
                   next if visited_fragments[fragment_name]
 
                   fragment = fragments[fragment_name]
                   next unless fragment
+
+                  append_arguments(
+                    args_hash, fragment_name, nil, arguments_from_directives(fragment.directives, query_variables)
+                  )
 
                   visited_fragments[fragment_name] = true
                   arguments_from_selections(
                     fragment.selections, query_variables, args_hash, fragments, visited_fragments
                   )
                   visited_fragments.delete(fragment_name)
-                  next
                 when ::GraphQL::Language::Nodes::Field
                   selection_name = selection.alias || selection.name
-
-                  if selection.arguments.any? || selection.directives.any?
-                    args_hash[selection_name] ||= []
-                    args_hash[selection_name] <<
-                      arguments_hash(selection.arguments, query_variables).merge!(
-                        arguments_from_directives(selection.directives, query_variables)
-                      )
-                  end
-
-                  arguments_from_selections(
-                    node_selections(selection), query_variables, args_hash, fragments, visited_fragments
+                  field_arguments = arguments_hash(selection.arguments, query_variables) unless selection.arguments.empty?
+                  append_arguments(
+                    args_hash,
+                    selection_name,
+                    field_arguments,
+                    arguments_from_directives(selection.directives, query_variables)
                   )
-                else
+
                   arguments_from_selections(
-                    node_selections(selection), query_variables, args_hash, fragments, visited_fragments
+                    selection.selections, query_variables, args_hash, fragments, visited_fragments
+                  )
+                when ::GraphQL::Language::Nodes::InlineFragment
+                  append_arguments(
+                    args_hash, selection.type.name, nil, arguments_from_directives(selection.directives, query_variables)
+                  )
+
+                  arguments_from_selections(
+                    selection.selections, query_variables, args_hash, fragments, visited_fragments
                   )
                 end
               end
             end
 
-            def node_selections(node)
-              return [] unless node.respond_to?(:selections)
+            def append_arguments(args_hash, selection_name, arguments, directive_arguments)
+              combined_arguments = if arguments
+                arguments.merge!(directive_arguments) if directive_arguments
+                arguments
+              else
+                directive_arguments
+              end
+              return unless combined_arguments
 
-              # @type var node: untyped
-              node.selections
+              args_hash[selection_name] ||= []
+              args_hash[selection_name] << combined_arguments
             end
 
             def arguments_from_directives(directives, query_variables)
-              directives.each_with_object({}) do |directive, args_hash|
-                # rubocop:disable Style/ClassEqualityComparison
-                next unless directive.class.name == Integration::AST_NODE_CLASS_NAMES[:directive]
-                # rubocop:enable Style/ClassEqualityComparison
+              return if directives.empty?
+
+              directive_arguments = directives.each_with_object({}) do |directive, args_hash|
+                next unless directive.is_a?(::GraphQL::Language::Nodes::Directive)
 
                 args_hash[directive.name] = arguments_hash(directive.arguments, query_variables)
               end
+
+              return if directive_arguments.empty?
+
+              directive_arguments
             end
 
             def arguments_hash(arguments, query_variables)

--- a/lib/datadog/appsec/contrib/graphql/integration.rb
+++ b/lib/datadog/appsec/contrib/graphql/integration.rb
@@ -16,6 +16,7 @@ module Datadog
           AST_NODE_CLASS_NAMES = {
             field: 'GraphQL::Language::Nodes::Field',
             directive: 'GraphQL::Language::Nodes::Directive',
+            fragment_spread: 'GraphQL::Language::Nodes::FragmentSpread',
             variable_identifier: 'GraphQL::Language::Nodes::VariableIdentifier',
             input_object: 'GraphQL::Language::Nodes::InputObject',
           }.freeze

--- a/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
+++ b/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
@@ -28,9 +28,16 @@ module Datadog
               ?::Hash[::String, bool] visited_fragments
             ) -> void
 
-            def node_selections: (::GraphQL::Language::Nodes::AbstractNode node) -> ::Array[::GraphQL::Language::Nodes::AbstractNode]
+            def append_arguments: (
+              ::Hash[::String, ::Array[::Hash[::String, any]]] args_hash,
+              ::String selection_name,
+              ::Hash[::String, any]? arguments,
+              ::Hash[::String, any]? directive_arguments
+            ) -> void
 
-            def arguments_from_directives: (::Array[::GraphQL::Language::Nodes::Directive] directives, any query_variables) -> ::Hash[::String, ::Hash[::String, any]]
+            def arguments_from_directives: (::Array[::GraphQL::Language::Nodes::Directive] directives, any query_variables) -> ::Hash[::String, ::Hash[::String, any]]?
+
+            def arguments_hash_unless_empty: (::Array[::GraphQL::Language::Nodes::Argument] arguments, any query_variables) -> ::Hash[::String, any]?
 
             def arguments_hash: (::Array[::GraphQL::Language::Nodes::Argument] arguments, any query_variables) -> ::Hash[::String, any]
 

--- a/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
+++ b/sig/datadog/appsec/contrib/graphql/gateway/multiplex.rbs
@@ -20,7 +20,15 @@ module Datadog
 
             def build_arguments_hash: () -> ::Hash[::String, ::Array[::Hash[::String, any]]]
 
-            def arguments_from_selections: (::Array[::GraphQL::Language::Nodes::Field] selections, any query_variables, ::Hash[::String, ::Array[::Hash[::String, any]]] args_hash) -> void
+            def arguments_from_selections: (
+              ::Array[::GraphQL::Language::Nodes::AbstractNode] selections,
+              any query_variables,
+              ::Hash[::String, ::Array[::Hash[::String, any]]] args_hash,
+              ::Hash[::String, ::GraphQL::Language::Nodes::FragmentDefinition] fragments,
+              ?::Hash[::String, bool] visited_fragments
+            ) -> void
+
+            def node_selections: (::GraphQL::Language::Nodes::AbstractNode node) -> ::Array[::GraphQL::Language::Nodes::AbstractNode]
 
             def arguments_from_directives: (::Array[::GraphQL::Language::Nodes::Directive] directives, any query_variables) -> ::Hash[::String, ::Hash[::String, any]]
 

--- a/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
@@ -288,6 +288,41 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::Gateway::Multiplex do
       end
     end
 
+    context 'query with arguments inside fragments' do
+      let(:queries) do
+        [
+          GraphQL::Query.new(
+            schema,
+            <<~END_OF_QUERY
+              fragment UserSearch on Query {
+                namedUser: userByName(name: "$namedattack") {
+                  id
+                }
+              }
+
+              query MyTestQuery {
+                ... on Query {
+                  userByName(name: "$testattack") {
+                    id
+                  }
+                }
+                ...UserSearch
+              }
+            END_OF_QUERY
+          )
+        ]
+      end
+
+      it 'returns arguments from inline and named fragments' do
+        expect(dd_multiplex.arguments).to(
+          eq(
+            'userByName' => [{'name' => '$testattack'}],
+            'namedUser' => [{'name' => '$namedattack'}]
+          )
+        )
+      end
+    end
+
     context 'mutation' do
       let(:queries) do
         [

--- a/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
@@ -294,19 +294,19 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::Gateway::Multiplex do
           GraphQL::Query.new(
             schema,
             <<~END_OF_QUERY
-              fragment UserSearch on Query {
+              fragment UserSearch on Query @custom(value: "$definitionattack") {
                 namedUser: userByName(name: "$namedattack") {
                   id
                 }
               }
 
               query MyTestQuery {
-                ... on Query {
-                  userByName(name: "$testattack") {
+                ... on Query @custom(value: "$testattack") {
+                  userByName(name: "$inlinefieldattack") {
                     id
                   }
                 }
-                ...UserSearch
+                ...UserSearch @custom(value: "$spreadattack")
               }
             END_OF_QUERY
           )
@@ -316,7 +316,12 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::Gateway::Multiplex do
       it 'returns arguments from inline and named fragments' do
         expect(dd_multiplex.arguments).to(
           eq(
-            'userByName' => [{'name' => '$testattack'}],
+            'Query' => [{'custom' => {'value' => '$testattack'}}],
+            'userByName' => [{'name' => '$inlinefieldattack'}],
+            'UserSearch' => [
+              {'custom' => {'value' => '$spreadattack'}},
+              {'custom' => {'value' => '$definitionattack'}}
+            ],
             'namedUser' => [{'name' => '$namedattack'}]
           )
         )

--- a/vendor/rbs/graphql/0/graphql.rbs
+++ b/vendor/rbs/graphql/0/graphql.rbs
@@ -4,6 +4,7 @@ module GraphQL
     def selected_operation_name: () -> String?
     def query_string: () -> String
     def variables: () -> untyped
+    def fragments: () -> Hash[String, Language::Nodes::FragmentDefinition]
     def context: () -> untyped
 
     class Result
@@ -62,7 +63,7 @@ module GraphQL
       class OperationDefinition < AbstractNode
         def name: () -> String?
         def operation_type: () -> Symbol?
-        def selections: () -> Array[Field]
+        def selections: () -> Array[AbstractNode]
         def directives: () -> Array[Directive]
       end
 
@@ -70,7 +71,18 @@ module GraphQL
         def alias: () -> String?
         def arguments: () -> Array[Argument]
         def directives: () -> Array[Directive]
-        def selections: () -> Array[Field]
+        def selections: () -> Array[AbstractNode]
+      end
+
+      class InlineFragment < AbstractNode
+        def selections: () -> Array[AbstractNode]
+      end
+
+      class FragmentSpread < AbstractNode
+      end
+
+      class FragmentDefinition < AbstractNode
+        def selections: () -> Array[AbstractNode]
       end
 
       class Directive < AbstractNode

--- a/vendor/rbs/graphql/0/graphql.rbs
+++ b/vendor/rbs/graphql/0/graphql.rbs
@@ -75,14 +75,21 @@ module GraphQL
       end
 
       class InlineFragment < AbstractNode
+        def directives: () -> Array[Directive]
         def selections: () -> Array[AbstractNode]
+        def type: () -> TypeName
       end
 
       class FragmentSpread < AbstractNode
+        def directives: () -> Array[Directive]
       end
 
       class FragmentDefinition < AbstractNode
+        def directives: () -> Array[Directive]
         def selections: () -> Array[AbstractNode]
+      end
+
+      class TypeName < AbstractNode
       end
 
       class Directive < AbstractNode


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for inline GraphQL fragments for AppSec WAF check.

**Motivation:**
This is a fix for an issue reported by Codex.

**Change log entry**
Yes. AppSec: Add detection of attacks inside inline fragments of GraphQL queries.

**Additional Notes:**
APMSP-3160

**How to test the change?**
CI and manual testing
