### PR TITLE
[NO-TICKET] Fix flaky profiling spec "expect(sample_count).to be > 0", got `nil`

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -680,7 +680,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         all_samples = try_wait_until do
           samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
-          samples if samples.any?
+          samples if samples_for_thread(samples, Thread.current).any?
         end
 
         cpu_and_wall_time_worker.stop


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the flaky profiling spec we saw in
https://github.com/DataDog/dd-trace-rb/actions/runs/28523919081/job/84555219767 :

```
Failures:

  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when using the no signals workaround always simulates signal delivery
     Failure/Error: expect(sample_count).to be > 0

       expected: > 0
            got:   nil
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:699:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:313:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:207:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 17.45 seconds (files took 0.96839 seconds to load)
812 examples, 1 failure, 113 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:678 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when using the no signals workaround always simulates signal delivery
```

TL;DR the problem here is that when this spec was written,

```ruby
        all_samples = try_wait_until do
          samples = samples_from_pprof_without_gc_and_overhead(recorder.serialize!)
          samples if samples.any?
        end
```

If you saw any samples that were NOT GC and NOT overhead, then for sure you were seeing a regular "sampled all the threads" event, and thus the current thread was for sure going to be in there.

This is no longer the case now that we have a mechanism for special-casing internal profiler threads and threads without the GVL (as well as sometimes leftover state -- that's being addressed in https://github.com/DataDog/dd-trace-rb/pull/5960 ).

Thus the TL;DR as far as this test cares, it can't just assume that if there's any samples in there, those would be the samples it's expecting to get.

To fix this, we check that we have samples for the current thread, which was the underlying assumption/expectation that wasn't being stated.

**Motivation:**

Zero flakiness in profiling!

**Change log entry**

None.

**Additional Notes:**

There were a few other specs that we changed recently for similar reasons -- they were written in simpler times ;)

Also, I gave a pass overall on this file to make sure there weren't other specs encoding the same wrong assumption that would flake in the future but as far as I saw, this is the last one.

**How to test the change?**

Green CI