### PR TITLE
Distinguish missing steep from type errors in steep:check

### DIFF
--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -6,9 +6,27 @@ namespace :steep do
     else
       args_sh = args.to_a.map { |a| "'#{a}'" }.join(' ')
 
-      begin
-        sh "steep check #{args_sh}".strip
-      rescue
+      # Exit status 127 (or a nil status when the process could not be spawned)
+      # means the shell could not find `steep`, i.e. it is not installed in the
+      # current bundle -- distinct from steep running and reporting type errors.
+      sh "steep check #{args_sh}".strip do |ok, status|
+        next if ok
+
+        if status.nil? || status.exitstatus == 127
+          warn <<-EOS
+          +------------------------------------------------------------------------------+
+          |  **Steep is not installed in the current bundle**                            |
+          |                                                                              |
+          | The `steep` executable could not be found, so no type checking was           |
+          | performed. This is NOT a type error.                                         |
+          |                                                                              |
+          | Install it with `bundle install`, or run this task from a bundle that        |
+          | includes the `steep` gem.                                                     |
+          +------------------------------------------------------------------------------+
+          EOS
+          exit 1
+        end
+
         warn <<-EOS
           +------------------------------------------------------------------------------+
           |  **Hello there, fellow contributor who just triggered a Steep type error**   |

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -20,8 +20,7 @@ namespace :steep do
           | The `steep` executable could not be found, so no type checking was           |
           | performed.                                                                   |
           |                                                                              |
-          | Install it with `bundle install`, or run this task from a bundle that        |
-          | includes the `steep` gem.                                                     |
+          | Run this task from a bundle that includes the `steep` gem.                   |
           +------------------------------------------------------------------------------+
           EOS
           exit 1

--- a/tasks/steep.rake
+++ b/tasks/steep.rake
@@ -18,7 +18,7 @@ namespace :steep do
           |  **Steep is not installed in the current bundle**                            |
           |                                                                              |
           | The `steep` executable could not be found, so no type checking was           |
-          | performed. This is NOT a type error.                                         |
+          | performed.                                                                   |
           |                                                                              |
           | Install it with `bundle install`, or run this task from a bundle that        |
           | includes the `steep` gem.                                                     |


### PR DESCRIPTION
**What does this PR do?**

Makes the `steep:check` rake task distinguish "steep is not installed" from "steep found type errors".

Previously the task wrapped the steep invocation in a bare `rescue` and printed the same "you triggered a Steep type error" banner for every failure. When `steep` is absent from the current bundle, the shell exits `127` (command not found), which was reported identically to a genuine type-check failure — no type checking actually ran, but the output claimed a type error.

The task now uses the `sh` block form and branches on the exit status: a distinct "steep is not installed" message on exit `127` (or a nil status when the process could not be spawned), and the original type-error banner only for genuine steep failures.

**Motivation:**

The wrapper reported the same failure surface whether steep found type errors or was never installed, making a missing-steep environment look like a real type error at a glance.

**Change log entry**

None.

**How to test the change?**

N/A
