### PR TITLE
[NO-TICKET] Fix AppSec devise contrib raising on non-standard Warden session serialization

### DIFF
--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -84,15 +84,17 @@ module Datadog
             nil
           end
 
-          # Devise stores the record as `[record.to_key, authenticatable_salt]`,
-          # e.g. `[[1], "0abc..."]`. Applications are free to override the
-          # serialization and store any other shape, in which case we skip
-          # the extraction.
+          # NOTE: This supports Devise's default session serialization:
+          #       `[record.to_key, record.authenticatable_salt]`,
+          #       e.g. `[[1], "0abc..."]`
+          #
+          # WARNING: Applications can redefine Warden serialization, replacing
+          #          this default format
           def extract_record_id(serialized_record)
-            return unless serialized_record.is_a?(::Array)
+            return unless serialized_record.is_a?(Array)
 
             record_key = serialized_record[0]
-            return unless record_key.is_a?(::Array)
+            return unless record_key.is_a?(Array)
 
             record_key[0]
           end

--- a/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
+++ b/lib/datadog/appsec/contrib/devise/tracking_middleware.rb
@@ -67,7 +67,7 @@ module Datadog
             session_serializer = warden.session_serializer
 
             key = session_key_for(session_serializer, ::Devise.default_scope)
-            id = session_serializer.session[key]&.dig(0, 0)
+            id = extract_record_id(session_serializer.session[key])
 
             return id if ::Devise.mappings.size == 1
             return "#{::Devise.default_scope}:#{id}" if id
@@ -76,12 +76,25 @@ module Datadog
               next if scope == ::Devise.default_scope
 
               key = session_key_for(session_serializer, scope)
-              id = session_serializer.session[key]&.dig(0, 0)
+              id = extract_record_id(session_serializer.session[key])
 
               return "#{scope}:#{id}" if id
             end
 
             nil
+          end
+
+          # Devise stores the record as `[record.to_key, authenticatable_salt]`,
+          # e.g. `[[1], "0abc..."]`. Applications are free to override the
+          # serialization and store any other shape, in which case we skip
+          # the extraction.
+          def extract_record_id(serialized_record)
+            return unless serialized_record.is_a?(::Array)
+
+            record_key = serialized_record[0]
+            return unless record_key.is_a?(::Array)
+
+            record_key[0]
           end
 
           def session_key_for(session_serializer, scope)

--- a/sig/datadog/appsec/contrib/devise/tracking_middleware.rbs
+++ b/sig/datadog/appsec/contrib/devise/tracking_middleware.rbs
@@ -3,9 +3,11 @@ module Datadog
     module Contrib
       module Devise
         class TrackingMiddleware
-          WARDEN_KEY: ::String
+          type record_id = String | Integer
 
-          SESSION_ID_KEY: ::String
+          WARDEN_KEY: String
+
+          SESSION_ID_KEY: String
 
           @app: untyped
 
@@ -17,11 +19,11 @@ module Datadog
 
           # NOTE: can't use ::Warden::Proxy because this gem is not a part of the
           #       standard bundle
-          def extract_id: (untyped warden) -> ::String?
+          def extract_id: (untyped warden) -> record_id?
 
-          def extract_record_id: (untyped serialized_record) -> untyped
+          def extract_record_id: (untyped serialized_record) -> record_id?
 
-          def transform: (::String? value) -> ::String?
+          def transform: (record_id? value) -> String?
 
           def anonymize?: () -> bool
         end

--- a/sig/datadog/appsec/contrib/devise/tracking_middleware.rbs
+++ b/sig/datadog/appsec/contrib/devise/tracking_middleware.rbs
@@ -19,6 +19,8 @@ module Datadog
           #       standard bundle
           def extract_id: (untyped warden) -> ::String?
 
+          def extract_record_id: (untyped serialized_record) -> untyped
+
           def transform: (::String? value) -> ::String?
 
           def anonymize?: () -> bool

--- a/spec/datadog/appsec/integration/contrib/devise/authenticated_single_user_tracking_spec.rb
+++ b/spec/datadog/appsec/integration/contrib/devise/authenticated_single_user_tracking_spec.rb
@@ -299,4 +299,24 @@ RSpec.describe 'Devise auto authenticated sing-user tracking' do
       )
     end
   end
+
+  context 'when application serializes the record into the session in a non-standard shape' do
+    before do
+      allow(User).to receive(:serialize_into_session) { |record| [record.id] }
+      allow(User).to receive(:serialize_from_session) { |id| User.to_adapter.get(id) }
+
+      user = User.create!(username: 'JohnDoe', email: 'john.doe@example.com', password: '123456')
+      login_as(user)
+    end
+
+    it 'allows authenticated user to visit private page and does not track it' do
+      get('/private')
+
+      expect(response).to be_ok
+      expect(response.body).to eq('This is private page')
+
+      expect(http_service_entry_span.tags).not_to have_key('usr.id')
+      expect(http_service_entry_span.tags).not_to have_key('_dd.appsec.usr.id')
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

Makes `AppSec::Contrib::Devise::TrackingMiddleware#extract_id` tolerant of
non-standard Warden session serializations. It extracts the authenticatable id
only from the shape Devise writes (`[[id], salt]`) and returns `nil` for any
other shape, instead of calling `dig(0, 0)` and raising.

### Motivation

Auto user instrumentation runs on every request. When an application overrides
`Warden::SessionSerializer#serialize_into_session` (or uses a non-Devise Warden
strategy) and stores e.g. a flat `[id]`, `session[key]&.dig(0, 0)` raises
`TypeError: Integer does not have #dig method` (`Array#dig` recursing into an
Integer), turning **every authenticated request into an HTTP 500**. `&.` only
guards `nil`, not a value that responds to `#dig` but is not diggable two levels
deep.

Regression introduced in #4625, released in v2.16.0.

Fixes #6063.

### Change log entry

Yes. Fix error in `devise` contrib for non-standard Warden session serialization.

### How to test the change?

Added a unit spec for `#extract_id` covering the standard `[[id], salt]` shape
plus the flat-array, bare-id, and nil shapes (the last three must not raise and
must return `nil`). CI.

### Additional notes

For apps hitting this on a released version, the immediate workaround is
`config.appsec.auto_user_instrumentation.mode = 'disabled'`.

Closes #6067
