### PR TITLE
Fix host configuration for AI Guard

### DIFF
--- a/lib/datadog/ai_guard/api_client.rb
+++ b/lib/datadog/ai_guard/api_client.rb
@@ -17,11 +17,13 @@ module Datadog
 
         @endpoint_uri = if endpoint
           URI(endpoint) #: URI::HTTP
+        elsif Datadog.configuration.site
+          host = Datadog.configuration.site.dup
+          host.prepend("app.") if host.count(".") == 1
+
+          URI::HTTPS.build(host: host, path: DEFAULT_PATH)
         else
-          URI::HTTPS.build(
-            host: Datadog.configuration.site || DEFAULT_SITE,
-            path: DEFAULT_PATH
-          )
+          URI::HTTPS.build(host: DEFAULT_SITE, path: DEFAULT_PATH)
         end
 
         @headers = {

--- a/spec/datadog/ai_guard/api_client_spec.rb
+++ b/spec/datadog/ai_guard/api_client_spec.rb
@@ -3,6 +3,65 @@
 require "datadog/ai_guard/api_client"
 
 RSpec.describe Datadog::AIGuard::APIClient do
+  describe "#initialize" do
+    subject(:api_client) do
+      described_class.new(
+        endpoint: endpoint,
+        api_key: "api-key",
+        application_key: "application-key",
+        timeout: 10000
+      )
+    end
+
+    after do
+      Datadog.configuration.reset!
+    end
+
+    context "when endpoint is not nil" do
+      let(:endpoint) { "https://api.example.com/api-guard" }
+
+      it "sets the @endpoint to a parsed uri" do
+        expect(api_client.instance_variable_get(:@endpoint_uri)).to eq(URI(endpoint))
+      end
+    end
+
+    context "when endpoint is nil and Datadog.configuration.site is not set" do
+      let(:endpoint) { nil }
+
+      before do
+        Datadog.configuration.site = nil
+      end
+
+      it "sets the @endpoint to a parsed uri" do
+        expect(api_client.instance_variable_get(:@endpoint_uri)).to eq(URI("https://app.datadoghq.com/api/v2/ai-guard"))
+      end
+    end
+
+    context "when endpoint is nil and Datadog.configuration.site does not have a subdomain" do
+      let(:endpoint) { nil }
+
+      before do
+        Datadog.configuration.site = "example.com"
+      end
+
+      it "adds app subdomain to the host and adds a correct path" do
+        expect(api_client.instance_variable_get(:@endpoint_uri)).to eq(URI("https://app.example.com/api/v2/ai-guard"))
+      end
+    end
+
+    context "when endpoint is nil and Datadog.configuration.site has a subdomain" do
+      let(:endpoint) { nil }
+
+      before do
+        Datadog.configuration.site = "us5.datadoghq.com"
+      end
+
+      it "does not change subdomain and adds a correct path" do
+        expect(api_client.instance_variable_get(:@endpoint_uri)).to eq(URI("https://us5.datadoghq.com/api/v2/ai-guard"))
+      end
+    end
+  end
+
   describe "#post" do
     let(:api_client) do
       described_class.new(


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the configuration of AI Guard via `DD_SITE` env variable. We need to add `app.` subdomain if the hostname specified in `DD_SITE` has no subdomain; if it has a subdomain already, we don't change it.

**Motivation:**
A bug was reported.

**Change log entry**
Yes. AI Guard: Fix endpoint configuration via `DD_SITE` environment variable.

**Additional Notes:**
APPSEC-68650.

**How to test the change?**
CI is enough.
