### PR TITLE
Improve macOS profiling compile guidance

### DIFF
--- a/ext/datadog_profiling_native_extension/native_extension_helpers.rb
+++ b/ext/datadog_profiling_native_extension/native_extension_helpers.rb
@@ -87,6 +87,12 @@ module Datadog
           "Get in touch with us if you're interested in profiling your app!"
         ].freeze
 
+        MACOS_DEVELOPMENT = [
+          "To compile the profiler for development, set",
+          "`DD_PROFILING_MACOS_TESTING=true` and run `bundle exec rake clean compile`.",
+          "See docs/LibdatadogDevelopment.md for more info."
+        ].freeze
+
         UPGRADE_RUBY = [
           "Upgrade to a modern Ruby to enable profiling for your app."
         ].freeze
@@ -161,7 +167,7 @@ module Datadog
         private_class_method def self.on_macos?
           macos_not_supported = explain_issue(
             "macOS is currently not supported by the Datadog Continuous Profiler.",
-            suggested: GET_IN_TOUCH,
+            suggested: MACOS_DEVELOPMENT,
           )
           # For development only; not supported otherwise
           macos_testing_override = ENV["DD_PROFILING_MACOS_TESTING"] == "true"

--- a/spec/datadog/profiling/native_extension_helpers_spec.rb
+++ b/spec/datadog/profiling/native_extension_helpers_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
       reason&.fetch(:reason)&.join("\n")
     end
 
+    let(:suggested) { described_class.unsupported_reason&.fetch(:suggested)&.join("\n") }
+
     before do
       allow(RbConfig::CONFIG).to receive(:[]).and_call_original
     end
@@ -61,7 +63,14 @@ RSpec.describe Datadog::Profiling::NativeExtensionHelpers::Supported do
 
         before { stub_const("RUBY_PLATFORM", "x86_64-darwin19") }
 
-        it { is_expected.to include "macOS" }
+        it { is_expected.to include "macOS is currently not supported" }
+
+        it "explains how to compile for development" do
+          expect(suggested).to include "for development"
+          expect(suggested).to include "DD_PROFILING_MACOS_TESTING=true"
+          expect(suggested).to include "bundle exec rake clean compile"
+          expect(suggested).to include "docs/LibdatadogDevelopment.md"
+        end
       end
 
       context "when not on Linux" do


### PR DESCRIPTION
Added explanation on how to compile the profiler for MacOS development to the compilation error message.

Today, 

```
+------------------------------------------------------------------------------+
| Could not compile the Datadog Continuous Profiler because                    |
| macOS is currently not supported by the Datadog Continuous Profiler.         |
|                                                                              |
| The Datadog Continuous Profiler will not be available,                       |
| but all other datadog features will work fine!                               |
|                                                                              |
| Get in touch with us if you're interested in profiling your app!             |
+------------------------------------------------------------------------------+
```

After this PR:
```
+------------------------------------------------------------------------------+
| Could not compile the Datadog Continuous Profiler because                    |
| macOS is currently not supported by the Datadog Continuous Profiler.         |
|                                                                              |
| The Datadog Continuous Profiler will not be available,                       |
| but all other datadog features will work fine!                               |
|                                                                              |
| To compile the profiler for development, set                                 |
| `DD_PROFILING_MACOS_TESTING=true` and run `bundle exec rake clean compile`.  |
| See docs/LibdatadogDevelopment.md for more info.                             |
+------------------------------------------------------------------------------+
```

I think this is more accurate of the desired experience, and prevents developers from having to find the correct way to make changes to the profiler.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
No.
