### PR TITLE
[PROF-15377] Profiling: Disallow heap profiling on Ruby 4.1+ (master)

### DIFF
--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -226,6 +226,15 @@ module Datadog
           return false
         end
 
+        # Heap profiling relies on `ObjectSpace._id2ref`, which was removed on Ruby 4.1
+        # (https://bugs.ruby-lang.org/issues/22135).
+        if RubyVersion.is?(">= 4.1")
+          logger.warn(
+            "Heap profiling is currently incompatible with Ruby 4.1+ and has been disabled."
+          )
+          return false
+        end
+
         unless allocation_profiling_enabled
           logger.warn(
             "Heap profiling was requested but allocation profiling is not enabled. " \

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -917,6 +917,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
 
         skip "Heap profiling is only supported on Ruby >= 2.7" unless RubyVersion.is?(">= 2.7")
+        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
       end
 
       after do |example|

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -365,6 +365,20 @@ RSpec.describe Datadog::Profiling::Component do
             end
           end
 
+          context "on Ruby 4.1 or newer" do
+            let(:testing_version) { "4.1.0" }
+
+            it "initializes StackRecorder without heap sampling support and warns" do
+              expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
+                .and_call_original
+
+              expect(logger).to receive(:warn).with(/Heap profiling is currently incompatible with Ruby 4.1/)
+
+              build_profiler_component
+            end
+          end
+
           context "and allocation profiling disabled" do
             before do
               settings.profiling.allocation_enabled = false

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -400,6 +400,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
 
       before do
+        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
+
         allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash,
           {"z" => -1, "y" => "-2", "x" => false}, Object.new]
         @num_allocations = 0
@@ -1049,6 +1051,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       before do
         skip "Heap profiling is only supported on Ruby >= 2.7" unless RubyVersion.is?(">= 2.7")
+        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
       end
 
       def sample_allocation(obj)


### PR DESCRIPTION
**What does this PR do?**

This PR disables heap profiling on Ruby 4.1+ (e.g. current Ruby master).

**Motivation:**

Our current implementation of heap profiling relies on `ObjectSpace._id2ref`, which was removed on Ruby 4.1 -- see
https://bugs.ruby-lang.org/issues/22135 .

Until we can re-implement the feature differently, we have no way of supporting 4.1+

**Change log entry**

Yes. Profiling: Disallow heap profiling on Ruby 4.1+

**Additional Notes:**

N/A

**How to test the change?**

Change includes test coverage.