### PR TITLE
Clear concurrent-ruby trace context after exec

### DIFF
--- a/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
+++ b/lib/datadog/tracing/contrib/concurrent_ruby/context_composite_executor_service.rb
@@ -25,11 +25,11 @@ module Datadog
             # Pass the original arguments to the composited executor, which
             # pushes them (possibly transformed) as block args
             executor.post(*args) do |*block_args|
-              Tracing.continue_trace!(digest)
-
-              # Pass the executor-provided block args as they should have been
-              # originally passed without composition, see ChainPromise#on_resolvable
-              yield(*block_args)
+              Tracing.continue_trace!(digest) do
+                # Pass the executor-provided block args as they should have been
+                # originally passed without composition, see ChainPromise#on_resolvable
+                yield(*block_args)
+              end
             end
           end
 

--- a/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
+++ b/spec/datadog/tracing/contrib/concurrent_ruby/integration_test_spec.rb
@@ -209,6 +209,23 @@ RSpec.describe 'ConcurrentRuby integration tests' do
         deferred_execution
         expect(inner_span.parent_id).to eq(outer_span.id)
       end
+
+      it 'clears the propagated context after execution' do
+        executor = Concurrent::SingleThreadExecutor.new
+        outer_span = tracer.trace('outer_span')
+        future = Concurrent::Future.new(executor: executor) {}
+        future.execute.wait
+        outer_span.finish
+
+        active_trace = :unset
+        executor.post { active_trace = Datadog::Tracing.active_trace }
+        executor.shutdown
+        executor.wait_for_termination(1)
+
+        expect(active_trace).to be_nil
+      ensure
+        executor&.kill
+      end
     end
   end
 


### PR DESCRIPTION

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Previously, `continue_trace!` was called without a block. When a task would create no spans, the trace remained active and caused memory retention across tasks.

Passing a block ensures the trace is finished, flushed, and previous context is restored.



**Motivation:**
<!-- What inspired you to submit this pull request? -->

Observed in our app due to a reasonably large memory leak across many runs.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->
Used Codex to find the issue and present a fix, spent time understanding the problem enough to write the commit / this PR.

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
There's an automated test.

<!-- Unsure? Have a question? Request a review! -->
