### PR TITLE
[PROF-15376] Profiling: Disable live heap size profiling on Ruby 4 due to incompatibility

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -244,6 +244,14 @@ module Datadog
 
         return false unless heap_profiling_enabled && heap_size_profiling_enabled
 
+        if RubyVersion.is?(">= 4")
+          logger.info(
+            "Heap live size profiling is currently incompatible with Ruby 4 and has been disabled. " \
+            "Heap live objects is not affected and remains enabled."
+          )
+          return false
+        end
+
         true
       end
 

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:gc_profiling_enabled) { true }
   let(:allocation_profiling_enabled) { false }
   let(:heap_profiling_enabled) { false }
+  let(:heap_size_profiling_available) { RubyVersion.is?("< 4") } # Currently incompatible with Ruby 4
+  let(:heap_size_profiling_enabled) { heap_profiling_enabled && heap_size_profiling_available }
   let(:recorder) do
     Datadog::Profiling::StackRecorder.for_testing(
       alloc_samples_enabled: true,
       heap_samples_enabled: heap_profiling_enabled,
-      heap_size_enabled: heap_profiling_enabled,
+      heap_size_enabled: heap_size_profiling_enabled,
       **stack_recorder_options,
     )
   end
@@ -968,7 +970,9 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         expected_size_of_object = 40 # 40 is the size of a basic object and we have test_num_allocated_object of them
 
-        expect(total_size).to eq test_num_allocated_object * expected_size_of_object
+        if heap_size_profiling_available
+          expect(total_size).to eq test_num_allocated_object * expected_size_of_object
+        end
       end
 
       describe "heap cleanup after GC" do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -342,6 +342,7 @@ RSpec.describe Datadog::Profiling::Component do
         context "when heap profiling is enabled", ruby: '>= 2.7' do
           # Universally supported ruby version for allocation profiling by default
           let(:testing_version) { "3.3.0" }
+          let(:heap_size_profiling_available) { RubyVersion.is?("< 4") } # Currently incompatible with Ruby 4
 
           before do
             settings.profiling.advanced.experimental_heap_enabled = true
@@ -387,7 +388,7 @@ RSpec.describe Datadog::Profiling::Component do
 
             it "initializes StackRecorder with heap sampling support and warns" do
               expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
+                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: heap_size_profiling_available))
                 .and_call_original
 
               expect(logger).to receive(:debug).with(/Ractors.+stopping/)
@@ -402,10 +403,12 @@ RSpec.describe Datadog::Profiling::Component do
 
               before { allow(logger).to receive(:debug) }
 
-              it "initializes StackRecorder with heap sampling support" do
+              it "initializes StackRecorder with heap sampling but without heap size profiling support and logs" do
                 expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                  .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
+                  .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
                   .and_call_original
+
+                expect(logger).to receive(:info).with(/Heap live size profiling is currently incompatible with Ruby 4/)
 
                 build_profiler_component
               end


### PR DESCRIPTION
**What does this PR do?**

The profiler supports two profile types related to heap profiling:
* Heap Live Objects
* Heap Live Size

This PR disables "Heap Live Size" on Ruby 4.0, leaving only "Heap Live Objects" available.

**Motivation:**

We've had reports of issues (such as https://github.com/DataDog/dd-trace-rb/issues/5936 when using heap live size on Ruby 4.0).

We've previously added a workaround in https://github.com/DataDog/dd-trace-rb/pull/5938 but we're now seeing issues with many different kinds of objects, not just classes, and thus we're disabling this feature on Ruby 4.0 until we can root cause the issue and fix it.

**Change log entry**

Yes. Profiling: Disable live heap size profiling on Ruby 4 due to incompatibility

**Additional Notes:**

This is how the message looks in practice:

```
I, [2026-07-10T11:24:56.368794 #2947286]  INFO -- datadog: [datadog]
Heap live size profiling is currently incompatible with Ruby 4 and has
been disabled. Heap live objects is not affected and remains enabled.
```

**How to test the change?**

I've included tests for this config change.