### PR TITLE
DEBUG-5089 Rescue all exceptions in DI and SymDB

### DIFF
--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -16,6 +16,19 @@ module Datadog
   module Core
     extend Core::Deprecations
 
+    # Exception classes that catch-all rescues must never swallow: they signal
+    # that the process is being torn down or has run out of memory and have to
+    # propagate. SignalException covers Interrupt (Ctrl+C) and every other
+    # signal delivered as an exception.
+    FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException, NoMemoryError].freeze
+
+    # Re-raise +exc+ when it is fatal (see FATAL_EXCEPTION_CLASSES). Call this as
+    # the first statement of a `rescue Exception` handler so that fatal
+    # conditions are not accidentally swallowed by a broad rescue.
+    def self.reraise_if_fatal(exc)
+      raise exc if FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+    end
+
     LIBDATADOG_API_FAILURE =
       begin
         require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"

--- a/lib/datadog/core.rb
+++ b/lib/datadog/core.rb
@@ -16,19 +16,6 @@ module Datadog
   module Core
     extend Core::Deprecations
 
-    # Exception classes that catch-all rescues must never swallow: they signal
-    # that the process is being torn down or has run out of memory and have to
-    # propagate. SignalException covers Interrupt (Ctrl+C) and every other
-    # signal delivered as an exception.
-    FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException, NoMemoryError].freeze
-
-    # Re-raise +exc+ when it is fatal (see FATAL_EXCEPTION_CLASSES). Call this as
-    # the first statement of a `rescue Exception` handler so that fatal
-    # conditions are not accidentally swallowed by a broad rescue.
-    def self.reraise_if_fatal(exc)
-      raise exc if FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
-    end
-
     LIBDATADOG_API_FAILURE =
       begin
         require "libdatadog_api.#{RUBY_VERSION[/\d+.\d+/]}_#{RUBY_PLATFORM}"

--- a/lib/datadog/di/base.rb
+++ b/lib/datadog/di/base.rb
@@ -8,6 +8,7 @@
 # are loaded, and also none of the rest of datadog library which also
 # has contrib code in other products.
 
+require_relative 'fatal_exceptions'
 require_relative 'code_tracker'
 
 # Needed since this file can be loaded without core
@@ -53,7 +54,8 @@ module Datadog
           # Activate code tracking by default because line trace points will not work
           # without it.
           Datadog::DI.activate_tracking!
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           if defined?(Datadog.logger)
             Datadog.logger.warn { "di: Failed to activate code tracking for DI: #{exc.class}: #{exc.message}" }
           else

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -120,7 +120,8 @@ module Datadog
           end
         end
         nil
-      rescue => exc
+      rescue Exception => exc # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(exc)
         # Backfill is best-effort — if it fails, line probes on
         # pre-loaded code won't work but everything else is unaffected.
         if component = DI.current_component
@@ -191,7 +192,8 @@ module Datadog
           # Since this method normally is called from customer applications,
           # rescue any exceptions that might not be handled to not break said
           # customer applications.
-          rescue => exc
+          rescue Exception => exc # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(exc)
             # Code tracker may be loaded without the rest of DI,
             # in which case DI.component will not yet be defined,
             # but we will have DI.current_component (set to nil).

--- a/lib/datadog/di/code_tracker.rb
+++ b/lib/datadog/di/code_tracker.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Lint/AssignmentInCondition
 
 require_relative 'error'
+require_relative 'fatal_exceptions'
 
 module Datadog
   module DI

--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -114,14 +114,16 @@ module Datadog
 
       def parse_probe_spec_and_notify(probe_spec)
         probe = ProbeBuilder.build_from_remote_config(probe_spec)
-      rescue => exc
+      rescue Exception => exc # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(exc)
         begin
           probe = Struct.new(:id).new(
             probe_spec['id'],
           )
           payload = probe_notification_builder.build_errored(probe, exc)
           probe_notifier_worker.add_status(payload)
-        rescue => nested_exc
+        rescue Exception => nested_exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(nested_exc)
           logger.debug { "di: failed to build error notification: #{nested_exc.class}: #{nested_exc.message}" }
           telemetry&.report(nested_exc, description: 'Error building probe error notification')
           raise

--- a/lib/datadog/di/component.rb
+++ b/lib/datadog/di/component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'fatal_exceptions'
+
 module Datadog
   module DI
     # Component for dynamic instrumentation.

--- a/lib/datadog/di/fatal_exceptions.rb
+++ b/lib/datadog/di/fatal_exceptions.rb
@@ -16,6 +16,9 @@ module Datadog
     # Re-raise +exc+ when it is fatal (see FATAL_EXCEPTION_CLASSES). Call this as
     # the first statement of a `rescue Exception` handler so that fatal
     # conditions are not accidentally swallowed by a broad rescue.
+    #
+    # @param exc [Exception] the currently-handled exception
+    # @return [nil] when +exc+ is not fatal; otherwise re-raises +exc+
     def self.reraise_if_fatal(exc)
       raise exc if FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
     end

--- a/lib/datadog/di/fatal_exceptions.rb
+++ b/lib/datadog/di/fatal_exceptions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Defined under DI rather than Core because the DI preload path
+# (datadog/di/preload -> base) activates code tracking before the rest of the
+# library, including Datadog::Core, is loaded. Catch-all rescues on that path
+# must be able to re-raise fatal exceptions without referencing Core.
+
+module Datadog
+  module DI
+    # Exception classes that catch-all rescues must never swallow: they signal
+    # that the process is being torn down or has run out of memory and have to
+    # propagate. SignalException covers Interrupt (Ctrl+C) and every other
+    # signal delivered as an exception.
+    FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException, NoMemoryError].freeze
+
+    # Re-raise +exc+ when it is fatal (see FATAL_EXCEPTION_CLASSES). Call this as
+    # the first statement of a `rescue Exception` handler so that fatal
+    # conditions are not accidentally swallowed by a broad rescue.
+    def self.reraise_if_fatal(exc)
+      raise exc if FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+    end
+  end
+end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -169,7 +169,8 @@ module Datadog
                     probe: probe, settings: settings, serializer: serializer,
                   )
                   continue = condition.satisfied?(context)
-                rescue => exc
+                rescue Exception => exc # standard:disable Lint/RescueException
+                  Datadog::DI.reraise_if_fatal(exc)
                   # Evaluation error exception can be raised for "expected"
                   # errors, we probably need another setting to control whether
                   # these exceptions are propagated.
@@ -183,7 +184,8 @@ module Datadog
                     # the probe notifier builder requires a context.
                     begin
                       responder.probe_condition_evaluation_failed_callback(context, exc)
-                    rescue => nested_exc
+                    rescue Exception => nested_exc # standard:disable Lint/RescueException
+                      Datadog::DI.reraise_if_fatal(nested_exc)
                       raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
                       instrumenter.logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc.message}" }
@@ -234,11 +236,10 @@ module Datadog
                 else
                   super(&target_block)
                 end
-              rescue NoMemoryError, Interrupt, SystemExit
-                raise
               rescue Exception => exc # standard:disable Lint/RescueException
-                # We will raise the exception captured here later, after
-                # the instrumentation callback runs.
+                Datadog::DI.reraise_if_fatal(exc)
+                # We will raise the (non-fatal) exception captured here later,
+                # after the instrumentation callback runs.
               end
 
               end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -278,7 +279,8 @@ module Datadog
                 responder.probe_executed_callback(context)
 
                 instrumenter.send(:check_and_disable_if_exceeded, probe, responder, di_start_time, di_duration)
-              rescue => di_exc
+              rescue Exception => di_exc # standard:disable Lint/RescueException
+                Datadog::DI.reraise_if_fatal(di_exc)
                 raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
                 instrumenter.logger.debug { "di: unhandled exception in method probe: #{di_exc.class}: #{di_exc.message}" }
@@ -559,7 +561,8 @@ module Datadog
           begin
             context = build_trace_point_context(probe, tp)
             return unless condition.satisfied?(context)
-          rescue => exc
+          rescue Exception => exc # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(exc)
             # Evaluation error exception can be raised for "expected"
             # errors, we probably need another setting to control whether
             # these exceptions are propagated.
@@ -573,7 +576,8 @@ module Datadog
               # the probe notifier builder requires a context.
               begin
                 responder.probe_condition_evaluation_failed_callback(context, condition, exc)
-              rescue => nested_exc
+              rescue Exception => nested_exc # standard:disable Lint/RescueException
+                Datadog::DI.reraise_if_fatal(nested_exc)
                 raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
                 logger.debug { "di: error in probe condition evaluation failed callback: #{nested_exc.class}: #{nested_exc.message}" }
@@ -606,7 +610,8 @@ module Datadog
         responder.probe_executed_callback(context)
 
         check_and_disable_if_exceeded(probe, responder, di_start_time)
-      rescue => exc
+      rescue Exception => exc # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(exc)
         raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
         logger.debug { "di: unhandled exception in line trace point: #{exc.class}: #{exc.message}" }
         telemetry&.report(exc, description: "Unhandled exception in line trace point")

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../core/utils/time'
+require_relative 'fatal_exceptions'
 
 # rubocop:disable Lint/AssignmentInCondition
 # rubocop:disable Style/AndOr

--- a/lib/datadog/di/probe_file_loader.rb
+++ b/lib/datadog/di/probe_file_loader.rb
@@ -2,6 +2,8 @@
 
 require 'json'
 
+require_relative 'fatal_exceptions'
+
 module Datadog
   module DI
     module ProbeFileLoader

--- a/lib/datadog/di/probe_file_loader.rb
+++ b/lib/datadog/di/probe_file_loader.rb
@@ -47,7 +47,8 @@ module Datadog
 
               payload = component.probe_notification_builder.build_errored(probe, exc)
               component.probe_notifier_worker.add_status(payload, probe: probe)
-            rescue => exc
+            rescue Exception => exc # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(exc)
               raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
               component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI probe file loader: #{exc.class}: #{exc.message}" }
@@ -58,7 +59,8 @@ module Datadog
               component.probe_notifier_worker.add_status(payload, probe: probe)
             end
           end
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
             should_propagate = true
             raise
@@ -67,7 +69,8 @@ module Datadog
           component.logger.debug { "di: unhandled exception handling a probe in DI probe file loader: #{exc.class}: #{exc.message}" }
           component.telemetry&.report(exc, description: "Unhandled exception handling probe in DI probe file loader")
         end
-      rescue
+      rescue Exception => exc # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(exc)
         # We should generally never get here, but if component tree
         # initialization fails for some unexpected reason, don't nuke
         # the customer application.

--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -2,6 +2,8 @@
 
 # rubocop:disable Lint/AssignmentInCondition
 
+require_relative 'fatal_exceptions'
+
 module Datadog
   module DI
     # Orchestrates probe lifecycle: installation, removal, and execution callbacks.

--- a/lib/datadog/di/probe_manager.rb
+++ b/lib/datadog/di/probe_manager.rb
@@ -28,7 +28,8 @@ module Datadog
 
         @definition_trace_point = TracePoint.trace(:end) do |tp|
           install_pending_method_probes(tp.self)
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
           logger.debug { "di: unhandled exception in definition trace point: #{exc.class}: #{exc.message}" }
           telemetry&.report(exc, description: "Unhandled exception in definition trace point")
@@ -129,7 +130,8 @@ module Datadog
             false
           end
         end
-      rescue => exc
+      rescue Exception => exc # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(exc)
         # In "propagate all exceptions" mode we will try to instrument again.
         raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
@@ -160,7 +162,8 @@ module Datadog
           begin
             instrumenter.unhook(probe)
             probe_repository.remove_installed(probe_id)
-          rescue => exc
+          rescue Exception => exc # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(exc)
             raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
             # Silence all exceptions?
             # TODO should we propagate here and rescue upstream?
@@ -190,7 +193,8 @@ module Datadog
                   break
                 rescue Error::DITargetNotDefined
                   # This should not happen... try installing again later?
-                rescue => exc
+                rescue Exception => exc # standard:disable Lint/RescueException
+                  Datadog::DI.reraise_if_fatal(exc)
                   raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
                   logger.debug { "di: error installing #{probe.type} probe at #{probe.location} (#{probe.id}) after class is defined: #{exc.class}: #{exc.message}" }

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -366,7 +366,8 @@ module Datadog
           else
             raise ArgumentError, "Invalid template segment type: #{segment}"
           end
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           evaluation_errors << {
             message: "#{exc.class}: #{exc.message}",
             expr: segment.dsl_expr, # steep:ignore NoMethod

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -2,6 +2,8 @@
 
 # rubocop:disable Lint/AssignmentInCondition
 
+require_relative 'fatal_exceptions'
+
 module Datadog
   module DI
     # Builds probe status notification and snapshot payloads.

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../core/semaphore'
+require_relative 'fatal_exceptions'
 
 module Datadog
   module DI

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -96,7 +96,7 @@ module Datadog
               Datadog::DI.reraise_if_fatal(exc)
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
-              logger.debug { "di: error in probe notifier worker: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
+              logger.debug { "di: error in probe notifier worker: #{exc.class}: #{exc.message} (at #{exc.backtrace&.first})" }
               telemetry&.report(exc, description: "Error in probe notifier worker")
             end
             @lock.synchronize do
@@ -322,7 +322,7 @@ module Datadog
             rescue Exception => exc # standard:disable Lint/RescueException
               Datadog::DI.reraise_if_fatal(exc)
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
-              logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
+              logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc.message} (at #{exc.backtrace&.first})" }
               telemetry&.report(exc, description: "Error sending #{event_type}")
             end
           end

--- a/lib/datadog/di/probe_notifier_worker.rb
+++ b/lib/datadog/di/probe_notifier_worker.rb
@@ -92,7 +92,8 @@ module Datadog
 
             begin
               more = maybe_send
-            rescue => exc
+            rescue Exception => exc # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(exc)
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
               logger.debug { "di: error in probe notifier worker: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
@@ -318,7 +319,8 @@ module Datadog
               @lock.synchronize do
                 @last_sent = time
               end
-            rescue => exc
+            rescue Exception => exc # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(exc)
               raise if settings.dynamic_instrumentation.internal.propagate_all_exceptions
               logger.debug { "di: failed to send #{event_name}: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
               telemetry&.report(exc, description: "Error sending #{event_type}")

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -89,7 +89,8 @@ module Datadog
             # message.
             # TODO assert content state (errored for this example)
             content.errored("Error applying dynamic instrumentation configuration: #{exc.class}: #{exc.message}")
-          rescue => exc
+          rescue Exception => exc # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(exc)
             raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
             component.logger.debug { "di: unhandled exception adding #{probe.type} probe at #{probe.location} (#{probe.id}) in DI remote receiver: #{exc.class}: #{exc.message}" }
@@ -114,7 +115,8 @@ module Datadog
           # try to remove instrumentation that is still supposed to be
           # active.
           #current_probe_ids[probe_spec.fetch('id')] = true
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
           component.logger.debug { "di: unhandled exception handling a probe in DI remote receiver: #{exc.class}: #{exc.message}" }
@@ -133,7 +135,8 @@ module Datadog
           probe_spec = parse_content(previous_content)
           probe_id = probe_spec.fetch('id')
           component.probe_manager.remove_probe(probe_id)
-        rescue => exc
+        rescue Exception => exc # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(exc)
           raise if component.settings.dynamic_instrumentation.internal.propagate_all_exceptions
 
           component.logger.debug { "di: unhandled exception removing probes in DI remote receiver: #{exc.class}: #{exc.message}" }

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'fatal_exceptions'
+
 module Datadog
   module DI
     # Provides an interface expected by the core Remote subsystem to

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -44,8 +44,11 @@ module Datadog
     class Serializer
       # Exception classes that should never be caught during serialization.
       # These represent fatal conditions (signals, interrupts, system exit)
-      # that must propagate to the caller.
-      FATAL_EXCEPTION_CLASSES = [SignalException, Interrupt, SystemExit].freeze
+      # that must propagate to the caller. NoMemoryError is deliberately
+      # excluded (unlike DI::FATAL_EXCEPTION_CLASSES): serialization of large
+      # or deeply recursive objects can exhaust memory, and the serializer must
+      # return a safe stub rather than tear the process down.
+      SERIALIZER_FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException].freeze
 
       # Third-party library integration / custom serializers.
       #
@@ -177,7 +180,9 @@ module Datadog
             if condition
               begin
                 condition_result = condition.call(value)
-              rescue => e
+              rescue Exception => e # standard:disable Lint/RescueException
+                raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| e.is_a?(klass) }
+
                 # If a custom serializer condition raises an exception (e.g., regex match
                 # against invalid UTF-8), skip it and continue with the next serializer.
                 # We don't want custom serializer conditions to break the entire serialization.
@@ -331,7 +336,7 @@ module Datadog
         rescue Exception => exc # standard:disable Lint/RescueException
           # Re-raise fatal exceptions that should not be caught
           # (signals, interrupts, system exit)
-          raise if FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+          raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
 
           # Catch all other exceptions including SystemStackError and NoMemoryError.
           # These inherit from Exception (not StandardError) but can occur during
@@ -429,7 +434,9 @@ module Datadog
           end
           "#<#{class_name(value.class)}#{serialized}>"
         end
-      rescue => exc
+      rescue Exception => exc # standard:disable Lint/RescueException
+        raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+
         telemetry&.report(exc, description: "Error serializing for message")
         # TODO class_name(foo) can also fail, which we don't handle here.
         # Telemetry reporting could potentially also fail?

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -48,7 +48,7 @@ module Datadog
       # excluded (unlike DI::FATAL_EXCEPTION_CLASSES): serialization of large
       # or deeply recursive objects can exhaust memory, and the serializer must
       # return a safe stub rather than tear the process down.
-      SERIALIZER_FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException].freeze
+      SERIALIZABLE_FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException].freeze
 
       # Third-party library integration / custom serializers.
       #
@@ -181,7 +181,7 @@ module Datadog
               begin
                 condition_result = condition.call(value)
               rescue Exception => e # standard:disable Lint/RescueException
-                raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| e.is_a?(klass) }
+                raise if SERIALIZABLE_FATAL_EXCEPTION_CLASSES.any? { |klass| e.is_a?(klass) }
 
                 # If a custom serializer condition raises an exception (e.g., regex match
                 # against invalid UTF-8), skip it and continue with the next serializer.
@@ -336,7 +336,7 @@ module Datadog
         rescue Exception => exc # standard:disable Lint/RescueException
           # Re-raise fatal exceptions that should not be caught
           # (signals, interrupts, system exit)
-          raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+          raise if SERIALIZABLE_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
 
           # Catch all other exceptions including SystemStackError and NoMemoryError.
           # These inherit from Exception (not StandardError) but can occur during
@@ -435,7 +435,7 @@ module Datadog
           "#<#{class_name(value.class)}#{serialized}>"
         end
       rescue Exception => exc # standard:disable Lint/RescueException
-        raise if SERIALIZER_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
+        raise if SERIALIZABLE_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
 
         telemetry&.report(exc, description: "Error serializing for message")
         # TODO class_name(foo) can also fail, which we don't handle here.

--- a/lib/datadog/di/transport/input.rb
+++ b/lib/datadog/di/transport/input.rb
@@ -113,7 +113,7 @@ module Datadog
                 send_input_chunk(chunked_payload, serialized_tags)
               rescue Exception => exc # standard:disable Lint/RescueException
                 Datadog::DI.reraise_if_fatal(exc)
-                logger.debug { "di: failed to send snapshot chunk: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
+                logger.debug { "di: failed to send snapshot chunk: #{exc.class}: #{exc.message} (at #{exc.backtrace&.first})" }
                 telemetry&.report(exc, description: "Error sending snapshot chunk")
               end
             end

--- a/lib/datadog/di/transport/input.rb
+++ b/lib/datadog/di/transport/input.rb
@@ -77,7 +77,8 @@ module Datadog
                 next
               end
               encoded_snapshots << encoded
-            rescue => exc
+            rescue Exception => exc # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(exc)
               # Serialization failed for this snapshot - report via callback
               # This catches JSON::GeneratorError, Encoding errors, TypeError, etc.
               probe_id = snapshot.dig(:debugger, :snapshot, :probe, :id)
@@ -87,7 +88,8 @@ module Datadog
               if probe_id
                 begin
                   on_serialization_error.call(probe_id, exc)
-                rescue => callback_exc
+                rescue Exception => callback_exc # standard:disable Lint/RescueException
+                  Datadog::DI.reraise_if_fatal(callback_exc)
                   logger.debug { "di: error in serialization error callback for probe #{probe_id}: #{callback_exc.class}: #{callback_exc.message}" }
                   telemetry&.report(callback_exc, description: "Error in serialization error callback")
                 end
@@ -109,7 +111,8 @@ module Datadog
               # subsequent chunks are attempted to be sent.
               begin
                 send_input_chunk(chunked_payload, serialized_tags)
-              rescue => exc
+              rescue Exception => exc # standard:disable Lint/RescueException
+                Datadog::DI.reraise_if_fatal(exc)
                 logger.debug { "di: failed to send snapshot chunk: #{exc.class}: #{exc.message} (at #{exc.backtrace.first})" }
                 telemetry&.report(exc, description: "Error sending snapshot chunk")
               end

--- a/lib/datadog/di/transport/input.rb
+++ b/lib/datadog/di/transport/input.rb
@@ -7,6 +7,7 @@ require_relative '../../core/transport/parcel'
 require_relative '../../core/transport/request'
 require_relative '../../core/transport/transport'
 require_relative '../error'
+require_relative '../fatal_exceptions'
 require_relative 'http/input'
 
 module Datadog

--- a/lib/datadog/symbol_database/component.rb
+++ b/lib/datadog/symbol_database/component.rb
@@ -5,6 +5,7 @@ require_relative 'logger'
 require_relative 'scope_batcher'
 require_relative 'uploader'
 require_relative '../core/utils/time'
+require_relative '../di/fatal_exceptions'
 
 module Datadog
   module SymbolDatabase
@@ -198,7 +199,8 @@ module Datadog
           @scheduler_cv.signal
           ensure_scheduler_thread
         end
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error scheduling upload: #{e.class}: #{e.message}" }
         @telemetry&.report(e, description: 'symdb: error scheduling upload')
       end
@@ -454,7 +456,8 @@ module Datadog
 
           extract_and_upload
         end
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: scheduler error: #{e.class}: #{e.message}" }
         @telemetry&.report(e, description: 'symdb: scheduler error')
       end
@@ -507,7 +510,8 @@ module Datadog
             @last_upload_scope_count = extracted_count
             @last_upload_time_cv.broadcast
           end
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           @logger.debug { "symdb: extraction error: #{e.class}: #{e.message}" }
           @telemetry&.report(e, description: 'symdb: extraction error')
           @mutex.synchronize do
@@ -557,7 +561,8 @@ module Datadog
           mod = tp.self
           next if MODULE_SINGLETON_CLASS_PRED.bind(mod).call
           component.send(:enqueue_hot_load, mod)
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           # Logger or telemetry can themselves raise (custom logger
           # implementation, telemetry worker in an unexpected state). The
           # :class TracePoint fires inside customer class bodies, so the
@@ -566,7 +571,8 @@ module Datadog
           begin
             logger.debug { "symdb: hot-load hook error: #{e.class}: #{e.message}" }
             telemetry&.report(e, description: 'symdb: hot-load hook error')
-          rescue
+          rescue Exception => report_exc # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(report_exc)
             nil
           end
         end

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -4,6 +4,7 @@ require_relative 'scope'
 require_relative 'symbol'
 require_relative 'file_hash'
 require_relative '../core/utils/enumerable_compat'
+require_relative '../di/fatal_exceptions'
 
 module Datadog
   module SymbolDatabase
@@ -145,7 +146,8 @@ module Datadog
         end
 
         wrap_in_file_scope(source_file, [inner_scope])
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: failed to extract #{mod_name || '<unknown>'}: #{e.class}: #{e.message}" }
         nil
       end
@@ -210,7 +212,8 @@ module Datadog
           end
           result
         end
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error in extract_all: #{e.class}: #{e.message}" }
         block_given? ? nil : []
       end
@@ -224,7 +227,8 @@ module Datadog
       # @return [String, nil] Module name or nil
       def safe_mod_name(mod)
         MODULE_NAME.bind(mod).call
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: safe_mod_name failed: #{e.class}: #{e.message}" }
         nil
       end
@@ -390,7 +394,8 @@ module Datadog
           if namespace
             location = begin
               namespace.const_source_location(const_name)
-            rescue => e
+            rescue Exception => e # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(e)
               @logger.debug { "symdb: const_source_location(#{const_name}) failed: #{e.class}: #{e.message}" }
               nil
             end
@@ -406,7 +411,8 @@ module Datadog
           MODULE_CONSTANTS.bind(mod).call(false).each do |child_const_name|
             location = begin
               mod.const_source_location(child_const_name)
-            rescue => e
+            rescue Exception => e # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(e)
               @logger.debug { "symdb: const_source_location(#{child_const_name}) failed: #{e.class}: #{e.message}" }
               nil
             end
@@ -422,7 +428,8 @@ module Datadog
         end
 
         fallback
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error finding source file for #{safe_mod_name(mod) || '<unknown>'}: #{e.class}: #{e.message}" }
         nil
       end
@@ -508,7 +515,8 @@ module Datadog
         return [UNKNOWN_MIN_LINE, UNKNOWN_MAX_LINE] if starts.empty?
 
         [starts.min, ends.max]
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error calculating line range for #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         [UNKNOWN_MIN_LINE, UNKNOWN_MAX_LINE]
       end
@@ -552,7 +560,8 @@ module Datadog
         specifics[:prepended_modules] = prepended unless prepended.empty?
 
         specifics
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error building language specifics for #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         {}
       end
@@ -575,7 +584,8 @@ module Datadog
         end
 
         scopes
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: failed to extract methods from #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         []
       end
@@ -610,7 +620,8 @@ module Datadog
           },
           symbols: extract_method_parameters(method)
         )
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: failed to extract method #{safe_mod_name(klass)}##{method_name}: #{e.class}: #{e.message}" }
         nil
       end
@@ -688,7 +699,8 @@ module Datadog
       def extract_method_parameters(method)
         method_name = begin
           method.name.to_s
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           @logger.debug { "symdb: method.name failed: #{e.class}: #{e.message}" }
           'unknown'
         end
@@ -710,7 +722,8 @@ module Datadog
             line: UNKNOWN_MIN_LINE,  # Parameters available in entire method
           )
         end
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: failed to extract parameters from #{method_name}: #{e.class}: #{e.message}" }
         []
       end
@@ -775,7 +788,8 @@ module Datadog
           file_to_names.each do |file_path, method_names|
             (index[file_path] ||= []) << [mod_name, mod, method_names]
           end
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           @logger.debug { "symdb: error indexing #{mod_name || '<unknown>'}: #{e.class}: #{e.message}" }
         end
 
@@ -800,13 +814,15 @@ module Datadog
             next unless user_code_path?(loc[0])
 
             result[loc[0]] << method_name
-          rescue => e
+          rescue Exception => e # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(e)
             @logger.debug { "symdb: error indexing method #{method_name}: #{e.class}: #{e.message}" }
           end
         end
 
         result
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: error indexing methods: #{e.class}: #{e.message}" }
         {}
       end
@@ -847,7 +863,8 @@ module Datadog
             loc = method.source_location
             next nil unless loc && loc[0] == file_path
             {name: name, method: method, type: :instance}
-          rescue => e
+          rescue Exception => e # standard:disable Lint/RescueException
+            Datadog::DI.reraise_if_fatal(e)
             @logger.debug { "symdb: error resolving #{mod_name}##{name}: #{e.class}: #{e.message}" }
             nil
           end
@@ -860,7 +877,8 @@ module Datadog
 
           parts = mod_name.split('::')
           place_in_tree(root, parts, mod, mod_name, method_infos, file_path)
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           @logger.debug { "symdb: error placing #{mod_name} in tree: #{e.class}: #{e.message}" }
         end
 
@@ -933,7 +951,8 @@ module Datadog
           current = MODULE_CONST_GET.bind(current).call(sym, false)
         end
         (Class === current) ? 'CLASS' : 'MODULE'
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e.message}, defaulting to MODULE" }
         'MODULE'
       end
@@ -1028,7 +1047,8 @@ module Datadog
           },
           symbols: extract_method_parameters(method)
         )
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         klass_name = klass ? (safe_mod_name(klass) || '<unknown>') : '<unknown>'
         @logger.debug { "symdb: failed to build method scope #{klass_name}##{method_name}: #{e.class}: #{e.message}" }
         nil
@@ -1071,14 +1091,16 @@ module Datadog
           # constant here keeps the rest of the module's symbols. Logged separately from
           # unexpected errors so the latter stand out in triage. Lint/ShadowedException
           # disabled: these descend from StandardError, but Ruby's rescue-clause-order
-          # semantics ensure the bare rescue below only catches exceptions not matched here.
+          # semantics ensure the catch-all rescue below only catches exceptions not matched here.
           @logger.debug { "symdb: skipping module constant #{const_name}: #{e.class}: #{e.message}" }
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           @logger.debug { "symdb: unexpected error reading module constant #{const_name}: #{e.class}: #{e.message}" }
         end
 
         symbols
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         mod_name = safe_mod_name(mod) || '<unknown>'
         @logger.debug { "symdb: failed to extract symbols from #{mod_name}: #{e.class}: #{e.message}" }
         []

--- a/lib/datadog/symbol_database/file_hash.rb
+++ b/lib/datadog/symbol_database/file_hash.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'digest/sha1'
+require_relative '../di/fatal_exceptions'
 
 module Datadog
   module SymbolDatabase
@@ -37,7 +38,8 @@ module Datadog
         # This is not a security vulnerability - we're computing file content hashes
         # to match against Git objects, not using SHA-1 for authentication/integrity.
         Digest::SHA1.hexdigest(git_blob)  # nosemgrep: ruby.lang.security.weak-hashes-sha1.weak-hashes-sha1
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         logger.debug { "symdb: file hash failed for #{file_path}: #{e.class}: #{e.message}" }
         nil
       end

--- a/lib/datadog/symbol_database/remote.rb
+++ b/lib/datadog/symbol_database/remote.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../di/fatal_exceptions'
+
 module Datadog
   module SymbolDatabase
     # Provides remote configuration integration for symbol database.
@@ -44,7 +46,8 @@ module Datadog
             telemetry = lookup_telemetry
             component = begin
               Datadog.send(:components, allow_initialization: false)&.symbol_database
-            rescue => e
+            rescue Exception => e # standard:disable Lint/RescueException
+              Datadog::DI.reraise_if_fatal(e)
               Datadog.logger.debug { "symdb: failed to look up component in RC receiver: #{e.class}: #{e.message}" }
               telemetry&.report(e, description: 'symdb: failed to look up component in RC receiver')
               nil
@@ -76,7 +79,8 @@ module Datadog
         # @api private
         def lookup_telemetry
           Datadog.send(:components, allow_initialization: false)&.telemetry
-        rescue
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           nil
         end
 
@@ -107,7 +111,8 @@ module Datadog
             # the Repository::Change union type where `Deleted` lacks `content`.
             change.content.errored("Unrecognized change type: #{change.type}") if change.respond_to?(:content) # steep:ignore NoMethod
           end
-        rescue => e
+        rescue Exception => e # standard:disable Lint/RescueException
+          Datadog::DI.reraise_if_fatal(e)
           component.logger.debug { "symdb: error processing remote config change: #{e.class}: #{e.message}" }
           telemetry&.report(e, description: 'symdb: error processing remote config change')
           # Rescue runs regardless of which branch raised — Steep cannot narrow the

--- a/lib/datadog/symbol_database/scope_batcher.rb
+++ b/lib/datadog/symbol_database/scope_batcher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require_relative '../di/fatal_exceptions'
 
 module Datadog
   module SymbolDatabase
@@ -122,7 +123,8 @@ module Datadog
 
         # Upload outside mutex (if batch was full)
         perform_upload(scopes_to_upload) if scopes_to_upload
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: failed to add scope: #{e.class}: #{e.message}" }
         # Don't propagate, continue operation
       end
@@ -267,7 +269,8 @@ module Datadog
             flush
           end
         end
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: timer thread error: #{e.class}: #{e.message}" }
       end
 
@@ -279,7 +282,8 @@ module Datadog
 
         @uploader.upload_scopes(scopes)
         @on_upload&.call(scopes)  # Notify tests after upload
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: upload failed: #{e.class}: #{e.message}" }
         # Don't propagate, uploader handles retries
       end

--- a/lib/datadog/symbol_database/uploader.rb
+++ b/lib/datadog/symbol_database/uploader.rb
@@ -9,6 +9,7 @@ require_relative '../core/vendor/multipart-post/multipart/post/composite_read_io
 require_relative '../tracing/ext'
 require_relative 'service_version'
 require_relative 'transport/http'
+require_relative '../di/fatal_exceptions'
 
 module Datadog
   module SymbolDatabase
@@ -86,7 +87,8 @@ module Datadog
         end
 
         perform_http_upload(compressed_data, scopes.size, upload_id: upload_id, batch_num: batch_num)
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         @logger.debug { "symdb: upload failed: #{e.class}: #{e.message}" }
         @telemetry&.report(e, description: 'symdb: upload failed')
       end

--- a/sig/datadog/di/fatal_exceptions.rbs
+++ b/sig/datadog/di/fatal_exceptions.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module DI
+    FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
+
+    def self.reraise_if_fatal: (::Exception exc) -> void
+  end
+end

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -3,7 +3,7 @@ module Datadog
     class Serializer
       MAX_MESSAGE_COLLECTION_SIZE: Integer
       MAX_MESSAGE_ATTRIBUTE_COUNT: Integer
-      SERIALIZER_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
+      SERIALIZABLE_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
 
       @@flat_registry: ::Array[{condition: ::Proc?, proc: ^(Serializer serializer, untyped value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped}]
 

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -3,7 +3,7 @@ module Datadog
     class Serializer
       MAX_MESSAGE_COLLECTION_SIZE: Integer
       MAX_MESSAGE_ATTRIBUTE_COUNT: Integer
-      FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
+      SERIALIZER_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
 
       @@flat_registry: ::Array[{condition: ::Proc?, proc: ^(Serializer serializer, untyped value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped}]
 

--- a/spec/datadog/di/fatal_exceptions_loading_spec.rb
+++ b/spec/datadog/di/fatal_exceptions_loading_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "datadog/di/spec_helper"
+require 'open3'
+
+# DI source files call Datadog::DI.reraise_if_fatal in their catch-all rescues.
+# That helper is defined in datadog/di/fatal_exceptions, which is loaded via
+# datadog/di/base (the DI boot path, MRI >= 2.6 only). Files that can be loaded
+# outside that path -- di/remote via core remote config (capabilities.rb), and
+# di/instrumenter required directly by specs -- must require fatal_exceptions
+# themselves, otherwise the rescue path raises NoMethodError while handling
+# another exception.
+RSpec.describe 'DI fatal_exceptions availability when loaded standalone' do
+  di_test
+
+  %w[
+    datadog/di/remote
+    datadog/di/instrumenter
+  ].each do |file|
+    it "defines Datadog::DI.reraise_if_fatal after requiring #{file}" do
+      script = <<-SCRIPT
+        require '#{file}'
+        unless Datadog::DI.respond_to?(:reraise_if_fatal)
+          raise "reraise_if_fatal undefined after requiring #{file}"
+        end
+      SCRIPT
+      out, status = Open3.capture2e('ruby', stdin_data: script)
+      expect(status.exitstatus).to eq(0), "subprocess failed for #{file}: #{out}"
+    end
+  end
+end

--- a/spec/datadog/di/fatal_exceptions_spec.rb
+++ b/spec/datadog/di/fatal_exceptions_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "datadog/di/spec_helper"
+require "datadog/di/fatal_exceptions"
+
+RSpec.describe "Datadog::DI.reraise_if_fatal" do
+  describe Datadog::DI::FATAL_EXCEPTION_CLASSES do
+    it 'contains the process-fatal exception classes' do
+      expect(Datadog::DI::FATAL_EXCEPTION_CLASSES).to eq([SystemExit, SignalException, NoMemoryError])
+    end
+
+    it 'is frozen' do
+      expect(Datadog::DI::FATAL_EXCEPTION_CLASSES).to be_frozen
+    end
+  end
+
+  describe '.reraise_if_fatal' do
+    context 'when given a fatal exception' do
+      [SystemExit.new, SignalException.new('TERM'), Interrupt.new, NoMemoryError.new].each do |exc|
+        it "re-raises #{exc.class}" do
+          expect { Datadog::DI.reraise_if_fatal(exc) }.to raise_error(exc.class)
+        end
+      end
+
+      it 're-raises the same exception instance' do
+        exc = SystemExit.new
+        expect { Datadog::DI.reraise_if_fatal(exc) }.to raise_error { |raised| expect(raised).to equal(exc) }
+      end
+    end
+
+    context 'when given a non-fatal exception' do
+      [StandardError.new, RuntimeError.new, NotImplementedError.new, LoadError.new, SystemStackError.new].each do |exc|
+        it "returns without raising for #{exc.class}" do
+          expect { Datadog::DI.reraise_if_fatal(exc) }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/di/fatal_exceptions_spec.rb
+++ b/spec/datadog/di/fatal_exceptions_spec.rb
@@ -4,16 +4,6 @@ require "datadog/di/spec_helper"
 require "datadog/di/fatal_exceptions"
 
 RSpec.describe "Datadog::DI.reraise_if_fatal" do
-  describe Datadog::DI::FATAL_EXCEPTION_CLASSES do
-    it 'contains the process-fatal exception classes' do
-      expect(Datadog::DI::FATAL_EXCEPTION_CLASSES).to eq([SystemExit, SignalException, NoMemoryError])
-    end
-
-    it 'is frozen' do
-      expect(Datadog::DI::FATAL_EXCEPTION_CLASSES).to be_frozen
-    end
-  end
-
   describe '.reraise_if_fatal' do
     context 'when given a fatal exception' do
       [SystemExit.new, SignalException.new('TERM'), Interrupt.new, NoMemoryError.new].each do |exc|
@@ -25,6 +15,23 @@ RSpec.describe "Datadog::DI.reraise_if_fatal" do
       it 're-raises the same exception instance' do
         exc = SystemExit.new
         expect { Datadog::DI.reraise_if_fatal(exc) }.to raise_error { |raised| expect(raised).to equal(exc) }
+      end
+
+      it 'preserves the original backtrace when re-raising' do
+        original = begin
+          raise SystemExit, 'shutting down'
+        rescue SystemExit => e
+          e
+        end
+
+        raised = begin
+          Datadog::DI.reraise_if_fatal(original)
+          nil
+        rescue SystemExit => e
+          e
+        end
+
+        expect(raised.backtrace).to eq(original.backtrace)
       end
     end
 

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -623,6 +623,41 @@ RSpec.describe Datadog::DI::Serializer do
         expect(serialized[:type]).to eq('String')
         expect(serialized[:value]).to eq('second serializer')
       end
+
+      it 'skips the custom serializer when the condition raises a non-StandardError' do
+        # NotImplementedError inherits from ScriptError, not StandardError, so the
+        # previous `rescue => e` would have let it escape the whole serialization.
+        condition = lambda do |value|
+          raise NotImplementedError, 'boom' if value == 'trigger non-standard'
+          false
+        end
+        described_class.register(condition: condition) do |serializer, value, name:, depth:|
+          serializer.serialize_value('should not be called')
+        end
+
+        expect(Datadog.logger).to receive(:warn).with(/Custom serializer condition failed: NotImplementedError/)
+        expect(telemetry).to receive(:report).with(
+          an_instance_of(NotImplementedError),
+          description: "Custom serializer condition failed"
+        )
+
+        serialized = serializer.serialize_value('trigger non-standard')
+
+        expect(serialized[:type]).to eq('String')
+        expect(serialized[:value]).to eq('trigger non-standard')
+      end
+
+      it 'propagates a fatal exception raised by the condition' do
+        condition = lambda do |value|
+          raise SystemExit if value == 'trigger fatal'
+          false
+        end
+        described_class.register(condition: condition) do |serializer, value, name:, depth:|
+          serializer.serialize_value('should not be called')
+        end
+
+        expect { serializer.serialize_value('trigger fatal') }.to raise_error(SystemExit)
+      end
     end
   end
 
@@ -650,6 +685,20 @@ RSpec.describe Datadog::DI::Serializer do
       ]
 
       define_serialize_value_cases(cases)
+    end
+  end
+
+  context 'when serialization raises a fatal exception' do
+    with_di_registry_change
+
+    before do
+      Datadog::DI::Serializer.register(condition: lambda { |value| DISerializerCustomExceptionTestClass === value }) do |*args|
+        raise SystemExit
+      end
+    end
+
+    it 'propagates the fatal exception instead of returning a safe stub' do
+      expect { serializer.serialize_value(DISerializerCustomExceptionTestClass.new) }.to raise_error(SystemExit)
     end
   end
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -1653,6 +1653,24 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
         expect(result).to be_nil
         expect(yielded).to be_empty
       end
+
+      it 'returns [] and logs when collection raises a non-StandardError' do
+        # A class overriding #name to raise NotImplementedError (or any other
+        # non-StandardError surfacing during introspection) must not abort the
+        # extraction pass and kill the scheduler thread.
+        allow(extractor).to receive(:build_per_file_index).and_raise(NotImplementedError, 'no name')
+        expect(logger).to receive(:debug) { |&block| expect(block.call).to match(/extract_all.*NotImplementedError.*no name/i) }
+
+        result = extractor.extract_all
+
+        expect(result).to eq([])
+      end
+
+      it 'propagates fatal exceptions instead of swallowing them' do
+        allow(extractor).to receive(:build_per_file_index).and_raise(SystemExit)
+
+        expect { extractor.extract_all }.to raise_error(SystemExit)
+      end
     end
 
     context 'block form' do


### PR DESCRIPTION
**What does this PR do?**

Replaces rescues of StandardError with rescues of Exception (with `SystemExit`, `SignalException`, `NoMemoryError`) reraised. The re-raise is centralized in a new `Datadog::DI.reraise_if_fatal` helper backed by `Datadog::DI::FATAL_EXCEPTION_CLASSES`. 

**Motivation:**

Testing SymDB extraction on an actual application (gitlab source) revealed that SymDB runs customer code and, in case of gitlab, that code raises NotImplemented which does not derive from SymDB. Result is dead SymDB worker thread and no symbols (but customer application otherwise is unaffected).

https://github.com/DataDog/dd-trace-rb/pull/5946 makes it less likely that SymDB will invoke customer code. This PR expands the exception rescues to the ones below StandardError.

**Change log entry**

Yes. DI: the symbol database and DI background threads no longer stop when application code raises a non-StandardError (e.g. NotImplementedError from an overridden #name) during introspection; previously this could silently disable symbol uploads for the rest of the process.

**How to test the change?**

Unit tests