### PR TITLE
Reproduce flaky: SymDB scheduler thread logger.debug

### DIFF
--- a/spec/datadog/symbol_database/logger_boom_reproducer_spec.rb
+++ b/spec/datadog/symbol_database/logger_boom_reproducer_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'datadog/symbol_database/component'
+require 'datadog/symbol_database/logger'
+require 'datadog/core/configuration'
+require 'logger'
+
+# Deterministic reproducer for the Ruby 2.6 `logger boom` flake observed
+# under `spec:main[--seed 5627]` with CI env vars
+# (see PR #5798, handoff-pr5798-ruby26-logger-boom-flake-rootcause.md).
+#
+# The bug is cross-version (not 2.6-specific): the failing test
+# `does not propagate exceptions when logger.debug itself raises` covers
+# the hot-load hook callback only, but `allow(raw_logger).to
+# receive(:debug).and_raise(...)` is process-wide. The scheduler thread's
+# `@logger.debug` calls in `extract_and_upload` (line 500), its rescue
+# handler (line 511), and `scheduler_loop`'s rescue handler (line 458)
+# have no inner rescue. When `raw_logger.debug` raises while the
+# scheduler is inside `extract_and_upload`, the exception terminates the
+# scheduler thread. `component.shutdown!` then calls
+# `@scheduler_thread&.join(5)`, and `Thread#join` re-raises the
+# unhandled exception in the test thread, surfacing as the example
+# failure with the scheduler thread's backtrace.
+#
+# This reproducer forces the timing race deterministically by holding
+# the scheduler thread inside `extract_all` on a Queue, then activating
+# the stub before releasing it.
+RSpec.describe 'SymDB scheduler logger boom reproducer' do
+  let(:settings) do
+    s = Datadog::Core::Configuration::Settings.new
+    s.symbol_database.enabled = true
+    s.symbol_database.internal.force_upload = true
+    s
+  end
+  let(:agent_settings) do
+    Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
+  end
+  let(:raw_logger) { instance_double(Logger, debug: nil, warn: nil) }
+  let(:logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
+
+  before do
+    # Skip the 5-second debounce so the scheduler enters extract_and_upload
+    # immediately on signal.
+    stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0)
+    # No-op the upload network path.
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:add_scope)
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:flush)
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:shutdown)
+    hide_const('ActiveSupport')
+    hide_const('Rails::Railtie')
+  end
+
+  it 'shutdown! does not propagate logger exceptions from the scheduler thread' do
+    entered_extract = Queue.new
+    resume_extract = Queue.new
+
+    # Hold the scheduler thread inside extract_all so we can flip the
+    # raw_logger.debug stub before the scheduler reaches `@logger.debug`
+    # at the success-path log line in extract_and_upload.
+    allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all) do
+      entered_extract.push(:in)
+      resume_extract.pop
+    end
+
+    component = Datadog::SymbolDatabase::Component.build(settings, agent_settings, logger)
+
+    # Wait for the scheduler to enter extract_all.
+    Timeout.timeout(5) { entered_extract.pop }
+
+    # Stub raw_logger.debug to raise. The scheduler is blocked inside
+    # extract_all and has not yet reached its post-extraction debug log.
+    allow(raw_logger).to receive(:debug).and_raise(RuntimeError.new('logger boom'))
+
+    # Release extract_all. The scheduler proceeds to the success-path
+    # `@logger.debug { "symdb: initial extracted ..." }` call, which now
+    # raises through the wrapped Forwardable chain.
+    resume_extract.push(:go)
+
+    # `shutdown!` invokes `@scheduler_thread&.join(5)`. Without the fix,
+    # the scheduler thread has terminated with the unhandled `logger boom`
+    # exception, and `Thread#join` re-raises it here.
+    expect { component.shutdown! }.not_to raise_error
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Reproducer for the flaky test `does not propagate exceptions when logger.debug itself raises` at `spec/datadog/symbol_database/component_spec.rb:752`, observed on Ruby 2.6 in [PR #5798](https://github.com/DataDog/dd-trace-rb/pull/5798). Forces the underlying race condition deterministically so CI fails in <1s on every Ruby version.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [Ruby 2.6 / build & test (standard) [0] on 2026-06-15](https://github.com/DataDog/dd-trace-rb/actions/runs/27573024017/job/81514231847).

**Hypothesis:**

The PR #5871 test name "does not propagate exceptions when logger.debug itself raises" expresses a property of `@logger.debug` everywhere in `Datadog::SymbolDatabase::Component`, but only `install_hot_load_hook` has the inner-rescue protection. When `allow(raw_logger).to receive(:debug).and_raise(...)` is set up, every `@logger.debug` call in the component raises — including on the scheduler thread, where there is no inner rescue:

- `extract_and_upload` success-path log at `lib/datadog/symbol_database/component.rb:500`
- `extract_and_upload`'s rescue handler at line 511
- `scheduler_loop`'s rescue handler at line 458
- `start_upload`'s rescue handler at line 202

If `raw_logger.debug` is stubbed to raise while the scheduler thread is inside `extract_and_upload`, the exception escapes line 500, then escapes line 511's rescue (calling `@logger.debug` again), then escapes line 458's rescue (calling `@logger.debug` again), terminating the scheduler thread. The test's `ensure` calls `component.shutdown!`, which invokes `@scheduler_thread&.join(5)`. [`Thread#join` re-raises the joined thread's unhandled exception in the caller](https://docs.ruby-lang.org/en/3.3/Thread.html#method-i-join) — standard Ruby semantics across every supported version. The exception surfaces in the test thread with the scheduler thread's backtrace, and RSpec records the failure.

Not Ruby-2.6-specific structurally — every link in the chain (missing rescues, `Thread#join` re-raising, etc.) is the same on all MRI Rubies. The 2.6-only CI flake is a timing artefact: `extract_all`'s `ObjectSpace` walk is slow enough on 2.6 in a loaded test environment that `wait_for_idle(timeout: 5)` regularly times out, leaving the scheduler thread inside `extract_and_upload` when the test sets up the stub.

**Reproducer technique:**

A new spec at `spec/datadog/symbol_database/logger_boom_reproducer_spec.rb` forces the race deterministically with a `Queue`:

1. `stub_const` overrides `EXTRACT_DEBOUNCE_INTERVAL` to 0 so the scheduler fires immediately.
2. `allow_any_instance_of(Extractor).to receive(:extract_all)` holds the scheduler inside `extract_all` on a Queue until the test releases it.
3. While the scheduler is held, the test installs `allow(raw_logger).to receive(:debug).and_raise(...)`.
4. The test releases `extract_all`. The scheduler proceeds to line 500 and raises.
5. `expect { component.shutdown! }.not_to raise_error` — without the fix, `shutdown!`'s `Thread#join` re-raises `RuntimeError('logger boom')`.

Verified failing locally on Ruby 2.6.10, 3.0.7, 3.1.7, 3.3.10, 3.4.8.

**Change log entry**

None.

**How to test the change?**

CI should show the new spec failing deterministically on every Ruby version. If it doesn't fail (especially on Rubies where the original CI flake is rarely seen), the hypothesis is wrong.

**Companion PRs:**
- Fix: #5943
- Validation: #5944