### PR TITLE
fix(openfeature): map invalid FFE configs to parse errors

### DIFF
--- a/lib/datadog/open_feature/ext.rb
+++ b/lib/datadog/open_feature/ext.rb
@@ -4,8 +4,10 @@ module Datadog
   module OpenFeature
     module Ext
       ERROR = 'ERROR'
+      DEFAULT = 'DEFAULT'
       INITIALIZING = 'INITIALIZING'
       UNKNOWN_TYPE = 'UNKNOWN_TYPE'
+      PARSE_ERROR = 'PARSE_ERROR'
       GENERAL = 'GENERAL'
       PROVIDER_FATAL = 'PROVIDER_FATAL'
       PROVIDER_NOT_READY = 'PROVIDER_NOT_READY'

--- a/lib/datadog/open_feature/native_evaluator.rb
+++ b/lib/datadog/open_feature/native_evaluator.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../core/feature_flags'
+require_relative 'ext'
+require_relative 'resolution_details'
 
 module Datadog
   module OpenFeature
     # This class is an interface of evaluation logic using native extension
     class NativeEvaluator
+      INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE = 'flag configuration is invalid or unsupported'
+
       # NOTE: In a currect implementation configuration is expected to be a raw
       #       JSON string containing feature flags (straight from the remote config)
       #       in the format expected by `libdatadog` without any modifications
@@ -27,11 +31,29 @@ module Datadog
       def get_assignment(flag_key, default_value:, expected_type:, context:)
         result = @configuration.get_assignment(flag_key, expected_type, context)
 
+        return invalid_flag_configuration_error(default_value) if invalid_flag_configuration?(result)
+
         # NOTE: This is a special case when we need to fallback to the default
         #       value, even tho the evaluation itself doesn't produce an error
         #       resolution details
         result.value = default_value if result.variant.nil?
         result
+      end
+
+      private
+
+      def invalid_flag_configuration?(result)
+        result.reason == Ext::DEFAULT &&
+          result.error_code.nil? &&
+          result.error_message == INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE
+      end
+
+      def invalid_flag_configuration_error(default_value)
+        ResolutionDetails.build_error(
+          value: default_value,
+          error_code: Ext::PARSE_ERROR,
+          error_message: INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE
+        )
       end
     end
   end

--- a/sig/datadog/open_feature/ext.rbs
+++ b/sig/datadog/open_feature/ext.rbs
@@ -5,7 +5,11 @@ module Datadog
 
       ERROR: ::String
 
+      DEFAULT: ::String
+
       UNKNOWN_TYPE: ::String
+
+      PARSE_ERROR: ::String
 
       GENERAL: ::String
 

--- a/sig/datadog/open_feature/native_evaluator.rbs
+++ b/sig/datadog/open_feature/native_evaluator.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module OpenFeature
     class NativeEvaluator
+      INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE: ::String
+
       @configuration: Core::FeatureFlags::Configuration
 
       def initialize: (::String configuration) -> void
@@ -10,7 +12,13 @@ module Datadog
         default_value: untyped,
         context: ::OpenFeature::SDK::EvaluationContext::fields_t,
         expected_type: ::Symbol
-      ) -> Core::FeatureFlags::ResolutionDetails
+      ) -> (Core::FeatureFlags::ResolutionDetails | ResolutionDetails)
+
+      private
+
+      def invalid_flag_configuration?: (Core::FeatureFlags::ResolutionDetails result) -> bool
+
+      def invalid_flag_configuration_error: (untyped default_value) -> ResolutionDetails
     end
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'datadog/open_feature/native_evaluator'
+
+RSpec.describe Datadog::OpenFeature::NativeEvaluator do
+  before do
+    stub_const('Datadog::Core::FeatureFlags::Configuration', configuration_class)
+    allow(Datadog::Core::FeatureFlags::Configuration)
+      .to receive(:new).with(configuration_json).and_return(configuration)
+    allow(configuration).to receive(:get_assignment).with(flag_key, expected_type, context).and_return(assignment)
+  end
+
+  subject(:evaluator) { described_class.new(configuration_json) }
+
+  let(:configuration_class) do
+    Class.new do
+      def initialize(_configuration)
+      end
+
+      def get_assignment(_flag_key, _expected_type, _context)
+      end
+    end
+  end
+  let(:configuration_json) { '{"flags":{}}' }
+  let(:configuration) { configuration_class.new(configuration_json) }
+  let(:flag_key) { 'flag' }
+  let(:expected_type) { :boolean }
+  let(:context) { {'targeting_key' => 'user-1'} }
+  let(:assignment_class) do
+    Class.new do
+      attr_accessor :value
+      attr_reader :reason, :error_code, :error_message, :variant
+
+      def initialize(reason:, error_code:, error_message:, variant:)
+        @reason = reason
+        @error_code = error_code
+        @error_message = error_message
+        @variant = variant
+      end
+    end
+  end
+  let(:assignment) do
+    assignment_class.new(reason: reason, error_code: error_code, error_message: error_message, variant: variant)
+  end
+  let(:reason) { 'TARGETING_MATCH' }
+  let(:error_code) { nil }
+  let(:error_message) { nil }
+  let(:variant) { 'on' }
+
+  describe '#get_assignment' do
+    subject(:result) do
+      evaluator.get_assignment(flag_key, default_value: false, expected_type: expected_type, context: context)
+    end
+
+    context 'when libdatadog reports an invalid per-flag configuration as caller default' do
+      let(:reason) { 'DEFAULT' }
+      let(:error_message) { 'flag configuration is invalid or unsupported' }
+      let(:variant) { nil }
+
+      it 'returns an OpenFeature parse error using the caller default' do
+        expect(assignment).not_to receive(:value=)
+
+        expect(result.value).to be(false)
+        expect(result.reason).to eq('ERROR')
+        expect(result.error_code).to eq('PARSE_ERROR')
+        expect(result.error_message).to eq('flag configuration is invalid or unsupported')
+        expect(result.error?).to be(true)
+      end
+    end
+
+    context 'when libdatadog reports an ordinary default result' do
+      let(:reason) { 'DEFAULT' }
+      let(:error_message) { 'default allocation is matched and is serving NULL' }
+      let(:variant) { nil }
+
+      it 'keeps the default result and applies the caller default value' do
+        expect(assignment).to receive(:value=).with(false)
+
+        expect(result).to be(assignment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

The libdatadog v36 bump in #5928 changes invalid per-flag FFE configuration failures to surface through the native result as caller-default behavior. Ruby then reports OpenFeature evaluation metrics with `feature_flag.result.reason:default` and no `error.type`, which breaks the existing system-test contract for invalid regex and variant type mismatch cases.

## Changes

This adds a narrow compatibility shim in the OpenFeature native evaluator. When libdatadog returns the v36 invalid-flag sentinel (`DEFAULT`, no error code, and `flag configuration is invalid or unsupported`), Ruby converts it into the existing OpenFeature parse-error resolution using the caller default value.

The change also adds the missing OpenFeature constants and RBS updates needed for that mapping, plus a regression spec for the invalid-configuration case and a guard that ordinary default fallthrough still remains default behavior.

## Decisions

The mapping stays at the OpenFeature evaluator boundary instead of metrics code, so provider resolution, hooks, exposure reporting, and metric tagging all see the same `ERROR` / `PARSE_ERROR` result. The check is intentionally narrow to avoid changing disabled flags, default allocations, or normal no-match fallthrough from libdatadog v36.

## Change log entry

Yes. Fix OpenFeature invalid FFE flag configurations to report parse errors instead of default evaluations.

## Validation

- `bundle install`
- `bundle exec rake test:open_feature 2>&1 | tee /tmp/full_rspec.log | grep -E 'Pending:|Failures:|Finished' -A 99` (ruby_3.2_openfeature_latest: 100 examples, 0 failures; ruby_3.2_openfeature_min: 100 examples, 0 failures)
- `STANDARDOPTS="lib/datadog/open_feature/ext.rb lib/datadog/open_feature/native_evaluator.rb spec/datadog/open_feature/native_evaluator_spec.rb" bundle exec rake standard`
- `bundle exec rake steep:check`