### PR TITLE
Fix flaky DI code_tracker_spec: stop code tracker before nilling global reference

### DIFF
--- a/spec/datadog/di/component_spec.rb
+++ b/spec/datadog/di/component_spec.rb
@@ -311,7 +311,13 @@ RSpec.describe Datadog::DI::Component do
     context "when code tracking is activated after the component is built (in-product enablement)" do
       before do
         # Simulate DI disabled at boot: no global code tracker exists when the
-        # component (and its instrumenter) are built.
+        # component (and its instrumenter) are built. Stop any tracker a prior
+        # example left active before dropping the global reference: nilling
+        # @code_tracker while its process-global :script_compiled TracePoint is
+        # still enabled orphans the TracePoint (deactivate_tracking! can no longer
+        # reach it), leaking it into later specs and double-firing
+        # code_tracker_spec's line-probe-installation examples.
+        Datadog::DI.deactivate_tracking!
         Datadog::DI.instance_variable_set(:@code_tracker, nil)
       end
 


### PR DESCRIPTION
**What does this PR do?**

Fixes a flaky test in `spec/datadog/di/code_tracker_spec.rb` — the `line probe installation` examples (`when a file is required` / `when a file is loaded`, `code_tracker_spec.rb:185` and `:197`) intermittently fail with:

```
Failure/Error: expect(component).to receive(:probe_manager).and_return(probe_manager)
  (InstanceDouble(Datadog::DI::Component) (anonymous)).probe_manager(*(any args))
      expected: 1 time with any arguments
      received: 2 times with any arguments
```

The fix stops the global DI code tracker before dropping the `@code_tracker` reference in `spec/datadog/di/component_spec.rb`.

**Motivation:**

`CodeTracker#start` installs a **process-global** `TracePoint.trace(:script_compiled)`. `Datadog::DI.deactivate_tracking!` stops whatever `@code_tracker` currently points to.

The `component_spec.rb` context "when code tracking is activated after the component is built (in-product enablement)" nilled `@code_tracker` in its `before` hook **without stopping it first**:

```ruby
before do
  Datadog::DI.instance_variable_set(:@code_tracker, nil)
end
```

When a prior example in the shuffled suite left the global tracker active (e.g. the implicit-enablement integration spec, whose `after` only calls `component.shutdown!` and does not stop the process-global tracker), this `before` hook orphaned that still-enabled TracePoint — `deactivate_tracking!` could no longer reach it. The orphan then survived into `code_tracker_spec` (whose `deactivate_code_tracking` `before(:all)` becomes a no-op once `@code_tracker` is `nil`) and double-fired the `:script_compiled` callback, so the local tracker plus the orphan each invoked `component.probe_manager` — twice instead of once.

This is order-dependent, which is why it surfaced on different Ruby versions depending on the RSpec seed (observed on Ruby 2.6–3.4 under one seed and on Ruby 4.0 under another). It is pre-existing on master; it was noticed while looking at CI for an unrelated docs-only PR.

**Change log entry**

None.

**Additional Notes:**

The sibling `after` hook in the same context already does the correct thing (`deactivate_tracking!` then nil); only the `before` hook was missing the stop.

**How to test the change?**

Reproduced locally on `master` (Ruby 3.2, `rake test:di:di_with_ext` suite, 1035 examples):

- Without the fix, RSpec seed `31097` fails the two `code_tracker_spec` examples deterministically (2 failures).
- `rspec --bisect` reduced the reproduction to the failing examples plus `component_spec` "adopts the global code tracker on start!", the implicit-enablement integration example, and the benchmark examples running before them.
- With the fix, seed `31097` and 25 additional random seeds all pass (0 failures).

A CI-runnable reproducer branch is not included: the flake depends on cross-file example ordering, and a pinned RSpec seed does not reproduce portably across environments (per-version pending counts differ, changing the shuffled order for the same seed), so a seed-pinned reproducer would not fail deterministically in CI.