### PR TITLE
[NO-TICKET] Profiling: Clean up logic for tracking time spent in GC

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -43,11 +43,8 @@
 // When `thread_context_collector_on_gc_start` gets called, the current cpu and wall-time get recorded to the thread
 // context: `cpu_time_at_gc_start_ns` and `wall_time_at_gc_start_ns`.
 //
-// While `cpu_time_at_gc_start_ns` is set, regular samples (if any) do not account for cpu-time any time that passes
-// after this timestamp. The idea is that this cpu-time will be blamed separately on GC, and not on the user thread.
-// Wall-time accounting is not affected by this (e.g. we still record 60 seconds every 60 seconds).
-//
-// (Regular samples can still account for the cpu-time between the previous sample and the start of GC.)
+// While `cpu_time_at_gc_start_ns` is set, we don't expect the thread to be sampled: the VM is doing GC
+// on the thread holding the GVL so no other samples can/will be triggered until GC finishes.
 //
 // When `thread_context_collector_on_gc_finish` gets called, the cpu-time and wall-time spent during GC gets recorded
 // into the global gc_tracking structure, and further samples are not affected. (The `cpu_time_at_previous_sample_ns`
@@ -326,7 +323,7 @@ static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context)
 static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE hash);
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state);
 static VALUE _native_per_thread_context(VALUE self, VALUE collector_instance);
-static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, long gc_start_time_ns, bool is_wall_time);
+static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, per_thread_context *thread_context, bool is_wall_time);
 static long cpu_time_now_ns(per_thread_context *thread_context);
 static long thread_id_for(VALUE thread);
 static VALUE _native_stats(VALUE self, VALUE collector_instance);
@@ -707,13 +704,13 @@ static void record_sampling_overhead(thread_context_collector_state *state, per_
   long overhead_cpu_time_ns = update_time_since_previous_sample(
     &current_thread_context->cpu_time_at_previous_sample_ns,
     cpu_time_after_sampling,
-    current_thread_context->gc_tracking.cpu_time_at_start_ns,
+    current_thread_context,
     IS_CPU_TIME);
 
   long overhead_wall_time_ns = update_time_since_previous_sample(
     &current_thread_context->wall_time_at_previous_sample_ns,
     wall_time_after_sampling,
-    INVALID_TIME,
+    current_thread_context,
     IS_WALL_TIME);
 
   ddog_prof_Label overhead_labels[] = {
@@ -813,14 +810,14 @@ static void update_metrics_and_sample(
   long cpu_time_elapsed_ns = is_gvl_waiting_state ? 0 : update_time_since_previous_sample(
     &thread_context->cpu_time_at_previous_sample_ns,
     current_cpu_time_ns,
-    thread_context->gc_tracking.cpu_time_at_start_ns,
+    thread_context,
     IS_CPU_TIME
   );
 
   long wall_time_elapsed_ns = update_time_since_previous_sample(
     &thread_context->wall_time_at_previous_sample_ns,
     current_monotonic_wall_time_ns,
-    INVALID_TIME,
+    thread_context,
     IS_WALL_TIME
   );
 
@@ -973,9 +970,9 @@ bool thread_context_collector_on_gc_finish(VALUE self_instance) {
   state->gc_tracking.accumulated_wall_time_ns += gc_wall_time_elapsed_ns;
   state->gc_tracking.wall_time_at_previous_gc_ns = wall_time_at_finish_ns;
 
-  // Update cpu-time accounting so it doesn't include the cpu-time spent in GC during the next sample
-  // We don't update the wall-time because we don't subtract the wall-time spent in GC (see call to
-  // `update_time_since_previous_sample` for wall-time in `update_metrics_and_sample`).
+  // Update cpu-time accounting so it doesn't include the cpu-time spent in GC during the next sample.
+  // We don't do the same for wall-time, because GC is just like any other reason a thread didn't make
+  // progress -- time always goes forward regardless of the thread making progress on what it wanted. 
   if (thread_context->cpu_time_at_previous_sample_ns != INVALID_TIME) {
     thread_context->cpu_time_at_previous_sample_ns += gc_cpu_time_elapsed_ns;
   }
@@ -1409,31 +1406,26 @@ static VALUE _native_per_thread_context(DDTRACE_UNUSED VALUE _self, VALUE collec
   return result;
 }
 
-// gc_start_time_ns should only be passed if IS_CPU_TIME
-static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, long gc_start_time_ns, bool is_wall_time) {
+static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, per_thread_context *thread_context, bool is_wall_time) {
   // If we didn't have a time for the previous sample, we use the current one
   if (*time_at_previous_sample_ns == INVALID_TIME) *time_at_previous_sample_ns = current_time_ns;
 
-  // We don't want wall-time accounting to change during GC.
-  // E.g. if 60 seconds pass in the real world, 60 seconds of wall-time are recorded, regardless of the thread doing GC or not.
-  bool is_thread_doing_gc = !is_wall_time && gc_start_time_ns != INVALID_TIME;
-  long elapsed_time_ns = -1;
-
-  if (is_thread_doing_gc) {
-    bool previous_sample_was_during_gc = gc_start_time_ns <= *time_at_previous_sample_ns;
-
-    if (previous_sample_was_during_gc) {
-      elapsed_time_ns = 0; // No time to account for -- any time since the last sample is going to get assigned to GC separately
-    } else {
-      elapsed_time_ns = gc_start_time_ns - *time_at_previous_sample_ns; // Capture time between previous sample and start of GC only
-    }
-
-    // Remaining time (from gc_start_time to current_time_ns) will be accounted for inside `sample_after_gc`
-    *time_at_previous_sample_ns = gc_start_time_ns;
-  } else {
-    elapsed_time_ns = current_time_ns - *time_at_previous_sample_ns; // Capture all time since previous sample
-    *time_at_previous_sample_ns = current_time_ns;
+  // We don't expect to be sampling a thread (and thus updating these counters) while Ruby is doing GC (between
+  // `thread_context_collector_on_gc_start` and `thread_context_collector_on_gc_finish`)
+  if (thread_context->gc_tracking.cpu_time_at_start_ns != INVALID_TIME) {
+    raise_error(
+      rb_eRuntimeError,
+      "BUG: Unexpected sample during GC (thread_id=%s, gc_tracking.cpu_time_at_start_ns=%ld, "
+      "gc_tracking.wall_time_at_start_ns=%ld, monotonic_wall_time_now_ns=%ld)",
+      thread_context->thread_id,
+      thread_context->gc_tracking.cpu_time_at_start_ns,
+      thread_context->gc_tracking.wall_time_at_start_ns,
+      monotonic_wall_time_now_ns(RAISE_ON_FAILURE)
+    );
   }
+
+  long elapsed_time_ns = current_time_ns - *time_at_previous_sample_ns; // Capture all time since previous sample
+  *time_at_previous_sample_ns = current_time_ns;
 
   if (elapsed_time_ns < 0) {
     if (is_wall_time) {
@@ -2327,14 +2319,14 @@ void thread_context_collector_on_serialize(VALUE self_instance) {
       long cpu_time_elapsed_ns = update_time_since_previous_sample(
         &thread_context->cpu_time_at_previous_sample_ns,
         current_cpu_time_ns,
-        thread_context->gc_tracking.cpu_time_at_start_ns,
+        thread_context,
         IS_CPU_TIME
       );
 
       long duration_until_start_of_gvl_waiting_ns = update_time_since_previous_sample(
         &thread_context->wall_time_at_previous_sample_ns,
         gvl_waiting_started_wall_time_ns,
-        INVALID_TIME,
+        thread_context,
         IS_WALL_TIME
       );
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -73,8 +73,6 @@
 
 #define THREAD_ID_LIMIT_CHARS 44 // Why 44? "#{2**64} (#{2**64})".size + 1 for \0
 #define THREAD_INVOKE_LOCATION_LIMIT_CHARS 512
-#define IS_WALL_TIME true
-#define IS_CPU_TIME false
 #define MISSING_TRACER_CONTEXT_KEY 0
 #define TIME_BETWEEN_GC_EVENTS_NS MILLIS_AS_NS(10)
 #define GVL_SUSPENDED ((uint64_t)1)
@@ -323,7 +321,8 @@ static VALUE per_thread_context_to_ruby_hash(per_thread_context *thread_context)
 static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE hash);
 static VALUE gc_tracking_as_ruby_hash(thread_context_collector_state *state);
 static VALUE _native_per_thread_context(VALUE self, VALUE collector_instance);
-static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, per_thread_context *thread_context, bool is_wall_time);
+static long update_cpu_time_since_previous_sample(per_thread_context *thread_context, long current_cpu_time_ns);
+static long update_wall_time_since_previous_sample(per_thread_context *thread_context, long current_wall_time_ns);
 static long cpu_time_now_ns(per_thread_context *thread_context);
 static long thread_id_for(VALUE thread);
 static VALUE _native_stats(VALUE self, VALUE collector_instance);
@@ -701,17 +700,8 @@ static void record_sampling_overhead(thread_context_collector_state *state, per_
   long wall_time_after_sampling = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
   long cpu_time_after_sampling = cpu_time_now_ns(current_thread_context);
 
-  long overhead_cpu_time_ns = update_time_since_previous_sample(
-    &current_thread_context->cpu_time_at_previous_sample_ns,
-    cpu_time_after_sampling,
-    current_thread_context,
-    IS_CPU_TIME);
-
-  long overhead_wall_time_ns = update_time_since_previous_sample(
-    &current_thread_context->wall_time_at_previous_sample_ns,
-    wall_time_after_sampling,
-    current_thread_context,
-    IS_WALL_TIME);
+  long overhead_cpu_time_ns = update_cpu_time_since_previous_sample(current_thread_context, cpu_time_after_sampling);
+  long overhead_wall_time_ns = update_wall_time_since_previous_sample(current_thread_context, wall_time_after_sampling);
 
   ddog_prof_Label overhead_labels[] = {
     {.key = DDOG_CHARSLICE_C("thread id"), .str = DDOG_CHARSLICE_C("0"), .num = 0},
@@ -807,19 +797,9 @@ static void update_metrics_and_sample(
   if (skip_sample(state, thread_context, is_gvl_waiting_state, force_sample)) return;
 
   // Don't assign/update cpu during "Waiting for GVL"
-  long cpu_time_elapsed_ns = is_gvl_waiting_state ? 0 : update_time_since_previous_sample(
-    &thread_context->cpu_time_at_previous_sample_ns,
-    current_cpu_time_ns,
-    thread_context,
-    IS_CPU_TIME
-  );
+  long cpu_time_elapsed_ns = is_gvl_waiting_state ? 0 : update_cpu_time_since_previous_sample(thread_context, current_cpu_time_ns);
 
-  long wall_time_elapsed_ns = update_time_since_previous_sample(
-    &thread_context->wall_time_at_previous_sample_ns,
-    current_monotonic_wall_time_ns,
-    thread_context,
-    IS_WALL_TIME
-  );
+  long wall_time_elapsed_ns = update_wall_time_since_previous_sample(thread_context, current_monotonic_wall_time_ns);
 
   // A thread enters "Waiting for GVL", well, as the name implies, without the GVL.
   //
@@ -1406,7 +1386,7 @@ static VALUE _native_per_thread_context(DDTRACE_UNUSED VALUE _self, VALUE collec
   return result;
 }
 
-static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, per_thread_context *thread_context, bool is_wall_time) {
+static long update_time_since_previous_sample(long *time_at_previous_sample_ns, long current_time_ns, per_thread_context *thread_context) {
   // If we didn't have a time for the previous sample, we use the current one
   if (*time_at_previous_sample_ns == INVALID_TIME) *time_at_previous_sample_ns = current_time_ns;
 
@@ -1427,20 +1407,36 @@ static long update_time_since_previous_sample(long *time_at_previous_sample_ns, 
   long elapsed_time_ns = current_time_ns - *time_at_previous_sample_ns; // Capture all time since previous sample
   *time_at_previous_sample_ns = current_time_ns;
 
+  return elapsed_time_ns;
+}
+
+static long update_cpu_time_since_previous_sample(per_thread_context *thread_context, long current_cpu_time_ns) {
+  long elapsed_time_ns = update_time_since_previous_sample(
+    &thread_context->cpu_time_at_previous_sample_ns,
+    current_cpu_time_ns,
+    thread_context
+  );
+
+  // We don't expect cpu-time to go backwards, so let's flag this as a bug
   if (elapsed_time_ns < 0) {
-    if (is_wall_time) {
-      // Wall-time can actually go backwards (e.g. when the system clock gets set) so we can't assume time going backwards
-      // was a bug.
-      // @ivoanjo: I've also observed time going backwards spuriously on macOS, see discussion on
-      // https://github.com/DataDog/dd-trace-rb/pull/2336.
-      elapsed_time_ns = 0;
-    } else {
-      // We don't expect non-wall time to go backwards, so let's flag this as a bug
-      raise_error(rb_eRuntimeError, "BUG: Unexpected negative elapsed_time_ns between samples");
-    }
+    raise_error(rb_eRuntimeError, "BUG: Unexpected negative elapsed_time_ns between samples");
   }
 
   return elapsed_time_ns;
+}
+
+static long update_wall_time_since_previous_sample(per_thread_context *thread_context, long current_wall_time_ns) {
+  long elapsed_time_ns = update_time_since_previous_sample(
+    &thread_context->wall_time_at_previous_sample_ns,
+    current_wall_time_ns,
+    thread_context
+  );
+
+  // Wall-time can actually go backwards (e.g. when the system clock gets set) so we can't assume time going backwards
+  // was a bug.
+  // @ivoanjo: I've also observed time going backwards spuriously on macOS, see discussion on
+  // https://github.com/DataDog/dd-trace-rb/pull/2336.
+  return long_max_of(elapsed_time_ns, 0);
 }
 
 // Safety: This function is assumed never to raise exceptions by callers
@@ -2316,19 +2312,10 @@ void thread_context_collector_on_serialize(VALUE self_instance) {
     long gvl_waiting_started_wall_time_ns = labs(gvl_waiting_at);
 
     if (thread_context->wall_time_at_previous_sample_ns < gvl_waiting_started_wall_time_ns) { // situation 1 above
-      long cpu_time_elapsed_ns = update_time_since_previous_sample(
-        &thread_context->cpu_time_at_previous_sample_ns,
-        current_cpu_time_ns,
-        thread_context,
-        IS_CPU_TIME
-      );
+      long cpu_time_elapsed_ns = update_cpu_time_since_previous_sample(thread_context, current_cpu_time_ns);
 
-      long duration_until_start_of_gvl_waiting_ns = update_time_since_previous_sample(
-        &thread_context->wall_time_at_previous_sample_ns,
-        gvl_waiting_started_wall_time_ns,
-        thread_context,
-        IS_WALL_TIME
-      );
+      long duration_until_start_of_gvl_waiting_ns =
+        update_wall_time_since_previous_sample(thread_context, gvl_waiting_started_wall_time_ns);
 
       // Push extra sample
       trigger_sample_for_thread(

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1419,7 +1419,7 @@ static long update_cpu_time_since_previous_sample(per_thread_context *thread_con
 
   // We don't expect cpu-time to go backwards, so let's flag this as a bug
   if (elapsed_time_ns < 0) {
-    raise_error(rb_eRuntimeError, "BUG: Unexpected negative elapsed_time_ns between samples");
+    raise_error(rb_eRuntimeError, "BUG: Unexpected CPU time going backwards between samples");
   }
 
   return elapsed_time_ns;

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -188,11 +188,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     yield
   end
 
-  # This method exists only so we can look for its name in the stack trace in a few tests
-  def another_way_of_calling_sample
-    sample
-  end
-
   describe ".new" do
     it "sets the waiting_for_gvl_threshold_ns to the provided value" do
       # This is a bit ugly but it saves us from having to introduce yet another way to poke at the native state
@@ -313,31 +308,12 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
       expect(t1_samples.map(&:values).map { |it| it.fetch(:"cpu-samples") }.reduce(:+)).to eq 5
     end
 
-    # WARNING:
-    # The following tests do on_gc_start() + sample() on the same thread,
-    # which cannot happen in reality since when a thread is doing GC it's definitely not calling Ruby methods.
-    # They should be changed to be more realistic if possible, probably by simplifying the state changes around GC
-    # so it does not e.g. prevent regular time to advance and is more like GVL waiting tracking.
-
-    context "when a thread is marked as being in garbage collection by on_gc_start" do
-      # @ivoanjo: This spec exists because for cpu-time the behavior is not this one (e.g. we don't keep recording
-      # cpu-time), and I wanted to validate that the different behavior does not get applied to wall-time.
-      it "keeps recording the wall-time after every sample" do
-        sample
-        wall_time_at_first_sample = per_thread_context.fetch(Thread.current).fetch(:wall_time_at_previous_sample_ns)
-
+    context "when a thread is in the middle of garbage collection (on_gc_start called without on_gc_finish)" do
+      it do
         on_gc_start
 
-        5.times { sample } # See WARNING above
-
-        time_after = Datadog::Core::Utils::Time.get_time(:nanosecond)
-
-        sample
-
-        wall_time_at_last_sample = per_thread_context.fetch(Thread.current).fetch(:wall_time_at_previous_sample_ns)
-
-        expect(wall_time_at_last_sample).to be >= wall_time_at_first_sample
-        expect(wall_time_at_last_sample).to be >= time_after
+        expect { sample(allow_exception: true) }
+          .to raise_error(RuntimeError, /BUG: Unexpected sample during GC/)
       end
     end
 
@@ -355,64 +331,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             .reduce(:+)
 
         expect(total_cpu_for_rspec_thread).to be_between(1, rspec_thread_spent_cpu_time)
-      end
-
-      context "when a thread is marked as being in garbage collection by on_gc_start" do
-        it "records the cpu-time between a previous sample and the start of garbage collection, and no further time" do
-          sample
-          cpu_time_at_first_sample = per_thread_context.fetch(Thread.current).fetch(:cpu_time_at_previous_sample_ns)
-
-          on_gc_start
-
-          cpu_time_at_gc_start = per_thread_context.fetch(Thread.current).fetch(:"gc_tracking.cpu_time_at_start_ns")
-
-          # Even though we keep calling sample, the result only includes the time until we called on_gc_start
-          5.times { another_way_of_calling_sample } # See WARNING above
-
-          total_cpu_for_rspec_thread =
-            samples_for_thread(samples, Thread.current)
-              .select { |it| it.locations.find { |frame| frame.base_label == "another_way_of_calling_sample" } }
-              .map { |it| it.values.fetch(:"cpu-time") }
-              .reduce(:+)
-
-          expect(total_cpu_for_rspec_thread).to be(cpu_time_at_gc_start - cpu_time_at_first_sample)
-        end
-
-        # When a thread is marked as being in GC the cpu_time_at_previous_sample_ns is not allowed to advance until
-        # the GC finishes.
-        it "does not advance cpu_time_at_previous_sample_ns for the thread beyond gc_tracking.cpu_time_at_start_ns" do
-          sample
-
-          on_gc_start
-
-          cpu_time_at_gc_start = per_thread_context.fetch(Thread.current).fetch(:"gc_tracking.cpu_time_at_start_ns")
-
-          5.times { sample } # See WARNING above
-
-          cpu_time_at_previous_sample_ns =
-            per_thread_context.fetch(Thread.current).fetch(:cpu_time_at_previous_sample_ns)
-
-          expect(cpu_time_at_previous_sample_ns).to be cpu_time_at_gc_start
-        end
-      end
-
-      context "when a thread is unmarked as being in garbage collection by on_gc_finish" do
-        it "lets cpu_time_at_previous_sample_ns advance again" do
-          sample
-
-          on_gc_start
-
-          cpu_time_at_gc_start = per_thread_context.fetch(Thread.current).fetch(:"gc_tracking.cpu_time_at_start_ns")
-
-          on_gc_finish
-
-          5.times { sample }
-
-          cpu_time_at_previous_sample_ns =
-            per_thread_context.fetch(Thread.current).fetch(:cpu_time_at_previous_sample_ns)
-
-          expect(cpu_time_at_previous_sample_ns).to be > cpu_time_at_gc_start
-        end
       end
     end
 

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -315,6 +315,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         expect { sample(allow_exception: true) }
           .to raise_error(RuntimeError, /BUG: Unexpected sample during GC/)
       end
+
+      # TODO: This can be removed after https://github.com/DataDog/dd-trace-rb/pull/5960 lands (it's here to prevent
+      # issues with state leaking to other tests)
+      after { on_gc_finish }
     end
 
     context "cpu-time behavior" do


### PR DESCRIPTION
**What does this PR do?**

This PR refactors the `update_time_since_previous_sample`  to remove the weird logic we had where cpu-time wasn't allowed to advance if we tried to sample between `on_gc_start` and `on_gc_finish`.

This logic was a leftover of past versions of the code where part of the time accounting for GC was split between `on_gc_finish` and `sample_after_gc`. Because we can't stop Ruby from GCing as many times as it wants before we're able to run `sample_after_gc`, this "freezing the clock" made sure we never lost GC time.

Yet, this became unneeded since https://github.com/DataDog/dd-trace-rb/pull/3313 as `on_gc_finish` immediately records all of the needed information.
Thus, we no longer need to deal with the above corner case, and we can massively simplify this logic.

**Motivation:**

Clean up unneeded and confusing logic.

**Change log entry**

None. (The whole point of this change is that this logic wasn't actually used in practice anymore)

**Additional Notes:**

I also took the opportunity to simplify the callers of `update_time_since_previous_sample` using helpers, since we were passing in a million arguments but only need to support two different cases.

**How to test the change?**

I've added a test that an exception gets raised if somehow a sample happens between `on_gc_start` and `on_gc_finish`.

The rest of the logic is unchanged, so existing test coverage is enough.