### PR TITLE
Allow Data Streams Monitoring Kafka instrumentation to run with tracing disabled

### DIFF
--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -178,7 +178,11 @@ module Datadog
             def instrument(integration_name, options = {}, &block)
               integration = fetch_integration(integration_name)
 
-              unless integration.nil? || !integration.default_configuration.enabled
+              # An integration is activated when its tracing is enabled, or when it opts into
+              # being patched while disabled (e.g. to install Data Streams Monitoring
+              # instrumentation without emitting tracing spans). See {Patchable#patch_when_disabled?}.
+              if !integration.nil? &&
+                  (integration.default_configuration.enabled || integration.patch_when_disabled?)
                 configuration_name = options[:describes] || :default
                 filtered_options = options.reject { |k, _v| k == :describes }
                 integration.configure(configuration_name, filtered_options, &block)

--- a/lib/datadog/tracing/contrib/extensions.rb
+++ b/lib/datadog/tracing/contrib/extensions.rb
@@ -177,15 +177,18 @@ module Datadog
             # @return [Datadog::Tracing::Contrib::Integration]
             def instrument(integration_name, options = {}, &block)
               integration = fetch_integration(integration_name)
+              return integration if integration.nil?
+
+              # Apply the options first, so the `enabled` check below reflects the value
+              # being set by this call, rather than whatever was configured previously.
+              configuration_name = options[:describes] || :default
+              filtered_options = options.reject { |k, _v| k == :describes }
+              integration.configure(configuration_name, filtered_options, &block)
 
               # An integration is activated when its tracing is enabled, or when it opts into
               # being patched while disabled (e.g. to install Data Streams Monitoring
               # instrumentation without emitting tracing spans). See {Patchable#patch_when_disabled?}.
-              if !integration.nil? &&
-                  (integration.default_configuration.enabled || integration.patch_when_disabled?)
-                configuration_name = options[:describes] || :default
-                filtered_options = options.reject { |k, _v| k == :describes }
-                integration.configure(configuration_name, filtered_options, &block)
+              if integration.default_configuration.enabled || integration.patch_when_disabled?
                 INSTRUMENTED_INTEGRATIONS_LOCK.synchronize do
                   @instrumented_integrations ||= {}
                   @instrumented_integrations[integration_name] = integration

--- a/lib/datadog/tracing/contrib/kafka/event.rb
+++ b/lib/datadog/tracing/contrib/kafka/event.rb
@@ -29,6 +29,13 @@ module Datadog
               Datadog.configuration.tracing[:kafka]
             end
 
+            # Checked on every event, rather than once at subscription time, so that
+            # toggling Kafka tracing at runtime (e.g. via `DD_TRACE_KAFKA_ENABLED`) takes
+            # effect even though `Events.subscribe!` only runs once per process.
+            def trace?(_event, _payload)
+              configuration[:enabled]
+            end
+
             def on_start(span, _event, _id, payload)
               span.set_tag(Tracing::Metadata::Ext::TAG_SVC_SRC, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)

--- a/lib/datadog/tracing/contrib/kafka/integration.rb
+++ b/lib/datadog/tracing/contrib/kafka/integration.rb
@@ -43,9 +43,11 @@ module Datadog
 
           # Data Streams Monitoring instruments Kafka producers/consumers through this
           # integration's patcher. Keep patching when tracing is disabled so DSM still
-          # works with `DD_TRACE_KAFKA_ENABLED=false`; the patcher skips the tracing spans.
+          # works with `DD_TRACE_KAFKA_ENABLED=false`; tracing spans stay off via
+          # `Kafka::Event#trace?`. `data_streams` settings are only present when
+          # `datadog/data_streams` has been loaded (always true via `require 'datadog'`).
           def patch_when_disabled?
-            Datadog.configuration.data_streams.enabled
+            Datadog.configuration.respond_to?(:data_streams) && Datadog.configuration.data_streams.enabled
           end
         end
       end

--- a/lib/datadog/tracing/contrib/kafka/integration.rb
+++ b/lib/datadog/tracing/contrib/kafka/integration.rb
@@ -40,6 +40,13 @@ module Datadog
           def patcher
             Patcher
           end
+
+          # Data Streams Monitoring instruments Kafka producers/consumers through this
+          # integration's patcher. Keep patching when tracing is disabled so DSM still
+          # works with `DD_TRACE_KAFKA_ENABLED=false`; the patcher skips the tracing spans.
+          def patch_when_disabled?
+            Datadog.configuration.data_streams.enabled
+          end
         end
       end
     end

--- a/lib/datadog/tracing/contrib/kafka/patcher.rb
+++ b/lib/datadog/tracing/contrib/kafka/patcher.rb
@@ -19,10 +19,14 @@ module Datadog
           end
 
           def patch
-            # Subscribe to Kafka events
-            Events.subscribe!
+            # Subscribe to Kafka events for tracing spans. This is skipped when tracing is
+            # disabled (e.g. `DD_TRACE_KAFKA_ENABLED=false`), while the DSM instrumentation
+            # below is still applied so Data Streams Monitoring keeps working.
+            Events.subscribe! if Datadog.configuration.tracing[:kafka].enabled
 
-            # Apply monkey patches for additional instrumentation (e.g., DSM)
+            # Apply monkey patches for additional instrumentation (e.g., DSM). These
+            # self-guard on `Datadog::DataStreams.enabled?`, so they are inert unless DSM
+            # is enabled, independent of whether tracing is enabled.
             patch_producer if defined?(::Kafka::Producer)
             patch_consumer if defined?(::Kafka::Consumer)
           end

--- a/lib/datadog/tracing/contrib/kafka/patcher.rb
+++ b/lib/datadog/tracing/contrib/kafka/patcher.rb
@@ -19,10 +19,11 @@ module Datadog
           end
 
           def patch
-            # Subscribe to Kafka events for tracing spans. This is skipped when tracing is
-            # disabled (e.g. `DD_TRACE_KAFKA_ENABLED=false`), while the DSM instrumentation
-            # below is still applied so Data Streams Monitoring keeps working.
-            Events.subscribe! if Datadog.configuration.tracing[:kafka].enabled
+            # Subscribe to Kafka events. This runs once per process (guarded by `Contrib::Patcher`'s
+            # `OnlyOnce`), so it must not be conditioned on the current `enabled` setting -- doing so would
+            # permanently skip tracing if the setting is later toggled at runtime. Each event instead checks
+            # `enabled` for itself when it fires (see `Kafka::Event#trace?`).
+            Events.subscribe!
 
             # Apply monkey patches for additional instrumentation (e.g., DSM). These
             # self-guard on `Datadog::DataStreams.enabled?`, so they are inert unless DSM

--- a/lib/datadog/tracing/contrib/patchable.rb
+++ b/lib/datadog/tracing/contrib/patchable.rb
@@ -102,6 +102,18 @@ module Datadog
           def auto_instrument?
             true
           end
+
+          # Should the integration still be patched when its `enabled` option is false?
+          #
+          # Normally a disabled integration is never patched. However, some integrations
+          # carry instrumentation for products other than tracing (e.g. Data Streams
+          # Monitoring). Those integrations can override this to `true` so their patcher
+          # still runs while tracing is disabled; the patcher is then responsible for only
+          # applying the non-tracing instrumentation.
+          # @return [Boolean] whether to patch this integration even though tracing is disabled
+          def patch_when_disabled?
+            false
+          end
         end
       end
     end

--- a/sig/datadog/tracing/contrib/kafka/integration.rbs
+++ b/sig/datadog/tracing/contrib/kafka/integration.rbs
@@ -17,7 +17,7 @@ module Datadog
 
           def patcher: () -> untyped
 
-          def patch_when_disabled?: () -> untyped
+          def patch_when_disabled?: () -> bool
         end
       end
     end

--- a/sig/datadog/tracing/contrib/kafka/integration.rbs
+++ b/sig/datadog/tracing/contrib/kafka/integration.rbs
@@ -16,6 +16,8 @@ module Datadog
           def new_configuration: () -> untyped
 
           def patcher: () -> untyped
+
+          def patch_when_disabled?: () -> untyped
         end
       end
     end

--- a/sig/datadog/tracing/contrib/patchable.rbs
+++ b/sig/datadog/tracing/contrib/patchable.rbs
@@ -14,6 +14,7 @@ module Datadog
           def patcher: () -> nil
           def patch: () -> ({ name: untyped, available: untyped, loaded: untyped, compatible: untyped, patchable: untyped } | true)
           def auto_instrument?: () -> true
+          def patch_when_disabled?: () -> bool
         end
       end
     end

--- a/spec/datadog/tracing/contrib/extensions_spec.rb
+++ b/spec/datadog/tracing/contrib/extensions_spec.rb
@@ -218,6 +218,35 @@ RSpec.describe Datadog::Tracing::Contrib::Extensions do
             end
           end
 
+          context 'for a disabled integration' do
+            include_context 'registry with integration'
+
+            before do
+              allow(integration).to receive(:default_configuration).and_return(double(enabled: false))
+              allow(integration).to receive(:configure)
+            end
+
+            context 'that does not opt into patching while disabled' do
+              before { allow(integration).to receive(:patch_when_disabled?).and_return(false) }
+
+              it 'is not activated' do
+                result
+                expect(settings.integrations_pending_activation).to_not include(integration)
+                expect(settings.instrumented_integrations).to_not include(integration_name => integration)
+              end
+            end
+
+            context 'that opts into patching while disabled' do
+              before { allow(integration).to receive(:patch_when_disabled?).and_return(true) }
+
+              it 'is activated so non-tracing instrumentation (e.g. DSM) can be applied' do
+                result
+                expect(settings.integrations_pending_activation).to include(integration)
+                expect(settings.instrumented_integrations).to include(integration_name => integration)
+              end
+            end
+          end
+
           context 'for an integration that includes Datadog::Tracing::Contrib::Integration' do
             include_context 'registry with integration' do
               let(:integration) do

--- a/spec/datadog/tracing/contrib/kafka/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/integration_spec.rb
@@ -97,4 +97,22 @@ RSpec.describe Datadog::Tracing::Contrib::Kafka::Integration do
 
     it { is_expected.to be Datadog::Tracing::Contrib::Kafka::Patcher }
   end
+
+  describe '#patch_when_disabled?' do
+    subject(:patch_when_disabled?) { integration.patch_when_disabled? }
+
+    after { Datadog.configuration.reset! }
+
+    context 'when Data Streams Monitoring is enabled' do
+      before { Datadog.configure { |c| c.data_streams.enabled = true } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when Data Streams Monitoring is disabled' do
+      before { Datadog.configure { |c| c.data_streams.enabled = false } }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/kafka/patcher_dsm_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/patcher_dsm_spec.rb
@@ -27,13 +27,28 @@ RSpec.describe 'Kafka patcher with tracing disabled' do
       expect(::Kafka::Consumer.ancestors).to include(Datadog::Tracing::Contrib::Kafka::Instrumentation::Consumer)
     end
 
-    it 'does not subscribe to Kafka tracing events' do
-      expect(Datadog::Tracing::Contrib::Kafka::Events).to_not receive(:subscribe!)
-
+    it 'does not create tracing spans for Kafka events' do
       Datadog.configure do |c|
         c.data_streams.enabled = true
         c.tracing.instrument :kafka, enabled: false
       end
+
+      expect(Datadog::Tracing).to_not receive(:trace)
+
+      ActiveSupport::Notifications.instrument('deliver_messages.producer.kafka', client_id: 'test-client') {}
+    end
+
+    it 'resumes creating tracing spans if Kafka tracing is enabled later at runtime' do
+      Datadog.configure do |c|
+        c.data_streams.enabled = true
+        c.tracing.instrument :kafka, enabled: false
+      end
+
+      Datadog.configure { |c| c.tracing.instrument :kafka, enabled: true }
+
+      expect(Datadog::Tracing).to receive(:trace).and_call_original
+
+      ActiveSupport::Notifications.instrument('deliver_messages.producer.kafka', client_id: 'test-client') {}
     end
   end
 
@@ -47,6 +62,8 @@ RSpec.describe 'Kafka patcher with tracing disabled' do
         c.data_streams.enabled = false
         c.tracing.instrument :kafka, enabled: false
       end
+
+      expect(Datadog::Tracing::Contrib::Kafka::Patcher.patched?).to be(false)
     end
   end
 end

--- a/spec/datadog/tracing/contrib/kafka/patcher_dsm_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/patcher_dsm_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'datadog/tracing/contrib/support/spec_helper'
+
+require 'ruby-kafka'
+require 'active_support'
+require 'datadog'
+
+RSpec.describe 'Kafka patcher with tracing disabled' do
+  # The patcher only patches once per process; reset the guard so `patch` runs
+  # again against this example's configuration.
+  before { Datadog::Tracing::Contrib::Kafka::Patcher.instance_variable_set(:@patch_only_once, nil) }
+
+  after do
+    Datadog.registry[:kafka].reset_configuration!
+    without_warnings { Datadog.configuration.reset! }
+  end
+
+  context 'when kafka tracing is disabled but Data Streams Monitoring is enabled' do
+    it 'still applies the Data Streams Monitoring instrumentation' do
+      Datadog.configure do |c|
+        c.data_streams.enabled = true
+        c.tracing.instrument :kafka, enabled: false
+      end
+
+      expect(::Kafka::Producer.ancestors).to include(Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer)
+      expect(::Kafka::Consumer.ancestors).to include(Datadog::Tracing::Contrib::Kafka::Instrumentation::Consumer)
+    end
+
+    it 'does not subscribe to Kafka tracing events' do
+      expect(Datadog::Tracing::Contrib::Kafka::Events).to_not receive(:subscribe!)
+
+      Datadog.configure do |c|
+        c.data_streams.enabled = true
+        c.tracing.instrument :kafka, enabled: false
+      end
+    end
+  end
+
+  context 'when both kafka tracing and Data Streams Monitoring are disabled' do
+    it 'does not patch the integration at all' do
+      # Neither tracing spans nor DSM instrumentation should be installed, so the
+      # patcher never runs and never subscribes to events.
+      expect(Datadog::Tracing::Contrib::Kafka::Events).to_not receive(:subscribe!)
+
+      Datadog.configure do |c|
+        c.data_streams.enabled = false
+        c.tracing.instrument :kafka, enabled: false
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Introduces `Patchable#patch_when_disabled?`, allowing an integration to opt into being patched even when its own tracing is disabled. The Kafka integration overrides it to return true whenever Data Streams Monitoring is enabled, and the Kafka patcher now only skips subscribing to tracing events (not the DSM monkey patches) when tracing is disabled.

**Motivation:**
Previously, disabling Kafka tracing via `DD_TRACE_KAFKA_ENABLED=false` also silently disabled Data Streams Monitoring for Kafka, since the patcher (which installs both tracing and DSM instrumentation) never ran for a disabled integration.

**Change log entry**
Yes. Data Streams Monitoring for Kafka now keeps working when Kafka tracing is disabled (e.g. via `DD_TRACE_KAFKA_ENABLED=false`).

**Additional Notes:**
None.

**How to test the change?**
Added specs covering:
- `Extensions#instrument` activating a disabled integration when it opts into `patch_when_disabled?` (`spec/datadog/tracing/contrib/extensions_spec.rb`)
- `Kafka::Integration#patch_when_disabled?` reflecting the Data Streams Monitoring setting (`spec/datadog/tracing/contrib/kafka/integration_spec.rb`)
- End-to-end behavior of the Kafka patcher with tracing disabled and DSM enabled/disabled (`spec/datadog/tracing/contrib/kafka/patcher_dsm_spec.rb`)