### PR TITLE
Remove tmp trigger for Github Actions workflows

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -4,11 +4,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - master
-      # A workaround to trigger the workflow for pull requests from forked repository,
-      # which does not have access to secrets.
-      #
-      # This is also useful for testing the workflow without opening a pull request.
-      - tmp/*
   pull_request:
     branches:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - master
-      # A workaround to trigger the workflow for pull requests from forked repository,
-      # which does not have access to secrets.
-      #
-      # This is also useful for testing the workflow without opening a pull request.
-      - tmp/*
   pull_request:
     branches:
       - master


### PR DESCRIPTION
**What does this PR do?**
Dropping the workaround

**Motivation:**

Pushing a `tmp/*` branch runs these workflows in a push-event context, which exposes secrets to anyone with write access to the repo, unlike `pull_request` events which withhold secrets. Dropping the workaround removes that exposure; testing without a PR can use workflow_dispatch or a draft PR instead.

**Change log entry**
None