### PR TITLE
[WIP] ci: add shared dependency gate to skip stale-lock CI runs

### DIFF
--- a/.github/scripts/deps_gate.sh
+++ b/.github/scripts/deps_gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Dependency gate decision (see .github/workflows/_deps_gate.yml).
+#
+# Runs only when dependency files changed. Probes every base gemfile against its
+# lockfile and emits proceed=true|false to "$GITHUB_OUTPUT":
+#   true  - every lockfile is consistent with its gemfile; dependent (expensive)
+#           jobs may run.
+#   false - at least one lockfile is stale; dependent jobs should skip and wait
+#           for the lock-dependency bot to regenerate and commit the lockfiles,
+#           which re-triggers CI on a fresh commit.
+#
+# All base gemfiles are probed (not just one) so that a change isolated to a
+# single Ruby's gemfile, or a broad change (gemspec, appraisal) that affects
+# every lockfile, is caught.
+set -uo pipefail
+
+export BUNDLE_FROZEN=true
+proceed=true
+
+for gemfile in gemfiles/ruby-*.gemfile; do
+  rc=0
+  BUNDLE_GEMFILE="$gemfile" ruby .github/scripts/deps_gate_probe.rb || rc=$?
+  case "$rc" in
+    0)
+      ;;
+    2)
+      echo "::notice::Stale lockfile for ${gemfile}; waiting for the lock-dependency bot."
+      proceed=false
+      ;;
+    *)
+      echo "::error::deps-gate probe errored for ${gemfile} (exit ${rc})."
+      exit 1
+      ;;
+  esac
+done
+
+echo "Dependency files changed; all lockfiles consistent: ${proceed}."
+echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/deps_gate_probe.rb
+++ b/.github/scripts/deps_gate_probe.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Dependency gate probe (see .github/workflows/_deps_gate.yml).
+#
+# Checks whether the gemfile in BUNDLE_GEMFILE is consistent with its lockfile,
+# WITHOUT installing gems or touching the network: it only compares the gemfile's
+# declared dependencies against the lockfile. Must run under BUNDLE_FROZEN=true,
+# which is what makes Bundler raise on a divergence instead of silently updating
+# the lockfile.
+#
+# Exit codes:
+#   0 - consistent: the lockfile matches the gemfile.
+#   2 - stale: the gemfile changed but the lockfile has not been regenerated yet.
+#   1 - probe error (e.g. a future Bundler renamed the API): surfaced loudly so it
+#       gets fixed, rather than silently gating out every dependency PR.
+require "bundler"
+
+Bundler.ui.level = "error"
+
+begin
+  Bundler.definition.ensure_equivalent_gemfile_and_lockfile
+  exit 0
+rescue Bundler::ProductionError, Bundler::GemfileError
+  exit 2
+rescue => e
+  warn "deps-gate: unexpected probe failure for #{ENV["BUNDLE_GEMFILE"]}: #{e.class}: #{e.message}"
+  exit 1
+end

--- a/.github/workflows/_deps_gate.yml
+++ b/.github/workflows/_deps_gate.yml
@@ -1,0 +1,57 @@
+name: Dependency Gate
+
+# Single source of truth for "may dependent (expensive) workflows run on this
+# commit yet?". Adopted by workflows whose jobs would otherwise run, and fail, on
+# a dependency PR before the lock-dependency bot has regenerated the lockfiles.
+#
+# A dependency PR triggers CI twice: once on the contributor's commit (gemfiles
+# changed, lockfiles still stale) and again on the bot's lock commit. This gate
+# lets expensive jobs skip the first, stale run and only run once the lockfiles
+# are consistent. It cannot reduce the two runs to one — the bot commit always
+# re-triggers CI — but it keeps the first run cheap.
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    outputs:
+      proceed:
+        description: >-
+          'true' when dependent jobs may run: either no dependency files changed,
+          or every lockfile is consistent with its gemfile. 'false' when a
+          dependency changed but at least one lockfile is still stale (the
+          lock-dependency bot has not regenerated and committed it yet).
+        value: ${{ jobs.changes.outputs.dependencies != 'true' || jobs.gate.outputs.proceed == 'true' }}
+
+# Default permissions for all jobs
+permissions: {}
+
+jobs:
+  changes:
+    name: detect dependency changes
+    runs-on: ubuntu-24.04
+    outputs:
+      dependencies: ${{ steps.changes.outputs.dependencies }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        with:
+          filters: .github/dependency_filters.yml
+
+  gate:
+    name: probe lockfile consistency
+    needs: changes
+    if: ${{ needs.changes.outputs.dependencies == 'true' }}
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/datadog/images-rb/engines/ruby:4.0-gnu-gcc
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Decide whether dependent jobs may proceed
+        id: decide
+        run: bash .github/scripts/deps_gate.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,17 +16,8 @@ concurrency:
 permissions: {}
 
 jobs:
-  gate:
-    uses: ./.github/workflows/_deps_gate.yml
-
-  # Gating `build` transitively skips the bundler-dependent jobs (standard, steep,
-  # frozen_string_literal) on a dependency PR whose lockfiles are still stale. The
-  # lock-independent jobs (semgrep, zizmor, actionlint, yaml-lint) do not need
-  # `build`, so they keep running.
   build:
     name: build
-    needs: gate
-    if: ${{ needs.gate.outputs.proceed == 'true' }}
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/datadog/images-rb/engines/ruby:4.0-gnu-gcc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,8 +16,17 @@ concurrency:
 permissions: {}
 
 jobs:
+  gate:
+    uses: ./.github/workflows/_deps_gate.yml
+
+  # Gating `build` transitively skips the bundler-dependent jobs (standard, steep,
+  # frozen_string_literal) on a dependency PR whose lockfiles are still stale. The
+  # lock-independent jobs (semgrep, zizmor, actionlint, yaml-lint) do not need
+  # `build`, so they keep running.
   build:
     name: build
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/datadog/images-rb/engines/ruby:4.0-gnu-gcc

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,10 @@ on: # yamllint disable-line rule:truthy
     # The branches below must be a subset of the branches above
     branches: [master]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,11 +8,20 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 
 jobs:
+  gate:
+    uses: ./.github/workflows/_deps_gate.yml
+
   test:
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -16,6 +16,10 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "00 04 * * 0-6"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -8,6 +8,10 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -12,7 +12,12 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 jobs:
+  gate:
+    uses: ./.github/workflows/_deps_gate.yml
+
   test-macos:
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -8,6 +8,10 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -12,7 +12,12 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 jobs:
+  gate:
+    uses: ./.github/workflows/_deps_gate.yml
+
   test-yjit:
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -8,16 +8,15 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
+
 # Default permissions for all jobs
 permissions: {}
 
 jobs:
-  gate:
-    uses: ./.github/workflows/_deps_gate.yml
-
   test-yjit:
-    needs: gate
-    if: ${{ needs.gate.outputs.proceed == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**What does this PR do?**

Reduces wasted CI on dependency PRs, which trigger CI twice: once on the contributor's commit (gemfiles changed, lockfiles still stale) and again on the `lock-dependency` bot's regenerated-lock commit. The first, stale run is pure waste. Two tools, matched to two waste shapes:

- **Dependency gate** (`.github/workflows/_deps_gate.yml`, reusable): a `changes` job (reusing `dependency_filters.yml`) plus a probe that checks each base gemfile against its lockfile via Bundler's frozen equivalence check — no gem install, no network. Guarded jobs run only when `proceed == 'true'`. Applied to **Test macOS** and **Test Nix**, whose jobs fail-fast (~12s, but macOS bills 6 jobs at 10×) or waste setup *before* the bot commit lands — so cancellation can't help; the gate must stop them from starting.

- **`cancel-in-progress`** added to the heavy workflows that lacked it (test-macos, test-yjit, nix, test-memory-leaks, system-tests, codeql). For long-running jobs (system-tests ~27min) the bot's lock commit supersedes the stale run mid-flight, and cancellation recovers most of the waste — simpler than a gate, and it also covers ordinary force-pushes. Scoped to non-master refs so master and scheduled runs are never cancelled.

**Motivation:**

A stale dependency-PR run wastes the most on expensive/long jobs: macOS (6 jobs × 10× billing) and system-tests (~27 min). YJIT and check were deliberately left out — they run on 1× runners and fail in ~12s, so the gate would cost about as much as it saves.

**Change log entry**

None.

**Additional Notes:**

Draft/WIP. Both gate paths are verified live: non-dependency PRs run the guarded jobs normally; a simulated stale-lock dependency PR skipped macOS/Nix as intended (the lock-dependency bot then regenerated the lock and re-triggered CI).

**How to test the change?**

On this PR's own CI (no dependency change): Test macOS and Test Nix run normally (`proceed == 'true'`). A stale-lock dependency PR is what triggers the skip; the bot's relock re-runs everything on the final commit.