### PR TITLE
[NO-TICKET] Profiling: Tweak spec assertion to avoid flakyness

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -552,8 +552,17 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           # it just passes and starts waiting)
 
           # This test should run for at least 200ms, which is how long we sleep for
-          # (unless somehow the missed_by_profiler_time is too big?)
-          expect(total_time).to be >= 200_000_000
+          # but if the profiler misses a whole thread scheduling cycle, we adjust the expectation.
+          # This isn't great, but measuring/causing this kind of effect end-to-end without making the spec really slow
+          # is tricky.
+          if missed_by_profiler_time < 100_000_000
+            expect(total_time).to be >= 200_000_000,
+              "Expected total_time to be >= 200ms, debug_failures: #{debug_failures}"
+          else
+            expect(total_time).to be >= 100_000_000,
+              "Expected total_time to be >= 100ms, debug_failures: #{debug_failures}"
+          end
+
           expect(waiting_for_gvl_time).to be < total_time,
             "Expected #{waiting_for_gvl_time} to be < #{total_time}, debug_failures: #{debug_failures}"
           expect(waiting_for_gvl_time).to be_within(5).percent_of(total_time),


### PR DESCRIPTION
**What does this PR do?**

This PR adjusts a spec assertion to avoid flakiness seen in https://github.com/DataDog/dd-trace-rb/actions/runs/27983586120/job/82819642459 :

```
Failures:

  1) Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when main thread is sleeping but a background thread is working when GVL profiling is enabled records Waiting for GVL samples
     Failure/Error: expect(total_time).to be >= 200_000_000

       expected: >= 200000000
            got:    100085400
     # ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:532:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:327:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:207:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-wait-0.0.10/lib/rspec/wait.rb:47:in `block (2 levels) in <top (required)>'
     # ./spec/support/execute_in_fork.rb:32:in `run'

Finished in 30.79 seconds (files took 1.09 seconds to load)
806 examples, 1 failure, 16 pending

Failed examples:

rspec ./spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb:457 # Datadog::Profiling::Collectors::CpuAndWallTimeWorker#start when main thread is sleeping but a background thread is working when GVL profiling is enabled records Waiting for GVL samples

Randomized with seed 59824
```

I was not able to reproduce the issue AND unfortunately the `debug_failures` wasn't printed for this assertion, but given the numbers that caused the issue, it looks like the background "burn-cpu thread" ran for a whole 100ms period before we started tracking the `background_thread_affected_by_gvl_contention`.

Thus, I've tweaked the assertion and now added code to print the `debug_info` so if this tweak doesn't fix the issue, we'll have more data about it next time.

**Motivation:**

Zero flaky tests!

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

Green CI is good!