### PR TITLE
[NO-TICKET] Profiling: Reset leftover per-thread state when creating new ThreadContext

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -173,12 +173,18 @@ typedef struct {
 
 // Tracks per-thread state
 struct per_thread_context {
+  // These **aren't** reset during ThreadContext initialization so they stay around across profiler
+  // restarts / new ThreadContext instances.
   sampling_buffer sampling_buffer;
   char thread_id[THREAD_ID_LIMIT_CHARS];
   ddog_CharSlice thread_id_char_slice;
   char thread_invoke_location[THREAD_INVOKE_LOCATION_LIMIT_CHARS];
   ddog_CharSlice thread_invoke_location_char_slice;
   thread_cpu_time_id thread_cpu_time_id;
+
+  // These are reset during ThreadContext initialization so we don't get leftover state and in particular we don't push
+  // weird samples representing periods where the profiler was stopped.
+  // Make sure to update `reset_context_state` when adding new fields here.
   long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
   long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
 
@@ -290,6 +296,7 @@ static void trigger_sample_for_thread(
 static VALUE _native_thread_list(VALUE self);
 static per_thread_context *get_or_create_context_for(VALUE thread, thread_context_collector_state *state);
 static void initialize_context(VALUE thread, per_thread_context *thread_context, thread_context_collector_state *state);
+static void reset_context_state(per_thread_context *thread_context);
 static VALUE _native_inspect(VALUE self, VALUE collector_instance);
 static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context);
 static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE hash);
@@ -583,6 +590,17 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
     // In this case, we can't really escape this because as of this writing, ruby master still calls `rb_to_id` inside
     // the implementation of Thread#[]= so any symbol that gets used as a key there will already be prevented from GC.
     state->tracer_context_key = rb_to_id(tracer_context_key);
+  }
+
+  // Reset per_thread_context state for all live threads. Since per_thread_context is stored in a global TLS key
+  // (not per-collector), a previous profiler instance may have left behind state that could cause unexpected
+  // behavior in this new instance, such as very large wall/cpu-time samples or a stale was_skipped_at_last_sample.
+  VALUE threads = thread_list(state);
+  const long thread_count = RARRAY_LEN(threads);
+  for (long i = 0; i < thread_count; i++) {
+    VALUE thread = RARRAY_AREF(threads, i);
+    per_thread_context *thread_context = get_per_thread_context(thread);
+    if (thread_context != NULL) reset_context_state(thread_context);
   }
 
   return Qtrue;
@@ -1207,16 +1225,18 @@ static void initialize_context(VALUE thread, per_thread_context *thread_context,
 
   thread_context->thread_cpu_time_id = thread_cpu_time_id_for(thread);
 
-  // These will get initialized during actual sampling
+  reset_context_state(thread_context);
+}
+
+static void reset_context_state(per_thread_context *thread_context) {
   thread_context->cpu_time_at_previous_sample_ns = INVALID_TIME;
   thread_context->wall_time_at_previous_sample_ns = INVALID_TIME;
-
-  // These will only be used during a GC operation
   thread_context->gc_tracking.cpu_time_at_start_ns = INVALID_TIME;
   thread_context->gc_tracking.wall_time_at_start_ns = INVALID_TIME;
-
   thread_context->gvl_waiting_at = 0;
   thread_context->gvl_state_change_count = 0;
+  thread_context->gvl_state_change_count_at_previous_sample = 0;
+  thread_context->was_skipped_at_last_sample = false;
 }
 
 static VALUE _native_inspect(DDTRACE_UNUSED VALUE _self, VALUE collector_instance) {

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     testing_threads.each { ready_queue.pop }
     # Make sure all threads have reached the `sleep` before moving on
     loop_until { testing_threads.all? { |t| t.status == "sleep" } }
-    expect(Thread.list).to include(*testing_threads)
 
     testing_threads_and_current.each { |t| clear_per_thread_context_for(t) }
   end
@@ -186,6 +185,23 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     it "sets the waiting_for_gvl_threshold_ns to the provided value" do
       # This is a bit ugly but it saves us from having to introduce yet another way to poke at the native state
       expect(thread_context_collector.inspect).to include("waiting_for_gvl_threshold_ns=222333444")
+    end
+
+    it "resets the sampling state of threads with existing per_thread_context" do
+      sample
+
+      expect(per_thread_context.fetch(t1)).to include(
+        cpu_time_at_previous_sample_ns: be > invalid_time,
+        wall_time_at_previous_sample_ns: be > invalid_time,
+      )
+
+      described_class.for_testing(recorder: recorder)
+
+      expect(per_thread_context.fetch(t1)).to include(
+        cpu_time_at_previous_sample_ns: invalid_time,
+        wall_time_at_previous_sample_ns: invalid_time,
+        was_skipped_at_last_sample: false,
+      )
     end
 
     context "when otel_context_enabled has an invalid value" do


### PR DESCRIPTION
**What does this PR do?**

Since https://github.com/DataDog/dd-trace-rb/pull/5816, we've been keeping the profiler's per-thread context directly attached to each Ruby thread.

This PR fixes a flaky spec that hit
[master](https://github.com/DataDog/dd-trace-rb/actions/runs/27937925206/job/82664232085):

```
Failures:

  1) Datadog::Profiling::Collectors::ThreadContext#sample_after_gvl_running if thread has not been sampled before does not sample the thread
     Failure/Error: expect(samples).to be_empty
       expected `[#<struct ProfileHelpers::Sample locations=[#<struct ProfileHelpers::Frame base_label="sleep", path="...26761, :state=>"sleeping", :"thread id"=>"14823 (39460)", :"thread name"=>"Timeout stdlib thread"}>].empty?` to be truthy, got false
     # ./spec/datadog/profiling/collectors/thread_context_spec.rb:1934:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:327:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:207:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 27.48 seconds (files took 1.09 seconds to load)
806 examples, 1 failure, 15 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/thread_context_spec.rb:1931 # Datadog::Profiling::Collectors::ThreadContext#sample_after_gvl_running if thread has not been sampled before does not sample the thread
```

This spec failed because we didn't account for the background timeout thread in our assertions, and thus we saw an extra thread that failed the assertion.

Specifically, what I believe happened is that the background thread got a `was_skipped_at_last_sample` in a previous test, and that carried over to this test that assumed only one thread (`t1`) was in such a pending state.

By resetting the state for a new instance of the `ThreadContext`, this issue will no longer happen.

**Motivation:**

Fix flaky test and what I argue is also a logic issue (see below).

**Change log entry**

None. (Specifically -- the behavior being fixed was introduced in https://github.com/DataDog/dd-trace-rb/pull/5816 which was not shipped to customers yet, so there's no actual changelog from a fix)

**Additional Notes:**

When looking into this one, it dawned on me that there was a deeper problem being exposed here, which is why the solution to this problem is inside the production code in `collectors_thread_context.c` and not in the `thread_context_spec.rb`.

Specifically, all of `cpu_time_at_previous_sample_ns`, `wall_time_at_previous_sample_ns`, `gvl_waiting_at`, `gvl_state_change_count`, `gvl_state_change_count_at_previous_sample`, `was_skipped_at_last_sample`, `gc_tracking.cpu_time_at_start_ns`, `gc_tracking.wall_time_at_start_ns` carry their state across profiler restarts.

So a similar problem to the one that happened in our specs could in fact happen in production, where state from a previous profiler is used in sampling decisions on a new profiler. This is a bit of a corner case but consider something like:

```ruby
Datadog.configure { |c| c.profiling.enabled = true }
Datadog::Profiling.wait_until_running
sleep 5
Datadog.configure { |c| c.profiling.enabled = false }
sleep 5
Datadog.configure { |c| c.profiling.enabled = true } # <-- profiler #2
```

I didn't try it, but I expect that profiler `#2` would suddenly start using `wall_time_at_previous_sample_ns` on existing threads and assign one single sample with all of the time while the profiler was stopped; this was what effectively was happening in the test, but at a much smaller scale.

This solution fixes this by forcing the new profiler to start with a clean state.

**How to test the change?**

Existing coverage + the new test should be enough for this one.