### PR TITLE
[NO-TICKET] Skip flaky profiling spec until a full fix

### DIFF
--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1929,6 +1929,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       end
 
       it "does not sample the thread" do
+        skip("This is flaky -- we're discussing a full fix in https://github.com/DataDog/dd-trace-rb/pull/5926 but for now let's skip")
+
         sample_after_gvl_running(t1)
 
         expect(samples).to be_empty


### PR DESCRIPTION
**What does this PR do?**

This PR skips a flaky spec that hit
[master](https://github.com/DataDog/dd-trace-rb/actions/runs/27937925206/job/82664232085):

```
Failures:

  1) Datadog::Profiling::Collectors::ThreadContext#sample_after_gvl_running if thread has not been sampled before does not sample the thread
     Failure/Error: expect(samples).to be_empty
       expected `[#<struct ProfileHelpers::Sample locations=[#<struct ProfileHelpers::Frame base_label="sleep", path="...26761, :state=>"sleeping", :"thread id"=>"14823 (39460)", :"thread name"=>"Timeout stdlib thread"}>].empty?` to be truthy, got false
     # ./spec/datadog/profiling/collectors/thread_context_spec.rb:1934:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:327:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:207:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 27.48 seconds (files took 1.09 seconds to load)
806 examples, 1 failure, 15 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/thread_context_spec.rb:1931 # Datadog::Profiling::Collectors::ThreadContext#sample_after_gvl_running if thread has not been sampled before does not sample the thread
```

We started fixing it in https://github.com/DataDog/dd-trace-rb/pull/5926 but it looks like the fix might be more involved than initially considered so let's unblock master while we figure out a good path.

**Motivation:**

Unblock master while we figure out a better solution

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

CI should be green, now that this test is skipped