### PR TITLE
Use 31-bit arithmetic in KnuthSampler to avoid Bignum allocations

### DIFF
--- a/lib/datadog/core/knuth_sampler.rb
+++ b/lib/datadog/core/knuth_sampler.rb
@@ -37,7 +37,7 @@ module Datadog
         end
 
         @rate = rate
-        @threshold = @rate * MAX
+        @threshold = @rate * (MAX + 1)
       end
 
       # Determines if the given input should be sampled.
@@ -49,7 +49,7 @@ module Datadog
       #   Typically a trace ID or incrementing counter.
       # @return [Boolean] +true+ if input should be sampled, +false+ otherwise
       def sample?(input)
-        (((input & MAX) * @knuth_factor) & MAX) <= @threshold
+        (((input & MAX) * @knuth_factor) & MAX) < @threshold
       end
     end
   end

--- a/lib/datadog/core/knuth_sampler.rb
+++ b/lib/datadog/core/knuth_sampler.rb
@@ -13,13 +13,12 @@ module Datadog
     # @api private
     # @see https://en.wikipedia.org/wiki/Hash_function#Multiplicative_hashing
     class KnuthSampler
-      # Maximum unsigned 64-bit integer for uniform distribution across 64-bit input space.
-      UINT64_MAX = (1 << 64) - 1
-      UINT64_MODULO = 1 << 64
+      # 31-bit arithmetic keeps all intermediate values in Fixnum (max product < 2^62).
+      MAX = (1 << 31) - 1
 
-      # Golden ratio constant for optimal distribution.
+      # Golden ratio constant for optimal distribution: round(2^31 / φ).
       # @see https://en.wikipedia.org/wiki/Hash_function#Fibonacci_hashing
-      DEFAULT_KNUTH_FACTOR = 11400714819323198485
+      DEFAULT_KNUTH_FACTOR = 1327217885
 
       attr_reader :rate
 
@@ -38,7 +37,7 @@ module Datadog
         end
 
         @rate = rate
-        @threshold = @rate * UINT64_MAX
+        @threshold = @rate * MAX
       end
 
       # Determines if the given input should be sampled.
@@ -50,7 +49,7 @@ module Datadog
       #   Typically a trace ID or incrementing counter.
       # @return [Boolean] +true+ if input should be sampled, +false+ otherwise
       def sample?(input)
-        ((input * @knuth_factor) % UINT64_MODULO) <= @threshold
+        (((input & MAX) * @knuth_factor) & MAX) <= @threshold
       end
     end
   end

--- a/lib/datadog/tracing/sampling/rate_sampler.rb
+++ b/lib/datadog/tracing/sampling/rate_sampler.rb
@@ -8,7 +8,7 @@ module Datadog
     module Sampling
       # {Datadog::Tracing::Sampling::RateSampler} is based on a sample rate.
       class RateSampler < Sampler
-        KNUTH_FACTOR = 1111111111111111111
+        KNUTH_FACTOR = 734294471
 
         # Initialize a {Datadog::Tracing::Sampling::RateSampler}.
         # This sampler keeps a random subset of the traces. Its main purpose is to

--- a/spec/datadog/core/knuth_sampler_spec.rb
+++ b/spec/datadog/core/knuth_sampler_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Datadog::Core::KnuthSampler do
     context 'when custom knuth_factor is provided' do
       it 'uses the custom factor for sampling' do
         result_default = described_class.new(0.5).sample?(1)
-        result_custom = described_class.new(0.5, knuth_factor: 1111111111111111111).sample?(1)
+        result_custom = described_class.new(0.5, knuth_factor: 734294471).sample?(1)
 
         expect(result_default).not_to eq(result_custom)
       end
@@ -86,14 +86,14 @@ RSpec.describe Datadog::Core::KnuthSampler do
       subject(:sampler) { described_class.new(0.5) }
 
       {
-        12078589664685934330 => false,
-        13794769880582338323 => true,
-        1882305164521835798 => false,
-        5198373796167680436 => true,
-        6272545487220484606 => true,
-        8696342848850656916 => true,
+        12078589664685934330 => true,
+        13794769880582338323 => false,
+        1882305164521835798 => true,
+        5198373796167680436 => false,
+        6272545487220484606 => false,
+        8696342848850656916 => false,
         18444899399302180860 => true,
-        18444899399302180862 => true,
+        18444899399302180862 => false,
         9223372036854775808 => true
       }.each do |input, expected|
         it { expect(sampler.sample?(input)).to be(expected) }

--- a/spec/datadog/core/knuth_sampler_spec.rb
+++ b/spec/datadog/core/knuth_sampler_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Datadog::Core::KnuthSampler do
       end
     end
 
+    context 'when rate is 0.0' do
+      subject(:sampler) { described_class.new(0.0) }
+
+      it { expect(sampler.sample?(0)).to be(false) }
+      it { expect(sampler.sample?(1)).to be(false) }
+    end
+
     context 'when rate is ~0.0' do
       subject(:sampler) { described_class.new(Float::MIN) }
 

--- a/spec/datadog/tracing/sampling/rate_sampler_spec.rb
+++ b/spec/datadog/tracing/sampling/rate_sampler_spec.rb
@@ -127,15 +127,15 @@ RSpec.describe Datadog::Tracing::Sampling::RateSampler do
       let(:sample_rate) { 0.5 }
       let(:trace_expectations) do
         {
-          12078589664685934330 => false,
+          12078589664685934330 => true,
           13794769880582338323 => true,
-          1882305164521835798 => true,
-          5198373796167680436 => false,
+          1882305164521835798 => false,
+          5198373796167680436 => true,
           6272545487220484606 => true,
-          8696342848850656916 => true,
-          18444899399302180860 => false,
-          18444899399302180862 => true,
-          9223372036854775808 => true, # Lands exactly on the sampling threshold 0.5 * MAX_UINT64
+          8696342848850656916 => false,
+          18444899399302180860 => true,
+          18444899399302180862 => false,
+          9223372036854775808 => true,
         }
       end
 


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
The 64-bit Knuth factor and modulo caused every `sample?` call to allocate multiple Bignums. Switching to 31-bit keeps all intermediate values in Fixnum (max product < 2^62), making it ~4x faster with Fixnum inputs.

**Motivation:**
Reduce overhead of tracing. Also avoids extra allocations on a fast path.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
