### PR TITLE
Add WAF timeout to the schema extraction call

### DIFF
--- a/lib/datadog/appsec/context.rb
+++ b/lib/datadog/appsec/context.rb
@@ -103,7 +103,8 @@ module Datadog
       end
 
       def extract_schema!
-        waf_result = @waf_runner.run({'waf.context.processor' => {'extract-schema' => true}}, {})
+        persistent_data = {'waf.context.processor' => {'extract-schema' => true}}
+        waf_result = run_waf(persistent_data, {}, Datadog.configuration.appsec.waf_timeout)
         security_event = AppSec::SecurityEvent.new(waf_result, trace: trace, span: span)
 
         @state[:schema_extracted] = security_event.schema?

--- a/spec/datadog/appsec/context_spec.rb
+++ b/spec/datadog/appsec/context_spec.rb
@@ -193,11 +193,17 @@ RSpec.describe Datadog::AppSec::Context do
   end
 
   describe '#extract_schema!' do
-    it 'calls waf runner with correct addresses and stores new security event' do
+    before { allow(Datadog.configuration.appsec).to receive(:waf_timeout).and_return(42) }
+
+    it 'runs the waf with extract-schema address and the configured timeout' do
       expect_any_instance_of(Datadog::AppSec::SecurityEngine::Runner).to receive(:run)
-        .with({'waf.context.processor' => {'extract-schema' => true}}, {})
+        .with({'waf.context.processor' => {'extract-schema' => true}}, {}, 42)
         .and_call_original
 
+      context.extract_schema!
+    end
+
+    it 'stores a new security event' do
       expect { context.extract_schema! }.to change { context.events.count }.by(1)
     end
 


### PR DESCRIPTION
**What does this PR do?**

Add missing timeout to the schema extraction call and in addition run schema extraction through established WAF method that provides metrics recordings (aligned with other libraries)

**Motivation:**

Closes https://github.com/DataDog/ruby-guild/issues/312

**Change log entry**

Yes. Fix API Security schema extraction timeout and telemetry

**Additional Notes:**

None.

**How to test the change?**

CI