### PR TITLE
Validate fix for flaky: SymDB hot-load extracts a class defined after the initial upload completes

### DIFF
--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -671,7 +671,16 @@ RSpec.describe Datadog::SymbolDatabase::Component do
       end
 
       component = described_class.build(settings, agent_settings, logger)
-      component.wait_for_idle(timeout: 5)
+      # Assert wait_for_idle returned true (not timed out). The previous form
+      # discarded the return value: on a runner where the initial extract_all
+      # over ObjectSpace takes longer than the timeout, the call returns false
+      # and the test silently proceeds with @last_upload_time still nil. The
+      # second wait_for_idle below would then either time out as well, or wake
+      # on the initial extract's eventual advance — either way, the hot-load
+      # extract has not yet run and extracted_modules is empty. 30s matches
+      # wait_for_idle's default timeout and gives slow CI runners (observed:
+      # macOS-15 Ruby 3.2) enough headroom for the initial ObjectSpace walk.
+      expect(component.wait_for_idle(timeout: 30)).to be(true)
 
       begin
         # Define a class — `class Foo` opens a class body, which fires
@@ -679,7 +688,7 @@ RSpec.describe Datadog::SymbolDatabase::Component do
         # drains and calls Extractor#extract.
         eval('class SymdbHotLoadSpecNewClass; def hello; end; end', binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
 
-        component.wait_for_idle(timeout: 5)
+        expect(component.wait_for_idle(timeout: 30)).to be(true)
 
         expect(extracted_modules.map(&:name)).to include('SymdbHotLoadSpecNewClass')
       ensure

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -664,6 +664,16 @@ RSpec.describe Datadog::SymbolDatabase::Component do
     end
 
     it 'extracts a class defined after the initial upload completes' do
+      # REPRODUCER (do not merge): force extract_all to sleep 12s — longer than the
+      # combined budget of both wait_for_idle(timeout: 5) calls. The first wait_for_idle
+      # times out at T=5s; the test ignores the return value and proceeds. The second
+      # wait_for_idle starts with start_time = @last_upload_time = nil (initial extract
+      # is still sleeping) and also times out — but the test ignores that too and asserts
+      # on extracted_modules, which is empty because the hot-load extract pass has not
+      # had a chance to run. This forces the race that on macOS-15 Ruby 3.2 surfaced
+      # naturally because the initial extract_all over ObjectSpace ran long enough to
+      # blow past the 5s timeout.
+      allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all) { sleep 12 }
       extracted_modules = []
       allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract) do |_inst, mod|
         extracted_modules << mod


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix in #5931 neutralizes the forced failure in #5930. This branch merges both:

- Reproducer PR: #5930 (forces `extract_all` to sleep 12s — exceeds the 5s timeout in both `wait_for_idle` calls)
- Fix PR: #5931 (asserts each `wait_for_idle` returned true, bumps timeout to 30s)

If CI passes, the fix addresses the exact failure mode the reproducer forces. If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for validation only.

**Companion PRs:**

- Reproducer: #5930
- Fix: #5931

**Change log entry**

None.

**How to test the change?**

- CI passes → fix works against the forced failure.
- CI fails → fix is insufficient and #5931 needs more work.

Locally verified: reproducer + fix together passes in 12.15s. Reproducer alone fails in 12.09s with `expected [] to include "SymdbHotLoadSpecNewClass"`.