### PR TITLE
Fix flaky: CpuAndWallTimeWorker "always simulates signal delivery"

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -678,9 +678,12 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       it "always simulates signal delivery" do
         start
 
+        # `serialize!` drains the recorder, so `all_samples` is exactly the batch drained by the iteration that
+        # satisfies the wait condition, and `sample_count` below is computed from it. Wait until that batch
+        # contains a main-thread sample so the batch we keep is guaranteed to have one.
         all_samples = try_wait_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples.any?
+          samples if samples_for_thread(samples, Thread.current).any?
         end
 
         cpu_and_wall_time_worker.stop


### PR DESCRIPTION
**What does this PR do?**

Fixes the flaky spec `spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:678` (`CpuAndWallTimeWorker#start when using the no signals workaround always simulates signal delivery`) by waiting on a reliable condition instead of `samples.any?`.

**Motivation:**

Observed flaking on [Ruby 2.7 / build & test (standard) [0]](https://github.com/DataDog/dd-trace-rb/actions/runs/28541849002/job/84617473203?pr=5956) (commit `ab2601db`), an unrelated PR. In that job `profiling:main` ran 3 times and this spec failed once and passed twice on the same commit; it passed on all other Ruby versions.

**Failure:**

```
Failure/Error: expect(sample_count).to be > 0
  expected: > 0
       got:   nil
# ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:699
```

**Root cause:**

`recorder.serialize!` drains the recorder, so the `all_samples` captured inside `try_wait_until` is only the single batch drained by the iteration whose wait condition first became truthy. The condition `samples.any?` becomes truthy on the first surviving (non-GC, non-overhead) sample of *any* thread.

Since the on-serialize flush was added in [#5955](https://github.com/DataDog/dd-trace-rb/pull/5955), every `serialize!` emits catch-up samples for the profiler-internal threads (the worker and the idle-sampling helper). Those samples are not GC and not `profiler overhead`, so they survive the filter. When a `serialize!` happens before the worker's first per-tick sample has hit the main thread, the drained batch contains only profiler-internal-thread samples (and/or another application thread) with no main-thread sample. `samples_for_thread(all_samples, Thread.current)` is then empty, `[].reduce(:+)` returns `nil`, and `expect(sample_count).to be > 0` fails with `got: nil`.

This is the same unreliable wait pattern that [#5955](https://github.com/DataDog/dd-trace-rb/pull/5955) migrated away from in the sibling specs of this file (switching to `stats.fetch(:cpu_sampled) > 0`), but this spec was not migrated.

**Fix:**

Wait until the drained batch actually contains a main-thread sample, so the batch kept as `all_samples` is guaranteed to have one. Test-synchronization change only; the assertions are unchanged (no weakening).

**Change log entry**

None.

**How to test the change?**

Reproduced deterministically and verified locally (Ruby 3.2.3):

- Naturally, on stock Ruby, by adding background CPU-bound threads (so the worker samples them instead of the main thread at the first tick): ~1-2% failure rate on the unmodified spec; 0 failures with this fix.
- Deterministically, on a locally patched Ruby that delays the profiler-internal threads' startup so the first `serialize!` flushes only profiler-internal-thread samples: the unmodified spec fails 20/20 with the exact `got: nil`; with the knob off it passes; with this fix applied it passes 30/30.