### PR TITLE
[NO-TICKET] ci: bump apm-sdks-benchmarks include ref to #215 merge commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
     file: ".gitlab/ci-ruby-acme-parallel.yml"
-    ref: "048736bed374852b222145dba601fb2cfd092844" # apm-sdks-benchmarks#214 merge commit
+    ref: "6e0c06b02f6e4642caec88abdb958ec32d69c6b8" # apm-sdks-benchmarks#215 merge commit
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
     file: ".gitlab/ci-ruby-acme-parallel.yml"
-    ref: "5f5ca440eaab196afb8f78255c2daf2d0bdcc492" # apm-sdks-benchmarks#209 merge commit
+    ref: "048736bed374852b222145dba601fb2cfd092844" # apm-sdks-benchmarks#214 merge commit
 
 variables:
   RUBY_CUSTOM_IMAGE_BASE: $DOCKER_REGISTRY/ci/dd-trace-rb/custom_ruby


### PR DESCRIPTION
**What does this PR do?**
Bumps the pinned `apm-sdks-benchmarks` include ref used by the Ruby benchmark pipeline in `.gitlab-ci.yml`, moving it from the `#209` merge commit (`5f5ca44`) to the `#215` merge commit (`6e0c06b`).

**Motivation:**
The Ruby benchmark is pinned in two layers: this include `ref` selects which `ci-ruby-acme-parallel.yml` is loaded, and that file's `APM_SDKS_BENCHMARKS_SHA` selects the apm-sdks-benchmarks commit each job clones at runtime. apm-sdks-benchmarks#215 (merge commit `6e0c06b`) sets `APM_SDKS_BENCHMARKS_SHA=048736b`. Pointing this `ref` at `6e0c06b` ensures the loaded pipeline definition and the cloned benchmark code are consistent. #215 is already merged, so there is no external blocker — this is a ready PR.

**Change log entry**
None. This is an internal CI change (benchmark pipeline pin), not customer-visible.

**Additional Notes:**
Single-line change to the `include: - project: "DataDog/apm-reliability/apm-sdks-benchmarks"` ref. No library code or user-facing behavior is affected.

**How to test the change?**
No code is modified. The change only updates a pinned Git ref for the benchmarking pipeline include; the benchmark CI pipeline exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)