### PR TITLE
Fix thread leaks in polling_spec and remove leak-checker exemption

### DIFF
--- a/spec/datadog/core/workers/polling_spec.rb
+++ b/spec/datadog/core/workers/polling_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe Datadog::Core::Workers::Polling do
       context 'when the worker has been started' do
         include_context 'graceful stop'
 
+        # +join+ is stubbed, so +stop+ returns before the background thread
+        # is reaped. Terminate it explicitly to avoid leaking the thread.
+        after { worker.terminate }
+
         before do
           worker.perform
           try_wait_until { worker.running? && worker.run_loop? }
@@ -260,6 +264,10 @@ RSpec.describe Datadog::Core::Workers::Polling do
       context 'given shutdown timeout' do
         subject(:stop) { worker.stop(false, 1000) }
         include_context 'graceful stop'
+
+        # +join+ is stubbed, so +stop+ returns before the background thread
+        # is reaped. Terminate it explicitly to avoid leaking the thread.
+        after { worker.terminate }
 
         before do
           expect(worker).to receive(:join)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -259,20 +259,6 @@ RSpec.configure do |config|
       end
 
       unless background_threads.empty?
-        # TODO: Temporarily disabled for `spec/datadog/tracing/workers`
-        # was meaningful changes are required to address clean
-        # teardown in those tests.
-        # They currently flood the output, making our test
-        # suite output unreadable.
-        if example.file_path.start_with?(
-          './spec/datadog/core/workers/',
-          './spec/datadog/tracing/workers/'
-        )
-          puts # Add newline so we get better output when the progress formatter is being used
-          RSpec.warning("FIXME: #{example.file_path}:#{example.metadata[:line_number]} is leaking threads")
-          next
-        end
-
         info = background_threads.each_with_index.flat_map do |t, idx|
           backtrace = t.backtrace
           if backtrace.nil? && t.alive? # Maybe the thread hasn't run yet? Let's give it a second chance


### PR DESCRIPTION
**What does this PR do?**

Fixes the two thread leaks in `spec/datadog/core/workers/polling_spec.rb` and removes the leak-checker exemption that hid them.

The `when the worker has been started` and `given shutdown timeout` examples include the `graceful stop` context, which stubs `#join`. As a result `#stop` returns before the background worker thread is reaped, and the `spec_helper` leak detector observes the thread still alive at the end of the example. Each affected context now terminates the worker in an `after` hook (matching the convention in `async_spec.rb`).

With those leaks fixed, the leak detector's exemption for `spec/datadog/core/workers/` and `spec/datadog/tracing/workers/` is removed, so leaks in those directories are reported like everywhere else.

**Motivation:**

The leak detector suppressed real thread leaks behind a `FIXME` warning instead of failing them. CI on master HEAD showed the only remaining leaks under the exemption were `polling_spec.rb:73` and `:273`; removing the exemption keeps these directories honest going forward.

**Change log entry**

None.

**Additional Notes:**

Verified the fix mechanically against `lib/datadog/core/workers/`: with the stubbed `#join`, the worker thread is still alive immediately after the example in 20/20 runs; adding `worker.terminate` reaps it in 0/20 runs while `#stop` still returns `true`. The full rspec suite was not run locally (dev gems unavailable in this environment); relying on CI here.

**How to test the change?**

Run `spec/datadog/core/workers/polling_spec.rb` and confirm no `Spec leaked N threads` / `is leaking threads` warnings are emitted.
