### PR TITLE
Skip per-tick sampling of profiler-internal threads

### DIFF
--- a/benchmarks/profiling_sample_overhead.rb
+++ b/benchmarks/profiling_sample_overhead.rb
@@ -40,6 +40,7 @@ samples = data.dig("worker_stats", "cpu_sampled")
 cpu_sampling_time_ns_total = data.dig("worker_stats", "cpu_sampling_time_ns_total")
 serialization_time_ns_total = data.dig("recorder_stats", "serialization_time_ns_total")
 inactive_thread_samples_skipped = data.dig("worker_stats", "inactive_thread_samples_skipped")
+profiler_thread_samples_skipped = data.dig("worker_stats", "profiler_thread_samples_skipped")
 cpu_sampling_overhead = cpu_sampling_time_ns_total / duration_ns
 
 overhead = ->(total) {
@@ -59,6 +60,7 @@ pp({
   sampling_rate: samples / duration,
   sample_every_n_ms: (duration / samples) * 1000,
   inactive_thread_samples_skipped: inactive_thread_samples_skipped,
+  profiler_thread_samples_skipped: profiler_thread_samples_skipped,
 })
 
 unless VALIDATE_BENCHMARK_MODE

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -530,6 +530,8 @@ static VALUE _native_sampling_loop(DDTRACE_UNUSED VALUE _self, VALUE instance) {
   // situation we stop immediately and never even start the sampling trigger loop.
   if (state->stop_thread == rb_thread_current()) return Qnil;
 
+  thread_context_collector_profiler_internal_thread_started();
+
   // Reset the dynamic sampling rate state, if any (reminder: the monotonic clock reference may change after a fork)
   dynamic_sampling_rate_reset(&state->cpu_dynamic_sampling_rate);
   long now = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
@@ -892,6 +894,8 @@ static VALUE release_gvl_and_run_sampling_trigger_loop(VALUE instance) {
 
   // If we stopped sampling due to an exception, re-raise it (now in the worker thread)
   if (state->failure_exception != Qnil) rb_exc_raise(state->failure_exception);
+
+  thread_context_collector_profiler_internal_thread_done(state->thread_context_collector_instance);
 
   return Qnil;
 }

--- a/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
+++ b/ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c
@@ -6,6 +6,7 @@
 #include "helpers.h"
 #include "ruby_helpers.h"
 #include "collectors_idle_sampling_helper.h"
+#include "collectors_thread_context.h"
 
 // Used by the Collectors::CpuAndWallTimeWorker to gather samples when the Ruby process is idle.
 //
@@ -30,7 +31,9 @@ typedef struct {
 
 static VALUE _native_new(VALUE klass);
 static void reset_state(idle_sampling_loop_state *state);
-static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance);
+static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance, VALUE thread_context_collector_instance);
+static VALUE idle_sampling_loop_body(VALUE self_instance);
+static VALUE idle_sampling_loop_ensure(VALUE thread_context_collector_instance);
 static VALUE _native_stop(DDTRACE_UNUSED VALUE self, VALUE self_instance);
 static void *run_idle_sampling_loop(void *state_ptr);
 static void interrupt_idle_sampling_loop(void *state_ptr);
@@ -56,7 +59,7 @@ void collectors_idle_sampling_helper_init(VALUE profiling_module) {
   // https://bugs.ruby-lang.org/issues/18007 for a discussion around this.
   rb_define_alloc_func(collectors_idle_sampling_helper_class, _native_new);
 
-  rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_idle_sampling_loop", _native_idle_sampling_loop, 1);
+  rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_idle_sampling_loop", _native_idle_sampling_loop, 2);
   rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_stop", _native_stop, 1);
   rb_define_singleton_method(collectors_idle_sampling_helper_class, "_native_reset", _native_reset, 1);
   rb_define_singleton_method(testing_module, "_native_idle_sampling_helper_request_action", _native_idle_sampling_helper_request_action, 1);
@@ -109,14 +112,25 @@ static VALUE _native_reset(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
   return Qtrue;
 }
 
-static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance) {
+static VALUE _native_idle_sampling_loop(DDTRACE_UNUSED VALUE self, VALUE self_instance, VALUE thread_context_collector_instance) {
+  return rb_ensure(idle_sampling_loop_body, self_instance, idle_sampling_loop_ensure, thread_context_collector_instance);
+}
+
+static VALUE idle_sampling_loop_body(VALUE self_instance) {
   idle_sampling_loop_state *state;
   TypedData_Get_Struct(self_instance, idle_sampling_loop_state, &idle_sampling_helper_typed_data, state);
+
+  thread_context_collector_profiler_internal_thread_started();
 
   // Release GVL and run the loop waiting for requests
   rb_thread_call_without_gvl(run_idle_sampling_loop, state, interrupt_idle_sampling_loop, state);
 
   return Qtrue;
+}
+
+static VALUE idle_sampling_loop_ensure(VALUE thread_context_collector_instance) {
+  thread_context_collector_profiler_internal_thread_done(thread_context_collector_instance);
+  return Qnil;
 }
 
 static void *run_idle_sampling_loop(void *state_ptr) {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -170,6 +170,7 @@ typedef struct {
     // How many per-thread samples were skipped because the thread has been continuously suspended
     // (no GVL) since its previous sample, so its Ruby stack cannot have changed.
     unsigned int inactive_thread_samples_skipped;
+    unsigned int profiler_thread_samples_skipped;
   } stats;
 
   struct {
@@ -256,6 +257,14 @@ struct per_thread_context {
   // but this is deemed worth it for this optimization. In any case we don't know exactly
   // at what time a thread was doing CPU work (unless it's on CPU 100% of the time).
   bool was_skipped_at_last_sample;
+  // Set as true for CpuAndWallTimeWorker and IdleSamplingHelper threads.
+  // When true, per-tick samples are skipped entirely; the thread is sampled only once per
+  // reporting period during the on_serialize flush.
+  //
+  // These threads are always in native code so their stacks aren't interesting;
+  // the Profiling::Scheduler thread on the other hand does a lot of different
+  // things using a mix of Ruby and native code, so that one isn't considered internal.
+  bool is_profiler_internal_thread;
 
   struct {
     // Both of these fields are set by on_gc_start and kept until on_gc_finish is called.
@@ -373,8 +382,9 @@ static VALUE safely_lookup_hash_without_going_into_ruby_code(VALUE hash, VALUE k
 static VALUE _native_system_epoch_time_now_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
 static VALUE _native_prepare_sample_inside_signal_handler(DDTRACE_UNUSED VALUE self);
 static VALUE _native_clear_per_thread_context_for(DDTRACE_UNUSED VALUE self, VALUE thread);
+static VALUE _native_mark_thread_as_profiler_internal(DDTRACE_UNUSED VALUE self, VALUE thread);
 static VALUE _native_remove_per_thread_context_for(DDTRACE_UNUSED VALUE self, VALUE thread);
-static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample_suspended);
+static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample);
 static void on_thread_begin_event(VALUE tracepoint_data, DDTRACE_UNUSED void *unused);
 
 void collectors_thread_context_init(VALUE profiling_module) {
@@ -412,6 +422,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_prepare_sample_inside_signal_handler", _native_prepare_sample_inside_signal_handler, 0);
   rb_define_singleton_method(testing_module, "_native_clear_per_thread_context_for", _native_clear_per_thread_context_for, 1);
   rb_define_singleton_method(testing_module, "_native_remove_per_thread_context_for", _native_remove_per_thread_context_for, 1);
+  rb_define_singleton_method(testing_module, "_native_mark_thread_as_profiler_internal", _native_mark_thread_as_profiler_internal, 1);
   #ifndef NO_GVL_INSTRUMENTATION
     rb_define_singleton_method(testing_module, "_native_on_gvl_waiting", _native_on_gvl_waiting, 1);
     rb_define_singleton_method(testing_module, "_native_gvl_waiting_at_for", _native_gvl_waiting_at_for, 1);
@@ -777,7 +788,16 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
   }
 
   state->stats.sample_count++;
-  record_sampling_overhead(state, current_thread_context);
+
+  // If the current thread is a profiler-internal thread, we don't use record_sampling_overhead()
+  // and accept the sampling overhead is attributed to the profiler-internal thread
+  // (both are under the same datadog group in the flamegraph).
+  // The reason we need to do this is profiler-internal threads are skipped during per-tick sampling
+  // so their timestamps are not updated. record_sampling_overhead() would see the stale previous-sample timestamps and
+  // attribute the entire sleep interval incorrectly as overhead instead of just the sampling work.
+  if (!current_thread_context->is_profiler_internal_thread) {
+    record_sampling_overhead(state, current_thread_context);
+  }
 }
 
 static void update_metrics_and_sample(
@@ -787,12 +807,12 @@ static void update_metrics_and_sample(
   sampling_buffer* sampling_buffer,
   long current_cpu_time_ns,
   long current_monotonic_wall_time_ns,
-  bool force_sample_suspended
+  bool force_sample
 ) {
   bool is_gvl_waiting_state =
     handle_gvl_waiting(state, thread_being_sampled, thread_context, sampling_buffer, current_cpu_time_ns);
 
-  if (skip_sample(state, thread_context, is_gvl_waiting_state, force_sample_suspended)) return;
+  if (skip_sample(state, thread_context, is_gvl_waiting_state, force_sample)) return;
 
   // Don't assign/update cpu during "Waiting for GVL"
   long cpu_time_elapsed_ns = is_gvl_waiting_state ? 0 : update_time_since_previous_sample(
@@ -838,7 +858,12 @@ static void update_metrics_and_sample(
   );
 }
 
-static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample_suspended) {
+static bool skip_sample(thread_context_collector_state *state, per_thread_context *thread_context, bool is_gvl_waiting_state, bool force_sample) {
+  if (!force_sample && thread_context->is_profiler_internal_thread) {
+    state->stats.profiler_thread_samples_skipped++;
+    return true;
+  }
+
   // Racy read but harmless, can only cause an extra sample
   uint64_t gvl_state_change_count = thread_context->gvl_state_change_count;
 
@@ -850,7 +875,7 @@ static bool skip_sample(thread_context_collector_state *state, per_thread_contex
   // in handle_gvl_waiting (situation 1 extra sample, situation 2 regular sample) keeps running.
   // TODO: we could probably also skip while "Waiting for GVL"
   if (!is_gvl_waiting_state &&
-      !force_sample_suspended &&
+      !force_sample &&
       (gvl_state_change_count & GVL_SUSPENDED) &&
       gvl_state_change_count == thread_context->gvl_state_change_count_at_previous_sample) {
     state->stats.inactive_thread_samples_skipped++;
@@ -1338,6 +1363,7 @@ static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context)
     ID2SYM(rb_intern("gvl_state_change_count")), /* => */ ULL2NUM(thread_context->gvl_state_change_count),
     ID2SYM(rb_intern("gvl_state_change_count_at_previous_sample")), /* => */ ULL2NUM(thread_context->gvl_state_change_count_at_previous_sample),
     ID2SYM(rb_intern("was_skipped_at_last_sample")), /* => */ thread_context->was_skipped_at_last_sample ? Qtrue : Qfalse,
+    ID2SYM(rb_intern("is_profiler_internal_thread")), /* => */ thread_context->is_profiler_internal_thread ? Qtrue : Qfalse,
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(context_as_hash, arguments[i], arguments[i+1]);
 
@@ -1351,6 +1377,7 @@ static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE has
     ID2SYM(rb_intern("gc_samples")),                               /* => */ UINT2NUM(state->stats.gc_samples),
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
     ID2SYM(rb_intern("inactive_thread_samples_skipped")),          /* => */ UINT2NUM(state->stats.inactive_thread_samples_skipped),
+    ID2SYM(rb_intern("profiler_thread_samples_skipped")),          /* => */ UINT2NUM(state->stats.profiler_thread_samples_skipped),
   };
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
   return hash;
@@ -2040,40 +2067,92 @@ void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance) {
   state->stats = (struct stats) {};
 }
 
+static void mark_thread_as_profiler_internal(per_thread_context *ctx) {
+  ctx->is_profiler_internal_thread = true;
+
+  // Seed timestamps so the first on_serialize produces a real delta instead of zero.
+  // Without this, update_time_since_previous_sample sees INVALID_TIME, sets it to
+  // current_time, and returns 0 — losing the entire first reporting period.
+  if (ctx->wall_time_at_previous_sample_ns == INVALID_TIME) {
+    ctx->wall_time_at_previous_sample_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+  }
+  if (ctx->cpu_time_at_previous_sample_ns == INVALID_TIME) {
+    ctx->cpu_time_at_previous_sample_ns = cpu_time_now_ns(ctx);
+  }
+}
+
+void thread_context_collector_profiler_internal_thread_started(void) {
+  per_thread_context *ctx = get_or_create_context_for(rb_thread_current());
+  mark_thread_as_profiler_internal(ctx);
+}
+
+static VALUE _native_mark_thread_as_profiler_internal(DDTRACE_UNUSED VALUE self, VALUE thread) {
+  per_thread_context *ctx = get_or_create_context_for(thread);
+  mark_thread_as_profiler_internal(ctx);
+  return Qnil;
+}
+
+// Called via rb_ensure when a profiler-internal thread (worker or idle helper) is about to exit.
+// Records a final sample so the thread's accumulated cpu/wall time since the last on_serialize
+// flush is not lost. on_serialize (below) also flushes profiler-internal threads during periodic
+// serialization, but it can't help at shutdown: by the time the final serialize runs, these
+// threads are already dead and absent from thread_list.
+void thread_context_collector_profiler_internal_thread_done(VALUE self_instance) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
+  VALUE current_thread = rb_thread_current();
+  per_thread_context *thread_context = get_or_create_context_for(current_thread);
+  if (!thread_context->is_profiler_internal_thread) {
+    rb_raise(rb_eRuntimeError, "current thread %"PRIsVALUE" is not profiler-internal thread", current_thread);
+  }
+
+  long current_cpu_time_ns = cpu_time_now_ns(thread_context);
+  long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+
+  update_metrics_and_sample(
+    state,
+    current_thread,
+    thread_context,
+    &thread_context->sampling_buffer,
+    current_cpu_time_ns,
+    current_monotonic_wall_time_ns,
+    true);
+}
+
+// Flushes threads whose last per-tick sample was skipped (either by the SUSPENDED-skip
+// optimization, or by is_profiler_internal_thread) so their accumulated time is recorded.
+// Called by the stack recorder at the start of _native_serialize (regular periodic flush).
+void thread_context_collector_on_serialize(VALUE self_instance) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
+  long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+  VALUE threads = thread_list(state);
+  const long thread_count = RARRAY_LEN(threads);
+
+  for (long i = 0; i < thread_count; i++) {
+    VALUE thread = RARRAY_AREF(threads, i);
+    per_thread_context *thread_context = get_per_thread_context(thread);
+
+    if (thread_context != NULL && (thread_context->was_skipped_at_last_sample || thread_context->is_profiler_internal_thread)) {
+      long current_cpu_time_ns = cpu_time_now_ns(thread_context);
+      // We need to force_sample=true otherwise this sample would be skipped too
+      update_metrics_and_sample(
+        state,
+        thread,
+        thread_context,
+        &thread_context->sampling_buffer,
+        current_cpu_time_ns,
+        current_monotonic_wall_time_ns,
+        true);
+    }
+  }
+}
+
 #ifndef NO_GVL_INSTRUMENTATION
   void thread_context_collector_on_gvl_released(per_thread_context *thread_context) {
     thread_context->gvl_state_change_count |= GVL_SUSPENDED;
-  }
-
-  // Called by the stack recorder at the start of _native_serialize, so that threads whose last
-  // per-tick sample was skipped by the SUSPENDED-skip optimization still get their accumulated
-  // time recorded in this reporting period. Without this, a thread that sleeps across the whole
-  // period would not be reported at all.
-  void thread_context_collector_on_serialize(VALUE self_instance) {
-    thread_context_collector_state *state;
-    TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
-
-    long current_monotonic_wall_time_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
-    VALUE threads = thread_list(state);
-    const long thread_count = RARRAY_LEN(threads);
-
-    for (long i = 0; i < thread_count; i++) {
-      VALUE thread = RARRAY_AREF(threads, i);
-      per_thread_context *thread_context = get_per_thread_context(thread);
-
-      if (thread_context != NULL && thread_context->was_skipped_at_last_sample) {
-        long current_cpu_time_ns = cpu_time_now_ns(thread_context);
-        // We need to force_sample_suspended=true otherwise this sample would be skipped too
-        update_metrics_and_sample(
-          state,
-          thread,
-          thread_context,
-          &thread_context->sampling_buffer,
-          current_cpu_time_ns,
-          current_monotonic_wall_time_ns,
-          true);
-      }
-    }
   }
 
   void thread_context_collector_on_gvl_waiting(per_thread_context *thread_context) {
@@ -2394,7 +2473,6 @@ void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance) {
     DDTRACE_UNUSED long current_cpu_time_ns
   ) { return false; }
 
-  void thread_context_collector_on_serialize(DDTRACE_UNUSED VALUE self_instance) { }
 #endif // NO_GVL_INSTRUMENTATION
 
 #define MAX_SAFE_LOOKUP_SIZE 16

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -368,8 +368,8 @@ static bool handle_gvl_waiting(
   static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread);
   static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception);
-  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 #endif
+static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 static void otel_without_ddtrace_trace_identifiers_for(
   thread_context_collector_state *state,
   VALUE thread,
@@ -429,8 +429,8 @@ void collectors_thread_context_init(VALUE profiling_module) {
     rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 2);
     rb_define_singleton_method(testing_module, "_native_on_gvl_released", _native_on_gvl_released, 1);
     rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 3);
-    rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
   #endif
+  rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
 
   at_active_span_id = rb_intern_const("@active_span");
   at_active_trace_id = rb_intern_const("@active_trace");
@@ -2453,17 +2453,6 @@ void thread_context_collector_on_serialize(VALUE self_instance) {
     return result;
   }
 
-  static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns) {
-    ENFORCE_THREAD(thread);
-
-    per_thread_context *thread_context = get_per_thread_context(thread);
-    if (thread_context == NULL) raise_error(rb_eArgError, "Unexpected: This method cannot be used unless the per-thread context for the thread already exists");
-
-    thread_context->cpu_time_at_previous_sample_ns += NUM2LONG(delta_ns);
-
-    return Qtrue;
-  }
-
 #else
   static bool handle_gvl_waiting(
     DDTRACE_UNUSED thread_context_collector_state *state,
@@ -2474,6 +2463,17 @@ void thread_context_collector_on_serialize(VALUE self_instance) {
   ) { return false; }
 
 #endif // NO_GVL_INSTRUMENTATION
+
+static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns) {
+  ENFORCE_THREAD(thread);
+
+  per_thread_context *thread_context = get_per_thread_context(thread);
+  if (thread_context == NULL) raise_error(rb_eArgError, "Unexpected: This method cannot be used unless the per-thread context for the thread already exists");
+
+  thread_context->cpu_time_at_previous_sample_ns += NUM2LONG(delta_ns);
+
+  return Qtrue;
+}
 
 #define MAX_SAFE_LOOKUP_SIZE 16
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -21,6 +21,8 @@ VALUE enforce_thread_context_collector_instance(VALUE object);
 void thread_context_collector_stats(VALUE self_instance, VALUE stats_hash);
 void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance);
 void thread_context_collector_on_serialize(VALUE self_instance);
+void thread_context_collector_profiler_internal_thread_started(void);
+void thread_context_collector_profiler_internal_thread_done(VALUE self_instance);
 
 #ifndef NO_GVL_INSTRUMENTATION
   typedef enum {

--- a/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
+++ b/lib/datadog/profiling/collectors/cpu_and_wall_time_worker.rb
@@ -49,7 +49,7 @@ module Datadog
           # profiler overhead!
           dynamic_sampling_rate_enabled: true,
           skip_idle_samples_for_testing: false,
-          idle_sampling_helper: IdleSamplingHelper.new
+          idle_sampling_helper: IdleSamplingHelper.new(thread_context_collector: thread_context_collector)
         )
           unless dynamic_sampling_rate_enabled
             Datadog.logger.warn(

--- a/lib/datadog/profiling/collectors/idle_sampling_helper.rb
+++ b/lib/datadog/profiling/collectors/idle_sampling_helper.rb
@@ -10,6 +10,7 @@ module Datadog
       class IdleSamplingHelper
         # @rbs @worker_thread: untyped
         # @rbs @start_stop_mutex: ::Thread::Mutex
+        # @rbs @thread_context_collector: Datadog::Profiling::Collectors::ThreadContext?
 
         private
 
@@ -17,10 +18,11 @@ module Datadog
 
         public
 
-        #: () -> void
-        def initialize
+        #: (thread_context_collector: Datadog::Profiling::Collectors::ThreadContext) -> void
+        def initialize(thread_context_collector:)
           @worker_thread = nil
           @start_stop_mutex = Mutex.new
+          @thread_context_collector = thread_context_collector
         end
 
         #: () -> (nil | true)
@@ -37,7 +39,7 @@ module Datadog
             @worker_thread = Thread.new do
               Thread.current.name = self.class.name
 
-              self.class._native_idle_sampling_loop(self)
+              self.class._native_idle_sampling_loop(self, @thread_context_collector)
 
               Datadog.logger.debug("IdleSamplingHelper thread stopping cleanly")
             rescue Exception => e # rubocop:disable Lint/RescueException

--- a/sig/datadog/profiling/collectors/idle_sampling_helper.rbs
+++ b/sig/datadog/profiling/collectors/idle_sampling_helper.rbs
@@ -7,7 +7,7 @@ module Datadog
 
         def self._native_reset: (Datadog::Profiling::Collectors::IdleSamplingHelper self_instance) -> true
 
-        def self._native_idle_sampling_loop: (Datadog::Profiling::Collectors::IdleSamplingHelper self_instance) -> true
+        def self._native_idle_sampling_loop: (Datadog::Profiling::Collectors::IdleSamplingHelper self_instance, Datadog::Profiling::Collectors::ThreadContext? thread_context_collector_instance) -> true
       end
     end
   end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -828,8 +828,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           end
         end
 
-        context "on Ruby 3.x" do
-          before { skip "Behavior only applies on Ruby 3.x" if RubyVersion.is?("< 3") }
+        context "on Ruby 3+" do
+          before { skip "Behavior only applies on Ruby 3+" if RubyVersion.is?("< 3") }
 
           it "records internal VM objects, including their specific kind" do
             start
@@ -848,7 +848,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
             # a known member of the imemo_type enum (even if we don't exactly match on which one)
             expect(imemo_samples.map { |s| s.labels.fetch(:"allocation class") }).to all(
               match(
-                /(env|cref|svar|throw_data|ifunc|memo|ment|iseq|tmpbuf|ast|parser_strterm|callinfo|callcache|constcache)/
+                /(env|cref|svar|throw_data|ifunc|memo|ment|iseq|tmpbuf|ast|parser_strterm|callinfo|callcache|constcache|fields)/
               )
             )
           end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -271,8 +271,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       start
 
       try_wait_until do
-        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-        samples if samples.any?
+        recorder.serialize!
+        cpu_and_wall_time_worker.stats.fetch(:cpu_sampled) > 0
       end
 
       cpu_and_wall_time_worker.stop
@@ -289,6 +289,30 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       expect(sampling_time_ns_avg).to be >= sampling_time_ns_min
       one_second_in_ns = 1_000_000_000
       expect(sampling_time_ns_max).to be < one_second_in_ns, "A single sample should not take longer than 1s, #{stats}"
+    end
+
+    it "profiler-internal threads flush themselves on stop" do
+      start
+
+      try_wait_until do
+        recorder.serialize!
+        cpu_and_wall_time_worker.stats.fetch(:cpu_sampled) > 0
+      end
+
+      worker_thread = cpu_and_wall_time_worker.instance_variable_get(:@worker_thread)
+      idle_helper = cpu_and_wall_time_worker.instance_variable_get(:@idle_sampling_helper)
+      idle_helper_thread = idle_helper.instance_variable_get(:@worker_thread)
+
+      # Drain all existing samples
+      recorder.serialize!
+
+      cpu_and_wall_time_worker.stop
+
+      # The final serialize should include samples for both profiler-internal threads,
+      # recorded by the threads themselves before exiting
+      all_samples = samples_from_pprof(recorder.serialize!)
+      expect(samples_for_thread(all_samples, worker_thread)).to_not be_empty
+      expect(samples_for_thread(all_samples, idle_helper_thread)).to_not be_empty
     end
 
     context "with allocation profiling enabled" do
@@ -1374,6 +1398,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           gc_samples: 0,
           gc_samples_missed_due_to_missing_context: 0,
           inactive_thread_samples_skipped: 0,
+          profiler_thread_samples_skipped: 0,
         }
       )
     end
@@ -1516,13 +1541,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       wait_until_running
 
       try_wait_until do
-        # Wait until we get CPU/Wall time samples. Since we have allocation
-        # profiling enabled, not adding the extra reject could lead us to
-        # prematurely stop waiting as soon as we get an allocation sample
-        # which would result in us reaching our expectation with cpu_sampled = 0
-        samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          .reject { |sample| sample.values[:"alloc-samples"] > 0 }
-        samples if samples.any?
+        recorder.serialize!
+        cpu_and_wall_time_worker.stats.fetch(:cpu_sampled) > 0
       end
 
       stub_const("CpuAndWallTimeWorkerSpec::TestStruct", Struct.new(:foo))

--- a/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
+++ b/spec/datadog/profiling/collectors/idle_sampling_helper_spec.rb
@@ -4,7 +4,12 @@ require "datadog/profiling/collectors/idle_sampling_helper"
 RSpec.describe Datadog::Profiling::Collectors::IdleSamplingHelper do
   before { skip_if_profiling_not_supported }
 
-  subject(:idle_sampling_helper) { described_class.new }
+  let(:thread_context_collector) {
+    Datadog::Profiling::Collectors::ThreadContext.for_testing(
+      recorder: Datadog::Profiling::StackRecorder.for_testing,
+    )
+  }
+  subject(:idle_sampling_helper) { described_class.new(thread_context_collector: thread_context_collector) }
 
   describe "#start" do
     subject(:start) { idle_sampling_helper.start }

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -657,11 +657,16 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       context "when sampling the idle sampling helper thread" do
         let(:expected_method_name) { "_native_idle_sampling_loop" }
-        let(:idle_sampling_helper) { Datadog::Profiling::Collectors::IdleSamplingHelper.new }
+        let(:thread_context_collector) {
+          Datadog::Profiling::Collectors::ThreadContext.for_testing(
+            recorder: Datadog::Profiling::StackRecorder.for_testing,
+          )
+        }
+        let(:idle_sampling_helper) { Datadog::Profiling::Collectors::IdleSamplingHelper.new(thread_context_collector: thread_context_collector) }
         let(:do_in_background_thread) do
           proc do |ready_queue|
             ready_queue << true
-            Datadog::Profiling::Collectors::IdleSamplingHelper._native_idle_sampling_loop(idle_sampling_helper)
+            Datadog::Profiling::Collectors::IdleSamplingHelper._native_idle_sampling_loop(idle_sampling_helper, thread_context_collector)
           end
         end
         let(:metric_values) { {"cpu-time" => 0, "cpu-samples" => 1, "wall-time" => 1} }

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -2085,6 +2085,65 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     end
   end
 
+  describe "profiler-internal thread skipping" do
+    def mark_thread_as_profiler_internal(thread)
+      described_class::Testing._native_mark_thread_as_profiler_internal(thread)
+    end
+
+    before do
+      sample # initialize cpu/wall timestamps (they start as INVALID_TIME)
+      recorder.serialize! # flush initial samples
+      mark_thread_as_profiler_internal(t1)
+    end
+
+    it "skips per-tick samples for profiler-internal threads" do
+      expect { sample }.to change { stats.fetch(:profiler_thread_samples_skipped) }.by(1)
+      expect(per_thread_context.fetch(t1).fetch(:is_profiler_internal_thread)).to be true
+    end
+
+    it "does not go through the inactive-thread skip path" do
+      sample
+      expect(per_thread_context.fetch(t1).fetch(:was_skipped_at_last_sample)).to be false
+    end
+
+    it "reports profiler-internal threads in the first reporting period" do
+      # This test does NOT use the before block's sample/serialize — it marks the thread
+      # as profiler-internal without any prior sample, to verify that marking alone seeds
+      # the timestamps (they would otherwise be INVALID_TIME, producing a zero-value sample).
+      t2 = Thread.new { sleep }
+      mark_thread_as_profiler_internal(t2)
+
+      sample
+      result = recorder.serialize!
+      t2_samples = samples_for_thread(samples_from_pprof(result), t2)
+      expect(t2_samples.size).to eq(1)
+      expect(t2_samples.first.values.fetch(:"wall-time")).to be > 0
+    ensure
+      t2&.kill
+      t2&.join
+    end
+
+    it "still records one sample per profile period via serialize" do
+      cpu_before = per_thread_context.fetch(t1).fetch(:cpu_time_at_previous_sample_ns)
+      wall_before = per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)
+
+      # Rewind cpu-clock by a known amount so we can verify the final sample covers it
+      apply_delta_to_cpu_time_at_previous_sample_ns(t1, -1_000_000)
+
+      10.times { sample }
+
+      # Timestamps are never updated by per-tick sampling since the thread is skipped
+      expect(per_thread_context.fetch(t1).fetch(:cpu_time_at_previous_sample_ns)).to eq(cpu_before - 1_000_000)
+      expect(per_thread_context.fetch(t1).fetch(:wall_time_at_previous_sample_ns)).to eq(wall_before)
+
+      result = recorder.serialize!
+      t1_samples = samples_for_thread(samples_from_pprof(result), t1)
+      expect(t1_samples.size).to eq(1)
+      expect(t1_samples.first.values.fetch(:"cpu-time")).to be >= 1_000_000
+      expect(t1_samples.first.values.fetch(:"wall-time")).to be > 0
+    end
+  end
+
   describe "#prepare_sample_inside_signal_handler" do
     def prepare_and_sample
       sample

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -34,7 +34,7 @@ module ProfileHelpers
 
     # Ensure profiling was loaded correctly
     raise "Profiling does not seem to be available: #{Datadog::Profiling.unsupported_reason}. " \
-      "Try running `bundle exec rake compile` before running this test."
+      "Try running `bundle exec rake clean compile` before running this test."
   end
 
   def decode_profile(encoded_profile)

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -81,7 +81,7 @@ module CoreHelpers
     return if Datadog::Core::LIBDATADOG_API_FAILURE.nil?
 
     raise "Libdatadog does not seem to be available: #{Datadog::Core::LIBDATADOG_API_FAILURE}. " \
-      "Try running `bundle exec rake compile` before running this test."
+      "Try running `bundle exec rake clean compile` before running this test."
   end
 
   module ClassMethods


### PR DESCRIPTION
CpuAndWallTimeWorker and IdleSamplingHelper threads are now sampled only once per profiling period (via the on-serialize flush) instead of every 10ms tick, reducing profiling overhead.

**What does this PR do?**
^

**Motivation:**
Reduce profiler overhead

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes, Changed: Profiling: Reduce profiler overhead by sampling profiler-internal threads only once per minute.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
