### PR TITLE
[APPSEC-68662] Fix cached request body analysis for Rack and Sinatra

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/watcher.rb
@@ -104,6 +104,10 @@ module Datadog
                       body = gateway_request.form_hash
                       persistent_data['server.request.body'] = body if body
                     end
+                  # NOTE: Body was parsed before measurement, keep byte_length unset
+                  elsif gateway_request.env.key?('rack.request.form_hash')
+                    body = gateway_request.env['rack.request.form_hash']
+                    persistent_data['server.request.body'] = body if body
                   end
 
                   next stack.call(request) if persistent_data.empty?

--- a/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
+++ b/lib/datadog/appsec/contrib/sinatra/gateway/watcher.rb
@@ -44,6 +44,10 @@ module Datadog
                       body = gateway_request.form_hash
                       persistent_data['server.request.body'] = body if body
                     end
+                  # NOTE: Body was parsed before measurement, keep byte_length unset
+                  elsif gateway_request.env.key?('rack.request.form_hash')
+                    body = gateway_request.env['rack.request.form_hash']
+                    persistent_data['server.request.body'] = body if body
                   end
 
                   next stack.call(request) if persistent_data.empty?

--- a/spec/datadog/appsec/contrib/rack/gateway/watcher_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/watcher_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Watcher do
         end
       end
 
+      context 'when the body was already parsed upstream' do
+        before do
+          gateway_request.env['rack.request.form_hash'] = {'name' => 'john'}
+          unsized_io.read
+        end
+
+        it 'runs WAF with the cached body without byte length' do
+          gateway.push('rack.request.body', gateway_request)
+
+          expect(context).to have_received(:run_waf).with(
+            {'server.request.body' => {'name' => 'john'}}, {}, anything
+          )
+        end
+      end
+
       context 'and the body exceeds the limit' do
         before { allow(Datadog.configuration.appsec).to receive(:body_parsing_size_limit).and_return(4) }
 

--- a/spec/datadog/appsec/contrib/sinatra/gateway/watcher_spec.rb
+++ b/spec/datadog/appsec/contrib/sinatra/gateway/watcher_spec.rb
@@ -103,6 +103,21 @@ RSpec.describe Datadog::AppSec::Contrib::Sinatra::Gateway::Watcher do
         end
       end
 
+      context 'when the body was already parsed upstream' do
+        before do
+          gateway_request.env['rack.request.form_hash'] = {'name' => 'john'}
+          unsized_io.read
+        end
+
+        it 'runs WAF with the cached body without byte length' do
+          gateway.push('sinatra.request.dispatch', gateway_request)
+
+          expect(context).to have_received(:run_waf).with(
+            {'server.request.body' => {'name' => 'john'}}, {}, anything
+          )
+        end
+      end
+
       context 'when the body exceeds the limit' do
         before { allow(Datadog.configuration.appsec).to receive(:body_parsing_size_limit).and_return(4) }
 


### PR DESCRIPTION
**What does this PR do?**

Fix WAF analysis for requests with already parsed/cached bodies that are impossible to read

**Motivation:**

Fix [APPSEC-68662](https://datadoghq.atlassian.net/browse/APPSEC-68662)

**Change log entry**

Yes. Fix WAF request analysis for cached/parsed bodies in Rack and Sinatra

**Additional Notes:**

None.

**How to test the change?**

CI

[APPSEC-68662]: https://datadoghq.atlassian.net/browse/APPSEC-68662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ