### PR TITLE
[APPSEC-68561] Fix Rack/Rails body parsing on exception

### DIFF
--- a/lib/datadog/appsec/contrib/rack/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rack/gateway/request.rb
@@ -83,6 +83,11 @@ module Datadog
               # usually Hash[String, String] but can be a more complex
               # Hash[String, (String|Array|Hash)] when e.g coming from JSON
               env['rack.request.form_hash']
+            rescue => e
+              Datadog.logger.debug { "AppSec: Failed to parse request body: #{e.class}: #{e.message}" }
+              AppSec.telemetry.report(e, description: 'AppSec: Failed to parse request body')
+
+              nil
             end
 
             # Returns the request body size in bytes using all available methods,

--- a/lib/datadog/appsec/contrib/rails/gateway/request.rb
+++ b/lib/datadog/appsec/contrib/rails/gateway/request.rb
@@ -52,6 +52,11 @@ module Datadog
               body.reject do |k, _v|
                 request.env['action_dispatch.request.path_parameters'].key?(k)
               end
+            rescue => e
+              Datadog.logger.debug { "AppSec: Failed to parse request body: #{e.class}: #{e.message}" }
+              AppSec.telemetry.report(e, description: 'AppSec: Failed to parse request body')
+
+              nil
             end
 
             def route_params

--- a/sig/datadog/appsec/utils/http/body_reader.rbs
+++ b/sig/datadog/appsec/utils/http/body_reader.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Utils
       module HTTP
         module BodyReader
-          def self?.read: (untyped body, limit: Integer, ?rewind_before_read: bool) -> String?
+          def self?.read: (any body, limit: Integer, ?rewind_before_read: bool) -> String?
 
           def self?.read_stream: (Utils::HTTP::_RewindableIO body, limit: Integer, rewind_before_read: bool) -> String?
                                | (Utils::HTTP::_ReadableIO body, limit: Integer, ?rewind_before_read: false) -> String

--- a/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rack/gateway/request_spec.rb
@@ -153,6 +153,29 @@ RSpec.describe Datadog::AppSec::Contrib::Rack::Gateway::Request do
         expect(request.form_hash).to eq({'name' => 'john'})
       end
     end
+
+    context 'when body parsing fails' do
+      before do
+        allow(request.request).to receive(:POST)
+          .and_raise(EOFError, 'bad multipart')
+      end
+
+      let(:request) do
+        described_class.new(
+          Rack::MockRequest.env_for(
+            'http://example.com:8080/?a=foo',
+            {:method => 'POST', :input => 'name=john', 'REMOTE_ADDR' => '10.10.10.10'}
+          )
+        )
+      end
+
+      it 'returns nil and reports telemetry' do
+        expect(Datadog::AppSec.telemetry).to receive(:report)
+          .with(instance_of(EOFError), description: 'AppSec: Failed to parse request body')
+
+        expect(request.form_hash).to be_nil
+      end
+    end
   end
 
   describe '#body_bytesize' do

--- a/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
+++ b/spec/datadog/appsec/contrib/rails/gateway/request_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe Datadog::AppSec::Contrib::Rails::Gateway::Request do
         expect(request.parsed_body).to eq('name' => 'john')
       end
     end
+
+    context 'when body parsing fails' do
+      before do
+        allow(request.request).to receive(:parameters)
+          .and_raise(EOFError, 'bad multipart')
+      end
+
+      it 'returns nil and reports telemetry' do
+        expect(Datadog::AppSec.telemetry).to receive(:report)
+          .with(instance_of(EOFError), description: 'AppSec: Failed to parse request body')
+
+        expect(request.parsed_body).to be_nil
+      end
+    end
   end
 
   describe '#body_bytesize' do


### PR DESCRIPTION
**What does this PR do?**

Add safe-guard for request body parsing classes

**Motivation:**

Fix [APPSEC-68561](https://datadoghq.atlassian.net/browse/APPSEC-68561)

**Change log entry**

Yes. Fix Rack-based and Rails request body analysis when body parsing fails

**Additional Notes:**

None.

**How to test the change?**

CI

[APPSEC-68561]: https://datadoghq.atlassian.net/browse/APPSEC-68561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ