### PR TITLE
[NO-TICKET] Disable routing finalization for route normalizer

### DIFF
--- a/spec/datadog/appsec/integration/contrib/rails/rails_route_pattern_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/rails/rails_route_pattern_spec.rb
@@ -9,6 +9,7 @@ require 'datadog/appsec/route_normalizer/rails_route_pattern'
 RSpec.describe Datadog::AppSec::RouteNormalizer::RailsRoutePattern do
   def build_route(path_spec)
     route_set = ActionDispatch::Routing::RouteSet.new
+    route_set.disable_clear_and_finalize = true
     route_set.draw { get path_spec, to: 'test#show' }
     route_set.routes.first
   end


### PR DESCRIPTION
**What does this PR do?**

Corrects intermittent error for AppSec route normalization

**Motivation:**

Due to the Devise integration tests leaking into other integration tests, we have those errors.

**Change log entry**

None.

**Additional Notes:**

None.

**How to test the change?**

CI