### PR TITLE
SymDB: raise minimum Ruby version from 2.6 to 2.7

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2980,7 +2980,7 @@ When Dynamic Instrumentation is enabled, the tracer can extract and upload symbo
 |---|---|---|---|
 | `c.symbol_database.enabled` | `Boolean` | Enable or disable symbol database upload. | `false` |
 
-Symbol Database requires MRI Ruby 2.6+ and Remote Configuration (enabled by default). For details on what is extracted, which code is included, and behavior differences across Ruby versions, see [Dynamic Instrumentation — Symbol Database](DynamicInstrumentation.md#symbol-database).
+Symbol Database requires MRI Ruby 2.7+ and Remote Configuration (enabled by default). For details on what is extracted, which code is included, and behavior differences across Ruby versions, see [Dynamic Instrumentation — Symbol Database](DynamicInstrumentation.md#symbol-database).
 
 ## Known issues and suggested configurations
 

--- a/integration/apps/rails-seven/spec/integration/symdb_spec.rb
+++ b/integration/apps/rails-seven/spec/integration/symdb_spec.rb
@@ -7,9 +7,9 @@ require 'json'
 # Exercises the real Rails environment — Zeitwerk autoloading, ActiveRecord method
 # generation, gem path filtering — without needing a running web server or mock agent.
 #
-# Guards match di_spec.rb (JRuby and Ruby < 2.6 unsupported by symdb).
+# Skipped on JRuby and Ruby < 2.7, where the Symbol Database is unsupported.
 RSpec.describe 'Symbol database extraction' do
-  di_test # reuse DI skip guards: JRuby and Ruby < 2.6 unsupported
+  symdb_test # JRuby and Ruby < 2.7 unsupported
 
   # Script executed inside the Rails process via `bin/rails runner`.
   # Force-loads all classes so ObjectSpace is fully populated before extraction.
@@ -96,8 +96,7 @@ RSpec.describe 'Symbol database extraction' do
   describe 'ApplicationController' do
     subject(:scope) { find_class('ApplicationController') }
 
-    it 'is extracted as empty CLASS on Ruby 2.7+',
-      skip: (RUBY_VERSION < '2.7') ? 'const_source_location unavailable on Ruby 2.6' : false do
+    it 'is extracted as empty CLASS' do
       expect(scope).not_to be_nil
     end
   end

--- a/integration/apps/rails-seven/spec/support/integration_helper.rb
+++ b/integration/apps/rails-seven/spec/support/integration_helper.rb
@@ -33,6 +33,19 @@ module IntegrationHelper
         end
       end
     end
+
+    def symdb_test
+      if RUBY_ENGINE == 'jruby'
+        before(:all) do
+          skip "Symbol database is not supported on JRuby"
+        end
+      end
+      if RUBY_VERSION < "2.7"
+        before(:all) do
+          skip "Symbol database requires Ruby 2.7 or higher"
+        end
+      end
+    end
   end
 
   def self.included(base)

--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -68,7 +68,7 @@ module Datadog
           return
         end
 
-        # Symbol database requires MRI Ruby 2.6+.
+        # Symbol database requires MRI Ruby 2.7+.
         # Configuration accessors (settings.symbol_database.*) remain available on all
         # platforms — only the component (upload) is disabled on unsupported engines/versions.
         # environment_supported? logs the specific reason (engine or version) internally.
@@ -375,7 +375,7 @@ module Datadog
       private
 
       # Check whether the runtime environment supports symbol database upload.
-      # Only MRI Ruby 2.6+ is supported. JRuby and TruffleRuby are not supported
+      # Only MRI Ruby 2.7+ is supported. JRuby and TruffleRuby are not supported
       # because ObjectSpace iteration and Method#source_location behave differently.
       # Configuration accessors remain available on all platforms — this only gates
       # the component (upload) itself.
@@ -386,8 +386,8 @@ module Datadog
           logger.debug { "symdb: not supported on #{RUBY_ENGINE}, skipping" }
           return false
         end
-        if RubyVersion.is?('< 2.6')
-          logger.debug { "symdb: requires Ruby 2.6+, running #{RUBY_VERSION}, skipping" }
+        if RubyVersion.is?('< 2.7')
+          logger.debug { "symdb: requires Ruby 2.7+, running #{RUBY_VERSION}, skipping" }
           return false
         end
         true

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -174,7 +174,7 @@ module Datadog
           # returns [key, value] on a non-empty hash and nil when empty, so the
           # `while (pair = ...)` form is the drain. Indexing pair[0]/pair[1] rather
           # than destructuring avoids introducing names into method scope that would
-          # then shadow the else-branch's block parameters on Ruby 2.5/2.6.
+          # then shadow the else-branch's block parameters.
           while (pair = index.shift)
             scope = build_file_scope(pair[0], pair[1])
             yield scope if scope
@@ -228,15 +228,10 @@ module Datadog
       #    subclass with its own binding resolves through the binding, an
       #    inherited autoload triggers nothing.
       #
-      # Ruby 2.7+ adds an inherit parameter to Module#autoload? —
-      # `current.autoload?(sym, false)` cleanly asks "is there an autoload
-      # registered directly on this namespace?". On Ruby 2.5 and 2.6 that
-      # parameter doesn't exist (per Ruby 2.7.0 NEWS), so the fallback
-      # branch uses `current.autoload?(sym)` which also reports inherited
-      # autoloads. The consequence on 2.5/2.6: a subclass binding whose
-      # name collides with an ancestor's pending autoload is conservatively
-      # treated as stale and dropped from extraction. The minimum supported
-      # Ruby is 2.5 per lib/datadog/version.rb, so this fallback ships.
+      # Uses `current.autoload?(sym, false)` (the inherit=false form, added
+      # in Ruby 2.7) so the question is strictly "is there an autoload
+      # registered directly on this namespace?" and ancestors' pending
+      # autoloads at the same name do not affect the result.
       # @param mod_name [String]
       # @param mod [Module]
       # @return [Boolean]
@@ -244,12 +239,7 @@ module Datadog
         current = Object
         mod_name.split('::').each do |seg|
           sym = seg.to_sym
-          pending_autoload = if RubyVersion.is?('>= 2.7')
-            current.autoload?(sym, false)
-          else
-            current.autoload?(sym)
-          end
-          return false if pending_autoload
+          return false if current.autoload?(sym, false)
           return false unless current.const_defined?(sym, false)
           current = current.const_get(sym, false)
         end
@@ -324,14 +314,9 @@ module Datadog
       # AR models get filtered out as gem code.
       #
       # For namespace-only modules (no instance or singleton methods), falls back to
-      # Module#const_source_location (Ruby 2.7+) to locate the module via its constants.
+      # Module#const_source_location to locate the module via its constants.
       # This handles patterns like `module ApplicationCable; class Channel...; end; end`
       # where the namespace module itself has no methods but defines user-code classes.
-      #
-      # On Ruby 2.6 (where const_source_location is unavailable), namespace-only modules
-      # and classes whose only methods are generated (e.g., AR models with only associations)
-      # may not be found — the extraction silently omits them. This is a graceful degradation:
-      # fewer symbols uploaded, no errors.
       #
       # @param mod [Module] The module
       # @return [String, nil] Source file path or nil
@@ -362,12 +347,12 @@ module Datadog
           fallback ||= path # steep:ignore
         end
 
-        # Try const_source_location (Ruby 2.7+) to find where this class/module is declared.
+        # Use const_source_location to find where this class/module is declared.
         # This handles two cases:
         #   1. Classes with no user-defined methods (e.g. AR models with only associations) whose
         #      generated methods point to gem code — we find the `class Foo` declaration instead.
         #   2. Namespace-only modules (`module Foo; class Bar; end; end`) with no methods at all.
-        if Module.method_defined?(:const_source_location) && mod.name
+        if mod.name
           # Look up the class/module by its last name component in its enclosing namespace.
           parts = mod.name.split('::')
           const_name = parts.last
@@ -743,11 +728,7 @@ module Datadog
         ObjectSpace.each_object(Module) do |mod|
           # Singleton classes (per-object metaclasses) are never user-code classes.
           # They're not const-referenced, DI cannot instrument methods on a singular
-          # object instance, and on Ruby 2.6 specifically, Module#name on unnamed
-          # singleton classes with long ancestor chains (e.g. through monkey-patches
-          # prepended into Kernel, common in dd-trace-rb test processes) is O(ancestors)
-          # — measured ~20ms per call, which dominates extract_all on heavily-loaded
-          # processes. Ruby 2.7+ optimized this path; the skip is a no-op there.
+          # object instance, so skipping them is both correct and cheap.
           next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
 
           seen += 1

--- a/spec/datadog/core/configuration/components_spec.rb
+++ b/spec/datadog/core/configuration/components_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Datadog::Core::Configuration::Components do
 
       context 'when symbol_database is enabled with remote config' do
         before(:all) do
-          skip 'Symbol database requires MRI Ruby 2.6+' if PlatformHelpers.jruby? || RubyVersion.is?('< 2.6')
+          skip 'Symbol database requires MRI Ruby 2.7+' if PlatformHelpers.jruby? || RubyVersion.is?('< 2.7')
         end
 
         before do

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -752,7 +752,6 @@ RSpec.describe Datadog::SymbolDatabase::Component do
     end
 
     it 'does not propagate exceptions when logger.debug itself raises' do
-      skip 'flaky on CI'
       # If the rescue handler's own logger call raises (custom logger
       # implementation, IO error), it would escape the outer rescue and
       # surface in the customer's class body. The inner rescue contains

--- a/spec/datadog/symbol_database/component_spec.rb
+++ b/spec/datadog/symbol_database/component_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Datadog::SymbolDatabase::Component do
   before { stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0.05) }
 
   describe '.environment_supported?', :symdb_supported_platforms do
-    it 'returns true on MRI Ruby 2.6+' do
+    it 'returns true on MRI Ruby 2.7+' do
       stub_const('RUBY_ENGINE', 'ruby')
       stub_const('RUBY_VERSION', '3.2.0')
       stub_const('Datadog::RubyVersion::CURRENT_RUBY_VERSION', Gem::Version.new(RUBY_VERSION))
@@ -60,11 +60,11 @@ RSpec.describe Datadog::SymbolDatabase::Component do
       expect(described_class.send(:environment_supported?, logger)).to be false
     end
 
-    it 'returns false and logs on Ruby < 2.6' do
+    it 'returns false and logs on Ruby < 2.7' do
       stub_const('RUBY_ENGINE', 'ruby')
-      stub_const('RUBY_VERSION', '2.5.0')
+      stub_const('RUBY_VERSION', '2.6.0')
       stub_const('Datadog::RubyVersion::CURRENT_RUBY_VERSION', Gem::Version.new(RUBY_VERSION))
-      expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/requires Ruby 2.6\+/) }
+      expect(raw_logger).to receive(:debug) { |&block| expect(block.call).to match(/requires Ruby 2.7\+/) }
       expect(described_class.send(:environment_supported?, logger)).to be false
     end
   end

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -272,21 +272,16 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(class_scope.name).to eq('TestNamespace::TestInnerClass')
       end
 
-      it 'extracts namespace-only module via const_source_location fallback (Ruby 2.7+)' do
+      it 'extracts namespace-only module via const_source_location fallback' do
         # TestNamespace has no methods but has a constant (TestInnerClass).
-        # On Ruby 2.7+, const_source_location finds the module's source via its constants.
+        # const_source_location finds the module's source via its constants.
         file_scope = extractor.extract(TestNamespace)
 
-        if Module.method_defined?(:const_source_location) || TestNamespace.respond_to?(:const_source_location)
-          expect(file_scope).not_to be_nil
-          expect(file_scope.scope_type).to eq('FILE')
-          module_scope = file_scope.scopes.first
-          expect(module_scope.scope_type).to eq('MODULE')
-          expect(module_scope.name).to eq('TestNamespace')
-        else
-          # Ruby < 2.7: const_source_location unavailable, module not extractable
-          expect(file_scope).to be_nil
-        end
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestNamespace')
       end
     end
 
@@ -413,40 +408,32 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
   describe '.extract edge cases' do
     context 'empty and minimal classes' do
-      it 'extracts empty top-level class as a CLASS scope with no methods (Ruby 2.7+)' do
+      it 'extracts empty top-level class as a CLASS scope with no methods' do
         # Matches Java/NET: empty classes are uploaded so they appear in the probe modal.
         # const_source_location finds the class declaration even with no methods.
         filename = create_user_code_file("class TestEmptyClass; end")
         load filename
         scope = extractor.extract(TestEmptyClass)
-        if Module.method_defined?(:const_source_location)
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-          expect(scope.scopes.first.scope_type).to eq('CLASS')
-          expect(scope.scopes.first.scopes).to be_empty
-        else
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.scopes.first.scope_type).to eq('CLASS')
+        expect(scope.scopes.first.scopes).to be_empty
         Object.send(:remove_const, :TestEmptyClass)
         cleanup_user_code_file(filename)
       end
 
-      it 'extracts empty top-level module as a MODULE scope with no methods (Ruby 2.7+)' do
+      it 'extracts empty top-level module as a MODULE scope with no methods' do
         filename = create_user_code_file("module TestEmptyModule; end")
         load filename
         scope = extractor.extract(TestEmptyModule)
-        if Module.method_defined?(:const_source_location)
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-          expect(scope.scopes.first.scope_type).to eq('MODULE')
-        else
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.scopes.first.scope_type).to eq('MODULE')
         Object.send(:remove_const, :TestEmptyModule)
         cleanup_user_code_file(filename)
       end
 
-      it 'handles top-level class with only constants on Ruby 2.7+' do
+      it 'handles top-level class with only constants' do
         filename = create_user_code_file(<<~RUBY)
           class TestConstOnlyClass
             SOME_CONST = 42
@@ -454,15 +441,10 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         RUBY
         load filename
 
+        # const_source_location finds source via constants.
         scope = extractor.extract(TestConstOnlyClass)
-        if TestConstOnlyClass.respond_to?(:const_source_location)
-          # Ruby 2.7+: const_source_location finds source via constants
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-        else
-          # Ruby 2.5/2.6: no const_source_location, cannot find source
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
 
         Object.send(:remove_const, :TestConstOnlyClass)
         cleanup_user_code_file(filename)
@@ -497,40 +479,29 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
 
       it 'extracts namespace modules via const_source_location when they have nested constants' do
-        # On Ruby 2.7+: TestA has const TestB (a module), TestA::TestB has const TestC (a class).
+        # TestA has const TestB (a module), TestA::TestB has const TestC (a class).
         # const_source_location finds the source file via these constants, so both modules ARE extracted.
-        if TestA.respond_to?(:const_source_location)
-          expect(extractor.extract(TestA)).not_to be_nil
-          expect(extractor.extract(TestA::TestB)).not_to be_nil
-        else
-          # Ruby < 2.7: no const_source_location, namespace modules without methods return nil
-          expect(extractor.extract(TestA)).to be_nil
-          expect(extractor.extract(TestA::TestB)).to be_nil
-        end
+        expect(extractor.extract(TestA)).not_to be_nil
+        expect(extractor.extract(TestA::TestB)).not_to be_nil
       end
 
-      it 'extracts all scopes in the namespace chain (Ruby 2.7+)' do
-        # TestA, TestA::TestB, TestA::TestB::TestC all get extracted on Ruby 2.7+
-        # because const_source_location propagates source file through the chain.
+      it 'extracts all scopes in the namespace chain' do
+        # TestA, TestA::TestB, TestA::TestB::TestC all get extracted because
+        # const_source_location propagates the source file through the chain.
         # Use explicit module list rather than ObjectSpace to avoid cross-test pollution.
         mods = [TestA, TestA::TestB, TestA::TestB::TestC]
         extracted = Datadog::Core::Utils::EnumerableCompat.filter_map(mods) { |mod| extractor.extract(mod) }
 
         # All scopes are FILE-wrapped. Inner scope names distinguish modules from classes.
-        if TestA.respond_to?(:const_source_location)
-          expect(extracted.size).to eq(3)
-          # All root scopes are FILE
-          expect(extracted.map(&:scope_type).uniq).to eq(['FILE'])
-          # Inner scopes: TestA and TestA::TestB are modules, TestA::TestB::TestC is a class
-          inner_names = extracted.map { |s| s.scopes.first&.name }
-          expect(inner_names).to include('TestA', 'TestA::TestB')
-          tc_file = extracted.find { |s| s.scopes.first&.name == 'TestA::TestB::TestC' }
-          expect(tc_file).not_to be_nil
-          expect(tc_file.scopes.first.scope_type).to eq('CLASS')
-        else
-          expect(extracted.size).to eq(1)
-          expect(extracted.first.scope_type).to eq('FILE')
-        end
+        expect(extracted.size).to eq(3)
+        # All root scopes are FILE
+        expect(extracted.map(&:scope_type).uniq).to eq(['FILE'])
+        # Inner scopes: TestA and TestA::TestB are modules, TestA::TestB::TestC is a class
+        inner_names = extracted.map { |s| s.scopes.first&.name }
+        expect(inner_names).to include('TestA', 'TestA::TestB')
+        tc_file = extracted.find { |s| s.scopes.first&.name == 'TestA::TestB::TestC' }
+        expect(tc_file).not_to be_nil
+        expect(tc_file.scopes.first.scope_type).to eq('CLASS')
       end
     end
 
@@ -538,8 +509,8 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       it 'extracts class whose only methods come from gem paths — finds declaration via const_source_location' do
         # Simulates ActiveRecord model with only associations (belongs_to, has_many).
         # Methods are all gem-generated with gem source paths. The class declaration
-        # is in user code. On Ruby 2.7+ we find it via const_source_location and upload
-        # an empty CLASS scope, matching Java/.NET behavior.
+        # is in user code. const_source_location finds it and we upload an empty
+        # CLASS scope, matching Java/.NET behavior.
         filename = create_user_code_file(<<~RUBY)
           class TestARStyleModel
           end
@@ -556,14 +527,10 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         allow(TestARStyleModel).to receive(:singleton_methods).with(false).and_return([])
 
         scope = extractor.extract(TestARStyleModel)
-        if Module.method_defined?(:const_source_location)
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-          expect(scope.scopes.first.scope_type).to eq('CLASS')
-          expect(scope.scopes.first.scopes).to be_empty
-        else
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.scopes.first.scope_type).to eq('CLASS')
+        expect(scope.scopes.first.scopes).to be_empty
 
         Object.send(:remove_const, :TestARStyleModel)
         cleanup_user_code_file(filename)
@@ -571,7 +538,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
       it 'extracts class with only Forwardable-delegated methods (def_delegators)' do
         # def_delegators creates methods whose source_location points to forwardable.rb (stdlib).
-        # The class declaration is in user code. Should extract as empty CLASS scope on Ruby 2.7+.
+        # The class declaration is in user code. Should extract as empty CLASS scope.
         filename = create_user_code_file(<<~RUBY)
           require 'forwardable'
           class TestForwardableModel
@@ -582,17 +549,13 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         load filename
 
         scope = extractor.extract(TestForwardableModel)
-        if Module.method_defined?(:const_source_location)
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-          inner = scope.scopes.first
-          expect(inner.scope_type).to eq('CLASS')
-          # Delegated methods point to forwardable.rb (stdlib) — not user code, not extracted
-          method_names = inner.scopes.map(&:name)
-          expect(method_names).not_to include('name', 'email')
-        else
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        inner = scope.scopes.first
+        expect(inner.scope_type).to eq('CLASS')
+        # Delegated methods point to forwardable.rb (stdlib) — not user code, not extracted
+        method_names = inner.scopes.map(&:name)
+        expect(method_names).not_to include('name', 'email')
 
         Object.send(:remove_const, :TestForwardableModel)
         cleanup_user_code_file(filename)
@@ -600,7 +563,7 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
     end
 
     context 'class with only class variables (no methods)' do
-      it 'extracts class with only class variables on Ruby 2.7+ via const_source_location' do
+      it 'extracts class with only class variables via const_source_location' do
         # @@class_var is not a constant, so constants(false) returns nothing.
         # But const_source_location on the class name itself finds the declaration.
         filename = create_user_code_file(<<~RUBY)
@@ -610,20 +573,16 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         RUBY
         load filename
         scope = extractor.extract(TestClassVarOnly)
-        if Module.method_defined?(:const_source_location)
-          expect(scope).not_to be_nil
-          expect(scope.scope_type).to eq('FILE')
-          expect(scope.scopes.first.scope_type).to eq('CLASS')
-        else
-          expect(scope).to be_nil
-        end
+        expect(scope).not_to be_nil
+        expect(scope.scope_type).to eq('FILE')
+        expect(scope.scopes.first.scope_type).to eq('CLASS')
         Object.send(:remove_const, :TestClassVarOnly)
         cleanup_user_code_file(filename)
       end
     end
 
     context 'module with only non-class-value constants' do
-      it 'is extracted on Ruby 2.7+ via const_source_location (non-class constants count)' do
+      it 'is extracted via const_source_location (non-class constants count)' do
         # const_source_location works for any constant including VALUE constants (FOO = 42),
         # not just class/module constants. So a module with only value constants IS found.
         filename = create_user_code_file(<<~RUBY)
@@ -634,15 +593,11 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         RUBY
         load filename
         file_scope = extractor.extract(TestValueConstModule)
-        if TestValueConstModule.respond_to?(:const_source_location)
-          expect(file_scope).not_to be_nil
-          expect(file_scope.scope_type).to eq('FILE')
-          module_scope = file_scope.scopes.first
-          expect(module_scope.scope_type).to eq('MODULE')
-          expect(module_scope.name).to eq('TestValueConstModule')
-        else
-          expect(file_scope).to be_nil
-        end
+        expect(file_scope).not_to be_nil
+        expect(file_scope.scope_type).to eq('FILE')
+        module_scope = file_scope.scopes.first
+        expect(module_scope.scope_type).to eq('MODULE')
+        expect(module_scope.name).to eq('TestValueConstModule')
         Object.send(:remove_const, :TestValueConstModule)
         cleanup_user_code_file(filename)
       end
@@ -661,15 +616,10 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
 
         scope = extractor.extract(TestNsFileHash)
 
-        if Module.method_defined?(:const_source_location)
-          # Ruby 2.7+: const_source_location finds the module via its constants
-          expect(scope).not_to be_nil
-          expect(scope.language_specifics[:file_hash]).not_to be_nil
-          expect(scope.language_specifics[:file_hash]).to match(/\A[0-9a-f]{40}\z/)
-        else
-          # Ruby < 2.7: namespace module with no methods is not extractable
-          expect(scope).to be_nil
-        end
+        # const_source_location finds the module via its constants.
+        expect(scope).not_to be_nil
+        expect(scope.language_specifics[:file_hash]).not_to be_nil
+        expect(scope.language_specifics[:file_hash]).to match(/\A[0-9a-f]{40}\z/)
 
         Object.send(:remove_const, :TestNsFileHash)
         cleanup_user_code_file(filename)
@@ -2374,8 +2324,9 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         RUBY
         load @file
         # Force singleton classes to materialize so ObjectSpace contains them.
-        # On Ruby 2.6, asking Module#name on these takes ~20ms each — extract_all
-        # must skip them to avoid O(singleton_count) wall-clock cost.
+        # extract_all must skip these regardless: they're never user-code classes
+        # and `Module#name` on unnamed singletons can be costly under monkey-patched
+        # ancestor chains.
         @objs = Array.new(10) { Object.new.tap { |o| o.singleton_class } }
       end
 
@@ -2449,16 +2400,6 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       # detects the direct subclass binding first, and const_get(sym, false)
       # returns it without triggering the ancestor's autoload.
       #
-      # Requires Module#autoload?(name, inherit) — the `inherit` parameter was
-      # added in Ruby 2.7 (Ruby 2.7.0 NEWS). On Ruby 2.5/2.6 the fallback in
-      # resolves_to_same_module? uses autoload?(name) which checks ancestors,
-      # so a subclass binding that collides with an ancestor's pending
-      # autoload is conservatively treated as stale and dropped. That is the
-      # documented fallback behavior and is unavoidable without the 2.7+ API.
-      before(:all) do
-        skip 'requires Module#autoload?(name, inherit) — Ruby 2.7+' unless RubyVersion.is?('>= 2.7')
-      end
-
       before do
         @parent_file = create_test_file('autoload_parent.rb', <<~RUBY)
           class ExtractAllAutoloadParent

--- a/spec/datadog/symbol_database/remote_config_integration_spec.rb
+++ b/spec/datadog/symbol_database/remote_config_integration_spec.rb
@@ -228,12 +228,11 @@ RSpec.describe 'Symbol Database Remote Config Integration' do
 
       begin
         # Step 1: initial load runs. Timeout matches the other e2e test in
-        # this file (line 84). On Ruby 2.6, extract_all is slow under heavy
-        # monkey-patching (see extractor.rb build_per_file_index
-        # comment about Module#name on singleton classes being O(ancestors)),
-        # so 5s is too short when an AppSec spec ran just before this one.
-        # Check the return value so a timeout fails the test loudly here
-        # instead of silently producing "captured_forms.size == 0" below.
+        # this file (line 84). Generous timeout protects against slow runners
+        # and noisy preceding specs that can leave extract_all walking a large
+        # ObjectSpace. Check the return value so a timeout fails the test
+        # loudly here instead of silently producing "captured_forms.size == 0"
+        # below.
         GC.start
         component.start_upload
         expect(component.wait_for_idle(timeout: 30)).to be true

--- a/spec/datadog/symbol_database/remote_spec.rb
+++ b/spec/datadog/symbol_database/remote_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Datadog::SymbolDatabase::Remote do
       let(:change) { mock_change(type: :insert, data: '{"upload_symbols": true}') }
 
       context 'when symbol_database component is not built' do
-        # Component.build returns nil on JRuby, Ruby 2.5, when symbol_database
+        # Component.build returns nil on JRuby, Ruby < 2.7, when symbol_database
         # is disabled, or when RC is disabled without force_upload. The receiver
         # block must not raise — it is stored and invoked later via
         # Dispatcher::Receiver#call, so a `return` would raise LocalJumpError.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,7 +140,7 @@ RSpec.configure do |config|
   end
 
   # Skip all symbol_database specs on unsupported platforms. Symbol database requires
-  # MRI Ruby 2.6+; on JRuby and Ruby <2.6 the entire suite is skipped wholesale so that
+  # MRI Ruby 2.7+; on JRuby and Ruby <2.7 the entire suite is skipped wholesale so that
   # individual specs do not need to repeat the platform guard.
   #
   # To run a spec on an otherwise-skipped platform, tag it with
@@ -163,10 +163,10 @@ RSpec.configure do |config|
     end
   end
 
-  if RubyVersion.is?('< 2.6')
+  if RubyVersion.is?('< 2.7')
     config.before(:each) do |example|
       if example.file_path.include?('/symbol_database/') && !example.metadata[:symdb_supported_platforms]
-        skip 'Symbol database requires Ruby 2.6+'
+        skip 'Symbol database requires Ruby 2.7+'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,7 +146,7 @@ RSpec.configure do |config|
   # To run a spec on an otherwise-skipped platform, tag it with
   # `symdb_supported_platforms: true`. This opt-out exists for tests that validate the
   # platform-guard behavior itself (e.g. that the Component refuses to initialize on
-  # JRuby) — those tests must run on JRuby/<2.6 to be meaningful.
+  # JRuby) — those tests must run on JRuby/<2.7 to be meaningful.
   #
   #    describe 'Component build on unsupported platform', symdb_supported_platforms: true do
   #      ...


### PR DESCRIPTION
**What does this PR do?**

Raises the minimum Ruby version for the Symbol Database (SymDB) component from **2.6 to 2.7**. `SymbolDatabase::Component.environment_supported?` now returns `false` on Ruby <2.7 and the component no-ops with a debug log (`symdb: requires Ruby 2.7+, running <version>, skipping`).

Configuration accessors (`settings.symbol_database.*`) remain available on all platforms — only the upload component itself is gated.

**Motivation**

Extraction on Ruby 2.6 is significantly slower than 2.7+ and can have a big impact on customer applications.

Concretely, on `master` Linux CI over the last 7 days, the hot-load TracePoint test `Datadog::SymbolDatabase::Component hot-load coverage (TracePoint :class) extracts a class defined after the initial upload completes` (which performs a full `ObjectSpace` walk via `Extractor#extract_all`) shows ~3x slower mean and a much wider tail on Ruby 2.6 vs every other supported Ruby:

| ruby | n   | min  | p50  | p90  | p99   | max   | mean |
| ---- | --- | ---- | ---- | ---- | ----- | ----- | ---- |
| 2.6  | 96  | 1.76 | 2.92 | 4.16 | 11.17 | 11.17 | 3.11 |
| 2.7  | 100 | 0.65 | 0.99 | 1.52 | 1.59  | 1.59  | 1.14 |
| 3.0  | 100 | 0.76 | 0.95 | 1.51 | 1.72  | 1.72  | 1.16 |
| 3.1  | 100 | 0.73 | 1.08 | 1.46 | 1.85  | 1.85  | 1.13 |
| 3.2  | 100 | 0.68 | 1.00 | 1.37 | 1.50  | 1.50  | 1.08 |
| 3.3  | 100 | 0.71 | 0.97 | 1.42 | 1.78  | 1.78  | 1.10 |
| 3.4  | 100 | 0.65 | 1.04 | 1.60 | 1.91  | 1.91  | 1.15 |
| 4.0  | 100 | 0.75 | 1.03 | 1.45 | 1.85  | 1.85  | 1.13 |

All times in seconds. Source: JUnit XML artifacts from `test.yml` `standard-0` shard, 50 master runs spanning `2026-06-16` … `2026-06-23`, two rake invocations per shard (`spec:main` and `spec:core_with_libdatadog_api`). 2.5 is omitted: SymDB already skipped there, all samples report `<skipped/>`.

Over the old `wait_for_idle(timeout: 5)` threshold: **5/896 samples (0.6%) exceeded 5s — all on Ruby 2.6**. One ruby-2.6 sample at 11.17s actually failed with the same `expected [] to include "SymdbHotLoadSpecNewClass"` signature as the macOS-15-3.2 flake fixed in #5931 (run [27718411901](https://github.com/DataDog/dd-trace-rb/actions/runs/27718411901), scheduled run on `25c5eb58`).

No other Ruby version exceeded 5s in the 7-day window.

**Scope**

Three commits, each independently reviewable:

1. Raise the version gate from `< 2.6` to `< 2.7` (`component.rb`, matching spec + `spec_helper` skip).
2. Revert #5935 ("Skip flaky symbol_database hot-load logger rescue spec"). That `skip 'flaky on CI'` was added to work around the Ruby 2.6-only flake reported in [DataDog/ruby-guild#308](https://github.com/DataDog/ruby-guild/issues/308); with 2.6 no longer supported the workaround is no longer needed and the spec runs unconditionally again.
3. Delete Ruby 2.6 dead code in `extractor.rb` (autoload `inherit=false` fallback, `Module.method_defined?(:const_source_location)` guard) and the `Module#autoload?(name, inherit) — Ruby 2.7+` skip and seven `Ruby < 2.7: expect(...).to be_nil` else branches in `extractor_spec.rb`; trim 2.6-specific historical comments throughout `lib/datadog/symbol_database/` and `spec/datadog/symbol_database/`.

**Related**

- #5931 — Fix flaky: SymDB hot-load extracts a class defined after the initial upload completes (macOS-15-3.2 manifestation of the same slow-`extract_all` exposure)
- #5935 — Skip flaky symbol_database hot-load logger rescue spec (reverted here)
- [DataDog/ruby-guild#308](https://github.com/DataDog/ruby-guild/issues/308) — `[FLAKY] SymDB component` (the underlying Ruby 2.6 flake that prompted #5935)

**Change log entry**

None: SymDB is not yet released to customers

**How to test the change?**

- `bundle exec rspec spec/datadog/symbol_database/component_spec.rb -e "environment_supported"` — passes on 2.7+ (returns `true`), returns `false` with the updated `requires Ruby 2.7+` log message on the stubbed 2.6 case.
- On a real Ruby 2.6 runtime, all of `spec/datadog/symbol_database/` is now wholesale-skipped by `spec_helper.rb` (mirroring the existing JRuby skip).

