### PR TITLE
Disable empty system-tests scenarios

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -91,6 +91,7 @@ jobs:
       force_execute: ${{ needs.build.outputs.forced_tests }}
       parametric_job_count: 8
       push_to_test_optimization: true
+      skip_empty_scenarios: true
 
   complete:
     name: System Tests (complete)


### PR DESCRIPTION
**What does this PR do?**
This PR adds skipping of empty scenarios for System Tests.

For the reference: https://github.com/DataDog/system-tests/blob/main/docs/CI/github-actions.md#parameters

**Motivation:**
We have `APPSEC_RUNTIME_ACTIVATION` tests running for 20 minutes, while we do not support Runtime Activation for AppSec yet.

**Change log entry**
None. This change is internal.

**Additional Notes:**
None.

**How to test the change?**
CI should be faster.