### PR TITLE
Clean up stale CircleCI references

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -102,7 +102,7 @@ dev/github:
 # Only repository CI changes
 dev/ci:
 - changed-files:
-  - all-globs-to-all-files: ['{.circleci/**,.gitlab-ci.yml}']
+  - all-globs-to-all-files: ['.gitlab-ci.yml']
 
 # Version bump pull request
 release:

--- a/Rakefile
+++ b/Rakefile
@@ -71,16 +71,7 @@ namespace :test do
         command = "bundle check || bundle install && bundle exec rake #{spec_task}"
         command += "'[#{spec_arguments}]'" if spec_arguments
 
-        total_executors = ENV.key?('CIRCLE_NODE_TOTAL') ? ENV['CIRCLE_NODE_TOTAL'].to_i : nil
-        current_executor = ENV.key?('CIRCLE_NODE_INDEX') ? ENV['CIRCLE_NODE_INDEX'].to_i : nil
-
-        if total_executors && current_executor && total_executors > 1
-          @execution_count ||= 0
-          @execution_count += 1
-          Bundler.with_unbundled_env { sh(env, command) } if @execution_count % total_executors == current_executor
-        else
-          Bundler.with_unbundled_env { sh(env, command) }
-        end
+        Bundler.with_unbundled_env { sh(env, command) }
       end
     end
   end

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:3.3.0-bullseye
 
 # Make apt non-interactive
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
-  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90ci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90ci
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/spec/datadog/di/integration/instrumentation_integration_test_class.rb
+++ b/spec/datadog/di/integration/instrumentation_integration_test_class.rb
@@ -34,7 +34,7 @@ class InstrumentationIntegrationTestClass
     $__password = password = 'password'
     $__redacted = redacted = {b: 33, session: 'blah'}
     # The following condition causes instrumentation trace point callback
-    # to be invoked multiple times in CircleCI on Ruby 3.0-3.2 and 3.4
+    # to be invoked multiple times in CI on Ruby 3.0-3.2 and 3.4
     #if true || password || redacted
     if true
       a * 2 # line 40

--- a/spec/datadog/tracing/integration_spec.rb
+++ b/spec/datadog/tracing/integration_spec.rb
@@ -144,12 +144,9 @@ RSpec.describe 'Tracer integration tests' do
         skip('datadog only supports unix socket connectivity on Linux') unless PlatformHelpers.linux?
 
         # DEV: To connect to a unix socket in another docker container (the agent container in our case)
-        # we need to share a volume with that container. Our current CircleCI setup uses `docker` executors
-        # which don't support sharing volumes. We'd have to migrate to using `machine` executors
-        # and manage the docker lifecycle ourselves if we want to share unix sockets for testing.
+        # we need to share a volume with that container, which our CI setup doesn't support.
         # In the mean time, this test is being skipped in CI.
-        # @see https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-        skip("Can't share docker volume to access unix socket in CircleCI currently") if PlatformHelpers.ci?
+        skip("Can't share docker volume to access unix socket in CI currently") if PlatformHelpers.ci?
 
         Datadog.configure do |c|
           c.agent.uds_path = ENV['TEST_DDAGENT_UNIX_SOCKET']


### PR DESCRIPTION
**What does this PR do?**
Cleans up leftover references to CircleCI, which this repo stopped using a while back in favor of GitLab/GitHub Actions. The changes are wording and dead-code removal only — nothing here changes what CI actually runs.

**Motivation:**
While investigating the CI setup, I kept finding comments, filenames, and a config glob that still assumed CircleCI, which is misleading for anyone reading them today. One of these was more than cosmetic: the Rakefile had a branch meant to shard test runs across CircleCI's parallel executors via `CIRCLE_NODE_TOTAL`/`CIRCLE_NODE_INDEX`, but neither GitLab nor GitHub Actions ever sets those variables, so that branch was silently dead code.

**Change log entry**
None. Internal cleanup, no behavior change.

**Additional Notes:**
N/A.

**How to test the change?**
No behavior change; covered by existing CI checks.