### PR TITLE
Fix GraphQL fragment expansion in AppSec

### DIFF
--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -72,8 +72,7 @@ module Datadog
                     args_hash, fragment_name, nil, arguments_from_directives(fragment.directives, query_variables)
                   )
 
-                  # Never unmark: re-expanding a reused fragment yields no new arguments but
-                  # allows exponential blow-up from a linear-sized query.
+                  # re-used fragments are not expanded
                   visited_fragments[fragment_name] = true
                   arguments_from_selections(
                     fragment.selections, query_variables, args_hash, fragments, visited_fragments

--- a/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
+++ b/lib/datadog/appsec/contrib/graphql/gateway/multiplex.rb
@@ -72,11 +72,12 @@ module Datadog
                     args_hash, fragment_name, nil, arguments_from_directives(fragment.directives, query_variables)
                   )
 
+                  # Never unmark: re-expanding a reused fragment yields no new arguments but
+                  # allows exponential blow-up from a linear-sized query.
                   visited_fragments[fragment_name] = true
                   arguments_from_selections(
                     fragment.selections, query_variables, args_hash, fragments, visited_fragments
                   )
-                  visited_fragments.delete(fragment_name)
                 when ::GraphQL::Language::Nodes::Field
                   selection_name = selection.alias || selection.name
                   field_arguments = arguments_hash(selection.arguments, query_variables) unless selection.arguments.empty?

--- a/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
+++ b/spec/datadog/appsec/contrib/graphql/gateway/multiplex_spec.rb
@@ -328,6 +328,29 @@ RSpec.describe Datadog::AppSec::Contrib::GraphQL::Gateway::Multiplex do
       end
     end
 
+    context 'query with fragments spread multiple times' do
+      let(:queries) do
+        fragments = (1..20).map do |level|
+          if level == 1
+            'fragment F1 on Query { userByName(name: "$attack") { id } }'
+          else
+            "fragment F#{level} on Query { ...F#{level - 1} ...F#{level - 1} }"
+          end
+        end
+
+        [
+          GraphQL::Query.new(
+            schema,
+            "#{fragments.join("\n")}\nquery MyTestQuery { ...F20 }\n"
+          )
+        ]
+      end
+
+      it 'expands each fragment at most once' do
+        expect(dd_multiplex.arguments).to eq('userByName' => [{'name' => '$attack'}])
+      end
+    end
+
     context 'mutation' do
       let(:queries) do
         [


### PR DESCRIPTION
**What does this PR do?**
This PR fixes recursive GraphQL fragment expansion.

**Motivation:**
Codex security scanning.

**Change log entry**
No. This is internal change

**Additional Notes:**
APPSEC-68661

**How to test the change?**
CI