### PR TITLE
Pin apm-sdks-benchmarks to a fixed SHA for Ruby benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-ruby-acme-parallel.yml'
-    ref: 'main'
+    ref: 'fbd5855de233ea9ade5a5e571770e7cbe407ea35'
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby


### PR DESCRIPTION
**What does this PR do?**
Pins the `apm-sdks-benchmarks` GitLab include `ref` from `main` to a fixed SHA (`fbd5855`) so the Ruby benchmark infrastructure is reproducible.

**Motivation:**
Using `ref: 'main'` means any change merged to `apm-sdks-benchmarks` silently affects Ruby benchmark CI runs in this repo. Pinning to a SHA makes it explicit and controllable.

**Change log entry**
None.

**Additional Notes:**
Only the Ruby benchmark include is affected. No other language benchmarks reference `apm-sdks-benchmarks` from this repo.

Companion PR: https://github.com/DataDog/apm-sdks-benchmarks/pull/191

**How to test the change?**
Trigger the Ruby benchmark pipeline and confirm it uses the pinned `apm-sdks-benchmarks` commit.