### PR TITLE
[NO-TICKET] Cherry-pick fix for flaky CpuAndWallTimeWorker spec

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -232,12 +232,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       it "triggers sampling and records the results", :memcheck_valgrind_skip do
         start
 
-        all_samples = loop_until do
+        loop_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples.any?
+          samples_for_thread(samples, Thread.current).any?
         end
-
-        expect(samples_for_thread(all_samples, Thread.current)).to_not be_empty
       end
 
       it(
@@ -247,15 +245,15 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       ) do
         start
 
-        all_samples = loop_until do
-          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
+        current_thread_samples = loop_until do
+          samples = samples_for_thread(samples_from_pprof_without_gc_and_overhead(recorder.serialize!), Thread.current)
           samples if samples.any?
         end
 
         cpu_and_wall_time_worker.stop
 
         sample_count =
-          samples_for_thread(all_samples, Thread.current)
+          current_thread_samples
             .map { |it| it.values.fetch(:"cpu-samples") }
             .reduce(:+)
 


### PR DESCRIPTION
**What does this PR do?**

This PR cherry-picks https://github.com/DataDog/dd-trace-rb/pull/5903/changes/bb557d3d0683d8a694ded33da3c70c75903f4137 from https://github.com/DataDog/dd-trace-rb/pull/5903 as we've started seeing flakiness in master due to that issue.

In particular the issue happens because we've recently been changing how the per-thread context works and when threads sample, and thus tests that trivially assumed that "if there's any samples, surely they are from the current thread" can no longer do that.

**Motivation:**

[Fix flaky spec from profiling](https://github.com/DataDog/dd-trace-rb/actions/runs/27825162860/job/82350728889):

```
Failures:

  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start sampling of active threads triggers sampling and records the results
     Failure/Error: expect(samples_for_thread(all_samples, Thread.current)).to_not be_empty
       expected `[].empty?` to be falsey, got true
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:240:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:327:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:207:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 29.73 seconds (files took 1.29 seconds to load)
806 examples, 1 failure, 15 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:232 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start sampling of active threads triggers sampling and records the results
```

**Change log entry**

None.

**Additional Notes:**

N/A


**How to test the change?**

Green CI is good!