### PR TITLE
Validate fix for flaky: SymDB scheduler logger.debug

### DIFF
--- a/lib/datadog/symbol_database/logger.rb
+++ b/lib/datadog/symbol_database/logger.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-
 module Datadog
   module SymbolDatabase
     # Logger facade that adds a config-gated +trace+ method.
@@ -11,10 +9,18 @@ module Datadog
     # is a no-op unless DD_TRACE_DEBUG is set, avoiding overhead for
     # high-frequency log sites (per-module filtering, dedup checks).
     #
+    # +debug+ and +warn+ swallow exceptions from the wrapped target. A
+    # customer-provided logger that raises (custom Logger subclass, IO
+    # error, frozen state, rspec-mocks stub) must never propagate into
+    # SymDB code paths — most callers are on the scheduler thread, which
+    # +Component#shutdown!+ joins, and +Thread#join+ re-raises any
+    # unhandled thread exception in the caller. Without this defense a
+    # misbehaving logger turns into a shutdown-time exception in the
+    # customer process. Telemetry-level reporting of the swallowed log
+    # error would itself require a working logger, so the swallow is silent.
+    #
     # @api private
     class Logger
-      extend Forwardable
-
       # @param settings [Configuration::Settings] Tracer settings (reads trace_logging flag)
       # @param target [::Logger] Underlying logger to delegate to
       def initialize(settings, target)
@@ -24,13 +30,25 @@ module Datadog
 
       attr_reader :settings
 
-      # Only debug and warn are delegated by design — symbol database
-      # extraction logs only at debug (high-volume diagnostics) and warn
-      # (user-actionable problems). Adding info/error would invite
-      # log-level drift; explicit additions can be made if needed.
-      def_delegators :@target, :debug, :warn
+      # Log at debug. Swallows exceptions from the wrapped target — see class
+      # docs.
+      # @return [void]
+      def debug(*args, &block)
+        @target.debug(*args, &block)
+      rescue
+        nil
+      end
 
-      # Log at trace level (sub-debug). No-op unless DD_TRACE_DEBUG is set.
+      # Log at warn. Swallows exceptions from the wrapped target — see class
+      # docs.
+      # @return [void]
+      def warn(*args, &block)
+        @target.warn(*args, &block)
+      rescue
+        nil
+      end
+
+      # Log at trace level (sub-debug). No-op unless trace_logging is enabled.
       # @yield Block that returns the log message string
       # @return [void]
       def trace(&block)

--- a/sig/datadog/symbol_database/logger.rbs
+++ b/sig/datadog/symbol_database/logger.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module SymbolDatabase
     class Logger
-      extend Forwardable
-
       @settings: untyped
 
       @target: ::Logger
@@ -13,7 +11,8 @@ module Datadog
 
       attr_reader target: ::Logger
 
-      # debug/warn accept either a positional message or a block (delegated to ::Logger)
+      # debug/warn accept either a positional message or a block (delegated to ::Logger).
+      # Both swallow exceptions raised by the wrapped target.
       def debug: (?untyped? message) ?{ () -> untyped } -> void
       def warn: (?untyped? message) ?{ () -> untyped } -> void
       def trace: () { () -> untyped } -> void

--- a/spec/datadog/symbol_database/logger_boom_reproducer_spec.rb
+++ b/spec/datadog/symbol_database/logger_boom_reproducer_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'datadog/symbol_database/component'
+require 'datadog/symbol_database/logger'
+require 'datadog/core/configuration'
+require 'logger'
+
+# Deterministic reproducer for the Ruby 2.6 `logger boom` flake observed
+# under `spec:main[--seed 5627]` with CI env vars
+# (see PR #5798, handoff-pr5798-ruby26-logger-boom-flake-rootcause.md).
+#
+# The bug is cross-version (not 2.6-specific): the failing test
+# `does not propagate exceptions when logger.debug itself raises` covers
+# the hot-load hook callback only, but `allow(raw_logger).to
+# receive(:debug).and_raise(...)` is process-wide. The scheduler thread's
+# `@logger.debug` calls in `extract_and_upload` (line 500), its rescue
+# handler (line 511), and `scheduler_loop`'s rescue handler (line 458)
+# have no inner rescue. When `raw_logger.debug` raises while the
+# scheduler is inside `extract_and_upload`, the exception terminates the
+# scheduler thread. `component.shutdown!` then calls
+# `@scheduler_thread&.join(5)`, and `Thread#join` re-raises the
+# unhandled exception in the test thread, surfacing as the example
+# failure with the scheduler thread's backtrace.
+#
+# This reproducer forces the timing race deterministically by holding
+# the scheduler thread inside `extract_all` on a Queue, then activating
+# the stub before releasing it.
+RSpec.describe 'SymDB scheduler logger boom reproducer' do
+  let(:settings) do
+    s = Datadog::Core::Configuration::Settings.new
+    s.symbol_database.enabled = true
+    s.symbol_database.internal.force_upload = true
+    s
+  end
+  let(:agent_settings) do
+    Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
+  end
+  let(:raw_logger) { instance_double(Logger, debug: nil, warn: nil) }
+  let(:logger) { Datadog::SymbolDatabase::Logger.new(settings, raw_logger) }
+
+  before do
+    # Skip the 5-second debounce so the scheduler enters extract_and_upload
+    # immediately on signal.
+    stub_const('Datadog::SymbolDatabase::Component::EXTRACT_DEBOUNCE_INTERVAL', 0)
+    # No-op the upload network path.
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:add_scope)
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:flush)
+    allow_any_instance_of(Datadog::SymbolDatabase::ScopeBatcher).to receive(:shutdown)
+    hide_const('ActiveSupport')
+    hide_const('Rails::Railtie')
+  end
+
+  it 'shutdown! does not propagate logger exceptions from the scheduler thread' do
+    entered_extract = Queue.new
+    resume_extract = Queue.new
+
+    # Hold the scheduler thread inside extract_all so we can flip the
+    # raw_logger.debug stub before the scheduler reaches `@logger.debug`
+    # at the success-path log line in extract_and_upload.
+    allow_any_instance_of(Datadog::SymbolDatabase::Extractor).to receive(:extract_all) do
+      entered_extract.push(:in)
+      resume_extract.pop
+    end
+
+    component = Datadog::SymbolDatabase::Component.build(settings, agent_settings, logger)
+
+    # Wait for the scheduler to enter extract_all.
+    Timeout.timeout(5) { entered_extract.pop }
+
+    # Stub raw_logger.debug to raise. The scheduler is blocked inside
+    # extract_all and has not yet reached its post-extraction debug log.
+    allow(raw_logger).to receive(:debug).and_raise(RuntimeError.new('logger boom'))
+
+    # Release extract_all. The scheduler proceeds to the success-path
+    # `@logger.debug { "symdb: initial extracted ..." }` call, which now
+    # raises through the wrapped Forwardable chain.
+    resume_extract.push(:go)
+
+    # `shutdown!` invokes `@scheduler_thread&.join(5)`. Without the fix,
+    # the scheduler thread has terminated with the unhandled `logger boom`
+    # exception, and `Thread#join` re-raises it here.
+    expect { component.shutdown! }.not_to raise_error
+  end
+end

--- a/spec/datadog/symbol_database/logger_spec.rb
+++ b/spec/datadog/symbol_database/logger_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'datadog/symbol_database/logger'
+require 'datadog/core/configuration'
+require 'logger'
+
+RSpec.describe Datadog::SymbolDatabase::Logger do
+  let(:settings) do
+    Datadog::Core::Configuration::Settings.new.tap do |s|
+      s.symbol_database.internal.trace_logging = trace_logging
+    end
+  end
+  let(:trace_logging) { false }
+  let(:target) { instance_double(::Logger, debug: nil, warn: nil) }
+  let(:wrapper) { described_class.new(settings, target) }
+
+  describe '#debug' do
+    it 'forwards a positional message to the target' do
+      expect(target).to receive(:debug).with('hello')
+      wrapper.debug('hello')
+    end
+
+    it 'forwards a block to the target' do
+      block = -> { 'hello' }
+      expect(target).to receive(:debug) do |&b|
+        expect(b).to be(block)
+      end
+      wrapper.debug(&block)
+    end
+
+    it 'returns nil' do
+      expect(wrapper.debug('hello')).to be_nil
+    end
+
+    context 'when the target raises' do
+      before { allow(target).to receive(:debug).and_raise(RuntimeError.new('logger boom')) }
+
+      it 'swallows the exception' do
+        expect { wrapper.debug('hello') }.not_to raise_error
+      end
+
+      it 'returns nil' do
+        expect(wrapper.debug('hello')).to be_nil
+      end
+
+      it 'swallows the exception when given a block' do
+        expect { wrapper.debug { 'hello' } }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#warn' do
+    it 'forwards a positional message to the target' do
+      expect(target).to receive(:warn).with('hello')
+      wrapper.warn('hello')
+    end
+
+    it 'forwards a block to the target' do
+      block = -> { 'hello' }
+      expect(target).to receive(:warn) do |&b|
+        expect(b).to be(block)
+      end
+      wrapper.warn(&block)
+    end
+
+    context 'when the target raises' do
+      before { allow(target).to receive(:warn).and_raise(RuntimeError.new('logger boom')) }
+
+      it 'swallows the exception' do
+        expect { wrapper.warn('hello') }.not_to raise_error
+      end
+
+      it 'swallows the exception when given a block' do
+        expect { wrapper.warn { 'hello' } }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#trace' do
+    context 'when trace_logging is disabled (default)' do
+      let(:trace_logging) { false }
+
+      it 'is a no-op' do
+        expect(target).not_to receive(:debug)
+        wrapper.trace { 'hello' }
+      end
+    end
+
+    context 'when trace_logging is enabled' do
+      let(:trace_logging) { true }
+
+      it 'forwards the block to debug' do
+        block = -> { 'hello' }
+        expect(target).to receive(:debug) do |&b|
+          expect(b).to be(block)
+        end
+        wrapper.trace(&block)
+      end
+
+      context 'when the target raises' do
+        before { allow(target).to receive(:debug).and_raise(RuntimeError.new('logger boom')) }
+
+        it 'swallows the exception' do
+          expect { wrapper.trace { 'hello' } }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Validates that the fix in #5943 neutralizes the forced failure in #5942. This branch merges:
- Reproducer PR: #5942 (forces the scheduler-thread `logger.debug` race deterministically)
- Fix PR: #5943 (makes `SymbolDatabase::Logger#debug` / `#warn` swallow target exceptions)

If CI passes, the fix addresses the exact failure mode the reproducer forces.
If CI fails, the fix is insufficient.

**Do not merge** — this PR exists for validation only.

**Change log entry**

None.

**How to test the change?**

CI passes = fix works against the forced failure. CI fails = fix is insufficient.

**Companion PRs:**
- Reproducer: #5942
- Fix: #5943