### PR TITLE
Add missing products to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,6 +37,44 @@ ci-app:
 - changed-files:
   - any-glob-to-any-file: ['lib/datadog/ci/**']
 
+# Changes to Data Streams Monitoring
+dsm:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'lib/datadog/data_streams.rb'
+    - 'lib/datadog/data_streams/**'
+
+# Changes to OpenFeature
+openfeature:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'lib/datadog/open_feature.rb'
+    - 'lib/datadog/open_feature/**'
+
+# Changes to Database Monitoring
+dbm:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'lib/datadog/tracing/contrib/propagation/sql_comment.rb'
+    - 'lib/datadog/tracing/contrib/propagation/sql_comment/**'
+    - 'lib/datadog/tracing/contrib/{pg,mysql2,trilogy}/**'
+
+# Changes to Log Management
+logging:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'lib/datadog/core/logging/**'
+    - 'lib/datadog/tracing/correlation.rb'
+    - 'lib/datadog/tracing/contrib/**/log_injection.rb'
+    - 'lib/datadog/tracing/contrib/{lograge,semantic_logger}/**'
+    - 'lib/datadog/opentelemetry/logs.rb'
+    - 'lib/datadog/opentelemetry/sdk/logs_exporter.rb'
+
+# Changes to Serverless Monitoring
+serverless:
+- changed-files:
+  - any-glob-to-any-file: ['lib/datadog/appsec/contrib/aws_lambda/**']
+
 # Changes to ASM
 appsec:
 - changed-files:


### PR DESCRIPTION
I noticed that a recent DSM PR didn't have useful labels, so this PR associates code changes for real Datadog products with (already existing) GitHub labels.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
No.