### PR TITLE
DI: reject method probes on Kernel#lambda

### DIFF
--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -107,17 +107,6 @@ module Datadog
             "Method probes on the Datadog namespace are not permitted: #{type_name}##{probe.method_name}"
         end
 
-        # Reject method probes targeting Kernel#lambda. The method-probe
-        # wrapper invokes the original method via super(&block); on Ruby 3.3+
-        # the original Kernel#lambda raises ArgumentError when reached this way
-        # with a non-literal block, so a probe on it would break every
-        # lambda { ... } call site that passes a captured block. Probing lambda
-        # creation has no legitimate customer use case. See #5560.
-        if type_name && probe.method_name == "lambda" && kernel_type_name?(type_name)
-          raise Error::ProbeTargetForbidden,
-            "Method probes on Kernel#lambda are not permitted: #{type_name}##{probe.method_name}"
-        end
-
         lock.synchronize do
           if probe.instrumentation_module
             # Already instrumented, warn?
@@ -128,8 +117,8 @@ module Datadog
         cls = symbolize_class_name(probe.type_name)
         serializer = self.serializer
         method_name = probe.method_name
-        loc = begin
-          cls.instance_method(method_name).source_location # steep:ignore ArgumentTypeMismatch
+        target_method = begin
+          cls.instance_method(method_name) # steep:ignore ArgumentTypeMismatch
         rescue NameError
           # The target method is not defined.
           # This could be because it will be explicitly defined later
@@ -137,7 +126,26 @@ module Datadog
           # or the method is virtual (provided by a method_missing handler).
           # In these cases we do not have a source location for the
           # target method here.
+          nil
         end
+
+        # Reject method probes whose target method resolves to Kernel#lambda,
+        # including inherited targets. Every class inherits Kernel#lambda, so a
+        # probe naming any type that does not override lambda (Object#lambda,
+        # String#lambda, a plain user class, ...) prepends the wrapper ahead of
+        # Kernel#lambda and reaches the wrapper's super(&block) path. On
+        # Ruby 3.3+ that path raises ArgumentError for every lambda { ... }
+        # call site passing a captured block, breaking lambda creation
+        # process-wide. Resolving the method owner catches the inherited case
+        # that a textual "Kernel" name match misses; a type that defines its
+        # own lambda has a different owner and is left alone. Probing lambda
+        # creation has no legitimate customer use case. See #5560.
+        if method_name == "lambda" && target_method&.owner == ::Kernel
+          raise Error::ProbeTargetForbidden,
+            "Method probes on Kernel#lambda are not permitted: #{probe.type_name}##{method_name}"
+        end
+
+        loc = target_method&.source_location
         rate_limiter = probe.rate_limiter
         settings = self.settings
         instrumenter = self
@@ -719,21 +727,6 @@ module Datadog
       # top-level constants.
       def datadog_namespace_type_name?(cls_name)
         DATADOG_NAMESPACE_TYPE_NAME.match?(cls_name)
-      end
-
-      # Matches the Kernel module by name, tolerating the same alias forms as
-      # DATADOG_NAMESPACE_TYPE_NAME: an optional leading "::" and any number
-      # of leading "Object::" segments, both of which Object.const_get
-      # resolves to the top-level Kernel module. Anchored at both ends so it
-      # matches Kernel itself and not a class merely named "KernelFoo".
-      KERNEL_TYPE_NAME = /\A(?:::)?(?:Object::)*Kernel\z/
-      private_constant :KERNEL_TYPE_NAME
-
-      # Returns true when +cls_name+ names the top-level +Kernel+ module,
-      # accounting for the +::+ and +Object::+ alias forms that resolve to it.
-      # The check is purely textual and does not require Kernel to be loaded.
-      def kernel_type_name?(cls_name)
-        KERNEL_TYPE_NAME.match?(cls_name)
       end
     end
   end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -107,6 +107,17 @@ module Datadog
             "Method probes on the Datadog namespace are not permitted: #{type_name}##{probe.method_name}"
         end
 
+        # Reject method probes targeting Kernel#lambda. The method-probe
+        # wrapper invokes the original method via super(&block); on Ruby 3.3+
+        # the original Kernel#lambda raises ArgumentError when reached this way
+        # with a non-literal block, so a probe on it would break every
+        # lambda { ... } call site that passes a captured block. Probing lambda
+        # creation has no legitimate customer use case. See #5560.
+        if type_name && probe.method_name == "lambda" && kernel_type_name?(type_name)
+          raise Error::ProbeTargetForbidden,
+            "Method probes on Kernel#lambda are not permitted: #{type_name}##{probe.method_name}"
+        end
+
         lock.synchronize do
           if probe.instrumentation_module
             # Already instrumented, warn?
@@ -708,6 +719,21 @@ module Datadog
       # top-level constants.
       def datadog_namespace_type_name?(cls_name)
         DATADOG_NAMESPACE_TYPE_NAME.match?(cls_name)
+      end
+
+      # Matches the Kernel module by name, tolerating the same alias forms as
+      # DATADOG_NAMESPACE_TYPE_NAME: an optional leading "::" and any number
+      # of leading "Object::" segments, both of which Object.const_get
+      # resolves to the top-level Kernel module. Anchored at both ends so it
+      # matches Kernel itself and not a class merely named "KernelFoo".
+      KERNEL_TYPE_NAME = /\A(?:::)?(?:Object::)*Kernel\z/
+      private_constant :KERNEL_TYPE_NAME
+
+      # Returns true when +cls_name+ names the top-level +Kernel+ module,
+      # accounting for the +::+ and +Object::+ alias forms that resolve to it.
+      # The check is purely textual and does not require Kernel to be loaded.
+      def kernel_type_name?(cls_name)
+        KERNEL_TYPE_NAME.match?(cls_name)
       end
     end
   end

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -11,6 +11,8 @@ module Datadog
 
       DATADOG_NAMESPACE_TYPE_NAME: ::Regexp
 
+      KERNEL_TYPE_NAME: ::Regexp
+
       @settings: Datadog::Core::Configuration::Settings
 
       @serializer: Serializer
@@ -61,6 +63,7 @@ module Datadog
 
       def symbolize_class_name: (String? cls_name) -> Module
       def datadog_namespace_type_name?: (::String cls_name) -> bool
+      def kernel_type_name?: (::String cls_name) -> bool
       def raise_if_probe_in_loaded_features: (Probe probe, Integer line_no, CodeTracker? code_tracker) -> void
     end
   end

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -11,8 +11,6 @@ module Datadog
 
       DATADOG_NAMESPACE_TYPE_NAME: ::Regexp
 
-      KERNEL_TYPE_NAME: ::Regexp
-
       @settings: Datadog::Core::Configuration::Settings
 
       @serializer: Serializer
@@ -63,7 +61,6 @@ module Datadog
 
       def symbolize_class_name: (String? cls_name) -> Module
       def datadog_namespace_type_name?: (::String cls_name) -> bool
-      def kernel_type_name?: (::String cls_name) -> bool
       def raise_if_probe_in_loaded_features: (Probe probe, Integer line_no, CodeTracker? code_tracker) -> void
     end
   end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -901,6 +901,65 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context 'when targeting Kernel#lambda' do
+      shared_examples 'rejects the probe' do |type_name|
+        let(:probe_args) do
+          {type_name: type_name, method_name: 'lambda'}
+        end
+
+        it "raises ProbeTargetForbidden for #{type_name}" do
+          expect do
+            hook_method(probe) do |payload|
+            end
+          end.to raise_error(Datadog::DI::Error::ProbeTargetForbidden,
+            /Method probes on Kernel#lambda are not permitted: #{Regexp.escape(type_name)}#lambda/)
+        end
+      end
+
+      it_behaves_like 'rejects the probe', 'Kernel'
+
+      # A leading "::" is Ruby's root-namespace prefix and any number of
+      # leading "Object::" segments resolve through Object.const_get to the
+      # same top-level Kernel module, so users cannot bypass the rejection by
+      # naming Kernel through one of these aliases.
+      it_behaves_like 'rejects the probe', '::Kernel'
+      it_behaves_like 'rejects the probe', 'Object::Kernel'
+      it_behaves_like 'rejects the probe', '::Object::Kernel'
+      it_behaves_like 'rejects the probe', 'Object::Object::Kernel'
+
+      context 'when targeting Kernel but not the lambda method' do
+        let(:probe_args) do
+          {type_name: 'Kernel', method_name: 'definitely_not_lambda'}
+        end
+
+        it 'is not rejected as a forbidden target' do
+          # Stub prepend so the wrapper module is not installed onto the real
+          # Kernel for the rest of the suite; this example only asserts that
+          # the forbidden check does not fire for a non-lambda Kernel method.
+          allow(Kernel).to receive(:prepend)
+          expect do
+            hook_method(probe) { |_| }
+          end.not_to raise_error
+        end
+      end
+
+      context 'when targeting a lambda method on a non-Kernel type' do
+        let(:probe_args) do
+          {type_name: 'KernelLike', method_name: 'lambda'}
+        end
+
+        # "KernelLike" is not the Kernel module, so a "lambda" method on it is
+        # an ordinary user method; the class does not exist here, so we expect
+        # the normal not-defined error rather than the forbidden error.
+        it 'does not reject as Kernel#lambda' do
+          expect do
+            hook_method(probe) do |payload|
+            end
+          end.to raise_error(Datadog::DI::Error::DITargetNotDefined)
+        end
+      end
+    end
+
     describe 'stack trace' do
       before do
         # Reload the test class because when methods are instrumented,

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -902,16 +902,24 @@ RSpec.describe Datadog::DI::Instrumenter do
     end
 
     context 'when targeting Kernel#lambda' do
-      # A leading "::" is Ruby's root-namespace prefix and any number of
-      # leading "Object::" segments resolve through Object.const_get to the
-      # same top-level Kernel module, so users cannot bypass the rejection by
-      # naming Kernel through one of these aliases.
+      # The first group is the Kernel module named directly: a leading "::" is
+      # Ruby's root-namespace prefix and any number of leading "Object::"
+      # segments resolve through Object.const_get to the same top-level Kernel
+      # module, so users cannot bypass the rejection by naming Kernel through
+      # one of these aliases.
+      #
+      # The second group names other types that inherit Kernel#lambda without
+      # overriding it: every class inherits it, so the target method resolves
+      # to Kernel#lambda regardless of the type name. These are rejected by
+      # resolving the method owner, not by matching the type name.
       [
         'Kernel',
         '::Kernel',
         'Object::Kernel',
         '::Object::Kernel',
         'Object::Object::Kernel',
+        'Object',
+        'String',
       ].each do |type_name|
         context "with type name #{type_name.inspect}" do
           let(:probe_args) do
@@ -956,6 +964,29 @@ RSpec.describe Datadog::DI::Instrumenter do
             hook_method(probe) do |payload|
             end
           end.to raise_error(Datadog::DI::Error::DITargetNotDefined)
+        end
+      end
+
+      context 'when the target type defines its own lambda method' do
+        before do
+          stub_const('OverridesLambda', Class.new do
+            def lambda
+              :not_kernel
+            end
+          end)
+        end
+
+        let(:probe_args) do
+          {type_name: 'OverridesLambda', method_name: 'lambda'}
+        end
+
+        # The owner of OverridesLambda#lambda is OverridesLambda, not Kernel,
+        # so this is an ordinary user method and the probe installs normally.
+        it 'is not rejected and instruments the user-defined method' do
+          observed = []
+          hook_method(probe) { |payload| observed << payload }
+          expect(OverridesLambda.new.lambda).to eq(:not_kernel)
+          expect(observed.length).to eq(1)
         end
       end
     end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -902,30 +902,30 @@ RSpec.describe Datadog::DI::Instrumenter do
     end
 
     context 'when targeting Kernel#lambda' do
-      shared_examples 'rejects the probe' do |type_name|
-        let(:probe_args) do
-          {type_name: type_name, method_name: 'lambda'}
-        end
-
-        it "raises ProbeTargetForbidden for #{type_name}" do
-          expect do
-            hook_method(probe) do |payload|
-            end
-          end.to raise_error(Datadog::DI::Error::ProbeTargetForbidden,
-            /Method probes on Kernel#lambda are not permitted: #{Regexp.escape(type_name)}#lambda/)
-        end
-      end
-
-      it_behaves_like 'rejects the probe', 'Kernel'
-
       # A leading "::" is Ruby's root-namespace prefix and any number of
       # leading "Object::" segments resolve through Object.const_get to the
       # same top-level Kernel module, so users cannot bypass the rejection by
       # naming Kernel through one of these aliases.
-      it_behaves_like 'rejects the probe', '::Kernel'
-      it_behaves_like 'rejects the probe', 'Object::Kernel'
-      it_behaves_like 'rejects the probe', '::Object::Kernel'
-      it_behaves_like 'rejects the probe', 'Object::Object::Kernel'
+      [
+        'Kernel',
+        '::Kernel',
+        'Object::Kernel',
+        '::Object::Kernel',
+        'Object::Object::Kernel',
+      ].each do |type_name|
+        context "with type name #{type_name.inspect}" do
+          let(:probe_args) do
+            {type_name: type_name, method_name: 'lambda'}
+          end
+
+          it 'raises ProbeTargetForbidden' do
+            expect do
+              hook_method(probe) { |_| }
+            end.to raise_error(Datadog::DI::Error::ProbeTargetForbidden,
+              /Method probes on Kernel#lambda are not permitted: #{Regexp.escape(type_name)}#lambda/)
+          end
+        end
+      end
 
       context 'when targeting Kernel but not the lambda method' do
         let(:probe_args) do


### PR DESCRIPTION
**What does this PR do?**

Rejects method probes that target `Kernel#lambda`. A probe whose target
type resolves to the top-level `Kernel` module and whose method is `lambda`
now raises `Error::ProbeTargetForbidden` at hook time instead of being
installed.

Companion to #5560.

**Motivation**

The method-probe wrapper invokes the original method via `super(&block)`.
On Ruby 3.3+ the original `Kernel#lambda` raises `ArgumentError` when it is
reached this way with a non-literal block, so a probe on `Kernel#lambda`
would break every `lambda { ... }` call site that passes a captured block.
This is the customer-facing limitation documented in #5560 ("On Ruby 3.3+,
method probes on `Kernel#lambda` may raise `ArgumentError` when the probed
call site passes a non-literal block").

There is no legitimate customer use case for probing lambda creation, and
the failure mode is silent and pervasive (every block-passing lambda call
in the process). Rejecting at hook time surfaces an immediate `ERROR`
status back to the backend so the user sees the problem in the Live
Debugger UI rather than wondering why their application started raising
`ArgumentError`.

This mirrors #5907 (reject probes on the Datadog namespace): both refuse a
class of method probes that cannot work, using the same
`Error::ProbeTargetForbidden`. It is orthogonal to #5560 — that PR makes
stdlib probes safe in general; this PR refuses the one stdlib target that
remains broken at a language layer below the tracer's control. Either can
land first.

**Change log entry**

Yes. Dynamic Instrumentation: reject method probes that target
`Kernel#lambda`, which cannot be instrumented safely.

**Implementation**

`Instrumenter#hook_method` resolves the target class, then rejects the
probe when `probe.method_name == "lambda"` and the resolved method's owner
is `Kernel`. Because every class inherits `Kernel#lambda`, this covers the
`Kernel` module named directly (including the `::Kernel`, `Object::Kernel`,
and chained `Object::Object::Kernel` alias forms that `Object.const_get`
resolves to the same module) as well as inherited targets such as
`Object#lambda` and `String#lambda` — a probe naming any type that does
not override `lambda` resolves to `Kernel#lambda` and is rejected. A type
that defines its own `lambda` has a different method owner and falls
through to normal class resolution as an ordinary user method.

Owner resolution replaces an earlier textual `Kernel` name match, which
missed inherited targets: a probe on `Object#lambda` named a type whose
name was not `Kernel`, so it bypassed the textual check and reached the
same broken `super(&block)` path.

The error reuses `Error::ProbeTargetForbidden` (added in #5907) and flows
through `ProbeManager#add_probe` via the existing `rescue => exc` branch —
it is recorded as a failed probe and an `ERROR` status is sent to the
backend without any further changes to the manager or notifier.

Line probes are unaffected: they install via TracePoint and do not carry a
`type_name`/`method_name`, so the rejection branch is unreachable for them.

**How to test the change?**

```
bundle exec rspec spec/datadog/di/instrumenter_spec.rb
```

105 examples, 0 failures, 8 pending (the same 8 Ruby-2-only pending tests as
on master).

The new specs live under `describe '.hook_method'` →
`context 'when targeting Kernel#lambda'` and cover:

- `'Kernel'`, `'::Kernel'`, `'Object::Kernel'`, `'::Object::Kernel'`,
  `'Object::Object::Kernel'` with method `lambda` — the Kernel module named
  directly and via aliases, all rejected with `ProbeTargetForbidden`
- `'Object'` and `'String'` with method `lambda` — inherited
  `Kernel#lambda` targets, also rejected with `ProbeTargetForbidden`
- `'Kernel'` with a non-`lambda` method — not rejected (prepend stubbed so
  the example does not install onto the real `Kernel`)
- `'KernelLike'` with method `lambda` — not defined here; falls through to
  `DITargetNotDefined` as expected
- a class that defines its own `lambda` — not rejected; the user-defined
  method is instrumented and still returns its value

