### PR TITLE
[NO-TICKET] Profiling: Fix using state on thread without GVL

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -635,19 +635,19 @@ static VALUE stop(VALUE self_instance, VALUE optional_exception, const char *opt
 // We need to be careful not to change any state that may be observed OR to restore it if we do. For instance, if anything
 // we do here can set `errno`, then we must be careful to restore the old `errno` after the fact.
 static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED siginfo_t *_info, DDTRACE_UNUSED void *_ucontext) {
-  cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
-
-  // This can potentially happen if the CpuAndWallTimeWorker was stopped while the signal delivery was happening; nothing to do
-  if (state == NULL) return;
-
+  // We must first check that we landed on the correct thread and can proceed.
+  // We must never touch the state before we confirm that we have landed on the thread that is holding the GVL on the main
+  // ractor as otherwise we may be concurrent with the profiler shutting down and removing its state.
   if (
     !ruby_native_thread_p() || // Not a Ruby thread
     !is_current_thread_holding_the_gvl() || // Not safe to enqueue a sample from this thread
     !ddtrace_rb_ractor_main_p() // We're not on the main Ractor; we currently don't support profiling non-main Ractors
-  ) {
-    // Never touch the `state` here -- since we don't have the GVL we may be concurrent with the profiler shutting down and whatnot
-    return;
-  }
+  ) return;
+
+  cpu_and_wall_time_worker_state *state = active_sampler_instance_state; // Read from global variable, see "sampler global state safety" note above
+
+  // This can potentially happen if the CpuAndWallTimeWorker was stopped while the signal delivery was happening; nothing to do
+  if (state == NULL) return;
 
   // We assume there can be no concurrent nor nested calls to handle_sampling_signal because
   // a) we get triggered using SIGPROF, and the docs state a second SIGPROF will not interrupt an existing one (see sigaction docs on sa_mask)

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -154,8 +154,6 @@ typedef struct {
     unsigned int signal_handler_enqueued_sample;
     // How many times we prepared a sample (sampled directly) from the signal handler
     unsigned int signal_handler_prepared_sample;
-    // How many times the signal handler was called from the wrong thread
-    unsigned int signal_handler_wrong_thread;
     // How many times we actually tried to interrupt a thread for sampling
     unsigned int interrupt_thread_attempts;
 
@@ -647,7 +645,7 @@ static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
     !is_current_thread_holding_the_gvl() || // Not safe to enqueue a sample from this thread
     !ddtrace_rb_ractor_main_p() // We're not on the main Ractor; we currently don't support profiling non-main Ractors
   ) {
-    state->stats.signal_handler_wrong_thread++;
+    // Never touch the `state` here -- since we don't have the GVL we may be concurrent with the profiler shutting down and whatnot
     return;
   }
 
@@ -1104,7 +1102,6 @@ static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance) {
     ID2SYM(rb_intern("simulated_signal_delivery")),                  /* => */ UINT2NUM(state->stats.simulated_signal_delivery),
     ID2SYM(rb_intern("signal_handler_enqueued_sample")),             /* => */ UINT2NUM(state->stats.signal_handler_enqueued_sample),
     ID2SYM(rb_intern("signal_handler_prepared_sample")),             /* => */ UINT2NUM(state->stats.signal_handler_prepared_sample),
-    ID2SYM(rb_intern("signal_handler_wrong_thread")),                /* => */ UINT2NUM(state->stats.signal_handler_wrong_thread),
     ID2SYM(rb_intern("interrupt_thread_attempts")),                  /* => */ UINT2NUM(state->stats.interrupt_thread_attempts),
 
     // CPU Stats

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1377,7 +1377,6 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           trigger_simulated_signal_delivery_attempts: 0,
           simulated_signal_delivery: 0,
           signal_handler_enqueued_sample: 0,
-          signal_handler_wrong_thread: 0,
           signal_handler_prepared_sample: 0,
           interrupt_thread_attempts: 0,
           cpu_sampled: 0,


### PR DESCRIPTION
**What does this PR do?**

This PR removes the `signal_handler_wrong_thread` stat, which we were keeping inside the state and bumping when we landed on a thread without GVL.

As pointed out in
https://github.com/DataDog/dd-trace-rb/pull/5960#discussion_r3535525017 this is unsafe: if the signal landed on a thread without the GVL, then we don't know what's going on concurrently so touching the state is not a good idea.

**Motivation:**

Avoid potential issue.

**Change log entry**

None. (This counter was internal and never user-visible)

**Additional Notes:**

In practice, for this to bite us, the following would need to happen:

* A signal arrives on the wrong thread (let's call it `wt`)
* `wt` observes a non-NULL `state` (profiler is active)
* `wt` loses the CPU before it bumps the stat
* The profiler gets stopped
* Ruby GC runs
* The state is cleaned
* `wt` resumes, and bumps the stat on an invalid state

So I wonder if this ever happened once in practice or not. Nevertheless, this counter was never used for anything (hence why the diff to remove it is very short), and we can always restore it as a global counter or something if we ever need it again.

**How to test the change?**

Green CI is good -- this counter is no longer kept.