### PR TITLE
Isolate lock-dependency's token-minting from PR-controlled workflow code

### DIFF
--- a/.github/chainguard/self.lock-dependency.sts.yaml
+++ b/.github/chainguard/self.lock-dependency.sts.yaml
@@ -1,11 +1,11 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: "repo:DataDog/dd-trace-rb:pull_request"
+subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/master"
 
 claim_pattern:
-  event_name: pull_request
+  event_name: workflow_run
   repository: DataDog/dd-trace-rb
-  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/lock-dependency\.yml@refs/pull/[0-9]+/merge
+  workflow_ref: DataDog/dd-trace-rb/\.github/workflows/lock-dependency-commit\.yml@refs/heads/master
 
 permissions:
   contents: write

--- a/.github/workflows/lock-dependency-commit.yml
+++ b/.github/workflows/lock-dependency-commit.yml
@@ -10,8 +10,8 @@ name: Lock Dependencies Commit
 # This job never checks out or executes PR-controlled code; it only
 # consumes lockfile artifacts from the untrusted `lock` job and commits
 # them with a token scoped to this trusted workflow.
-on: # yamllint disable-line rule:truthy # zizmor: ignore[dangerous-triggers]
-  workflow_run:
+on: # yamllint disable-line rule:truthy
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows:
       - Lock Dependencies
     types:

--- a/.github/workflows/lock-dependency-commit.yml
+++ b/.github/workflows/lock-dependency-commit.yml
@@ -40,7 +40,7 @@ jobs:
       # the workspace before cloning. No privileged token is needed for this step.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
       # gemfiles/ is tracked, so checkout above already populated it; this only
       # overwrites paths with the newly generated lockfiles.

--- a/.github/workflows/lock-dependency-commit.yml
+++ b/.github/workflows/lock-dependency-commit.yml
@@ -33,17 +33,14 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - name: Get GitHub Token via dd-octo-sts
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/dd-trace-rb
-          policy: self.lock-dependency
+      # Checked out with the ambient, read-only token first, since checkout wipes
+      # the workspace before cloning. No privileged token is needed for this step.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-          persist-credentials: true # required for `git` operations (commit & push) at later steps
-          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+      # gemfiles/ is tracked, so checkout above already populated it; this only
+      # overwrites paths with the newly generated lockfiles.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: gemfiles
@@ -56,7 +53,23 @@ jobs:
       - name: Stage changes
         run: git add gemfiles
       - run: git diff --cached --color=always
+      # A PR that doesn't touch dependency files never runs the upstream `lock`
+      # job, so no artifacts are downloaded and the checked-out gemfiles/ is
+      # unchanged, leaving nothing staged here. Gating on that (rather than on
+      # the upstream conclusion alone) keeps the privileged token from being
+      # minted on every PR.
+      - name: Check for staged changes
+        id: check
+        run: echo "changed=$(git diff --cached --quiet && echo false || echo true)" >> "$GITHUB_OUTPUT"
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        if: steps.check.outputs.changed == 'true'
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.lock-dependency
       - name: Commit changes
+        if: steps.check.outputs.changed == 'true'
         uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
         with:
           repo: ${{ github.repository }}

--- a/.github/workflows/lock-dependency-commit.yml
+++ b/.github/workflows/lock-dependency-commit.yml
@@ -1,0 +1,67 @@
+name: Lock Dependencies Commit
+
+# This workflow is intentionally separate from lock-dependency.yml.
+#
+# It always runs the version of this file committed to master, never a
+# version from the triggering pull request, because workflow_run workflows
+# are resolved from the default branch. This keeps the privileged
+# token-minting and push logic out of reach of a pull request that edits
+# lock-dependency.yml, which triggers the untrusted `lock` job.
+on: # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows:
+      - Lock Dependencies
+    types:
+      - completed
+
+# Default permissions for all jobs
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  commit:
+    name: Commit changes
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.event.workflow_run.repository.full_name }}
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      actions: read
+    steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.lock-dependency
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          persist-credentials: true # required for `git` operations (commit & push) at later steps
+          token: ${{ steps.generate-token.outputs.token }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: gemfiles
+          pattern: lock-dependency-${{ github.event.workflow_run.id }}-*
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      # FIXME: The ghcommit-action does not pick up untracked/unstaged files
+      #        https://github.com/planetscale/ghcommit-action/issues/43
+      - name: Stage changes
+        run: git add gemfiles
+      - run: git diff --cached --color=always
+      - name: Commit changes
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          repo: ${{ github.repository }}
+          branch: ${{ github.event.workflow_run.head_branch }}
+          file_pattern: "gemfiles/*"
+          commit_message: "[🤖] Lock Dependency: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/lock-dependency-commit.yml
+++ b/.github/workflows/lock-dependency-commit.yml
@@ -7,7 +7,10 @@ name: Lock Dependencies Commit
 # are resolved from the default branch. This keeps the privileged
 # token-minting and push logic out of reach of a pull request that edits
 # lock-dependency.yml, which triggers the untrusted `lock` job.
-on: # yamllint disable-line rule:truthy
+# This job never checks out or executes PR-controlled code; it only
+# consumes lockfile artifacts from the untrusted `lock` job and commits
+# them with a token scoped to this trusted workflow.
+on: # yamllint disable-line rule:truthy # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows:
       - Lock Dependencies

--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
       - run: |
           ruby -v

--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -78,47 +78,10 @@ jobs:
             gemfiles/${{ matrix.engine.name }}_${{ matrix.engine.version }}*
           retention-days: 1
 
-  commit:
-    name: Commit changes
-    needs: lock
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-    steps:
-      - name: Get GitHub Token via dd-octo-sts
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/dd-trace-rb
-          policy: self.lock-dependency
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: true # required for `git` operations (commit & push) at later steps
-          token: ${{ steps.generate-token.outputs.token }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: gemfiles
-          pattern: lock-dependency-${{ github.run_id }}-*
-          merge-multiple: true
-      # FIXME: The ghcommit-action does not pick up untracked/unstaged files
-      #        https://github.com/planetscale/ghcommit-action/issues/43
-      - name: Stage changes
-        run: git add gemfiles
-      - run: git diff --cached --color=always
-      - name: Commit changes
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          repo: ${{ github.repository }}
-          branch: ${{ github.head_ref }}
-          file_pattern: "gemfiles/*"
-          commit_message: "[🤖] Lock Dependency: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
   complete:
     name: Lock Dependencies (complete)
     runs-on: ubuntu-24.04
     needs:
-      - commit
+      - lock
     steps:
       - run: echo "DONE!"


### PR DESCRIPTION
**What does this PR do?**
Splits token-minting/commit out of `lock-dependency.yml` into a new `lock-dependency-commit.yml`, triggered via `workflow_run`. STS policy is re-pinned to trust only that workflow's `master` definition, and a token is only minted when there are staged changes to commit.

**Motivation:**
The STS trust policy trusted `job_workflow_ref@refs/pull/[0-9]+/merge` — the PR's own version of the workflow file, not master's. A PR editing `lock-dependency.yml` could exploit this to mint a `contents: write` token for itself. Pinning to master directly isn't possible since `pull_request` events never resolve `job_workflow_ref` to master. `workflow_run` does resolve from master, so moving token-minting there closes the gap without touching the untrusted `bundle install` step.

**Change log entry**
None.

**Additional Notes:**
- Doesn't rely on org fork-PR approval settings — this also covers same-repo PRs with write access, which that setting doesn't gate.
- Gates token minting on `git diff --cached` having staged changes, since `download-artifact@v8` succeeds silently on zero matches.

**How to test the change?**
Validated YAML syntax and checkout/download-artifact ordering against source. End-to-end behavior confirms once merged, since `workflow_run` only fires off the default branch.