### PR TITLE
Pin injector and system-tests to Ruby 4 dev refs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,8 +134,9 @@ install-dependencies:
   parallel:
     matrix:
       # ADD NEW RUBIES HERE
-      # TODO: Ruby 4.0 - Not added here yet to avoid increasing SSI OCI image size and adding premature support for 4.0.
-      - RUBY_VERSION: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+      # TEMPORARY: Ruby 4.0 added to package a ruby/4.0.0 gem home so SSI can
+      # inject on Ruby 4.0 (system-tests#7249). Revisit OCI size before merge.
+      - RUBY_VERSION: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
         ARCH: ["amd64", "arm64"]
   stage: package
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,9 +12,9 @@ stages:
 include:
   - local: ".gitlab/one-pipeline.locked.yml"
   - local: ".gitlab/benchmarks.yml"
-  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
-    file: '.gitlab/ci-ruby-acme-parallel.yml'
-    ref: '5f5ca440eaab196afb8f78255c2daf2d0bdcc492' # apm-sdks-benchmarks#209 merge commit
+  - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
+    file: ".gitlab/ci-ruby-acme-parallel.yml"
+    ref: "5f5ca440eaab196afb8f78255c2daf2d0bdcc492" # apm-sdks-benchmarks#209 merge commit
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby
@@ -167,7 +167,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: 7bac407189037b3f22eb2f752d52377410119723 # Automated: Updated by .github/workflows/update-system-tests.yml.
+    SYSTEM_TESTS_REF: e591e675491c258d1289325d1d2cf7f61db07ea9 # TEMPORARY: system-tests#7249 (Ruby 4 / Bundler 4). Revert to automated ref before merge.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: 568b9cf1f7d0d51990b26df12918f78e8c20107e # TEMPORARY: system-tests#7249 (Ruby 4 / Bundler 4). Revert to automated ref before merge.
+    SYSTEM_TESTS_REF: 7bac407189037b3f22eb2f752d52377410119723 # Automated: Updated by .github/workflows/update-system-tests.yml.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,6 +144,9 @@ install-dependencies:
   script:
     - export RUBY_PACKAGE_VERSION=$(cat tmp/version)
     - export DATADOG_GEM_LOCATION=$(readlink -f pkg/datadog-*.gem)
+    # TEMPORARY (Ruby 4.0): the centos custom image builds Ruby with devtoolset-10
+    # but defaults to an older gcc at runtime; enable it so native gems (ffi) build.
+    - if [ -f /opt/rh/devtoolset-10/enable ]; then export MANPATH="${MANPATH:-}"; . /opt/rh/devtoolset-10/enable; fi
     - ruby -v
     - gem -v
     - bundler -v

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ requirements_json_test:
 
 configure_system_tests:
   variables:
-    SYSTEM_TESTS_REF: e591e675491c258d1289325d1d2cf7f61db07ea9 # TEMPORARY: system-tests#7249 (Ruby 4 / Bundler 4). Revert to automated ref before merge.
+    SYSTEM_TESTS_REF: 568b9cf1f7d0d51990b26df12918f78e8c20107e # TEMPORARY: system-tests#7249 (Ruby 4 / Bundler 4). Revert to automated ref before merge.
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_appsec,lib-injection,docker_ssi"
     SYSTEM_TEST_BUILD_ATTEMPTS: 3
 

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -14,7 +14,7 @@ fi
 ## Obtain injector source
 
 injector_repo="https://github.com/DataDog/datadog-injector-rb.git"
-injector_ref="v1.3.0"
+injector_ref="v1.4.0"
 injector_path="${HOME}/datadog-injector-rb"
 
 git clone "${injector_repo}" --branch "${injector_ref}" "${injector_path}"


### PR DESCRIPTION
**What does this PR do?**
Temporary integration branch to validate Ruby 4.0 / RubyGems 4.0 / Bundler 4.0
single-step instrumentation (SSI) end-to-end before either dependency is released.

- `.gitlab/prepare-oci-package.sh`: build the OCI package from the injector
  development branch `lloeki/ruby4-bundler4` (datadog-injector-rb#65) instead of
  `v1.3.0`.
- `.gitlab-ci.yml`: run system-tests at the Ruby 4 / Bundler 4 branch commit
  (system-tests#7249) instead of the automated ref.

**Motivation:**
The injector guard change (datadog-injector-rb#65) and the new Rails 8 / Ruby 4 /
Bundler 4 SSI weblog (system-tests#7249) need to be exercised together against this
repo`\`s OCI packaging and system-tests pipeline. The tracer already supports Ruby
4.0 (`MAXIMUM_RUBY_VERSION = 4.1`), so injection into a Ruby 4 app should succeed.

**Change log entry**
None. CI-only, temporary integration branch.

**Additional Notes:**
Both pins are marked TEMPORARY in-line and MUST be reverted to released/automated
refs before merge:
- `injector_ref` back to a released injector tag.
- `SYSTEM_TESTS_REF` back to the value managed by
  `.github/workflows/update-system-tests.yml`.

Also depends on the images-rb Ruby 4 / Bundler 4 toolchain rollout.

**How to test the change?**
Runs the `docker_ssi` and `lib-injection` system-tests scenario groups in CI against
the pinned refs; the new `rails8-app*` (RB40) weblog should build and inject.