### PR TITLE
[NO-TICKET] Profiling: Add extra check when collecting stack to try to avoid crash

### DIFF
--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -514,6 +514,13 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
           // rb_profile_frames does not do this check, but `backtrace_each` (`vm_backtrace.c`) does. This frame is not
           // exposed by the Ruby backtrace APIs and for now we want to match its behavior 1:1
         }
+        else if (cfp->ep == NULL) {
+          // Do nothing -- this frame should not be used
+          //
+          // We're not sure this can ever happen, but we've seen a crash inside `VM_FRAME_RUBYFRAME_P` below (which
+          // dereferences `cfp->ep`), so "just in case" we're adding this extra sanity check to avoid crashing on a
+          // NULL `ep`.
+        }
         else if (VM_FRAME_RUBYFRAME_P(cfp)) {
             if (start > 0) {
                 start--;


### PR DESCRIPTION
**What does this PR do?**

This PR adds an attempted workaround for a crash we saw in production:

```
SIGSEGV (SEGV_MAPERR) at address 0x0000000000000000

0xffff860b75ac ddtrace_rb_profile_frames (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/private_vm_api_access.c:517)
0xffff860ac0cc sample_thread (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/collectors_stack.c:260)
0xffff860ae634 trigger_sample_for_thread (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/collectors_thread_context.c:1188)
0xffff860b14b8 thread_context_collector_sample (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/collectors_thread_context.c:777)
0xffff860a6d68 rescued_sample_from_postponed_job (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c:820)
0xffffaeec1f74 rb_vrescue2 (/tmp/ruby-4.0.5/eval.c:1063)
0xffffaeec2180 rb_rescue2 (/tmp/ruby-4.0.5/eval.c:1047)
0xffff860a53a0 sample_from_postponed_job (/usr/src/app/vendor/gems/ruby/4.0.0/gems/datadog-2.37.0/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c:802)
0xffffaf0ea1d8 rb_postponed_job_flush (/tmp/ruby-4.0.5/vm_trace.c:2013)
0xffffaf06d95c rb_threadptr_execute_interrupts (/tmp/ruby-4.0.5/thread.c:2648)
0xffffaf0c5af8 vm_exec_core (/tmp/ruby-4.0.5/insns.def:1173)
0xffffaf0cab20 rb_vm_exec (/tmp/ruby-4.0.5/vm.c:2801)
0xffffaf0ce678 rb_yield_values2 (/tmp/ruby-4.0.5/vm_eval.c:1420)
0xffffaee9a3d0 filter_map_i (/tmp/ruby-4.0.5/enum.c:546)
```

The current working theory is the crash was during the `VM_FRAME_RUBYFRAME_P(cfp)` check due to `cfp->ep` being null.

I couldn't reproduce the issue or figure out in what situation this might happen, yet doing a NULL check here is very cheap so either this stops the issue and we never see the crash again; or we'll see the crash again and next time we know it's not from the `cfp->ep` being `NULL` so we'll have made some progress.

**Motivation:**

Avoid crash observed in production.

**Change log entry**

None.

**Additional Notes:**

Datadog-internal link to the full crash is at https://app.datadoghq.com/error-tracking/issue/2072c380-8542-11f1-b6c6-da7ad0900002 .

**How to test the change?**

Simulating this would be really awkward, so for now there's no coverage testing the `NULL` situation.

Nevertheless, there is a lot of existing test coverage for stacks being what we expect, so we know that this won't break collection of stacks.