### PR TITLE
Reproduce flaky: SymDB hot-load extracts a class defined after the initial upload completes

### DIFF
--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -664,6 +664,16 @@ RSpec.describe Datadog::SymbolDatabase::Component do
     end
 
     it 'extracts a class defined after the initial upload completes' do
+      # REPRODUCER (do not merge): force extract_all to sleep 12s — longer than the
+      # combined budget of both wait_for_idle(timeout: 5) calls. The first wait_for_idle
+      # times out at T=5s; the test ignores the return value and proceeds. The second
+      # wait_for_idle starts with start_time = @last_upload_time = nil (initial extract
+      # is still sleeping) and also times out — but the test ignores that too and asserts
+      # on extracted_modules, which is empty because the hot-load extract pass has not
+      # had a chance to run. This forces the race that on macOS-15 Ruby 3.2 surfaced
+      # naturally because the initial extract_all over ObjectSpace ran long enough to
+      # blow past the 5s timeout.
+      allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all) { sleep 12 }
       extracted_modules = []
       allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract) do |_inst, mod|
         extracted_modules << mod


### PR DESCRIPTION
**What does this PR do?**

Reproducer for flaky test [`spec/datadog/symbol_database/component_spec.rb:666`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/symbol_database/component_spec.rb#L666) — `Datadog::SymbolDatabase::Component hot-load coverage (TracePoint :class) extracts a class defined after the initial upload completes`.

Forces the race condition to validate the hypothesis in CI. Expected result: the test fails deterministically with `expected [] to include "SymdbHotLoadSpecNewClass"`.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Failing CI job on PR #5560: https://github.com/DataDog/dd-trace-rb/actions/runs/27979665665/job/82806216544 (`Test (macos-15, 3.2)`, commit `0a3dae07`). Same describe block has also failed at line 768 in unrelated macOS runs (master commit `22c838c5` run [27965497655](https://github.com/DataDog/dd-trace-rb/actions/runs/27965497655), and PR branch `leo.romanovsky/ffl-2446-evp-flagevaluation-ruby` run [27853830220](https://github.com/DataDog/dd-trace-rb/actions/runs/27853830220)).

**Hypothesis:**

The test calls `component.wait_for_idle(timeout: 5)` twice and discards both return values. When the initial `Extractor#extract_all` over ObjectSpace runs longer than 5 seconds, both `wait_for_idle` calls time out silently. The second call's `start_time` is captured as `@last_upload_time = nil` (initial extract has not advanced it yet), so it never gets a "hot-load advance" to wait for. The test asserts on `extracted_modules` before the scheduler's hot-load extract pass has run — array is empty, assertion fails.

The same race manifests in a milder form when initial extract finishes between the first and second timeout: the second `wait_for_idle` returns true because `@last_upload_time` finally advanced from nil to T1, but T1 was set by the **initial** extract, not the hot-load extract — assertion runs immediately and the hot-load extract has not yet run.

**Reproducer technique:**

Stub `Datadog::SymbolDatabase::Extractor#extract_all` to `sleep 12` inside the failing `it` block. 12s exceeds the combined budget of `5s + 5s = 10s`, so both `wait_for_idle(timeout: 5)` calls reliably time out. The failure mode is identical to the CI failure: `expected [] to include "SymdbHotLoadSpecNewClass"`.

Verified locally: reproducer alone fails in 12.09s with the same assertion error as CI.

**Companion PRs:**

- Fix: #5931
- Validation: #5932

**Change log entry**

None.

**How to test the change?**

CI should show the test failing deterministically with `expected [] to include "SymdbHotLoadSpecNewClass"`. If it does not, the hypothesis is wrong.