### PR TITLE
Bump zizmor to v1.26.1 in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
       # Updated by .github/workflows/update-system-tests.yml, which keeps the workflow's `ref` input in sync.
       - dependency-name: "DataDog/system-tests/.github/workflows/system-tests.yml"
     cooldown:
-      default-days: 2
+      default-days: 7

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           ruby-version: "4.0.1"
       - name: Install gem
+        # zizmor: ignore[adhoc-packages] installs the artifact just built by this workflow, not an external dependency
         run: |
           gem install pkg/*.gem
   push:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -106,7 +106,7 @@ jobs:
   semgrep:
     name: semgrep/ci
     runs-on: ubuntu-24.04
-    container: semgrep/semgrep # PENDING: Possible to be rate limited.
+    container: semgrep/semgrep:1.169.0 # PENDING: Possible to be rate limited.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,7 +137,7 @@ jobs:
           scope: DataDog/dd-trace-rb
           policy: self.check
       - name: Run zizmor 🌈
-        uses: docker://ghcr.io/woodruffw/zizmor:1.4.1
+        uses: docker://ghcr.io/woodruffw/zizmor:1.26.1
         with:
           args: --min-severity low .
         env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,7 +120,6 @@ jobs:
         env:
           SEMGREP_RULES: p/default
 
-  # https://woodruffw.github.io/zizmor/
   zizmor:
     name: zizmor
     runs-on: ubuntu-24.04
@@ -136,8 +135,8 @@ jobs:
         with:
           scope: DataDog/dd-trace-rb
           policy: self.check
-      - name: Run zizmor 🌈
-        uses: docker://ghcr.io/woodruffw/zizmor:1.26.1
+      - name: Run zizmor
+        uses: docker://ghcr.io/zizmorcore/zizmor:1.26.1
         with:
           args: --min-severity low .
         env:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # main
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - name: Print ruby version
         run: |
           nix develop --command which ruby

--- a/.github/workflows/typing-stats.yml
+++ b/.github/workflows/typing-stats.yml
@@ -52,6 +52,7 @@ jobs:
           ruby-version: "4.0"
 
       - name: Install steep
+        # zizmor: ignore[adhoc-packages] pinned tool install for computing typing stats, not an app dependency
         run: gem install steep -v 2.0
 
       - name: Copy scripts to directory outside of workspace


### PR DESCRIPTION
**What does this PR do?**
Bumps the zizmor Docker image pin in `.github/workflows/check.yml` from `1.4.1` to `1.26.1`, and fixes the new findings this surfaces.

**Motivation:**
Keep the zizmor GitHub Actions linter up to date to pick up new rules and fixes since 1.4.1.

**Change log entry**
None.

**Additional Notes:**
Upgrading zizmor surfaced several new findings against pre-existing workflow state (not introduced by this PR's own changes), which needed fixing for CI to stay green:
- `check.yml`: pinned the previously-untagged `semgrep/semgrep` container image, since zizmor 1.26.1 added a stricter unpinned-image check; also switched the zizmor image itself to `ghcr.io/zizmorcore/zizmor` since the old `ghcr.io/woodruffw/zizmor` namespace doesn't serve 1.26.1.
- `nix.yml`: fixed a stale version comment on the `nix-installer-action` pin (`# main` → `# v22`).
- `dependabot.yml`: increased the dependency cooldown from 2 to 7 days, per zizmor's `dependabot-cooldown` check.
- `build-gem.yml` and `typing-stats.yml`: suppressed `adhoc-packages` findings with `zizmor: ignore` comments and an explanation, since both install gems intentionally outside of a lockfile (a just-built local artifact, and a pinned tool version for computing stats) rather than an unpinned external dependency.

This PR also serves as a negative-test case for the `lock-dependency.yml` / `lock-dependency-commit.yml` split (#6028): it doesn't touch any path in `.github/dependency_filters.yml`, so the `lock` job should be skipped and `lock-dependency-commit.yml` should never fire.

**How to test the change?**
Confirm CI passes, and confirm the "Lock Dependencies" workflow's `dependency` job reports `changes: false` with the `lock` job skipped.