### PR TITLE
Revert "profiling: use clock_gettime for current-thread CPU time on macOS"

### DIFF
--- a/ext/datadog_profiling_native_extension/clock_id_from_mach.c
+++ b/ext/datadog_profiling_native_extension/clock_id_from_mach.c
@@ -5,7 +5,6 @@
 #ifdef HAVE_MACH_THREAD_INFO
 
 #include <pthread.h>
-#include <time.h>
 #include <mach/mach.h>
 #include <mach/thread_info.h>
 
@@ -47,17 +46,11 @@ thread_cpu_time thread_cpu_time_for(thread_cpu_time_id time_id) {
 
   if (!time_id.valid) return error;
 
-  // Fast path: clock_gettime(CLOCK_THREAD_CPUTIME_ID) is ~5x cheaper than thread_info()
-  // and gives sub-microsecond precision (vs microsecond), but only measures the calling
-  // thread on macOS (there is no pthread_getcpuclockid() equivalent).
-  if (time_id.clock_id == pthread_mach_thread_np(pthread_self())) {
-    struct timespec ts;
-    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0) {
-      return (thread_cpu_time) {.valid = true, .result_ns = SECONDS_AS_NS(ts.tv_sec) + ts.tv_nsec};
-    }
-    // Fall through to thread_info on the unlikely failure case.
-  }
-
+  // We intentionally use thread_info() for all threads, including the current one, even though
+  // clock_gettime(CLOCK_THREAD_CPUTIME_ID) is ~5x faster for the current thread. Mixing the two
+  // sources causes CPU time to appear to go backwards: thread_info() has microsecond precision
+  // while clock_gettime() has nanosecond precision, and comparing values across sources on
+  // successive samples produces small negative deltas.
   struct thread_basic_info info;
   mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
   kern_return_t kr = thread_info(time_id.clock_id, THREAD_BASIC_INFO, (thread_info_t)&info, &count);


### PR DESCRIPTION
* This reverts commit 39511b652c09802e1e5263317b914f804527eb50.
* See comment in code for why it's problematic.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

An alternative would be to round which seems to produce no negative deltas (truncation does), but it's somewhat brittle and adds more complexity for little reason.

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Fix fatal error (only on macOS, rare).

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
