### PR TITLE
[APMS-19921] Fix Ruby 2.5/2.6 ArgumentError in Kafka producer instrumentation causing BufferOverflow

### DIFF
--- a/lib/datadog/tracing/contrib/kafka/instrumentation/producer.rb
+++ b/lib/datadog/tracing/contrib/kafka/instrumentation/producer.rb
@@ -12,7 +12,7 @@ module Datadog
             end
 
             module InstanceMethods
-              def deliver_messages(**kwargs)
+              def deliver_messages
                 if Datadog::DataStreams.enabled?
                   begin
                     pending_messages = instance_variable_get(:@pending_message_queue)
@@ -37,7 +37,7 @@ module Datadog
                 super
               end
 
-              def send_messages(messages, **kwargs)
+              def send_messages(messages)
                 if Datadog::DataStreams.enabled?
                   begin
                     messages.each do |message|

--- a/sig/datadog/tracing/contrib/kafka/instrumentation/producer.rbs
+++ b/sig/datadog/tracing/contrib/kafka/instrumentation/producer.rbs
@@ -6,8 +6,8 @@ module Datadog
           module Producer
             def self.included: (untyped base) -> untyped
             module InstanceMethods
-              def deliver_messages: (**untyped kwargs) -> untyped
-              def send_messages: (untyped messages, **untyped kwargs) -> untyped
+              def deliver_messages: () -> untyped
+              def send_messages: (untyped messages) -> untyped
             end
           end
         end

--- a/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
@@ -223,4 +223,60 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
       }.not_to raise_error
     end
   end
+
+  # Regression: the producer instrumentation must mirror the argument signature
+  # of the ruby-kafka methods it wraps. Kafka::Producer#deliver_messages takes
+  # no arguments and is always called with none. If the wrapper declares
+  # `**kwargs` and calls `super`, JRuby forwards an empty `**kwargs` as an empty
+  # positional hash, raising `ArgumentError: wrong number of arguments
+  # (given 1, expected 0)`. That crashes ruby-kafka's async delivery thread,
+  # which stops draining the queue and eventually raises Kafka::BufferOverflow.
+  describe 'argument forwarding to wrapped ruby-kafka methods' do
+    before do
+      Datadog.configure do |c|
+        c.tracing.instrument :kafka
+        c.data_streams.enabled = false
+      end
+    end
+
+    let(:producer_class) do
+      Class.new do
+        # Mirrors ruby-kafka's Kafka::Producer#deliver_messages: no arguments.
+        def deliver_messages
+          :delivered
+        end
+
+        # Mirrors a single-argument producer method.
+        def send_messages(messages)
+          messages
+        end
+
+        prepend Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer
+      end
+    end
+
+    it 'calls deliver_messages with no arguments without raising' do
+      expect { producer_class.new.deliver_messages }.not_to raise_error
+    end
+
+    it 'passes the deliver_messages return value through' do
+      expect(producer_class.new.deliver_messages).to eq(:delivered)
+    end
+
+    it 'passes send_messages arguments through' do
+      expect(producer_class.new.send_messages([:a, :b])).to eq([:a, :b])
+    end
+
+    it 'wraps deliver_messages with a no-argument signature' do
+      params = Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer::InstanceMethods
+        .instance_method(:deliver_messages).parameters
+      expect(params).to eq([])
+    end
+
+    it 'wraps send_messages without a keyword splat' do
+      params = Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer::InstanceMethods
+        .instance_method(:send_messages).parameters
+      expect(params).to eq([[:req, :messages]])
+    end
+  end
 end

--- a/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
@@ -256,7 +256,8 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
         Class.new do
           attr_writer :worker_events
 
-          def produce(_value, **_options); end
+          def produce(_value, **_options)
+          end
 
           def buffer_size
             0
@@ -266,7 +267,8 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
             @worker_events << :delivered
           end
 
-          def shutdown; end
+          def shutdown
+          end
 
           prepend Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer
         end
@@ -293,11 +295,10 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
         allow(sync_producer).to receive(:buffer_size) { buffer_size }
         allow(sync_producer).to receive(:shutdown) do
           # Simulate producers continuing to enqueue after the delivery worker crashes.
-          begin
-            3.times { |index| async_producer.produce("queued-#{index}", topic: 'reproducer') }
-          rescue Kafka::BufferOverflow => e
-            worker_events << e
-          end
+
+          3.times { |index| async_producer.produce("queued-#{index}", topic: 'reproducer') }
+        rescue Kafka::BufferOverflow => e
+          worker_events << e
         end
       end
 

--- a/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
@@ -224,13 +224,8 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
     end
   end
 
-  # Regression: the producer instrumentation must mirror the argument signature
-  # of the ruby-kafka methods it wraps. Kafka::Producer#deliver_messages takes
-  # no arguments and is always called with none. If the wrapper declares
-  # `**kwargs` and calls `super`, JRuby forwards an empty `**kwargs` as an empty
-  # positional hash, raising `ArgumentError: wrong number of arguments
-  # (given 1, expected 0)`. That crashes ruby-kafka's async delivery thread,
-  # which stops draining the queue and eventually raises Kafka::BufferOverflow.
+  # Regression: the wrappers must not add `**kwargs`. On JRuby an empty `**kwargs`
+  # forwarded through `super` becomes a positional hash and raises ArgumentError.
   describe 'argument forwarding to wrapped ruby-kafka methods' do
     before do
       Datadog.configure do |c|
@@ -241,12 +236,10 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
 
     let(:producer_class) do
       Class.new do
-        # Mirrors ruby-kafka's Kafka::Producer#deliver_messages: no arguments.
         def deliver_messages
           :delivered
         end
 
-        # Mirrors a single-argument producer method.
         def send_messages(messages)
           messages
         end

--- a/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
+++ b/spec/datadog/tracing/contrib/kafka/data_streams_spec.rb
@@ -4,6 +4,8 @@ require 'datadog/tracing/contrib/support/spec_helper'
 require 'datadog/core'
 require 'datadog/core/ddsketch'
 require 'ostruct'
+require 'logger'
+require 'ruby-kafka'
 require 'datadog/tracing/contrib/kafka/integration'
 require 'datadog/tracing/contrib/kafka/instrumentation/producer'
 require 'datadog/tracing/contrib/kafka/instrumentation/consumer'
@@ -224,8 +226,8 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
     end
   end
 
-  # Regression: the wrappers must not add `**kwargs`. On JRuby an empty `**kwargs`
-  # forwarded through `super` becomes a positional hash and raises ArgumentError.
+  # Regression: the wrappers must not add `**kwargs`. On Ruby 2.5 and Ruby 2.6 an
+  # empty `**kwargs` forwarded through `super` becomes a positional hash and raises ArgumentError.
   describe 'argument forwarding to wrapped ruby-kafka methods' do
     before do
       Datadog.configure do |c|
@@ -245,6 +247,75 @@ RSpec.describe 'Kafka Data Streams instrumentation' do
         end
 
         prepend Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer
+      end
+    end
+
+    describe 'Kafka::AsyncProducer' do
+      let(:worker_events) { Queue.new }
+      let(:sync_producer_class) do
+        Class.new do
+          attr_writer :worker_events
+
+          def produce(_value, **_options); end
+
+          def buffer_size
+            0
+          end
+
+          def deliver_messages
+            @worker_events << :delivered
+          end
+
+          def shutdown; end
+
+          prepend Datadog::Tracing::Contrib::Kafka::Instrumentation::Producer
+        end
+      end
+      let(:sync_producer) do
+        producer = sync_producer_class.new
+        producer.worker_events = worker_events
+        producer
+      end
+      let(:kafka_logger) { Logger.new(File::NULL) }
+      let(:async_producer) do
+        Kafka::AsyncProducer.new(
+          sync_producer: sync_producer,
+          max_queue_size: 2,
+          delivery_threshold: 1,
+          instrumenter: Kafka::Instrumenter.new(client_id: 'buffer-overflow-reproducer'),
+          logger: kafka_logger
+        )
+      end
+
+      before do
+        buffer_size = 0
+        allow(sync_producer).to receive(:produce) { buffer_size += 1 }
+        allow(sync_producer).to receive(:buffer_size) { buffer_size }
+        allow(sync_producer).to receive(:shutdown) do
+          # Simulate producers continuing to enqueue after the delivery worker crashes.
+          begin
+            3.times { |index| async_producer.produce("queued-#{index}", topic: 'reproducer') }
+          rescue Kafka::BufferOverflow => e
+            worker_events << e
+          end
+        end
+      end
+
+      after do
+        allow(sync_producer).to receive(:shutdown)
+        begin
+          async_producer.shutdown
+        ensure
+          kafka_logger.close
+        end
+      end
+
+      it 'keeps the queue draining' do
+        async_producer.produce('first', topic: 'reproducer')
+        worker_event = worker_events.pop
+        raise worker_event if worker_event.is_a?(Kafka::BufferOverflow)
+
+        expect(worker_event).to eq(:delivered)
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

Removes the unused `**kwargs` parameter from the Kafka producer instrumentation's `deliver_messages` and `send_messages` wrappers so their signatures match the ruby-kafka methods they wrap.

**Motivation:**

`Kafka::Producer#deliver_messages` takes no arguments, but the DSM wrapper declared `deliver_messages(**kwargs)` and called bare `super`. On Ruby < 2.7, an empty `**kwargs` forwarded through `super` is passed as a positional empty hash, raising `ArgumentError: wrong number of arguments (given 1, expected 0)`. That exception is not a `Kafka::Error`, so it crashes ruby-kafka's async producer delivery thread; the thread then stops draining the queue, which fills up and eventually raises `Kafka::BufferOverflow`. Removing the unused splat restores correct argument forwarding, and the DSM checkpoint logic never used the captured kwargs.

**Change log entry**

Yes. Fix an `ArgumentError` (and the resulting `Kafka::BufferOverflow`) raised by the Kafka producer integration on Ruby 2.5 and 2.6.

**Additional Notes:**

- The wrappers now mirror the arity of ruby-kafka's methods; `deliver_messages` takes no arguments in ruby-kafka 0.7.10 and 1.5.0.
- `send_messages` has no matching public method on `Kafka::Producer` and appears to be dead code; this PR only corrects its signature and does not otherwise change it.
- The failure was reproduced and the fix validated on `jruby 9.2.21.0 (2.5.8)` and on CRuby 2.5/2.6. Although we do not support JRuby anymore, the issue was originally found on a JRuby setup but is not exclusive to JRuby.

**How to test the change?**

Added regression specs in `spec/datadog/tracing/contrib/kafka/data_streams_spec.rb` that assert the wrappers expose a signature with no keyword splat (the cross-platform guard, since the failure only manifests on JRuby) and that arguments and return values forward correctly. Existing kafka specs (`data_streams_spec.rb`, `patcher_spec.rb`) pass.
