### PR TITLE
Fix flaky: SymDB hot-load extracts a class defined after the initial upload completes

### DIFF
--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -671,7 +671,16 @@ RSpec.describe Datadog::SymbolDatabase::Component do
       end
 
       component = described_class.build(settings, agent_settings, logger)
-      component.wait_for_idle(timeout: 5)
+      # Assert wait_for_idle returned true (not timed out). The previous form
+      # discarded the return value: on a runner where the initial extract_all
+      # over ObjectSpace takes longer than the timeout, the call returns false
+      # and the test silently proceeds with @last_upload_time still nil. The
+      # second wait_for_idle below would then either time out as well, or wake
+      # on the initial extract's eventual advance — either way, the hot-load
+      # extract has not yet run and extracted_modules is empty. 30s matches
+      # wait_for_idle's default timeout and gives slow CI runners (observed:
+      # macOS-15 Ruby 3.2) enough headroom for the initial ObjectSpace walk.
+      expect(component.wait_for_idle(timeout: 30)).to be(true)
 
       begin
         # Define a class — `class Foo` opens a class body, which fires
@@ -679,7 +688,7 @@ RSpec.describe Datadog::SymbolDatabase::Component do
         # drains and calls Extractor#extract.
         eval('class SymdbHotLoadSpecNewClass; def hello; end; end', binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
 
-        component.wait_for_idle(timeout: 5)
+        expect(component.wait_for_idle(timeout: 30)).to be(true)
 
         expect(extracted_modules.map(&:name)).to include('SymdbHotLoadSpecNewClass')
       ensure


### PR DESCRIPTION
**What does this PR do?**

Fixes the flaky test [`spec/datadog/symbol_database/component_spec.rb:666`](https://github.com/DataDog/dd-trace-rb/blob/master/spec/datadog/symbol_database/component_spec.rb#L666) — `Datadog::SymbolDatabase::Component hot-load coverage (TracePoint :class) extracts a class defined after the initial upload completes`.

**Motivation:**

Failed on PR #5560 commit `0a3dae07` in [`Test (macos-15, 3.2)`](https://github.com/DataDog/dd-trace-rb/actions/runs/27979665665/job/82806216544). Same describe block has produced macOS failures on master (`Test (macos-15, 4.0)`, run [27965497655](https://github.com/DataDog/dd-trace-rb/actions/runs/27965497655)) and on other PR branches (run [27853830220](https://github.com/DataDog/dd-trace-rb/actions/runs/27853830220)) — different `it` blocks in the same describe, but all macOS-15-specific.

**Failure:**

```
1) Datadog::SymbolDatabase::Component hot-load coverage (TracePoint :class) extracts a class defined after the initial upload completes
   Failure/Error: expect(extracted_modules.map(&:name)).to include('SymdbHotLoadSpecNewClass')
     expected [] to include "SymdbHotLoadSpecNewClass"
   # ./spec/datadog/symbol_database/component_spec.rb:684
```

**Test introduced in:** #5697 (commit `3ff4f70f42` — "SymDB: TracePoint :class hot-load hook for incremental class extraction"). The describe block `hot-load coverage (TracePoint :class)` and its `it` blocks, including the failing one, were added in that PR with the `wait_for_idle(timeout: 5)`/ignore-return-value pattern that this PR fixes.

**Root cause:**

The test calls `component.wait_for_idle(timeout: 5)` twice and discards both return values. When the initial `Extractor#extract_all` over ObjectSpace takes longer than 5 seconds:

1. First `wait_for_idle` times out at T=5s, returns false. Test ignores it, proceeds.
2. `eval('class SymdbHotLoadSpecNewClass; ...')` triggers `:class` TracePoint. The new class is pushed onto `@hot_load_buffer`; `@scheduled_at` is set. The scheduler thread is still busy in the initial extract.
3. Second `wait_for_idle` starts. `start_time = @last_upload_time = nil` (initial extract has not advanced it yet).
4. When initial extract eventually completes and advances `@last_upload_time` from nil to T1, second `wait_for_idle`'s loop condition `@last_upload_time == start_time` (`nil`) is no longer true — returns true. But the advance was the **initial** extract's, not the hot-load extract's. The scheduler has not yet entered the second pass that would drain the buffer.
5. Test asserts on `extracted_modules`. Empty. Fail.

(If initial extract takes longer than 10s total, both `wait_for_idle` calls return false and the test still proceeds to the empty-array assertion. Same outcome by a slightly different path.)

Production code (`lib/datadog/symbol_database/component.rb`) is correct and unchanged. The bug is in the test fixture.

**Fix:**

- Assert that each `wait_for_idle` returned `true` (not timed out). A timeout is now a clear, actionable test failure (`expected true, got false`) instead of a misleading empty-array assertion.
- Bump the timeout from 5s to `wait_for_idle`'s default of 30s. Sibling macOS Ruby version jobs on the same commit (`3.0/3.1/3.3/3.4/4.0`) all completed the initial ObjectSpace walk well under 30s; 30s gives a clear upper bound while leaving headroom for slow runners.

**Companion PRs:**

- Reproducer: #5930
- Validation: #5932

**Change log entry**

None.

**How to test the change?**

- Reproducer PR #5930 demonstrates that without this fix, forcing the initial extract to exceed 5s reproduces the CI failure exactly.
- Validation PR (TBD) merges this fix with the reproducer and confirms the test passes.
- Locally: with `Extractor#extract_all` stubbed to `sleep 12`, this fix passes (12.13s); without the fix, it fails (12.09s, `expected [] to include "SymdbHotLoadSpecNewClass"`).