### PR TITLE
Fix handling of `ASM_DD` config when ruleset name changes

### DIFF
--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -78,9 +78,8 @@ module Datadog
             engine = AppSec.security_engine
             next unless engine
 
-            # Process deletes before inserts/updates so that when a path changes (e.g. ASM_DD
-            # ruleset path rename), the old config is removed from the WAF builder before the
-            # new one is added, preventing duplicate-rule errors.
+            # We must process delete operations before insert and update operations
+            # to prevent duplicate-rule errors when the config name changes
             changes.each do |change|
               next unless change.type == :delete
 

--- a/lib/datadog/appsec/remote.rb
+++ b/lib/datadog/appsec/remote.rb
@@ -78,17 +78,24 @@ module Datadog
             engine = AppSec.security_engine
             next unless engine
 
+            # Process deletes before inserts/updates so that when a path changes (e.g. ASM_DD
+            # ruleset path rename), the old config is removed from the WAF builder before the
+            # new one is added, preventing duplicate-rule errors.
+            changes.each do |change|
+              next unless change.type == :delete
+
+              engine.remove_config_at_path(change.path.to_s)
+            end
+
             changes.each do |change|
               content = repository[change.path]
-              next unless content || change.type == :delete
+              next unless content
 
               case change.type
               when :insert, :update
                 # @type var content: Core::Remote::Configuration::Content
                 engine.add_or_update_config(parse_content(content), path: change.path.to_s)
                 content.applied
-              when :delete
-                engine.remove_config_at_path(change.path.to_s)
               end
             end
 

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -177,6 +177,75 @@ RSpec.describe Datadog::AppSec::Remote do
 
           expect(content.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::ACKNOWLEDGED)
         end
+
+        context 'when the ASM_DD ruleset path changes' do
+          let(:rules_v2) do
+            {
+              version: '2.2',
+              metadata: {
+                rules_version: '2.0.0'
+              },
+              rules: []
+            }.to_json
+          end
+
+          let(:content_v1) do
+            Datadog::Core::Remote::Configuration::Content.parse(
+              {
+                path: 'datadog/603646/ASM_DD/v1/config',
+                content: rules,
+              }
+            )
+          end
+
+          let(:content_v2) do
+            Datadog::Core::Remote::Configuration::Content.parse(
+              {
+                path: 'datadog/603646/ASM_DD/v2/config',
+                content: rules_v2,
+              }
+            )
+          end
+
+          let(:target_v2) do
+            Datadog::Core::Remote::Configuration::Target.parse(
+              {
+                'custom' => {
+                  'v' => 1,
+                },
+                'hashes' => {'sha256' => Digest::SHA256.hexdigest(rules_v2)},
+                'length' => rules_v2.length
+              }
+            )
+          end
+
+          before do
+            repository.transaction do |_, txn|
+              txn.insert(content_v1.path, target, content_v1)
+            end
+          end
+
+          it 'processes deletes before inserts regardless of changeset order' do
+            changeset = repository.transaction do |_, txn|
+              txn.insert(content_v2.path, target_v2, content_v2)
+              txn.delete(content_v1.path)
+            end
+
+            engine = Datadog::AppSec.security_engine
+            call_order = []
+
+            allow(engine).to receive(:remove_config_at_path) { |path| call_order << [:remove, path] }
+            allow(engine).to receive(:add_or_update_config) { |_, path:| call_order << [:add, path] }
+            allow(Datadog::AppSec).to receive(:reconfigure!)
+
+            receiver.call(repository, changeset)
+
+            expect(call_order).to eq([
+              [:remove, 'datadog/603646/ASM_DD/v1/config'],
+              [:add, 'datadog/603646/ASM_DD/v2/config'],
+            ])
+          end
+        end
       end
     end
   end

--- a/spec/datadog/appsec/remote_spec.rb
+++ b/spec/datadog/appsec/remote_spec.rb
@@ -185,7 +185,39 @@ RSpec.describe Datadog::AppSec::Remote do
               metadata: {
                 rules_version: '2.0.0'
               },
-              rules: []
+              rules: [
+                {
+                  id: 'rasp-003-001',
+                  name: 'SQL Injection',
+                  tags: {
+                    type: 'sql_injection',
+                    category: 'exploit',
+                    module: 'rasp'
+                  },
+                  conditions: [
+                    {
+                      operator: 'sqli_detector',
+                      parameters: {
+                        resource: [{address: 'server.db.statement'}],
+                        params: [{address: 'server.request.query'}],
+                        db_type: [{address: 'server.db.system'}]
+                      }
+                    }
+                  ],
+                  on_match: ['block-sqli']
+                }
+              ],
+              actions: [
+                {
+                  id: 'block-sqli',
+                  type: 'block',
+                  parameters: {
+                    status_code: '418',
+                    grpc_status_code: '42',
+                    type: 'auto'
+                  }
+                }
+              ]
             }.to_json
           end
 
@@ -234,15 +266,23 @@ RSpec.describe Datadog::AppSec::Remote do
             engine = Datadog::AppSec.security_engine
             call_order = []
 
-            allow(engine).to receive(:remove_config_at_path) { |path| call_order << [:remove, path] }
-            allow(engine).to receive(:add_or_update_config) { |_, path:| call_order << [:add, path] }
-            allow(Datadog::AppSec).to receive(:reconfigure!)
+            allow(engine).to receive(:remove_config_at_path).and_wrap_original do |original, path|
+              call_order << [:remove, path]
+              original.call(path)
+            end
+            allow(engine).to receive(:add_or_update_config).and_wrap_original do |original, config, **kwargs|
+              call_order << [:add, kwargs.fetch(:path)]
+              original.call(config, **kwargs)
+            end
 
             receiver.call(repository, changeset)
+
+            engine.reconfigure!
 
             expect(call_order).to eq([
               [:remove, 'datadog/603646/ASM_DD/v1/config'],
               [:add, 'datadog/603646/ASM_DD/v2/config'],
+              [:remove, 'ASM_DD/default']
             ])
           end
         end


### PR DESCRIPTION
**What does this PR do?**
The Remote Configuration received in AppSec needs to handle deletes before inserts and updates - this prevents errors such as "duplicated rule", since old configs are deleted before new ones are applied.

**Motivation:**
There were lots of suspicious telemetry errors about duplicated rules in the config, when Remote Config was applied for AppSec.

**Change log entry**
Yes. AppSec: Fix remote configuration errors when the config name changes.

**Additional Notes:**
None.

**How to test the change?**
CI.