### PR TITLE
Add Trace Source Propagated Tag for AI Guard

### DIFF
--- a/lib/datadog/ai_guard/evaluation.rb
+++ b/lib/datadog/ai_guard/evaluation.rb
@@ -15,6 +15,7 @@ module Datadog
               Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER,
               Tracing::Sampling::Ext::Decision::AI_GUARD
             )
+            trace.set_distributed_source(Ext::PRODUCT_BIT)
             trace.set_tag(Ext::EVENT_TAG, true)
             trace.set_tag(Ext::TRACE_EXECUTED_TAG, "1")
 

--- a/lib/datadog/ai_guard/ext.rb
+++ b/lib/datadog/ai_guard/ext.rb
@@ -4,6 +4,8 @@ module Datadog
   module AIGuard
     # AI Guard specific constants
     module Ext
+      PRODUCT_BIT = 0x20
+
       SPAN_NAME = "ai_guard"
       TARGET_TAG = "ai_guard.target"
       TOOL_NAME_TAG = "ai_guard.tool_name"

--- a/sig/datadog/ai_guard/ext.rbs
+++ b/sig/datadog/ai_guard/ext.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module AIGuard
     module Ext
+      PRODUCT_BIT: ::Integer
+
       SPAN_NAME: ::String
       TARGET_TAG: ::String
       TOOL_NAME_TAG: ::String

--- a/spec/datadog/ai_guard/evaluation_spec.rb
+++ b/spec/datadog/ai_guard/evaluation_spec.rb
@@ -60,7 +60,16 @@ RSpec.describe Datadog::AIGuard::Evaluation do
 
       trace = traces.first
       expect(trace.sampling_priority).to eq(Datadog::Tracing::Sampling::Ext::Priority::USER_KEEP)
-      expect(trace.send(:sampling_decision_maker)).to eq("-13")
+      expect(trace.sampling_decision_maker).to eq("-13")
+    end
+
+    it "sets distributed source on the trace with AI Guard product bit" do
+      described_class.perform([
+        Datadog::AIGuard.message(role: :user, content: "Some content")
+      ])
+
+      trace = traces.first
+      expect(trace.send(:meta).fetch("_dd.p.ts")).to eq("20")
     end
 
     it "sets ai_guard.event tag on the trace with AI Guard evaluations" do


### PR DESCRIPTION
**What does this PR do?**
This PR adds setting of `_dd.p.ts` tag (Trace Source) on the trace when AI Guard evaluation is made.

**Motivation:**
We want to enable standalone billing for AI Guard.

**Change log entry**
None. This change is internal.

**Additional Notes:**
APPSEC-68488

**How to test the change?**
CI