### PR TITLE
Fix version bump step from release

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           VERSION: ${{ inputs.version }}
+          BUNDLE_FROZEN: "false"
         run: bundle exec rake "release_prep:prepare[${VERSION}]"
 
       - name: Update supported integration versions


### PR DESCRIPTION
**What does this PR do?**

Set `BUNDLE_FROZEN` to false for this step.

**Motivation:**

In CI, `BUNDLE_FROZEN=true`  and the step failed with `"Version mismatch: 0 != 2.36.0"`, 

**Change log entry**
None

**How to test the change?**
Validate locally.