### PR TITLE
Fix route processing for AppSec

### DIFF
--- a/lib/datadog/appsec/contrib/rails/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/request.rb
@@ -57,9 +57,7 @@ module Datadog
             def route_params
               excluded = [:controller, :action]
 
-              return {} unless request.env['action_dispatch.request.path_parameters']
-
-              request.env['action_dispatch.request.path_parameters'].reject do |k, _v|
+              request.env.fetch('action_dispatch.request.path_parameters', {}).reject do |k, _v|
                 excluded.include?(k)
               end
             end

--- a/lib/datadog/appsec/contrib/rails/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/request.rb
@@ -47,6 +47,7 @@ module Datadog
               body = request.env['action_dispatch.request.request_parameters']
 
               return if body.nil?
+              return body unless request.env['action_dispatch.request.path_parameters']
 
               body.reject do |k, _v|
                 request.env['action_dispatch.request.path_parameters'].key?(k)
@@ -55,6 +56,8 @@ module Datadog
 
             def route_params
               excluded = [:controller, :action]
+
+              return {} unless request.env['action_dispatch.request.path_parameters']
 
               request.env['action_dispatch.request.path_parameters'].reject do |k, _v|
                 excluded.include?(k)

--- a/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
@@ -18,6 +18,50 @@ RSpec.describe Datadog::AppSec::Contrib::Rails::Gateway::Request do
     )
   end
 
+  describe '#route_params' do
+    context 'when the router has populated path parameters' do
+      before do
+        env['action_dispatch.request.path_parameters'] = {controller: 'users', action: 'show', id: '42'}
+      end
+
+      it 'returns the path parameters without :controller and :action' do
+        expect(request.route_params).to eq(id: '42')
+      end
+    end
+
+    context 'when the router was bypassed and path parameters are nil' do
+      before { env.delete('action_dispatch.request.path_parameters') }
+
+      it 'returns an empty hash instead of raising' do
+        expect(request.route_params).to eq({})
+      end
+    end
+  end
+
+  describe '#parsed_body' do
+    context 'when the router has populated path parameters' do
+      before do
+        env['action_dispatch.request.request_parameters'] = {'name' => 'john'}
+        env['action_dispatch.request.path_parameters'] = {id: '42'}
+      end
+
+      it 'returns the request body parameters' do
+        expect(request.parsed_body).to eq('name' => 'john')
+      end
+    end
+
+    context 'when the router was bypassed and path parameters are nil' do
+      before do
+        env['action_dispatch.request.request_parameters'] = {'name' => 'john'}
+        env.delete('action_dispatch.request.path_parameters')
+      end
+
+      it 'returns the request parameters instead of raising' do
+        expect(request.parsed_body).to eq('name' => 'john')
+      end
+    end
+  end
+
   describe '#body_bytesize' do
     context 'when raw posted data is present' do
       before { env['RAW_POST_DATA'] = '{"name":"john"}' }

--- a/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Datadog::AppSec::Contrib::Rails::Gateway::Request do
         env.delete('action_dispatch.request.path_parameters')
       end
 
-      it 'returns the request parameters instead of raising' do
+      it 'returns the request parameters' do
         expect(request.parsed_body).to eq('name' => 'john')
       end
     end


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
When Warden invokes `Devise::FailureApp` directly, the router is bypassed so `ActionDispatch::Routing::RouteSet` never runs and `path_parameters` is `nil` in `env`. This causes a `NoMethodError`.

**Change log entry**
Yes. AppSec: Fix an exception for unauthorized requests when using Devise with Rails.

**Additional Notes:**
SCRS-2273

**How to test the change?**
CI.
