### PR TITLE
test(open_feature): prove agents apply RuboCop rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repository is the source code of a Ruby gem created by Datadog to provide D
 - Discover gemfiles: `bundle exec rake dependency:list`. Shows values for `BUNDLE_GEMFILE`.
 - Using alternate gemfile: `BUNDLE_GEMFILE=$(pwd)/gemfiles/<name>.gemfile`. For running matrix-specific jobs.
 - Smoke verification: `bundle exec rake test:main`. Baseline general testing (no native or integration testing).
-- Lint and type check: run `rubocop <changed Ruby paths>`, then `bundle exec rake standard typecheck`. Treat the root `.rubocop.yml` and its custom cops as the source of truth; resolve every offense instead of copying individual lint rules into agent guidance.
+- Lint and type check: run `bundle exec rubocop <changed Ruby paths>`, then `bundle exec rake standard typecheck`. Treat the root `.rubocop.yml` and its custom cops as the source of truth; resolve every offense instead of copying individual lint rules into agent guidance.
 - Discover tasks: `bundle exec rake -T`.
 - Targeted test runs (only for `test:main` specs): `bundle exec rspec spec/path/to/file_spec.rb[:line]`. For contrib/integration tests, always use `bundle exec rake test:TASK_KEY` (see "Testing matrix" below).
 - Native extension compilation: `bundle exec rake compile` or `bundle exec rake clean compile`. See `docs/ProfilingDevelopment.md` & `docs/LibdatadogDevelopment.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repository is the source code of a Ruby gem created by Datadog to provide D
 - Discover gemfiles: `bundle exec rake dependency:list`. Shows values for `BUNDLE_GEMFILE`.
 - Using alternate gemfile: `BUNDLE_GEMFILE=$(pwd)/gemfiles/<name>.gemfile`. For running matrix-specific jobs.
 - Smoke verification: `bundle exec rake test:main`. Baseline general testing (no native or integration testing).
-- Lint and type check: `bundle exec rake standard typecheck`.
+- Lint and type check: run `rubocop <changed Ruby paths>`, then `bundle exec rake standard typecheck`. Treat the root `.rubocop.yml` and its custom cops as the source of truth; resolve every offense instead of copying individual lint rules into agent guidance.
 - Discover tasks: `bundle exec rake -T`.
 - Targeted test runs (only for `test:main` specs): `bundle exec rspec spec/path/to/file_spec.rb[:line]`. For contrib/integration tests, always use `bundle exec rake test:TASK_KEY` (see "Testing matrix" below).
 - Native extension compilation: `bundle exec rake compile` or `bundle exec rake clean compile`. See `docs/ProfilingDevelopment.md` & `docs/LibdatadogDevelopment.md`.

--- a/tools/agent-evals/open_feature_guidance/README.md
+++ b/tools/agent-evals/open_feature_guidance/README.md
@@ -10,9 +10,17 @@ The first phase covers awareness only. Separate cases verify the root route for 
 
 These cases do not evaluate whether the agent follows the scoped guide's content.
 
-## Next steps
+## RuboCop adherence
 
-After [#6032](https://github.com/DataDog/dd-trace-rb/pull/6032) makes the repository's RuboCop configuration directly discoverable and enforceable, add a separate content-adherence phase that verifies agents find and run those lint rules. Keep the executable lint configuration as the source of truth instead of duplicating individual cops in agent guidance.
+The writable lint eval verifies more than awareness:
+
+```bash
+ruby tools/agent-evals/open_feature_guidance/run_lint.rb
+```
+
+It creates a temporary detached worktree, installs an eval-only subset of the forthcoming [RuboCop configuration from #6032](https://github.com/DataDog/dd-trace-rb/pull/6032), and asks a fresh Codex session to make a small OpenFeature change. The case passes only when the Codex JSON trace contains a RuboCop command, an independent RuboCop post-check reports no offenses, the requested change is present, and no unrelated files changed.
+
+The fixture starts with a double-quoted string while the configuration requires single quotes. A minimal string-value edit therefore cannot pass accidentally. RuboCop remains the executable source of truth; the agent guidance names the workflow without duplicating individual cops.
 
 Run all cases from any directory in the checkout:
 

--- a/tools/agent-evals/open_feature_guidance/README.md
+++ b/tools/agent-evals/open_feature_guidance/README.md
@@ -18,7 +18,7 @@ The writable lint eval verifies more than awareness:
 ruby tools/agent-evals/open_feature_guidance/run_lint.rb
 ```
 
-It creates a temporary detached worktree, installs an eval-only subset of the forthcoming [RuboCop configuration from #6032](https://github.com/DataDog/dd-trace-rb/pull/6032), and asks a fresh Codex session to make a small OpenFeature change. The case passes only when the Codex JSON trace contains a RuboCop command, an independent RuboCop post-check reports no offenses, the requested change is present, and no unrelated files changed.
+It creates a temporary detached worktree, installs an eval-only subset of the forthcoming [RuboCop configuration from #6032](https://github.com/DataDog/dd-trace-rb/pull/6032) with the repository's pinned RuboCop version, and asks a fresh Codex session to make a small OpenFeature change. The case passes only when the Codex JSON trace contains a RuboCop command, an independent RuboCop post-check reports no offenses, the requested change is present, and no unrelated files changed.
 
 The fixture starts with a double-quoted string while the configuration requires single quotes. A minimal string-value edit therefore cannot pass accidentally. RuboCop remains the executable source of truth; the agent guidance names the workflow without duplicating individual cops.
 

--- a/tools/agent-evals/open_feature_guidance/fixtures/future_rubocop.yml
+++ b/tools/agent-evals/open_feature_guidance/fixtures/future_rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 2.5
+  NewCops: disable
+  SuggestExtensions: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes

--- a/tools/agent-evals/open_feature_guidance/fixtures/rubocop.gemfile
+++ b/tools/agent-evals/open_feature_guidance/fixtures/rubocop.gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rubocop', '~> 1.75.2', require: false

--- a/tools/agent-evals/open_feature_guidance/fixtures/string_literals_target.rb
+++ b/tools/agent-evals/open_feature_guidance/fixtures/string_literals_target.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Datadog
+  module OpenFeature
+    module RubocopEvalFixture
+      def self.message
+        "before"
+      end
+    end
+  end
+end

--- a/tools/agent-evals/open_feature_guidance/lint_cases/string_literals.json
+++ b/tools/agent-evals/open_feature_guidance/lint_cases/string_literals.json
@@ -1,0 +1,9 @@
+{
+  "name": "string_literals",
+  "description": "OpenFeature development discovers and applies repository RuboCop rules.",
+  "prompt": "Update lib/datadog/open_feature/rubocop_eval_fixture.rb so Datadog::OpenFeature::RubocopEvalFixture.message returns the string after instead of before. Treat this as a normal code change: inspect the repository instructions, make the change, and run the relevant automated checks. Modify only that file; the evaluator provides the fixture and does not require tests, signatures, documentation, or a commit.",
+  "target_file": "lib/datadog/open_feature/rubocop_eval_fixture.rb",
+  "target_fixture": "string_literals_target.rb",
+  "rubocop_fixture": "future_rubocop.yml",
+  "expected_text": "'after'"
+}

--- a/tools/agent-evals/open_feature_guidance/lint_cases/string_literals.json
+++ b/tools/agent-evals/open_feature_guidance/lint_cases/string_literals.json
@@ -5,5 +5,6 @@
   "target_file": "lib/datadog/open_feature/rubocop_eval_fixture.rb",
   "target_fixture": "string_literals_target.rb",
   "rubocop_fixture": "future_rubocop.yml",
+  "gemfile_fixture": "rubocop.gemfile",
   "expected_text": "'after'"
 }

--- a/tools/agent-evals/open_feature_guidance/run_lint.rb
+++ b/tools/agent-evals/open_feature_guidance/run_lint.rb
@@ -40,12 +40,12 @@ unless missing_case_paths.empty?
   exit 2
 end
 
-def capture(*command, chdir:)
-  Open3.capture3(*command, chdir: chdir)
+def capture(*command, chdir:, env: {})
+  Open3.capture3(env, *command, chdir: chdir)
 end
 
-def run!(*command, chdir:)
-  stdout, stderr, status = capture(*command, chdir: chdir)
+def run!(*command, chdir:, env: {})
+  stdout, stderr, status = capture(*command, chdir: chdir, env: env)
   return stdout if status.success?
 
   raise "#{command.join(' ')} failed (#{status.exitstatus})\n#{stderr}\n#{stdout}"
@@ -63,11 +63,16 @@ end
 def install_fixtures(case_config, workspace)
   target_file = case_config.fetch('target_file')
   target_path = File.join(workspace, target_file)
+  gemfile = File.join(workspace, '.agent-eval.gemfile')
   FileUtils.mkdir_p(File.dirname(target_path))
   FileUtils.cp(File.join(FIXTURES_DIR, case_config.fetch('target_fixture')), target_path)
   FileUtils.cp(File.join(FIXTURES_DIR, case_config.fetch('rubocop_fixture')), File.join(workspace, '.rubocop.yml'))
+  FileUtils.cp(File.join(FIXTURES_DIR, case_config.fetch('gemfile_fixture')), gemfile)
 
-  run!('git', 'add', '.rubocop.yml', target_file, chdir: workspace)
+  bundle_env = {'BUNDLE_GEMFILE' => gemfile}
+  run!('bundle', 'lock', '--local', chdir: workspace, env: bundle_env)
+
+  run!('git', 'add', '.agent-eval.gemfile', '.rubocop.yml', target_file, chdir: workspace)
   run!(
     'git',
     '-c', 'user.name=OpenFeature agent eval',
@@ -75,9 +80,11 @@ def install_fixtures(case_config, workspace)
     'commit', '--no-gpg-sign', '-m', 'Add lint eval fixture',
     chdir: workspace
   )
+
+  bundle_env
 end
 
-def run_codex(prompt, model, workspace)
+def run_codex(prompt, model, workspace, env)
   command = [
     'codex', 'exec',
     '--ephemeral',
@@ -90,7 +97,7 @@ def run_codex(prompt, model, workspace)
   command.concat(['--model', model]) if model
   command << prompt
 
-  capture(*command, chdir: workspace)
+  capture(*command, chdir: workspace, env: env)
 end
 
 def command_results_from_trace(trace)
@@ -112,8 +119,8 @@ def changed_paths(workspace)
   (modified + untracked).reject(&:empty?).uniq
 end
 
-def rubocop_result(target_file, workspace)
-  capture('rubocop', '--config', '.rubocop.yml', target_file, chdir: workspace)
+def rubocop_result(target_file, workspace, env)
+  capture('bundle', 'exec', 'rubocop', '--config', '.rubocop.yml', target_file, chdir: workspace, env: env)
 end
 
 failures = []
@@ -129,16 +136,16 @@ case_paths.each do |case_path|
     begin
       create_worktree(evaluation_root, workspace, options[:revision])
       worktree_created = true
-      install_fixtures(case_config, workspace)
+      bundle_env = install_fixtures(case_config, workspace)
 
-      trace, codex_stderr, codex_status = run_codex(case_config.fetch('prompt'), options[:model], workspace)
+      trace, codex_stderr, codex_status = run_codex(case_config.fetch('prompt'), options[:model], workspace, bundle_env)
       command_results = command_results_from_trace(trace)
       rubocop_results = command_results.select { |result| result.fetch(:command).match?(RUBOCOP_COMMAND) }
       rubocop_evidence = rubocop_results.map do |result|
         "#{result.fetch(:command)} (exit #{result.fetch(:exit_code).inspect})"
       end
       target_file = case_config.fetch('target_file')
-      lint_stdout, lint_stderr, lint_status = rubocop_result(target_file, workspace)
+      lint_stdout, lint_stderr, lint_status = rubocop_result(target_file, workspace, bundle_env)
       unexpected_paths = changed_paths(workspace) - [target_file]
       target_contents = File.read(File.join(workspace, target_file))
 

--- a/tools/agent-evals/open_feature_guidance/run_lint.rb
+++ b/tools/agent-evals/open_feature_guidance/run_lint.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'optparse'
+require 'tmpdir'
+
+DEFAULT_ROOT = File.expand_path('../../..', __dir__)
+FIXTURES_DIR = File.join(__dir__, 'fixtures')
+LINT_CASES_DIR = File.join(__dir__, 'lint_cases')
+RUBOCOP_COMMAND = /(?:^|[';&|]\s*)(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:(?:bundle|rbenv)\s+exec\s+)?rubocop(?:\s|$)/
+
+options = {cases: [], model: nil, root: DEFAULT_ROOT, revision: 'HEAD'}
+OptionParser.new do |parser|
+  parser.banner = 'Usage: ruby tools/agent-evals/open_feature_guidance/run_lint.rb [options]'
+  parser.on('--case NAME', 'Run one named case (repeatable)') { |name| options[:cases] << name }
+  parser.on('--model MODEL', 'Pass a model override to codex exec') { |model| options[:model] = model }
+  parser.on('--root PATH', 'Evaluate another repository checkout') { |root| options[:root] = root }
+  parser.on('--revision REV', 'Evaluate a revision from the selected checkout') { |rev| options[:revision] = rev }
+end.parse!
+
+evaluation_root = File.expand_path(options[:root])
+unless File.directory?(evaluation_root)
+  warn "Unknown evaluation root: #{evaluation_root}"
+  exit 2
+end
+
+case_paths =
+  if options[:cases].empty?
+    Dir[File.join(LINT_CASES_DIR, '*.json')].sort
+  else
+    options[:cases].map { |name| File.join(LINT_CASES_DIR, "#{name}.json") }
+  end
+
+missing_case_paths = case_paths.reject { |path| File.file?(path) }
+unless missing_case_paths.empty?
+  names = missing_case_paths.map { |path| File.basename(path, '.json') }
+  warn "Unknown lint eval case(s): #{names.join(', ')}"
+  exit 2
+end
+
+def capture(*command, chdir:)
+  Open3.capture3(*command, chdir: chdir)
+end
+
+def run!(*command, chdir:)
+  stdout, stderr, status = capture(*command, chdir: chdir)
+  return stdout if status.success?
+
+  raise "#{command.join(' ')} failed (#{status.exitstatus})\n#{stderr}\n#{stdout}"
+end
+
+def create_worktree(root, workspace, revision)
+  run!('git', 'worktree', 'add', '--detach', workspace, revision, chdir: root)
+end
+
+def remove_worktree(root, workspace)
+  _stdout, stderr, status = capture('git', 'worktree', 'remove', '--force', workspace, chdir: root)
+  warn "Could not remove eval worktree #{workspace}: #{stderr}" unless status.success?
+end
+
+def install_fixtures(case_config, workspace)
+  target_file = case_config.fetch('target_file')
+  target_path = File.join(workspace, target_file)
+  FileUtils.mkdir_p(File.dirname(target_path))
+  FileUtils.cp(File.join(FIXTURES_DIR, case_config.fetch('target_fixture')), target_path)
+  FileUtils.cp(File.join(FIXTURES_DIR, case_config.fetch('rubocop_fixture')), File.join(workspace, '.rubocop.yml'))
+
+  run!('git', 'add', '.rubocop.yml', target_file, chdir: workspace)
+  run!(
+    'git',
+    '-c', 'user.name=OpenFeature agent eval',
+    '-c', 'user.email=openfeature-agent-eval@example.invalid',
+    'commit', '--no-gpg-sign', '-m', 'Add lint eval fixture',
+    chdir: workspace
+  )
+end
+
+def run_codex(prompt, model, workspace)
+  command = [
+    'codex', 'exec',
+    '--ephemeral',
+    '--ignore-user-config',
+    '--sandbox', 'workspace-write',
+    '--color', 'never',
+    '--cd', workspace,
+    '--json'
+  ]
+  command.concat(['--model', model]) if model
+  command << prompt
+
+  capture(*command, chdir: workspace)
+end
+
+def command_results_from_trace(trace)
+  trace.each_line.each_with_object([]) do |line, results|
+    event = JSON.parse(line)
+    item = event['item']
+    next unless event['type'] == 'item.completed'
+    next unless item && item['type'] == 'command_execution'
+
+    results << {command: item.fetch('command'), exit_code: item['exit_code']}
+  rescue JSON::ParserError
+    next
+  end
+end
+
+def changed_paths(workspace)
+  modified = run!('git', 'diff', '--name-only', 'HEAD', chdir: workspace).lines.map(&:strip)
+  untracked = run!('git', 'ls-files', '--others', '--exclude-standard', chdir: workspace).lines.map(&:strip)
+  (modified + untracked).reject(&:empty?).uniq
+end
+
+def rubocop_result(target_file, workspace)
+  capture('rubocop', '--config', '.rubocop.yml', target_file, chdir: workspace)
+end
+
+failures = []
+
+case_paths.each do |case_path|
+  case_config = JSON.parse(File.read(case_path))
+  name = case_config.fetch('name')
+
+  Dir.mktmpdir("open-feature-lint-eval-#{name}") do |tmpdir|
+    workspace = File.join(tmpdir, 'repo')
+    worktree_created = false
+
+    begin
+      create_worktree(evaluation_root, workspace, options[:revision])
+      worktree_created = true
+      install_fixtures(case_config, workspace)
+
+      trace, codex_stderr, codex_status = run_codex(case_config.fetch('prompt'), options[:model], workspace)
+      command_results = command_results_from_trace(trace)
+      rubocop_results = command_results.select { |result| result.fetch(:command).match?(RUBOCOP_COMMAND) }
+      rubocop_evidence = rubocop_results.map do |result|
+        "#{result.fetch(:command)} (exit #{result.fetch(:exit_code).inspect})"
+      end
+      target_file = case_config.fetch('target_file')
+      lint_stdout, lint_stderr, lint_status = rubocop_result(target_file, workspace)
+      unexpected_paths = changed_paths(workspace) - [target_file]
+      target_contents = File.read(File.join(workspace, target_file))
+
+      errors = []
+      errors << "codex exec failed (#{codex_status.exitstatus})\n#{codex_stderr}" unless codex_status.success?
+      errors << 'no RuboCop command observed in Codex trace' if rubocop_results.empty?
+      errors << "RuboCop post-check failed\n#{lint_stderr}\n#{lint_stdout}" unless lint_status.success?
+      errors << "target does not contain #{case_config.fetch('expected_text').inspect}" unless target_contents.include?(case_config.fetch('expected_text'))
+      errors << "unexpected changed paths: #{unexpected_paths.join(', ')}" unless unexpected_paths.empty?
+      errors << "observed RuboCop command(s): #{rubocop_evidence.join(' | ')}" unless rubocop_evidence.empty? || errors.empty?
+
+      if errors.empty?
+        puts "PASS #{name}"
+        puts "  observed: #{rubocop_evidence.join(' | ')}"
+      else
+        failures << [name, errors.join("\n")]
+      end
+    rescue JSON::ParserError, KeyError, RuntimeError => e
+      failures << [name, e.message]
+    ensure
+      remove_worktree(evaluation_root, workspace) if worktree_created
+    end
+  end
+end
+
+unless failures.empty?
+  failures.each do |name, details|
+    warn "FAIL #{name}"
+    warn details
+  end
+  exit 1
+end
+
+puts "#{case_paths.length} lint eval(s) passed"

--- a/tools/agent-evals/open_feature_guidance/run_lint.rb
+++ b/tools/agent-evals/open_feature_guidance/run_lint.rb
@@ -160,6 +160,7 @@ case_paths.each do |case_path|
       if errors.empty?
         puts "PASS #{name}"
         puts "  observed: #{rubocop_evidence.join(' | ')}"
+        puts '  post-check: RuboCop clean; requested change present; only target file changed'
       else
         failures << [name, errors.join("\n")]
       end


### PR DESCRIPTION
**AI-generated:** This PR includes an AI-generated, repository-local Codex eval runner and fixtures.

## Motivation

Mechanical lint feedback that reaches human review slows contributors and spends reviewer attention that should go to architecture and APM customer behavior. [#6029](https://github.com/DataDog/dd-trace-rb/pull/6029) proves that agents discover the scoped OpenFeature guide, but discovery alone does not prove they use the executable lint rules that [#6032](https://github.com/DataDog/dd-trace-rb/pull/6032) is making authoritative.

We added the writable eval first and ran it against #6029's exact head, `b811b5b298`, with the same pinned RuboCop runtime and rule fixture used by the passing run:

```text
FAIL string_literals
no RuboCop command observed in Codex trace
RuboCop post-check failed

lib/datadog/open_feature/rubocop_eval_fixture.rb:7:9:
  Style/StringLiterals: Prefer single-quoted strings
        "after"
        ^^^^^^^

1 file inspected, 1 offense detected
target does not contain "'after'"
```

The agent completed the requested behavior change but neither invoked the authoritative linter nor satisfied its configured rule. That failing evidence motivates the additional routing in this PR.

## Changes

The root `AGENTS.md` now tells agents to run `bundle exec rubocop` on changed Ruby paths, treat the root configuration and custom cops as the source of truth, and resolve every offense. A separate writable eval creates a temporary detached worktree, installs an isolated subset of #6032's configuration with RuboCop 1.75.2, asks a fresh Codex session to change an OpenFeature fixture, and inspects the JSON execution trace plus the resulting files.

## Decisions

The eval requires both process and outcome: an actual RuboCop invocation must appear in the trace, an independent post-check must be clean, the requested change must exist, and no unrelated files may change. The fixture uses #6032's deterministic single-quote rule so a minimal value edit fails without lint; individual rules remain in executable configuration rather than being copied into agent prose. The same workflow will pick up the OpenFeature custom cops from [#6033](https://github.com/DataDog/dd-trace-rb/pull/6033) without making `AGENTS.md` longer.

## Validation

Running the eval on final commit `d328fdd973` produced:

```text
PASS string_literals
  observed: bundle exec rubocop lib/datadog/open_feature/rubocop_eval_fixture.rb
  post-check: RuboCop clean; requested change present; only target file changed
1 lint eval(s) passed
```

The inherited discovery suite remains green:

```text
PASS lib_awareness
PASS sig_awareness
PASS spec_awareness
3 eval(s) passed
```

Ruby syntax, JSON parsing, StandardRB, strict YAML lint, and `git diff --check` also pass.

## Impact

Future agents are directed to execute the same RuboCop rules as developers and CI instead of approximating them from verbose guidance. Human reviewers can then spend their attention on architectural correctness and APM customer needs.

## Stacking

This draft is stacked on #6029 and depends on #6032 making the root RuboCop workflow operational. #6033 demonstrates how OpenFeature-specific review feedback can join that executable rule set.

## Change log entry

None.
