### PR TITLE
Use registry classes for supported versions packages

### DIFF
--- a/.github/scripts/update_supported_versions.rb
+++ b/.github/scripts/update_supported_versions.rb
@@ -4,29 +4,19 @@ require 'bundler'
 
 LIB_PATH = File.expand_path('../../lib', __dir__).freeze
 GEMFILES_DIR = 'gemfiles/'.freeze
-CONTRIB_DIR = 'lib/datadog/tracing/contrib/'.freeze
 OUTPUT_DOC = 'docs/integration_versions.md'.freeze
 OUTPUT_DATA = 'docs/integration_versions.json'.freeze
 THIRD_PARTY_URL = {
-  'httpx' => '[3rd-party support](https://honeyryderchuck.gitlab.io/httpx/)',
-}.freeze
+  'httpx' => 'https://honeyryderchuck.gitlab.io/httpx/',
+}.map { |integration, url| [integration, "[3rd-party support](#{url})"] }.to_h.freeze
 
 $LOAD_PATH.unshift(LIB_PATH) unless $LOAD_PATH.include?(LIB_PATH)
 require 'datadog'
 
 class GemfileProcessor
-  SPECIAL_CASES = {
-    "opensearch" => "OpenSearch", # special case because opensearch = OpenSearch not Opensearch
-  }.freeze
-  EXCLUDED_INTEGRATIONS = ["configuration", "propagation", "utils"].freeze
-
-  def initialize(directory: GEMFILES_DIR, contrib_dir: CONTRIB_DIR)
+  def initialize(directory: GEMFILES_DIR)
     unless Dir.exist?(directory)
       warn("Directory #{directory} does not exist")
-    end
-
-    unless Dir.exist?(contrib_dir)
-      warn("Directory #{contrib_dir} does not exist")
     end
     @directory = directory
     @min_gems = { 'ruby' => {} }
@@ -109,13 +99,11 @@ class GemfileProcessor
     false
   end
 
-
   def process_integrations
-    integrations = Datadog::Tracing::Contrib::REGISTRY.map(&:name).map(&:to_s)
-    integrations.each do |integration|
-      next if EXCLUDED_INTEGRATIONS.include?(integration)
-
-      package = resolve_integration_name(integration)
+    Datadog::Tracing::Contrib::REGISTRY.each do |entry|
+      integration = entry.name.to_s
+      integration_class = entry.klass.class
+      package = integration_class.respond_to?(:gem_name) ? integration_class.gem_name : integration
 
       @supported_versions << {
         integration: integration,
@@ -142,20 +130,10 @@ class GemfileProcessor
     @supported_versions << {
       integration: 'makara',
       package: 'makara',
-      source: 'rubygems.org',
-      min_tested: '0.5.1',
-      max_tested: '0.5.1',
+      source: @gem_sources['ruby']['makara'],
+      min_tested: @min_gems['ruby']['makara'],
+      max_tested: @max_gems['ruby']['makara'],
     }
-  end
-
-  def resolve_integration_name(integration)
-    mod_name = SPECIAL_CASES[integration] || integration.split('_').map(&:capitalize).join
-    module_name = "Datadog::Tracing::Contrib::#{mod_name}"
-    integration_module = Object.const_get(module_name)::Integration
-    integration_module.respond_to?(:gem_name) ? integration_module.gem_name : integration
-  rescue NameError, NoMethodError
-    puts "Fallback for #{integration}: module or gem_name not found."
-    integration
   end
 
   def write_markdown_output
@@ -212,6 +190,5 @@ class GemfileProcessor
     THIRD_PARTY_URL[support[:integration]] || support[key] || 'None'
   end
 end
-
 
 GemfileProcessor.new.process

--- a/docs/integration_versions.json
+++ b/docs/integration_versions.json
@@ -141,10 +141,10 @@
   },
   {
     "integration": "http",
-    "package": "http",
+    "package": "net-http",
     "source": "rubygems.org",
-    "min_tested": "5.0.1",
-    "max_tested": "6.0.2"
+    "min_tested": "0.6.0",
+    "max_tested": "0.9.1"
   },
   {
     "integration": "httpclient",
@@ -201,7 +201,7 @@
     "package": "makara",
     "source": "rubygems.org",
     "min_tested": "0.5.1",
-    "max_tested": "0.5.1"
+    "max_tested": "0.6.0.pre"
   },
   {
     "integration": "mongo",

--- a/docs/integration_versions.md
+++ b/docs/integration_versions.md
@@ -29,7 +29,7 @@ For a list of available integrations, and their supported version ranges, refer 
 | graphql                  | 1.13.21             | 2.3.22              |
 | grpc                     | 1.48.0              | 1.67.0              |
 | hanami                   | 1.3.5               | 1.3.5               |
-| http                     | 5.0.1               | 6.0.2               |
+| http                     | 0.6.0               | 0.9.1               |
 | httpclient               | 2.8.3               | 2.9.0               |
 | httprb                   | 5.0.1               | 6.0.2               |
 | httpx                    | [3rd-party support](https://honeyryderchuck.gitlab.io/httpx/) | [3rd-party support](https://honeyryderchuck.gitlab.io/httpx/) |
@@ -37,7 +37,7 @@ For a list of available integrations, and their supported version ranges, refer 
 | karafka                  | 2.0.41              | 2.5.9               |
 | kicks                    | 3.0.0               | 3.2.0               |
 | lograge                  | 0.12.0              | 0.14.0              |
-| makara                   | 0.5.1               | 0.5.1               |
+| makara                   | 0.5.1               | 0.6.0.pre           |
 | mongo                    | 2.11.0              | 2.24.1              |
 | mysql2                   | 0.5.5               | 0.5.7               |
 | opensearch               | 2.1.0               | 3.4.0               |


### PR DESCRIPTION
We were doing a bunch of hacks, instead of using integration metadata information already present in `Datadog::Tracing::Contrib::REGISTRY`.

This PR cleans that up.

Most importantly, this fixed the duplicated package named `"package": "http"`. One is `net/http` the other `http.rb`, which is now correctly reported.

**Change log entry**
No.
