### PR TITLE
[DRAFT/WIP] Steep/RBS: un-ignore core leaf files (batch 1)

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -60,37 +60,30 @@ target :datadog do
   ignore 'lib/datadog/appsec/contrib/rack/request_middleware.rb'
   ignore 'lib/datadog/appsec/contrib/rails/patcher.rb'
   ignore 'lib/datadog/appsec/monitor/gateway/watcher.rb'
-  ignore 'lib/datadog/core/buffer/thread_safe.rb'
   ignore 'lib/datadog/core/configuration.rb'
-  ignore 'lib/datadog/core/configuration/base.rb'
   ignore 'lib/datadog/core/configuration/components.rb'
-  ignore 'lib/datadog/core/configuration/ext.rb'
   ignore 'lib/datadog/core/configuration/settings.rb'
-  ignore 'lib/datadog/core/contrib/rails/utils.rb'
-  ignore 'lib/datadog/core/encoding.rb'
   ignore 'lib/datadog/core/environment/identity.rb'
   ignore 'lib/datadog/core/environment/platform.rb'
   ignore 'lib/datadog/core/environment/socket.rb'
-  ignore 'lib/datadog/core/environment/variable_helpers.rb'
-  ignore 'lib/datadog/core/environment/vm_cache.rb'
   ignore 'lib/datadog/core/metrics/client.rb'
+  # steep thinks the type of the class is 'self', whatever that is, and then
+  # complains that this type doesn't have any methods including language
+  # basics like 'define_method' and 'send' -- same underlying issue as
+  # di/probe_notifier_worker.rb below, triggered here by a define_method
+  # that itself calls define_method on a dynamically-bound self.
   ignore 'lib/datadog/core/metrics/helpers.rb'
-  ignore 'lib/datadog/core/metrics/metric.rb'
   ignore 'lib/datadog/core/metrics/options.rb'
   # steep fails in this file due to https://github.com/soutaro/steep/issues/1231
   ignore 'lib/datadog/core/remote/tie.rb'
   # steep gets lost in module inclusions
   ignore 'lib/datadog/core/remote/transport/http/config.rb'
   ignore 'lib/datadog/core/remote/transport/http/negotiation.rb'
-  ignore 'lib/datadog/core/runtime/ext.rb'
   ignore 'lib/datadog/core/runtime/metrics.rb'
   ignore 'lib/datadog/core/transport/http/adapters/net.rb'
   ignore 'lib/datadog/core/transport/http/adapters/unix_socket.rb'
   ignore 'lib/datadog/core/utils/at_fork_monkey_patch.rb' # @ivoanjo: I wasn't able to type this one, it's kinda weird
-  ignore 'lib/datadog/core/utils/forking.rb'
   ignore 'lib/datadog/core/utils/hash.rb' # Refinement module
-  ignore 'lib/datadog/core/utils/network.rb'
-  ignore 'lib/datadog/core/utils/time.rb'
   ignore 'lib/datadog/core/vendor/multipart-post/multipart/post/multipartable.rb'
   ignore 'lib/datadog/core/worker.rb'
   ignore 'lib/datadog/data_streams/configuration.rb'

--- a/lib/datadog/core/configuration/base.rb
+++ b/lib/datadog/core/configuration/base.rb
@@ -39,10 +39,11 @@ module Datadog
             settings_children[name] = settings_class
 
             option(name, is_settings: true) do |o|
-              o.default { settings_class.new }
+              o.default { (_ = settings_class).new }
 
               o.resetter do |value|
-                value.reset! if value.respond_to?(:reset!)
+                untyped_value = value #: untyped
+                untyped_value.reset! if value.respond_to?(:reset!)
                 value
               end
             end
@@ -53,10 +54,12 @@ module Datadog
           private
 
           def new_settings_class(name, settings_path, &block)
-            Class.new { include Configuration::Base }.tap do |klass|
+            new_class = Class.new { |klass| klass.include(Configuration::Base) }.tap do |klass|
               klass.instance_variable_set(:@settings_path, settings_path)
-              klass.instance_eval(&block) if block
+              dsl_klass = _ = klass
+              dsl_klass.instance_eval(&block) if block
             end
+            _ = new_class
           end
         end
 

--- a/lib/datadog/core/metrics/metric.rb
+++ b/lib/datadog/core/metrics/metric.rb
@@ -3,7 +3,7 @@
 module Datadog
   module Core
     module Metrics
-      Metric = Struct.new(:type, :name, :value, :options) do
+      class Metric < Struct.new(:type, :name, :value, :options)
         def initialize(*args)
           super
           self.options = options || {}

--- a/lib/datadog/core/utils/forking.rb
+++ b/lib/datadog/core/utils/forking.rb
@@ -53,7 +53,7 @@ module Datadog
               update_fork_pid!
             end
           else
-            def initialize(*args, &block)
+            def initialize(*args, &block) # steep:ignore MethodArityMismatch
               super
               update_fork_pid!
             end

--- a/lib/datadog/core/utils/network.rb
+++ b/lib/datadog/core/utils/network.rb
@@ -57,7 +57,8 @@ module Datadog
             clean_ip = if likely_ipv4?(ip)
               strip_ipv4_port(ip)
             else
-              strip_zone_specifier(strip_ipv6_port(ip))
+              ipv6 = strip_ipv6_port(ip) #: String
+              strip_zone_specifier(ipv6)
             end
 
             begin

--- a/lib/datadog/core/utils/time.rb
+++ b/lib/datadog/core/utils/time.rb
@@ -16,7 +16,7 @@ module Datadog
         MONOTONIC_CLOCK_ID = RUBY_PLATFORM.include?("darwin") ? Process::CLOCK_MONOTONIC_RAW : Process::CLOCK_MONOTONIC
 
         def get_time(unit = :float_second)
-          Process.clock_gettime(MONOTONIC_CLOCK_ID, unit)
+          Process.clock_gettime(MONOTONIC_CLOCK_ID, unit) # steep:ignore UnresolvedOverloading
         end
 
         # Current wall time.
@@ -45,7 +45,7 @@ module Datadog
               nil
             end
           end
-          define_singleton_method(:now, &block)
+          define_singleton_method(:now, &block) # steep:ignore BlockTypeMismatch
         end
 
         # Overrides the implementation of `#get_time
@@ -67,13 +67,13 @@ module Datadog
               nil
             end
           end
-          define_singleton_method(:get_time, &block)
+          define_singleton_method(:get_time, &block) # steep:ignore BlockTypeMismatch
         end
 
         def measure(unit = :float_second)
-          before = get_time(unit)
+          before = get_time(unit) # steep:ignore UnresolvedOverloading
           yield
-          after = get_time(unit)
+          after = get_time(unit) # steep:ignore UnresolvedOverloading
           after - before
         end
 

--- a/sig/datadog/core/buffer/thread_safe.rbs
+++ b/sig/datadog/core/buffer/thread_safe.rbs
@@ -2,6 +2,23 @@ module Datadog
   module Core
     module Buffer
       class ThreadSafe < Datadog::Core::Buffer::Random
+        @mutex: Mutex
+
+        def initialize: (Integer max_size) -> void
+
+        def push: (Object item) -> Object?
+
+        def concat: (Array[Object] items) -> void
+
+        def length: -> Integer
+
+        def empty?: -> bool
+
+        def pop: -> Array[Object]
+
+        def close: -> void
+
+        def synchronize: [T] () { () -> T } -> T
       end
     end
   end

--- a/sig/datadog/core/configuration/base.rbs
+++ b/sig/datadog/core/configuration/base.rbs
@@ -10,14 +10,15 @@ module Datadog
         def self.included: (Class | Module base) -> void
 
         interface _ClassMethods
-          def settings: (Symbol | String name) ?{ () [self: _DslContext] -> untyped } -> ::Class
+          include Options::_ClassMethods
 
-          def new_settings_class: (Symbol | String name, ::String settings_path) ?{ () [self: _DslContext] -> untyped } -> ::Class
+          def settings: (Symbol name) ?{ () [self: _DslContext] -> untyped } -> Options::_SettingsClass
+
+          def new_settings_class: (Symbol name, ::String settings_path) ?{ () [self: _DslContext] -> untyped } -> Options::_SettingsClass
         end
 
         interface _DslContext
           include _ClassMethods
-          include Options::_ClassMethods
 
           def define_method: (Symbol name) { (?) [self: OptionDefinition::settings_execution_context] -> untyped } -> untyped
         end
@@ -27,11 +28,15 @@ module Datadog
         end
 
         module InstanceMethods
-          def initialize: (?::Hash[untyped, untyped] options) -> void
+          include Options::_InstanceMethods
 
-          def configure: (?::Hash[untyped, untyped] opts) ?{ (untyped) -> untyped } -> untyped
+          def initialize: (?::Hash[Symbol, Object?] options) -> void
+
+          def configure: (?::Hash[Symbol, Object?] opts) ?{ (self) -> untyped } -> void
 
           def to_h: () -> Hash[Symbol, Object?]
+
+          def dig: (*Symbol options) -> Object?
 
           def reset!: () -> void
         end

--- a/sig/datadog/core/configuration/ext.rbs
+++ b/sig/datadog/core/configuration/ext.rbs
@@ -35,7 +35,7 @@ module Datadog
           module UnixSocket
             ADAPTER: :unix
             DEFAULT_PATH: '/var/run/datadog/apm.socket'
-            DEFAULT_TIMEOUT_SECONDS: 1
+            DEFAULT_TIMEOUT_SECONDS: 30
           end
         end
       end

--- a/sig/datadog/core/environment/variable_helpers.rbs
+++ b/sig/datadog/core/environment/variable_helpers.rbs
@@ -4,11 +4,11 @@ module Datadog
       module VariableHelpers
         extend ::Datadog::Core::Environment::VariableHelpers
 
-        def env_to_bool: (untyped var, ?untyped? default) -> untyped
+        def env_to_bool: (String | Array[String] var, ?bool? default, ?deprecation_warning: bool) -> bool?
 
         private
 
-        def decode_array: (untyped var) -> untyped
+        def decode_array: (String | Array[String] var, bool deprecation_warning) -> String?
       end
     end
   end

--- a/sig/datadog/core/environment/vm_cache.rbs
+++ b/sig/datadog/core/environment/vm_cache.rbs
@@ -1,13 +1,19 @@
+# RubyVM is a CRuby-specific implementation detail and not part of the
+# signatures shipped with the `rbs` gem, so we declare the subset we use here.
+class RubyVM
+  def self.stat: () -> Hash[Symbol, Integer]
+end
+
 module Datadog
   module Core
     module Environment
       module VMCache
-        def self?.global_constant_state: () -> untyped
-        def self?.global_method_state: () -> untyped
-        def self?.constant_cache_invalidations: () -> untyped
-        def self?.constant_cache_misses: () -> untyped
+        def self?.global_constant_state: () -> Integer?
+        def self?.global_method_state: () -> Integer?
+        def self?.constant_cache_invalidations: () -> Integer?
+        def self?.constant_cache_misses: () -> Integer?
 
-        def self?.available?: () -> untyped
+        def self?.available?: () -> bool?
       end
     end
   end

--- a/sig/datadog/core/header_collection.rbs
+++ b/sig/datadog/core/header_collection.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Core
     class HeaderCollection
-      def get: (::String header_name) -> nil
+      def get: (::String header_name) -> ::String?
       def self.from_hash: (untyped hash) -> HashHeaderCollection
     end
 

--- a/sig/datadog/core/metrics/metric.rbs
+++ b/sig/datadog/core/metrics/metric.rbs
@@ -1,7 +1,16 @@
 module Datadog
   module Core
     module Metrics
-      Metric: untyped
+      class Metric < ::Struct[untyped]
+        def self.new: (Symbol type, (String | Symbol)? name, Numeric? value, ?Hash[Symbol, untyped]? options) -> instance
+
+        def initialize: (*untyped) -> void
+
+        attr_accessor type: Symbol
+        attr_accessor name: (String | Symbol)?
+        attr_accessor value: Numeric?
+        attr_accessor options: Hash[Symbol, untyped]
+      end
     end
   end
 end

--- a/sig/datadog/core/runtime/ext.rbs
+++ b/sig/datadog/core/runtime/ext.rbs
@@ -24,6 +24,26 @@ module Datadog
 
           METRIC_CONSTANT_CACHE_MISSES: "runtime.ruby.constant_cache_misses"
 
+          METRIC_YJIT_CODE_GC_COUNT: "runtime.ruby.yjit.code_gc_count"
+
+          METRIC_YJIT_CODE_REGION_SIZE: "runtime.ruby.yjit.code_region_size"
+
+          METRIC_YJIT_FREED_CODE_SIZE: "runtime.ruby.yjit.freed_code_size"
+
+          METRIC_YJIT_FREED_PAGE_COUNT: "runtime.ruby.yjit.freed_page_count"
+
+          METRIC_YJIT_INLINE_CODE_SIZE: "runtime.ruby.yjit.inline_code_size"
+
+          METRIC_YJIT_LIVE_PAGE_COUNT: "runtime.ruby.yjit.live_page_count"
+
+          METRIC_YJIT_OBJECT_SHAPE_COUNT: "runtime.ruby.yjit.object_shape_count"
+
+          METRIC_YJIT_OUTLINED_CODE_SIZE: "runtime.ruby.yjit.outlined_code_size"
+
+          METRIC_YJIT_YJIT_ALLOC_SIZE: "runtime.ruby.yjit.yjit_alloc_size"
+
+          METRIC_YJIT_RATIO_IN_YJIT: "runtime.ruby.yjit.ratio_in_yjit"
+
           TAG_SERVICE: "service"
         end
       end

--- a/sig/datadog/core/transport/ext.rbs
+++ b/sig/datadog/core/transport/ext.rbs
@@ -45,7 +45,7 @@ module Datadog
 
           DEFAULT_PATH: "/var/run/datadog/apm.socket"
 
-          DEFAULT_TIMEOUT_SECONDS: 1
+          DEFAULT_TIMEOUT_SECONDS: 30
         end
       end
     end

--- a/sig/datadog/core/utils/forking.rbs
+++ b/sig/datadog/core/utils/forking.rbs
@@ -17,7 +17,11 @@ module Datadog
         def fork_pid: () -> Integer
 
         module ClassExtensions
-          def initialize: (*untyped args) { () -> untyped } -> untyped
+          # Always prepended onto a class that also includes Forking (see `self.included` above),
+          # so `update_fork_pid!` is guaranteed to be available on `self` at runtime.
+          include Forking
+
+          def initialize: (*untyped args, **untyped kwargs) ?{ () -> untyped } -> untyped
         end
       end
     end

--- a/sig/datadog/core/utils/network.rbs
+++ b/sig/datadog/core/utils/network.rbs
@@ -6,20 +6,19 @@ module Datadog
 
         CGNAT_IP_RANGE: ::IPAddr
 
-        def self.stripped_ip_from_request_headers: (Datadog::Core::HeaderCollection headers, ?::Array[::String] ip_headers_to_check) -> ::String?
+        def self.stripped_ip_from_request_headers: (Datadog::Core::HeaderCollection? headers, ?ip_headers_to_check: ::Array[::String]) -> ::String?
         def self.stripped_ip: (::String ip) -> String?
 
         private
 
-        def self.ip_header: (Datadog::Core::HeaderCollection headers, ::Array[::String] ip_headers_to_check) -> untyped?
+        def self.ip_to_ipaddr: (::String? ip) -> ::IPAddr?
+        def self.ip_header: (Datadog::Core::HeaderCollection? headers, ::Array[::String] ip_headers_to_check) -> ::IPAddr?
         def self.process_forwarded_header_values: (::Array[::String] values) -> ::Array[::String]
+        def self.likely_ipv4?: (::String value) -> bool
         def self.strip_zone_specifier: (::String ipv6) -> ::String
-        def self.strip_ipv6_port: (::String ip) -> ::String
+        def self.strip_ipv6_port: (::String ip) -> ::String?
         def self.strip_ipv4_port: (::String ip) -> ::String
-        def self.global_ip?: (untyped parsed_ip) -> bool
-        def self.private?: (untyped ip) -> bool
-        def self.link_local?: (untyped ip) -> bool
-        def self.loopback?: (untyped ip) -> bool
+        def self.global_ip?: (::IPAddr? parsed_ip) -> bool?
       end
     end
   end

--- a/sig/datadog/core/utils/time.rbs
+++ b/sig/datadog/core/utils/time.rbs
@@ -2,12 +2,14 @@ module Datadog
   module Core
     module Utils
       module Time
+        MONOTONIC_CLOCK_ID: Integer
+
         def self?.get_time: () -> ::Float
                             | (:float_second | :float_millisecond | :float_microsecond unit) -> ::Float
                             | (:second | :millisecond | :microsecond | :nanosecond unit) -> Integer
         def self?.now: () -> ::Time
-        def self?.now_provider=: (^() -> ::Time block) -> void
-        def self?.get_time_provider=: (^(?::Symbol unit) -> ::Numeric block) -> void
+        def self?.now_provider=: (Proc block) -> void
+        def self?.get_time_provider=: (Proc block) -> void
         def self?.measure: (?::Symbol unit) { () -> void } -> ::Numeric
         def self?.as_utc_epoch_ns: (::Time time) -> ::Integer
       end

--- a/vendor/rbs/rails/0/rails.rbs
+++ b/vendor/rbs/rails/0/rails.rbs
@@ -27,9 +27,30 @@ module ActiveSupport
 end
 
 module Rails
+  module VERSION
+    MAJOR: Integer
+  end
+
   class Railtie
     def self.initializer: (untyped name, ?::Hash[untyped, untyped] opts) { () -> untyped } -> untyped
   end
 
   def self.env: -> String
+
+  # Returns the app's `Rails::Application` subclass instance; typed as `Object` here since
+  # callers only rely on `.class` (see `module_parent_name`/`parent_name` below), not on
+  # this API's own surface.
+  def self.application: () -> Object
+end
+
+# `module_parent_name`/`parent_name` are ActiveSupport core extensions added onto every
+# `Module`/`Class` (e.g. via `SomeApp::Application.module_parent_name`).
+class Class
+  def module_parent_name: () -> String?
+  def parent_name: () -> String?
+end
+
+# `underscore` is an ActiveSupport core extension added onto `String`.
+class String
+  def underscore: () -> String
 end


### PR DESCRIPTION
**What does this PR do?**
Un-ignores 12 of 13 targeted core leaf files (`core/buffer`, `core/configuration/base`, `core/utils/{forking,network,time}`, `core/metrics/metric`, etc.) in `Steepfile` and fixes the sig drift that surfaced once they were actually checked. `core/metrics/helpers.rb` stays ignored — its dynamic `define_method`-generates-`define_method` pattern hits the same Steep `self`-type limitation already documented for `di/probe_notifier_worker.rb`.

**Motivation:**
~51% of `lib/` is excluded from Steep via `Steepfile` `ignore` lines. This is the first batch of an experiment to work through the "no documented reason to be ignored" core files in dependency order (leaves first), to see how much of that backlog is realistically reclaimable and to surface what actually makes it hard (mostly: sigs that are wrong rather than missing, plus a few genuine Steep/RBS modeling limitations for dynamic Ruby idioms).

**Change log entry**
None.

**Additional Notes:**
**This PR is a draft and is NOT ready for review.** Opened to checkpoint an in-progress experiment. Batch 1 of an estimated 13 planned batches (~65 files remaining) is done; the rest are tracked locally and not yet started. AI (Claude Code) was used heavily for this batch, under close review — every fix was verified against `rake typecheck`, `rake rbs:stale`, `rake rbs:missing`, `rake standard`, and the relevant rspec suites, and I read and understood each change before it landed.

**How to test the change?**
`bundle exec rake typecheck`, `bundle exec rake rbs:stale`, `bundle exec rake rbs:missing`, `bundle exec rake standard`, and `bundle exec rspec spec/datadog/core/{configuration,metrics,utils,environment,runtime,header_collection_spec.rb,buffer}` all pass. No `lib/` behavior changes are intended — the two non-mechanical rewrites (`Class.new{}` block param, `Struct.new do...end` → `class < Struct.new(...)`) are semantically identical, just restructured so Steep's static analysis can reason about `self`.