### PR TITLE
Add sane RuboCop defaults

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           lockfile: ${{ needs.build.outputs.lockfile }}
           cache-key: ${{ needs.build.outputs.cache-key }}
+      - run: bundle exec rubocop -D
       - run: bundle exec rake standard
 
   rubocop:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - integration/**/**
     - lib/datadog/**/vendor/**/*
     - lib/datadog/profiling/ext/exec_monkey_patch.rb
+    - vendor/bundle/**/*
   NewCops: disable
   SuggestExtensions: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,42 @@
+require:
+  - standard
+  - standard-custom
+  - standard-performance
+  - rubocop-performance
+
+inherit_gem:
+  standard: config/base.yml
+  standard-custom: config/base.yml
+  standard-performance: config/base.yml
+
+AllCops:
+  TargetRubyVersion: 2.5
+  Exclude:
+    - appraisal/**/**
+    - gemfiles/**/**
+    - integration/**/**
+    - lib/datadog/**/vendor/**/*
+    - lib/datadog/profiling/ext/exec_monkey_patch.rb
+  NewCops: disable
+  SuggestExtensions: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/QuotedSymbols:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Enabled: false

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -23,3 +23,4 @@ ignore:
   - integration/**/**
   - lib/datadog/**/vendor/**/*
   - lib/datadog/profiling/ext/exec_monkey_patch.rb # This is Ruby 2.7+ and standard doesn't like it
+  - vendor/bundle/**/*

--- a/rubocop/standard_overrides.rubocop.yml
+++ b/rubocop/standard_overrides.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - "gemfiles/**/**"
     - "integration/**/**"
     - "lib/datadog/**/vendor/**/*"
+    - "vendor/bundle/**/*"
 
 # standard requires a space after '#', which breaks Steep inline annotations (`#:`, `#$`).
 # We can drop this override if https://github.com/standardrb/standard/pull/820 (proposing


### PR DESCRIPTION
**What does this PR do?**

Reintroduces a minimal `.rubocop.yml`, absent since #5934 removed RuboCop as an operational concern in favor of `standard` alone. `rubocop` remains directly invocable — by developers, editors/IDEs, and LLM tooling — so running it bare currently produces output entirely unaware of `standard`'s rules. This PR:

- Adds `.rubocop.yml`, inheriting `standard`'s ruleset so a bare `rubocop` run matches what `rake standard` already enforces.
- Excludes `vendor/bundle/**/*` from the linter configs, which otherwise get crawled and can crash `rubocop` on gem-vendored config files.
- ~Enforces `Style/StringLiterals`, `Style/QuotedSymbols`, and `Style/StringLiteralsInInterpolation` to `single_quotes`, autocorrecting the codebase — these had gone unenforced and drifted since `standard.yml` disables `StringLiterals` and standalone `rubocop` was removed.~ https://github.com/DataDog/dd-trace-rb/pull/6038

**Motivation:**

`standard` is the enforced linter, but it isn't the only thing that runs when someone types `rubocop` — and right now that's a materially different, unmaintained experience that can suggest or auto-apply changes inconsistent with (or in addition to) `standard`'s. This PR makes the two agree.

**Change log entry**

None.

**Additional Notes:**

`rubocop/standard_overrides.rubocop.yml` (from #6013) is separate from `.rubocop.yml` and covers cops `standard`'s config-merging won't let `.customcops.yml` override. It may be worth folding into `.rubocop.yml` in the future, but this PR is scoped to restoring the missing baseline coverage and fixing the crash, not consolidating the two.

`TargetRubyVersion: 2.5` matches `.standard.yml`'s `ruby_version` and the gemspec's `MINIMUM_RUBY_VERSION`; without it, RuboCop's own auto-detection falls back to a hardcoded default rather than reading the gemspec, which would otherwise cause the two linters to silently target different Ruby versions.

**How to test the change?**

- `bundle exec rubocop -D` — 1900 files inspected, no offences.
- `bundle exec rake standard` — no offences.
- `bundle exec rake rubocop` — 1901 files inspected, no offences.