### PR TITLE
[APPSEC-68774] Add `Kit::AppSec::Events::V2#track_user_signup`

### DIFF
--- a/lib/datadog/kit/appsec/events/v2.rb
+++ b/lib/datadog/kit/appsec/events/v2.rb
@@ -9,14 +9,17 @@ module Datadog
       module Events
         # The second version of Business Logic Events SDK
         module V2
+          SIGNUP_EVENT = 'users.signup'
           LOGIN_SUCCESS_EVENT = 'users.login.success'
           LOGIN_FAILURE_EVENT = 'users.login.failure'
+
           TELEMETRY_METRICS_NAMESPACE = 'appsec'
           TELEMETRY_METRICS_SDK_EVENT = 'sdk.event'
           TELEMETRY_METRICS_SDK_VERSION = 'v2'
           TELEMETRY_METRICS_EVENTS_INTO_TYPES = {
             LOGIN_SUCCESS_EVENT => 'login_success',
-            LOGIN_FAILURE_EVENT => 'login_failure'
+            LOGIN_FAILURE_EVENT => 'login_failure',
+            SIGNUP_EVENT => 'signup'
           }.freeze
 
           class << self
@@ -125,6 +128,61 @@ module Datadog
               ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
             end
 
+            # Attach user signup information to the service entry span
+            # and trigger AppSec event processing.
+            #
+            # @param login [String] The user login (e.g., username or email).
+            # @param user_or_id [String, Hash<Symbol, String>] (optional) If a
+            #   String, considered as a user ID, if a Hash, considered as a user
+            #   attributes. The Hash must include `:id` as a key.
+            # @param metadata [Hash<Symbol, String>] Additional flat free-form
+            #   metadata to attach to the event.
+            #
+            # @example Login only
+            #   Datadog::Kit::AppSec::Events::V2.track_user_signup('alice@example.com')
+            #
+            # @example Login, user attributes, and metadata
+            #   Datadog::Kit::AppSec::Events::V2.track_user_signup(
+            #     'alice@example.com',
+            #     { id: 'user-123', email: 'alice@example.com', name: 'Alice' },
+            #     ip: '192.168.1.1', device: 'mobile', 'usr.country': 'US'
+            #   )
+            #
+            # @return [void]
+            def track_user_signup(login, user_or_id = nil, metadata = {})
+              trace = service_entry_trace
+              span = service_entry_span
+
+              if trace.nil? || span.nil?
+                return Datadog.logger.warn(
+                  'Kit::AppSec: Tracing is not enabled. Please enable tracing if you want to track events'
+                )
+              end
+
+              raise TypeError, '`login` argument must be a String' unless login.is_a?(String)
+              raise TypeError, '`metadata` argument must be a Hash' unless metadata.is_a?(Hash)
+
+              user_attributes = build_user_attributes(user_or_id, login)
+
+              set_span_tags(span, metadata, namespace: SIGNUP_EVENT)
+              set_span_tags(span, user_attributes, namespace: "#{SIGNUP_EVENT}.usr")
+              span.set_tag('appsec.events.users.signup.track', 'true')
+              span.set_tag('_dd.appsec.events.users.signup.sdk', 'true')
+
+              ::Datadog::AppSec::TraceKeeper.keep!(trace)
+
+              record_event_telemetry_metric(SIGNUP_EVENT)
+
+              if user_attributes.key?(:id)
+                Kit::Identity.set_user(trace, span, **user_attributes)
+              else
+                # NOTE: {Datadog::Kit::Identity.set_user} requires an ID,
+                #       but WAF can evaluate login alone
+                user = ::Datadog::AppSec::Instrumentation::Gateway::User.new(nil, login)
+                ::Datadog::AppSec::Instrumentation.gateway.push('identity.set_user', user)
+              end
+            end
+
             private
 
             # NOTE: Current tracer implementation does not provide a way to
@@ -155,7 +213,7 @@ module Datadog
                 raise ArgumentError, 'missing required user key `:id`' unless user_or_id.key?(:id)
                 raise TypeError, 'user key `:id` must be a String' unless user_or_id[:id].is_a?(String)
 
-                user_or_id.merge(login: login) #: {login: ::String, ?id: ::String?}
+                user_or_id.merge(login: login)
               else
                 raise TypeError, '`user_or_id` argument must be either String or Hash'
               end

--- a/sig/datadog/kit/appsec/events/v2.rbs
+++ b/sig/datadog/kit/appsec/events/v2.rbs
@@ -3,40 +3,45 @@ module Datadog
     module AppSec
       module Events
         module V2
-          type attributes = {
-            ?login: ::String?,
-            ?id: ::String?
-          }
+          type attributes = Hash[Symbol, String?]
 
-          type user_or_id = nil | ::String | attributes
+          type user_or_id = nil |
+                            String |
+                            {id: String} & Hash[Symbol, String?]
 
-          LOGIN_SUCCESS_EVENT: ::String
+          type metadata = Hash[Symbol, String]
 
-          LOGIN_FAILURE_EVENT: ::String
+          LOGIN_SUCCESS_EVENT: String
 
-          TELEMETRY_METRICS_NAMESPACE: ::String
+          LOGIN_FAILURE_EVENT: String
 
-          TELEMETRY_METRICS_SDK_EVENT: ::String
+          SIGNUP_EVENT: String
 
-          TELEMETRY_METRICS_SDK_VERSION: ::String
+          TELEMETRY_METRICS_NAMESPACE: String
 
-          TELEMETRY_METRICS_EVENTS_INTO_TYPES: Hash[::String, ::String]
+          TELEMETRY_METRICS_SDK_EVENT: String
 
-          def self.track_user_login_success: (::String login, ?user_or_id user_or_id, ?attributes metadata) -> void
+          TELEMETRY_METRICS_SDK_VERSION: String
 
-          def self.track_user_login_failure: (::String login, ?bool user_exists, ?attributes metadata) -> void
+          TELEMETRY_METRICS_EVENTS_INTO_TYPES: Hash[String, String]
+
+          def self.track_user_login_success: (String login, ?user_or_id user_or_id, ?metadata metadata) -> void
+
+          def self.track_user_signup: (String login, ?user_or_id user_or_id, ?metadata metadata) -> void
+
+          def self.track_user_login_failure: (String login, ?bool user_exists, ?metadata metadata) -> void
 
           private
 
-          def self.service_entry_trace: () -> (::Datadog::Tracing::TraceSegment | ::Datadog::Tracing::TraceOperation)?
+          def self.service_entry_trace: () -> (Datadog::Tracing::TraceSegment | Datadog::Tracing::TraceOperation)?
 
-          def self.service_entry_span: () -> ::Datadog::Tracing::SpanOperation?
+          def self.service_entry_span: () -> Datadog::Tracing::SpanOperation?
 
-          def self.build_user_attributes: (user_or_id? user_or_id, ::String login) -> attributes
+          def self.build_user_attributes: (user_or_id? user_or_id, String login) -> attributes
 
-          def self.set_span_tags: (::Datadog::Tracing::SpanOperation span, ::Hash[::Symbol, untyped] tags, namespace: ::String) -> void
+          def self.set_span_tags: (Datadog::Tracing::SpanOperation span, Hash[Symbol, untyped] tags, namespace: String) -> void
 
-          def self.record_event_telemetry_metric: (::String event) -> void
+          def self.record_event_telemetry_metric: (String event) -> void
         end
       end
     end

--- a/spec/datadog/kit/appsec/events/v2_spec.rb
+++ b/spec/datadog/kit/appsec/events/v2_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
         let(:components) { instance_double(Datadog::Core::Configuration::Components) }
         let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
 
-        it 'record telemetry metrics' do
+        it 'records telemetry metrics' do
           expect(telemetry).to receive(:inc)
             .with('appsec', 'sdk.event', 1, tags: {event_type: 'login_success', sdk_version: 'v2'})
 
@@ -144,6 +144,157 @@ RSpec.describe Datadog::Kit::AppSec::Events::V2 do
           expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
 
           sdk.track_user_login_success('john.snow')
+        end
+      end
+    end
+  end
+
+  describe '#track_user_signup' do
+    context 'when AppSec context is active' do
+      let(:context) { instance_double(Datadog::AppSec::Context, trace: trace, span: span) }
+      let(:trace) { Datadog::Tracing::TraceOperation.new }
+      let(:span) { trace.build_span('root') }
+      let(:gateway) { ::Datadog::AppSec::Instrumentation.gateway }
+
+      before { allow(Datadog::AppSec).to receive(:active_context).and_return(context) }
+
+      it 'raises exception when user key :id is missing' do
+        expect { sdk.track_user_signup('john.snow', {}) }
+          .to raise_error(ArgumentError, 'missing required user key `:id`')
+      end
+
+      it 'raises exception when user key :id is not String' do
+        expect { sdk.track_user_signup('john.snow', {id: 15}) }
+          .to raise_error(TypeError, 'user key `:id` must be a String')
+      end
+
+      it 'raises exception when user id argument is not string' do
+        expect { sdk.track_user_signup('john.snow', 15) }
+          .to raise_error(TypeError, '`user_or_id` argument must be either String or Hash')
+      end
+
+      it 'raises exception when login argument is not string' do
+        expect { sdk.track_user_signup(12, '42') }
+          .to raise_error(TypeError, '`login` argument must be a String')
+      end
+
+      it 'raises exception when metadata argument is not Hash' do
+        expect { sdk.track_user_signup('john.snow', '42', 15) }
+          .to raise_error(TypeError, '`metadata` argument must be a Hash')
+      end
+
+      it 'sets required tags on service entry span' do
+        expect { sdk.track_user_signup('john.snow', '13') }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.signup.usr.id' => '13',
+            'appsec.events.users.signup.usr.login' => 'john.snow',
+            'appsec.events.users.signup.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.signup.sdk' => 'true',
+          )
+      end
+
+      context 'when user ID is omitted' do
+        before { allow(gateway).to receive(:push).and_call_original }
+
+        it 'sends login to AppSec for evaluation' do
+          expect(gateway).to receive(:push)
+            .with(
+              'identity.set_user',
+              have_attributes(id: nil, login: 'john.snow', session_id: nil)
+            )
+            .and_call_original
+
+          expect { sdk.track_user_signup('john.snow') }
+            .to change { span.tags }.to include(
+              'appsec.events.users.signup.usr.login' => 'john.snow',
+              'appsec.events.users.signup.track' => 'true',
+              '_dd.appsec.events.users.signup.sdk' => 'true',
+            )
+
+          expect(span.tags).not_to have_key('usr.id')
+          expect(span.tags).not_to have_key('usr.login')
+          expect(span.tags).not_to have_key('_dd.appsec.user.collection_mode')
+        end
+
+        it 'sets metadata as tags on service entry span' do
+          expect { sdk.track_user_signup('john.snow', nil, hello: 'world') }
+            .to change { span.tags }.to include(
+              'appsec.events.users.signup.usr.login' => 'john.snow',
+              'appsec.events.users.signup.hello' => 'world',
+              'appsec.events.users.signup.track' => 'true',
+              '_dd.appsec.events.users.signup.sdk' => 'true',
+            )
+        end
+      end
+
+      it 'sets metadata as tags on service entry span' do
+        expect { sdk.track_user_signup('john.snow', '13', hello: 'world') }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.signup.usr.id' => '13',
+            'appsec.events.users.signup.usr.login' => 'john.snow',
+            'appsec.events.users.signup.hello' => 'world',
+            'appsec.events.users.signup.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.signup.sdk' => 'true',
+          )
+      end
+
+      it 'sets user login from argument and overrides it in user object' do
+        expect { sdk.track_user_signup('john.snow', {id: '13', login: 'john.wick'}) }
+          .to change { span.tags }.to include(
+            'usr.id' => '13',
+            'usr.login' => 'john.snow',
+            'appsec.events.users.signup.usr.id' => '13',
+            'appsec.events.users.signup.usr.login' => 'john.snow',
+            'appsec.events.users.signup.track' => 'true',
+            '_dd.appsec.user.collection_mode' => 'sdk',
+            '_dd.appsec.events.users.signup.sdk' => 'true',
+          )
+      end
+
+      it 'sets track to true even if metadata track key is false' do
+        expect { sdk.track_user_signup('john.snow', '42', track: 'false') }
+          .to change { span.tags }.to include(
+            'appsec.events.users.signup.track' => 'true',
+          )
+      end
+
+      context 'when telemetry is available' do
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(telemetry)
+        end
+
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
+        let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
+
+        it 'records telemetry metrics' do
+          expect(telemetry).to receive(:inc)
+            .with('appsec', 'sdk.event', 1, tags: {event_type: 'signup', sdk_version: 'v2'})
+
+          sdk.track_user_signup('john.snow', '13')
+        end
+      end
+
+      context 'when telemetry is not available' do
+        before do
+          allow(Datadog).to receive(:components).and_return(components)
+          allow(components).to receive(:telemetry).and_return(nil)
+          allow(components).to receive(:logger).and_return(logger)
+        end
+
+        let(:logger) { instance_double(Logger) }
+        let(:components) { instance_double(Datadog::Core::Configuration::Components) }
+
+        it 'does not record telemetry metrics' do
+          expect(logger).to receive(:debug).with(/Telemetry component is unavailable/)
+
+          sdk.track_user_signup('john.snow', '13')
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**

Adds missing functionality to track user signup events to have similar visibility as for login success/failures

**Motivation:**

Ongoing collaboration with Rubygems.org

**Change log entry**

Yes. Add signup event tracking to `Datadog::Kit::AppSec::Events::V2`

**Additional Notes:**

Interface follow the same guidelines as existing V2 functionality

**How to test the change?**

CI