### PR TITLE
Use CLOCK_MONOTONIC_RAW on macOS for nanosecond precision

### DIFF
--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -132,9 +132,6 @@ if RUBY_PLATFORM.include?("linux")
   # but it's slower to build
   # so instead we just assume that we have the function we need on Linux, and nowhere else
   $defs << "-DHAVE_PTHREAD_GETCPUCLOCKID"
-
-  # Not available on macOS
-  $defs << "-DHAVE_CLOCK_MONOTONIC_COARSE"
 elsif RUBY_PLATFORM.include?("darwin")
   # On macOS, we use Mach thread APIs to get per-thread CPU time
   $defs << "-DHAVE_MACH_THREAD_INFO"

--- a/ext/datadog_profiling_native_extension/time_helpers.h
+++ b/ext/datadog_profiling_native_extension/time_helpers.h
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <time.h>
 
-#include "extconf.h" // Needed for HAVE_CLOCK_MONOTONIC_COARSE
+#include "extconf.h"
 #include "ruby_helpers.h"
 
 #define SECONDS_AS_NS(value) (value * 1000 * 1000 * 1000L)
@@ -33,7 +33,16 @@ static inline long retrieve_clock_as_ns(clockid_t clock_id, raise_on_failure_set
   return clock_value.tv_nsec + SECONDS_AS_NS(clock_value.tv_sec);
 }
 
-static inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC, raise_on_failure); }
+// CLOCK_MONOTONIC on macOS only has microsecond precision, CLOCK_MONOTONIC_RAW has nanosecond precision
+#ifdef __APPLE__
+  #define CLOCK_MONOTONIC_FOR_PROFILING CLOCK_MONOTONIC_RAW
+  #define CLOCK_MONOTONIC_COARSE_FOR_PROFILING CLOCK_MONOTONIC_RAW_APPROX
+#else
+  #define CLOCK_MONOTONIC_FOR_PROFILING CLOCK_MONOTONIC
+  #define CLOCK_MONOTONIC_COARSE_FOR_PROFILING CLOCK_MONOTONIC_COARSE
+#endif
+
+static inline long monotonic_wall_time_now_ns(raise_on_failure_setting raise_on_failure) { return retrieve_clock_as_ns(CLOCK_MONOTONIC_FOR_PROFILING, raise_on_failure); }
 static inline long system_epoch_time_now_ns(raise_on_failure_setting raise_on_failure)   { return retrieve_clock_as_ns(CLOCK_REALTIME,  raise_on_failure); }
 
 // Coarse instants use CLOCK_MONOTONIC_COARSE on Linux which is expected to provide resolution in the millisecond range:
@@ -47,11 +56,7 @@ typedef struct {
 static inline coarse_instant to_coarse_instant(long timestamp_ns) { return (coarse_instant) {.timestamp_ns = timestamp_ns}; }
 
 static inline coarse_instant monotonic_coarse_wall_time_now_ns(void) {
- #ifdef HAVE_CLOCK_MONOTONIC_COARSE // Linux
-    return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE, DO_NOT_RAISE_ON_FAILURE));
-  #else // macOS
-    return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC, DO_NOT_RAISE_ON_FAILURE));
-  #endif
+  return to_coarse_instant(retrieve_clock_as_ns(CLOCK_MONOTONIC_COARSE_FOR_PROFILING, DO_NOT_RAISE_ON_FAILURE));
 }
 
 long monotonic_to_system_epoch_ns(monotonic_to_system_epoch_state *state, long monotonic_wall_time_ns);

--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -825,14 +825,14 @@ module Datadog
         # It must respect the interface of [Datadog::Core::Utils::Time#get_time] method.
         #
         # For [Timecop](https://rubygems.org/gems/timecop), for example,
-        # `->(unit = :float_second) { ::Process.clock_gettime_without_mock(::Process::CLOCK_MONOTONIC, unit) }`
+        # `->(unit = :float_second) { ::Process.clock_gettime_without_mock(Datadog::Core::Utils::Time::MONOTONIC_CLOCK_ID, unit) }`
         # allows Datadog features to use the real monotonic time when time is frozen with
         # `Timecop.mock_process_clock = true`.
         #
-        # @default `->(unit = :float_second) { ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, unit)}`
+        # @default `->(unit = :float_second) { ::Process.clock_gettime(Core::Utils::Time::MONOTONIC_CLOCK_ID, unit) }`
         # @return [Proc<Numeric>]
         option :get_time_provider do |o|
-          o.default_proc { |unit = :float_second| ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, unit) }
+          o.default_proc { |unit = :float_second| ::Process.clock_gettime(Core::Utils::Time::MONOTONIC_CLOCK_ID, unit) }
           o.type :proc
 
           o.after_set do |get_time_provider|
@@ -840,7 +840,7 @@ module Datadog
           end
 
           o.resetter do |_value|
-            ->(unit = :float_second) { ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, unit) }.tap do |default|
+            ->(unit = :float_second) { ::Process.clock_gettime(Core::Utils::Time::MONOTONIC_CLOCK_ID, unit) }.tap do |default|
               Core::Utils::Time.get_time_provider = default
             end
           end

--- a/lib/datadog/core/utils/time.rb
+++ b/lib/datadog/core/utils/time.rb
@@ -8,11 +8,15 @@ module Datadog
         module_function
 
         # Current monotonic time
+        # On macOS, CLOCK_MONOTONIC only has microsecond precision,
+        # so we use CLOCK_MONOTONIC_RAW which has nanosecond precision instead.
         #
         # @param unit [Symbol] unit for the resulting value, same as ::Process#clock_gettime, defaults to :float_second
         # @return [Float|Integer] timestamp in the requested unit, since some unspecified starting point
+        MONOTONIC_CLOCK_ID = RUBY_PLATFORM.include?("darwin") ? Process::CLOCK_MONOTONIC_RAW : Process::CLOCK_MONOTONIC
+
         def get_time(unit = :float_second)
-          Process.clock_gettime(Process::CLOCK_MONOTONIC, unit)
+          Process.clock_gettime(MONOTONIC_CLOCK_ID, unit)
         end
 
         # Current wall time.

--- a/spec/datadog/core/configuration/settings_spec.rb
+++ b/spec/datadog/core/configuration/settings_spec.rb
@@ -1509,7 +1509,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
     end
 
     context 'when default' do
-      before { allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, unit).and_return(1) }
+      before { allow(Process).to receive(:clock_gettime).with(Datadog::Core::Utils::Time::MONOTONIC_CLOCK_ID, unit).and_return(1) }
 
       it 'delegates to Process.clock_gettime' do
         expect(settings.get_time_provider.call(unit)).to eq(get_time)
@@ -1542,7 +1542,7 @@ RSpec.describe Datadog::Core::Configuration::Settings do
 
       before do
         set_get_time_provider
-        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, unit).and_return(original_get_time)
+        allow(Process).to receive(:clock_gettime).with(Datadog::Core::Utils::Time::MONOTONIC_CLOCK_ID, unit).and_return(original_get_time)
       end
 
       it 'returns the provided time' do

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -122,12 +122,12 @@ module ProfileHelpers
   end
 
   def loop_until(timeout_seconds: 5, check_condition_every_seconds: 0)
-    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+    started_at = Datadog::Core::Utils::Time.get_time
 
     deadline = started_at + timeout_seconds
     condition_deadline = started_at + check_condition_every_seconds
 
-    while (now = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)) < deadline
+    while (now = Datadog::Core::Utils::Time.get_time) < deadline
       if check_condition_every_seconds > 0
         if now >= condition_deadline
           condition_deadline = now + check_condition_every_seconds


### PR DESCRIPTION
CLOCK_MONOTONIC on macOS only has microsecond precision, while CLOCK_MONOTONIC_RAW has nanosecond precision.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Finer-grained times on macOS, same granularity as on Linux, which may help avoid flaky tests.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
