### PR TITLE
fix(ci): repin apm-sdks-benchmarks include ref off dangling squash-merge SHA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-ruby-acme-parallel.yml'
-    ref: 'fayssal/update-rb-ref' # TODO(pre-merge): repin to the apm-sdks-benchmarks merge-commit SHA once DataDog/apm-sdks-benchmarks#209 merges
+    ref: '5f5ca440eaab196afb8f78255c2daf2d0bdcc492' # apm-sdks-benchmarks#209 merge commit
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-ruby-acme-parallel.yml'
-    ref: '52a8c0712ac6409f488fb2fb1266e886a9cbf816'
+    ref: 'fayssal/update-rb-ref' # TODO(pre-merge): repin to the apm-sdks-benchmarks merge-commit SHA once DataDog/apm-sdks-benchmarks#209 merges
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby


### PR DESCRIPTION
**What does this PR do?**

Repoints the `apm-sdks-benchmarks` `include: ref:` in `.gitlab-ci.yml` off a dangling commit SHA (`52a8c07...`) that no longer exists anywhere reachable, to `5f5ca440`, the merge commit of the companion fix.

**Motivation:**

The Ruby benchmark pipeline (`ruby-acme-parallel*` stages) fails with:

```
fatal: reference is not a tree: e5f4885074854207bdc785471fc470fe7707a7a1
```

Root cause: `.gitlab-ci.yml`'s `include:` block pins to `52a8c07...`, a commit that only ever existed on the feature branch of `apm-sdks-benchmarks#191`. That PR was squash-merged on GitHub, so `52a8c07...` was never part of `apm-sdks-benchmarks`'s `main` and is dangling. That commit's file content also bakes in another dangling SHA (`APM_SDKS_BENCHMARKS_SHA: e5f4885...`) from the same feature branch, which is what the checkout step in the included file actually fails on.

Companion PR **DataDog/apm-sdks-benchmarks#209** fixed the `APM_SDKS_BENCHMARKS_SHA` pin on the `apm-sdks-benchmarks` side and has merged as `5f5ca440eaab196afb8f78255c2daf2d0bdcc492`. This PR now pins `ref:` to that permanent, reachable merge-commit SHA (not the feature branch, which would repeat the exact class of bug being fixed here).

**Change log entry**

None. CI-only change, not customer-visible.

**Additional Notes:**

Validated end-to-end on a live GitLab pipeline run against this fix (pipeline 123751612, triggered from the `fayssal/update-rb-ref` branch): `build-and-push-image`, `linux-ruby-acme-parallel`, `ruby-acme-parallel-check-slo-breaches`, `ruby-acme-parallel-notify-slo-breaches`, `ruby-acme-parallel-generate-slos`, and `ruby-acme-parallel-upload-to-bp-api` all succeeded.

**How to test the change?**

No Ruby code paths are affected — this only changes which commit of `apm-sdks-benchmarks`'s `.gitlab/ci-ruby-acme-parallel.yml` is included by this repo's GitLab pipeline. Validated via a live pipeline run (see above); confirmed the target SHA is a real, reachable commit on `apm-sdks-benchmarks` `main`.