### PR TITLE
Set wall/CPU times eagerly in initialize_context()

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -203,8 +203,8 @@ struct per_thread_context {
   char thread_invoke_location[THREAD_INVOKE_LOCATION_LIMIT_CHARS];
   ddog_CharSlice thread_invoke_location_char_slice;
   thread_cpu_time_id thread_cpu_time_id;
-  long cpu_time_at_previous_sample_ns;  // Can be INVALID_TIME until initialized or if getting it fails for another reason
-  long wall_time_at_previous_sample_ns; // Can be INVALID_TIME until initialized
+  long cpu_time_at_previous_sample_ns;
+  long wall_time_at_previous_sample_ns;
 
   // There are 3 possible states for the GVL (per thread), and 3 transitions for which we receive GVL events:
   // Thread holds the GVL
@@ -1292,9 +1292,8 @@ static void initialize_context(VALUE thread, per_thread_context *thread_context)
 
   thread_context->thread_cpu_time_id = thread_cpu_time_id_for(thread);
 
-  // These will get initialized during actual sampling
-  thread_context->cpu_time_at_previous_sample_ns = INVALID_TIME;
-  thread_context->wall_time_at_previous_sample_ns = INVALID_TIME;
+  thread_context->wall_time_at_previous_sample_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
+  thread_context->cpu_time_at_previous_sample_ns = cpu_time_now_ns(thread_context);
 
   // These will only be used during a GC operation
   thread_context->gc_tracking.cpu_time_at_start_ns = INVALID_TIME;
@@ -2061,16 +2060,6 @@ void thread_context_collector_stats_reset_not_thread_safe(VALUE self_instance) {
 
 static void mark_thread_as_profiler_internal(per_thread_context *ctx) {
   ctx->is_profiler_internal_thread = true;
-
-  // Seed timestamps so the first on_serialize produces a real delta instead of zero.
-  // Without this, update_time_since_previous_sample sees INVALID_TIME, sets it to
-  // current_time, and returns 0 — losing the entire first reporting period.
-  if (ctx->wall_time_at_previous_sample_ns == INVALID_TIME) {
-    ctx->wall_time_at_previous_sample_ns = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
-  }
-  if (ctx->cpu_time_at_previous_sample_ns == INVALID_TIME) {
-    ctx->cpu_time_at_previous_sample_ns = cpu_time_now_ns(ctx);
-  }
 }
 
 void thread_context_collector_profiler_internal_thread_started(void) {

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -302,8 +302,7 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
       t1_samples = samples_for_thread(samples, t1)
 
-      wall_time = t1_samples.map(&:values).map { |it| it.fetch(:"wall-time") }.reduce(:+)
-      expect(wall_time).to be(wall_time_at_second_sample - wall_time_at_first_sample)
+      expect(t1_samples.last.values.fetch(:"wall-time")).to be(wall_time_at_second_sample - wall_time_at_first_sample)
     end
 
     it "tags samples with how many times they were seen" do
@@ -2091,8 +2090,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     end
 
     before do
-      sample # initialize cpu/wall timestamps (they start as INVALID_TIME)
-      recorder.serialize! # flush initial samples
       mark_thread_as_profiler_internal(t1)
     end
 
@@ -2107,9 +2104,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     end
 
     it "reports profiler-internal threads in the first reporting period" do
-      # This test does NOT use the before block's sample/serialize — it marks the thread
-      # as profiler-internal without any prior sample, to verify that marking alone seeds
-      # the timestamps (they would otherwise be INVALID_TIME, producing a zero-value sample).
+      # Timestamps are seeded by initialize_context, so the first on_serialize flush
+      # produces a real wall-time delta even without any prior sample.
       t2 = Thread.new { sleep }
       mark_thread_as_profiler_internal(t2)
 
@@ -2378,9 +2374,13 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     end
 
     it "resets the current Thread per_thread_context" do
-      expect { reset_after_fork }.to change {
-        per_thread_context.dig(Thread.current, :cpu_time_at_previous_sample_ns)
-      }.to(-1)
+      apply_delta_to_cpu_time_at_previous_sample_ns(Thread.current, -123_456_789)
+      cpu_time_before = per_thread_context.dig(Thread.current, :cpu_time_at_previous_sample_ns)
+
+      reset_after_fork
+
+      cpu_time_after = per_thread_context.dig(Thread.current, :cpu_time_at_previous_sample_ns)
+      expect(cpu_time_after).to_not eq(cpu_time_before)
     end
 
     it "clears the stats" do


### PR DESCRIPTION
All threads now get real first-sample deltas instead of losing the first interval to INVALID_TIME initialization. This simplifies mark_thread_as_profiler_internal to a simple flag setter.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Simplicity and not losing the first sample.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
