### PR TITLE
Symbol database: stop invoking application-overridable reflection during extraction

### DIFF
--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -89,6 +89,26 @@ module Datadog
       # so we bind the original Module#name to get the real module name safely.
       MODULE_NAME = Module.instance_method(:name)
 
+      # Cached UnboundMethods for the remaining class/module/object introspection
+      # used during extraction. Like MODULE_NAME, these bind the original
+      # implementations and are dispatched explicitly so that application code
+      # which overrides any of them (per-class, on a subclass, or in a singleton
+      # class) can neither intercept extraction nor be executed as a side effect
+      # of it. KERNEL_CLASS recovers an object's real class without calling a
+      # possibly-overridden #class.
+      CLASS_SUPERCLASS = Class.instance_method(:superclass)
+      MODULE_INCLUDED_MODULES = Module.instance_method(:included_modules)
+      MODULE_ANCESTORS = Module.instance_method(:ancestors)
+      MODULE_CLASS_VARIABLES = Module.instance_method(:class_variables)
+      MODULE_CONSTANTS = Module.instance_method(:constants)
+      MODULE_AUTOLOAD_P = Module.instance_method(:autoload?)
+      MODULE_CONST_GET = Module.instance_method(:const_get)
+      MODULE_CONST_DEFINED = Module.instance_method(:const_defined?)
+      KERNEL_CLASS = ::Kernel.instance_method(:class)
+      private_constant :CLASS_SUPERCLASS, :MODULE_INCLUDED_MODULES, :MODULE_ANCESTORS,
+        :MODULE_CLASS_VARIABLES, :MODULE_CONSTANTS, :MODULE_AUTOLOAD_P, :MODULE_CONST_GET,
+        :MODULE_CONST_DEFINED, :KERNEL_CLASS
+
       # @param logger [Logger] Logger instance (SymbolDatabase::Logger facade or compatible)
       # @param settings [Configuration::Settings] Tracer settings
       def initialize(logger:, settings:)
@@ -109,7 +129,7 @@ module Datadog
       # @param mod [Module, Class] The module or class to extract from
       # @return [Scope, nil] FILE scope wrapping extracted scope, or nil if filtered out
       def extract(mod)
-        return nil unless mod.is_a?(Module)
+        return nil unless Module === mod
         mod_name = safe_mod_name(mod)
         return nil unless mod_name
 
@@ -118,7 +138,7 @@ module Datadog
         source_file = find_source_file(mod)
         return nil unless source_file
 
-        inner_scope = if mod.is_a?(Class)
+        inner_scope = if Class === mod
           extract_class_scope(mod)
         else
           extract_module_scope(mod)
@@ -239,12 +259,12 @@ module Datadog
         current = Object
         mod_name.split('::').each do |seg|
           sym = seg.to_sym
-          return false if current.autoload?(sym, false)
-          return false unless current.const_defined?(sym, false)
-          current = current.const_get(sym, false)
+          return false if MODULE_AUTOLOAD_P.bind(current).call(sym, false)
+          return false unless MODULE_CONST_DEFINED.bind(current).call(sym, false)
+          current = MODULE_CONST_GET.bind(current).call(sym, false)
         end
         current.equal?(mod)
-      rescue NameError, ArgumentError
+      rescue NameError, ArgumentError, TypeError
         # Expected "no" outcome for stale/detached classes — the whole point
         # of this predicate. Per the rescue convention in this file's header
         # comment: inner per-item rescues are expected failures, no logging.
@@ -352,13 +372,14 @@ module Datadog
         #   1. Classes with no user-defined methods (e.g. AR models with only associations) whose
         #      generated methods point to gem code — we find the `class Foo` declaration instead.
         #   2. Namespace-only modules (`module Foo; class Bar; end; end`) with no methods at all.
-        if mod.name
+        mod_name = safe_mod_name(mod)
+        if mod_name
           # Look up the class/module by its last name component in its enclosing namespace.
-          parts = mod.name.split('::')
+          parts = mod_name.split('::')
           const_name = parts.last
           namespace = if parts.length > 1
             begin
-              Object.const_get(parts[0..-2].join('::')) # steep:ignore
+              MODULE_CONST_GET.bind(Object).call(parts[0..-2].join('::')) # steep:ignore
             rescue NameError
               nil
             end
@@ -382,7 +403,7 @@ module Datadog
           end
 
           # Also scan constants defined by mod itself (namespace-only modules).
-          mod.constants(false).each do |child_const_name|
+          MODULE_CONSTANTS.bind(mod).call(false).each do |child_const_name|
             location = begin
               mod.const_source_location(child_const_name)
             rescue => e
@@ -438,7 +459,7 @@ module Datadog
 
         Scope.new(
           scope_type: 'MODULE',
-          name: mod.name,
+          name: safe_mod_name(mod),
           source_file: source_file,
           start_line: UNKNOWN_MIN_LINE,
           end_line: UNKNOWN_MAX_LINE,
@@ -456,7 +477,7 @@ module Datadog
 
         Scope.new(
           scope_type: 'CLASS',
-          name: klass.name,
+          name: safe_mod_name(klass),
           source_file: source_file,
           start_line: start_line,
           end_line: end_line,
@@ -488,7 +509,7 @@ module Datadog
 
         [starts.min, ends.max]
       rescue => e
-        @logger.debug { "symdb: error calculating line range for #{klass.name}: #{e.class}: #{e.message}" }
+        @logger.debug { "symdb: error calculating line range for #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         [UNKNOWN_MIN_LINE, UNKNOWN_MAX_LINE]
       end
 
@@ -502,8 +523,9 @@ module Datadog
         # Emitted as an array named super_classes — consistent with Java, .NET, and Python.
         # Array allows for multiple entries if future Ruby versions or mixins expand the chain.
         # Anonymous superclasses (class Foo < Class.new { ... }) have nil name; compact to skip.
-        if klass.superclass && klass.superclass != Object && klass.superclass != BasicObject
-          super_name = klass.superclass.name # steep:ignore
+        superclass = CLASS_SUPERCLASS.bind(klass).call
+        if superclass && !superclass.equal?(Object) && !superclass.equal?(BasicObject)
+          super_name = safe_mod_name(superclass)
           specifics[:super_classes] = [super_name] if super_name
         end
 
@@ -511,7 +533,7 @@ module Datadog
         # included_modules returns the entire ancestor chain's mixins, not only directly
         # included ones. This is intentional: the field reports "modules this class
         # responds to," which is what the consumer (UI navigation, probe context) needs.
-        included = klass.included_modules.map(&:name).reject do |name|
+        included = MODULE_INCLUDED_MODULES.bind(klass).call.map { |m| safe_mod_name(m) }.reject do |name|
           name.nil? || EXCLUDED_COMMON_MODULES.any? { |prefix| name.start_with?(prefix) }
         end
         specifics[:included_modules] = included unless included.empty?
@@ -522,16 +544,16 @@ module Datadog
         # Single-pass collection avoids the intermediate arrays from take_while.map.compact.
         # Test coverage: spec/datadog/symbol_database/extractor_spec.rb tests prepend behavior.
         prepended = []
-        klass.ancestors.each do |a|
-          break if a == klass
-          name = a.name
+        MODULE_ANCESTORS.bind(klass).call.each do |a|
+          break if a.equal?(klass)
+          name = safe_mod_name(a)
           prepended << name if name
         end
         specifics[:prepended_modules] = prepended unless prepended.empty?
 
         specifics
       rescue => e
-        @logger.debug { "symdb: error building language specifics for #{klass.name}: #{e.class}: #{e.message}" }
+        @logger.debug { "symdb: error building language specifics for #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         {}
       end
 
@@ -554,7 +576,7 @@ module Datadog
 
         scopes
       rescue => e
-        @logger.debug { "symdb: failed to extract methods from #{klass.name}: #{e.class}: #{e.message}" }
+        @logger.debug { "symdb: failed to extract methods from #{safe_mod_name(klass)}: #{e.class}: #{e.message}" }
         []
       end
 
@@ -589,7 +611,7 @@ module Datadog
           symbols: extract_method_parameters(method)
         )
       rescue => e
-        @logger.debug { "symdb: failed to extract method #{klass.name}##{method_name}: #{e.class}: #{e.message}" }
+        @logger.debug { "symdb: failed to extract method #{safe_mod_name(klass)}##{method_name}: #{e.class}: #{e.message}" }
         nil
       end
 
@@ -876,12 +898,12 @@ module Datadog
         if leaf
           # Node exists (was created as intermediate or from another entry).
           # Update type and mod — the actual module object is authoritative.
-          leaf[:type] = mod.is_a?(Class) ? 'CLASS' : 'MODULE'
+          leaf[:type] = Class === mod ? 'CLASS' : 'MODULE'
           leaf[:mod] = mod
         else
           leaf = {
             name: mod_name,
-            type: mod.is_a?(Class) ? 'CLASS' : 'MODULE',
+            type: Class === mod ? 'CLASS' : 'MODULE',
             children: {}, methods: [],
             mod: mod, source_file: file_path,
             fqn: mod_name
@@ -898,8 +920,19 @@ module Datadog
       # @param fqn [String] Fully-qualified name (e.g. "Authentication::Strategies")
       # @return [String] 'CLASS' or 'MODULE'
       def resolve_scope_type(fqn)
-        const = Object.const_get(fqn)
-        const.is_a?(Class) ? 'CLASS' : 'MODULE'
+        current = Object
+        fqn.split('::').each do |seg|
+          sym = seg.to_sym
+          pending_autoload = if RubyVersion.is?('>= 2.7')
+            MODULE_AUTOLOAD_P.bind(current).call(sym, false)
+          else
+            MODULE_AUTOLOAD_P.bind(current).call(sym)
+          end
+          return 'MODULE' if pending_autoload
+          return 'MODULE' unless MODULE_CONST_DEFINED.bind(current).call(sym, false)
+          current = MODULE_CONST_GET.bind(current).call(sym, false)
+        end
+        Class === current ? 'CLASS' : 'MODULE'
       rescue => e
         @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e.message}, defaulting to MODULE" }
         'MODULE'
@@ -1009,8 +1042,8 @@ module Datadog
         symbols = []
 
         # Class variables (only for classes)
-        if mod.is_a?(Class)
-          mod.class_variables(false).each do |var_name|
+        if Class === mod
+          MODULE_CLASS_VARIABLES.bind(mod).call(false).each do |var_name|
             symbols << Symbol.new(
               symbol_type: 'STATIC_FIELD',
               name: var_name.to_s,
@@ -1021,23 +1054,24 @@ module Datadog
 
         # Constants (excluding nested modules/classes).
         # Skip autoloaded constants to avoid triggering loading as a side effect.
-        mod.constants(false).each do |const_name|
-          next if mod.autoload?(const_name)
-          const_value = mod.const_get(const_name)
-          next if const_value.is_a?(Module)
+        MODULE_CONSTANTS.bind(mod).call(false).each do |const_name|
+          next if MODULE_AUTOLOAD_P.bind(mod).call(const_name)
+          const_value = MODULE_CONST_GET.bind(mod).call(const_name)
+          next if Module === const_value
 
           symbols << Symbol.new(
             symbol_type: 'STATIC_FIELD',
             name: const_name.to_s,
             line: UNKNOWN_MIN_LINE,
-            type: const_value.class.name
+            type: safe_mod_name(KERNEL_CLASS.bind(const_value).call)
           )
-        rescue NameError, LoadError, NoMethodError => e # standard:disable Lint/ShadowedException
-          # Expected: constant removed/undefined, autoload failure, or const value missing
-          # #class. Logged separately from unexpected errors so the latter stand out in triage.
-          # Lint/ShadowedException disabled: NameError/NoMethodError do descend from
-          # StandardError, but Ruby's rescue-clause-order semantics ensure the bare rescue
-          # below only catches exceptions not matched here.
+        rescue NameError, LoadError, NoMethodError, TypeError => e # standard:disable Lint/ShadowedException
+          # Expected: constant removed/undefined (NameError), autoload failure (LoadError),
+          # or a value whose class cannot be read (NoMethodError/TypeError). Skipping one
+          # constant here keeps the rest of the module's symbols. Logged separately from
+          # unexpected errors so the latter stand out in triage. Lint/ShadowedException
+          # disabled: these descend from StandardError, but Ruby's rescue-clause-order
+          # semantics ensure the bare rescue below only catches exceptions not matched here.
           @logger.debug { "symdb: skipping module constant #{const_name}: #{e.class}: #{e.message}" }
         rescue => e
           @logger.debug { "symdb: unexpected error reading module constant #{const_name}: #{e.class}: #{e.message}" }

--- a/lib/datadog/symbol_database/extractor.rb
+++ b/lib/datadog/symbol_database/extractor.rb
@@ -898,12 +898,12 @@ module Datadog
         if leaf
           # Node exists (was created as intermediate or from another entry).
           # Update type and mod — the actual module object is authoritative.
-          leaf[:type] = Class === mod ? 'CLASS' : 'MODULE'
+          leaf[:type] = (Class === mod) ? 'CLASS' : 'MODULE'
           leaf[:mod] = mod
         else
           leaf = {
             name: mod_name,
-            type: Class === mod ? 'CLASS' : 'MODULE',
+            type: (Class === mod) ? 'CLASS' : 'MODULE',
             children: {}, methods: [],
             mod: mod, source_file: file_path,
             fqn: mod_name
@@ -932,7 +932,7 @@ module Datadog
           return 'MODULE' unless MODULE_CONST_DEFINED.bind(current).call(sym, false)
           current = MODULE_CONST_GET.bind(current).call(sym, false)
         end
-        Class === current ? 'CLASS' : 'MODULE'
+        (Class === current) ? 'CLASS' : 'MODULE'
       rescue => e
         @logger.debug { "symdb: resolve_scope_type(#{fqn}) failed: #{e.class}: #{e.message}, defaulting to MODULE" }
         'MODULE'

--- a/sig/datadog/symbol_database/extractor.rbs
+++ b/sig/datadog/symbol_database/extractor.rbs
@@ -7,6 +7,15 @@ module Datadog
       TARGETABLE_LINE_EVENTS: Array[::Symbol]
       MODULE_SINGLETON_CLASS_PRED: ::UnboundMethod
       MODULE_NAME: ::UnboundMethod
+      CLASS_SUPERCLASS: ::UnboundMethod
+      MODULE_INCLUDED_MODULES: ::UnboundMethod
+      MODULE_ANCESTORS: ::UnboundMethod
+      MODULE_CLASS_VARIABLES: ::UnboundMethod
+      MODULE_CONSTANTS: ::UnboundMethod
+      MODULE_AUTOLOAD_P: ::UnboundMethod
+      MODULE_CONST_GET: ::UnboundMethod
+      MODULE_CONST_DEFINED: ::UnboundMethod
+      KERNEL_CLASS: ::UnboundMethod
       SLEEP_EVERY_N_MODULES: Integer
       SLEEP_SECONDS: Float
 

--- a/spec/datadog/symbol_database/extractor_spec.rb
+++ b/spec/datadog/symbol_database/extractor_spec.rb
@@ -2679,4 +2679,161 @@ RSpec.describe Datadog::SymbolDatabase::Extractor do
       end
     end
   end
+
+  # Reflection during extraction is dispatched through cached unbound methods
+  # (and safe_mod_name) so application overrides of name/superclass/ancestors/
+  # included_modules/class/is_a?/const_get/constants/autoload? can neither
+  # intercept extraction nor run as a side effect of it.
+  describe 'immunity to customer-overridden reflection' do
+    describe '#build_class_language_specifics' do
+      it 'reads the real superclass name when the superclass overrides .name' do
+        base = stub_const('FindingTwoBase', Class.new)
+        base.define_singleton_method(:name) { raise 'hostile superclass #name' }
+        derived = stub_const('FindingTwoDerived', Class.new(base))
+
+        specifics = extractor.send(:build_class_language_specifics, derived)
+
+        expect(specifics[:super_classes]).to eq(['FindingTwoBase'])
+      end
+
+      it 'reads the real included-module name when the module overrides .name' do
+        stub_const('FindingTwoMixin', Module.new)
+        FindingTwoMixin.define_singleton_method(:name) { raise 'hostile mixin #name' }
+        klass = stub_const('FindingTwoIncluder', Class.new { include FindingTwoMixin })
+
+        specifics = extractor.send(:build_class_language_specifics, klass)
+
+        expect(specifics[:included_modules]).to include('FindingTwoMixin')
+      end
+
+      it 'reads the real prepended-module name when the module overrides .name' do
+        stub_const('FindingTwoPrepend', Module.new)
+        FindingTwoPrepend.define_singleton_method(:name) { raise 'hostile prepend #name' }
+        klass = stub_const('FindingTwoPrepender', Class.new { prepend FindingTwoPrepend })
+
+        specifics = extractor.send(:build_class_language_specifics, klass)
+
+        expect(specifics[:prepended_modules]).to include('FindingTwoPrepend')
+      end
+
+      it 'is immune to a class overriding superclass/included_modules/ancestors' do
+        stub_const('FindingTwoRealMixin', Module.new)
+        klass = stub_const('FindingTwoHostileReflection', Class.new { include FindingTwoRealMixin })
+        klass.define_singleton_method(:superclass) { raise 'hostile #superclass' }
+        klass.define_singleton_method(:included_modules) { raise 'hostile #included_modules' }
+        klass.define_singleton_method(:ancestors) { raise 'hostile #ancestors' }
+
+        specifics = extractor.send(:build_class_language_specifics, klass)
+
+        expect(specifics[:included_modules]).to include('FindingTwoRealMixin')
+      end
+    end
+
+    describe '#extract_scope_symbols' do
+      it 'records the real class of a constant value whose #class is overridden' do
+        value = +'a string constant'
+        value.define_singleton_method(:class) { raise 'hostile value #class' }
+        mod = Module.new
+        mod.const_set(:FINDING_TWO_HOSTILE, value)
+
+        symbols = extractor.send(:extract_scope_symbols, mod)
+        sym = symbols.find { |s| s.name == 'FINDING_TWO_HOSTILE' }
+
+        expect(sym).not_to be_nil
+        expect(sym.type).to eq('String')
+      end
+
+      it 'does not misclassify a constant value that lies via #is_a?' do
+        value = Object.new
+        value.define_singleton_method(:is_a?) { |*| true }
+        mod = Module.new
+        mod.const_set(:FINDING_TWO_FAKE_MODULE, value)
+
+        symbols = extractor.send(:extract_scope_symbols, mod)
+
+        # `Module === value` is false even though value.is_a?(Module) lies true,
+        # so it is emitted as a STATIC_FIELD rather than skipped as a module.
+        expect(symbols.map(&:name)).to include('FINDING_TWO_FAKE_MODULE')
+      end
+
+      it 'enumerates constants when the module overrides .constants and .const_get' do
+        mod = Module.new
+        mod.const_set(:FINDING_TWO_REAL, 42)
+        mod.define_singleton_method(:constants) { |*| raise 'hostile #constants' }
+        mod.define_singleton_method(:const_get) { |*| raise 'hostile #const_get' }
+
+        symbols = extractor.send(:extract_scope_symbols, mod)
+        sym = symbols.find { |s| s.name == 'FINDING_TWO_REAL' }
+
+        expect(sym).not_to be_nil
+        expect(sym.type).to eq('Integer')
+      end
+
+      it 'classifies a BasicObject constant value without invoking its methods' do
+        mod = Module.new
+        mod.const_set(:FINDING_TWO_BASIC, BasicObject.new)
+
+        symbols = extractor.send(:extract_scope_symbols, mod)
+        sym = symbols.find { |s| s.name == 'FINDING_TWO_BASIC' }
+
+        expect(sym).not_to be_nil
+        expect(sym.type).to eq('BasicObject')
+      end
+
+      it 'skips autoloaded constants without triggering the autoload' do
+        mod = Module.new
+        mod.autoload(:FindingTwoLazy, '/nonexistent/finding_two_extract.rb')
+
+        symbols = extractor.send(:extract_scope_symbols, mod)
+
+        expect(symbols.map(&:name)).not_to include('FindingTwoLazy')
+        expect(mod.autoload?(:FindingTwoLazy)).to eq('/nonexistent/finding_two_extract.rb')
+      end
+    end
+
+    describe '#resolve_scope_type' do
+      it 'does not trigger an autoload while classifying' do
+        ns = stub_const('FindingTwoResolveNs', Module.new)
+        ns.autoload(:FindingTwoResolveLazy, '/nonexistent/finding_two_resolve.rb')
+
+        result = extractor.send(:resolve_scope_type, 'FindingTwoResolveNs::FindingTwoResolveLazy')
+
+        expect(result).to eq('MODULE')
+        expect(ns.autoload?(:FindingTwoResolveLazy)).to eq('/nonexistent/finding_two_resolve.rb')
+      end
+
+      it 'classifies a nested class' do
+        ns = stub_const('FindingTwoNestNs', Module.new)
+        ns.const_set(:Inner, Class.new)
+
+        expect(extractor.send(:resolve_scope_type, 'FindingTwoNestNs::Inner')).to eq('CLASS')
+      end
+    end
+
+    describe '#extract' do
+      it 'extracts a user-code class that overrides is_a?' do
+        file = create_user_code_file(<<~RUBY)
+          class FindingTwoHostileIsA
+            def self.is_a?(*)
+              raise 'hostile #is_a?'
+            end
+
+            def real_method; end
+          end
+        RUBY
+        load file
+
+        begin
+          scope = extractor.extract(FindingTwoHostileIsA)
+          expect(scope).not_to be_nil
+          class_scope = scope.scopes.first
+          expect(class_scope.scope_type).to eq('CLASS')
+          expect(class_scope.scopes.map(&:name)).to include('real_method')
+        ensure
+          Object.send(:remove_const, :FindingTwoHostileIsA) if defined?(FindingTwoHostileIsA)
+          cleanup_user_code_file(file)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

Stops symbol database extraction from calling application-overridable reflection methods directly. Extraction now dispatches `name`, `superclass`, `included_modules`, `ancestors`, `class`, `is_a?`, `const_get`, `constants`, `class_variables`, and `autoload?` through cached unbound `Module`/`Class`/`Kernel` methods (the precedent already set by `MODULE_NAME` / `safe_mod_name`), routes every name lookup through `safe_mod_name`, and replaces `obj.is_a?(Klass)` checks with `Klass === obj`. `resolve_scope_type` now walks the fully-qualified name segment by segment with autoload guards instead of `Object.const_get`, so it classifies CLASS vs MODULE without triggering autoloads.

**Motivation:**

Extraction introspects arbitrary application objects. Calling these methods directly executes application code during a passive introspection pass: an overridden method can return wrong data, run customer code as a side effect, or raise, and `const_get`/`Object.const_get` can autoload (loading customer code) while merely classifying a constant. `safe_mod_name` already guarded the primary module-name lookup; this extends the same protection to the remaining sites.

**Change log entry**

None.

**Additional Notes:**

- Independent of the catch-all-rescue hardening in #5945; both branch from `master`.
- Behaviour note: a constant whose value is a `BasicObject` is now classified (`type: "BasicObject"`) instead of being dropped, because the real class is read via an unbound `Kernel#class`.

**How to test the change?**

- `bundle exec rake standard typecheck` is clean.
- New specs under `spec/datadog/symbol_database/extractor_spec.rb` ("immunity to customer-overridden reflection") assert each site reads real data and avoids side effects when an application overrides reflection, including the autoload-safe classification path.
- `bundle exec rspec spec/datadog/symbol_database` — 372 examples, 0 failures.
