### PR TITLE
Fix flaky: SymDB Logger wrapper swallows target exceptions

### DIFF
--- a/lib/datadog/symbol_database/logger.rb
+++ b/lib/datadog/symbol_database/logger.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-
 module Datadog
   module SymbolDatabase
     # Logger facade that adds a config-gated +trace+ method.
@@ -11,10 +9,18 @@ module Datadog
     # is a no-op unless DD_TRACE_DEBUG is set, avoiding overhead for
     # high-frequency log sites (per-module filtering, dedup checks).
     #
+    # +debug+ and +warn+ swallow exceptions from the wrapped target. A
+    # customer-provided logger that raises (custom Logger subclass, IO
+    # error, frozen state, rspec-mocks stub) must never propagate into
+    # SymDB code paths — most callers are on the scheduler thread, which
+    # +Component#shutdown!+ joins, and +Thread#join+ re-raises any
+    # unhandled thread exception in the caller. Without this defense a
+    # misbehaving logger turns into a shutdown-time exception in the
+    # customer process. Telemetry-level reporting of the swallowed log
+    # error would itself require a working logger, so the swallow is silent.
+    #
     # @api private
     class Logger
-      extend Forwardable
-
       # @param settings [Configuration::Settings] Tracer settings (reads trace_logging flag)
       # @param target [::Logger] Underlying logger to delegate to
       def initialize(settings, target)
@@ -24,13 +30,25 @@ module Datadog
 
       attr_reader :settings
 
-      # Only debug and warn are delegated by design — symbol database
-      # extraction logs only at debug (high-volume diagnostics) and warn
-      # (user-actionable problems). Adding info/error would invite
-      # log-level drift; explicit additions can be made if needed.
-      def_delegators :@target, :debug, :warn
+      # Log at debug. Swallows exceptions from the wrapped target — see class
+      # docs.
+      # @return [void]
+      def debug(*args, &block)
+        @target.debug(*args, &block)
+      rescue
+        nil
+      end
 
-      # Log at trace level (sub-debug). No-op unless DD_TRACE_DEBUG is set.
+      # Log at warn. Swallows exceptions from the wrapped target — see class
+      # docs.
+      # @return [void]
+      def warn(*args, &block)
+        @target.warn(*args, &block)
+      rescue
+        nil
+      end
+
+      # Log at trace level (sub-debug). No-op unless trace_logging is enabled.
       # @yield Block that returns the log message string
       # @return [void]
       def trace(&block)

--- a/sig/datadog/symbol_database/logger.rbs
+++ b/sig/datadog/symbol_database/logger.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module SymbolDatabase
     class Logger
-      extend Forwardable
-
       @settings: untyped
 
       @target: ::Logger
@@ -13,7 +11,8 @@ module Datadog
 
       attr_reader target: ::Logger
 
-      # debug/warn accept either a positional message or a block (delegated to ::Logger)
+      # debug/warn accept either a positional message or a block (delegated to ::Logger).
+      # Both swallow exceptions raised by the wrapped target.
       def debug: (?untyped? message) ?{ () -> untyped } -> void
       def warn: (?untyped? message) ?{ () -> untyped } -> void
       def trace: () { () -> untyped } -> void

--- a/spec/datadog/symbol_database/logger_spec.rb
+++ b/spec/datadog/symbol_database/logger_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'datadog/symbol_database/logger'
+require 'datadog/core/configuration'
+require 'logger'
+
+RSpec.describe Datadog::SymbolDatabase::Logger do
+  let(:settings) do
+    Datadog::Core::Configuration::Settings.new.tap do |s|
+      s.symbol_database.internal.trace_logging = trace_logging
+    end
+  end
+  let(:trace_logging) { false }
+  let(:target) { instance_double(::Logger, debug: nil, warn: nil) }
+  let(:wrapper) { described_class.new(settings, target) }
+
+  describe '#debug' do
+    it 'forwards a positional message to the target' do
+      expect(target).to receive(:debug).with('hello')
+      wrapper.debug('hello')
+    end
+
+    it 'forwards a block to the target' do
+      block = -> { 'hello' }
+      expect(target).to receive(:debug) do |&b|
+        expect(b).to be(block)
+      end
+      wrapper.debug(&block)
+    end
+
+    it 'returns nil' do
+      expect(wrapper.debug('hello')).to be_nil
+    end
+
+    context 'when the target raises' do
+      before { allow(target).to receive(:debug).and_raise(RuntimeError.new('logger boom')) }
+
+      it 'swallows the exception' do
+        expect { wrapper.debug('hello') }.not_to raise_error
+      end
+
+      it 'returns nil' do
+        expect(wrapper.debug('hello')).to be_nil
+      end
+
+      it 'swallows the exception when given a block' do
+        expect { wrapper.debug { 'hello' } }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#warn' do
+    it 'forwards a positional message to the target' do
+      expect(target).to receive(:warn).with('hello')
+      wrapper.warn('hello')
+    end
+
+    it 'forwards a block to the target' do
+      block = -> { 'hello' }
+      expect(target).to receive(:warn) do |&b|
+        expect(b).to be(block)
+      end
+      wrapper.warn(&block)
+    end
+
+    context 'when the target raises' do
+      before { allow(target).to receive(:warn).and_raise(RuntimeError.new('logger boom')) }
+
+      it 'swallows the exception' do
+        expect { wrapper.warn('hello') }.not_to raise_error
+      end
+
+      it 'swallows the exception when given a block' do
+        expect { wrapper.warn { 'hello' } }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#trace' do
+    context 'when trace_logging is disabled (default)' do
+      let(:trace_logging) { false }
+
+      it 'is a no-op' do
+        expect(target).not_to receive(:debug)
+        wrapper.trace { 'hello' }
+      end
+    end
+
+    context 'when trace_logging is enabled' do
+      let(:trace_logging) { true }
+
+      it 'forwards the block to debug' do
+        block = -> { 'hello' }
+        expect(target).to receive(:debug) do |&b|
+          expect(b).to be(block)
+        end
+        wrapper.trace(&block)
+      end
+
+      context 'when the target raises' do
+        before { allow(target).to receive(:debug).and_raise(RuntimeError.new('logger boom')) }
+
+        it 'swallows the exception' do
+          expect { wrapper.trace { 'hello' } }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Fixes the Ruby 2.6 flake of [`spec/datadog/symbol_database/component_spec.rb:752`](https://github.com/DataDog/dd-trace-rb/blob/fd1e1b0660/spec/datadog/symbol_database/component_spec.rb#L752) — "does not propagate exceptions when logger.debug itself raises" — observed in [PR #5798](https://github.com/DataDog/dd-trace-rb/pull/5798) CI.

**Motivation:**

Flaky test [Ruby 2.6 / build & test (standard) [0] on 2026-06-15](https://github.com/DataDog/dd-trace-rb/actions/runs/27573024017/job/81514231847).

**Failure:**

The test sets up `allow(raw_logger).to receive(:debug).and_raise(RuntimeError.new('logger boom'))` then defines a class to trigger the hot-load `TracePoint(:class)`. The reported failure points to the hot-load hook's `logger.debug` call site at `component.rb:567`, suggesting the inner rescue at `component.rb:566-571` failed to catch.

**Root cause:**

The hot-load hook's inner rescue **is not broken** — it catches every time. Diagnostic STDERR.puts confirmed:

```
[symdb-diag outer-rescue] caught RuntimeError: simulated hot-load enqueue failure
[symdb-diag pre-debug] logger=Datadog::SymbolDatabase::Logger target=Datadog::SymbolDatabase::Logger
[symdb-diag inner-rescue] caught RuntimeError: logger boom
[symdb-diag outer-rescue-done]
```

The `logger boom` exception that surfaces in the test is from the **scheduler thread**, not the hook callback. The rspec-mocks stub is process-wide, so every `@logger.debug` call in `Datadog::SymbolDatabase::Component` raises — including the four scheduler-path sites that have no inner rescue:

- `extract_and_upload` success-path log at [`component.rb:500`](https://github.com/DataDog/dd-trace-rb/blob/fd1e1b0660/lib/datadog/symbol_database/component.rb#L500)
- `extract_and_upload`'s rescue handler at [`component.rb:511`](https://github.com/DataDog/dd-trace-rb/blob/fd1e1b0660/lib/datadog/symbol_database/component.rb#L511)
- `scheduler_loop`'s rescue handler at [`component.rb:458`](https://github.com/DataDog/dd-trace-rb/blob/fd1e1b0660/lib/datadog/symbol_database/component.rb#L458)
- `start_upload`'s rescue handler at [`component.rb:202`](https://github.com/DataDog/dd-trace-rb/blob/fd1e1b0660/lib/datadog/symbol_database/component.rb#L202)

Causal chain on the failing run:

1. `Component.build` with `force_upload = true` starts the scheduler thread, which enters `extract_and_upload`.
2. `extract_all` (ObjectSpace walk) takes longer than `wait_for_idle(timeout: 5)` in a loaded test environment.
3. `wait_for_idle` returns `false`; the test ignores the return value.
4. Test sets up `allow(raw_logger).to receive(:debug).and_raise(...)` while the scheduler is still inside `extract_and_upload`.
5. Scheduler reaches `@logger.debug { "symdb: initial extracted ..." }` → stub raises.
6. Exception escapes line 500, is caught at line 510, line 511's `@logger.debug` raises again, escapes to scheduler_loop's rescue at line 457, line 458 raises again, escapes scheduler_loop entirely.
7. Scheduler thread terminates. `Thread.report_on_exception=true` prints the trace.
8. Test's `ensure` calls `component.shutdown!`, which invokes `@scheduler_thread&.join(5)`. [`Thread#join` re-raises the joined thread's unhandled exception in the caller](https://docs.ruby-lang.org/en/3.3/Thread.html#method-i-join) — standard Ruby semantics, all MRI versions.
9. The re-raised exception escapes the `ensure`, surfaces as the example failure with the scheduler thread's backtrace.

The flake is not Ruby-2.6-specific — every link in the chain (missing rescues, `Thread#join` re-raise) is identical across all supported MRI Rubies. The 2.6-only CI observation is a timing artefact: Ruby 2.6's slower `ObjectSpace` iteration and no-JIT bytecode dispatch make `extract_all` more likely to exceed the 5-second `wait_for_idle` budget.

**Fix:**

`Datadog::SymbolDatabase::Logger` is a thin wrapper around the customer's logger. Its job is to be a defensive facade — but the `Forwardable.def_delegators` it uses for `debug` and `warn` propagates target exceptions verbatim. Replace `def_delegators` with explicit methods that swallow exceptions:

```ruby
def debug(*args, &block)
  @target.debug(*args, &block)
rescue
  nil
end
```

`#trace` already routes through `#debug`, so it inherits the protection. Every `@logger.debug` / `@logger.warn` / `@logger.trace` call site in `Datadog::SymbolDatabase::*` now silently tolerates a misbehaving target without further per-site rescues.

Bare `rescue` (StandardError) is intentional: `IOError` / `Errno` from a disk-full or broken-pipe logger are caught; `SignalException` / `SystemExit` are not.

The existing inner rescue at `component.rb:566-571` (around `install_hot_load_hook`'s `logger.debug` + `telemetry.report`) is left in place — it still protects against `telemetry.report` raising, which the logger fix does not cover.

**Change log entry**

None.

**How to test the change?**

- `bundle exec rspec spec/datadog/symbol_database/logger_spec.rb` — 13 examples covering debug/warn/trace under both success and target-raises conditions.
- `bundle exec rspec spec/datadog/symbol_database/` — full symbol_database suite passes (374 examples) on Ruby 2.6.10, 3.0.7, 3.1.7, 3.3.10, 3.4.8.
- The companion reproducer PR #5942 forces the race deterministically; with this fix merged in, that reproducer passes (see validation PR linked below once created).

**Companion PRs:**
- Reproducer: #5942
- Validation: #5944