### PR TITLE
Include Ruby extension API version in bundle cache key

### DIFF
--- a/.github/actions/bundle-cache/action.yml
+++ b/.github/actions/bundle-cache/action.yml
@@ -18,7 +18,8 @@ runs:
       shell: bash
       run: |
         id=$(ruby -e "puts RUBY_DESCRIPTION") # Includes patchlevel, os, and arch
-        echo "id=$id" >> "$GITHUB_OUTPUT"
+        ext_api_version=$(ruby -e "puts Gem.extension_api_version") # Busts the cache when native extension ABI changes (e.g. static vs shared build)
+        echo "id=$id-$ext_api_version" >> "$GITHUB_OUTPUT"
     - name: Resolve lockfile
       id: lockfile
       shell: bash


### PR DESCRIPTION
**What does this PR do?**
Adds `Gem.extension_api_version` alongside `RUBY_DESCRIPTION` when computing the bundle cache key in `.github/actions/bundle-cache/action.yml`, so the cache is invalidated whenever the native-extension ABI of the CI Ruby image changes, not just when the Ruby version string does.

**Motivation:**
All `Ruby * / batch` CI jobs started failing at `bundle check` after new `images-rb` engine images were published. The images kept the same `RUBY_DESCRIPTION` but changed `Gem.extension_api_version` (to a `-static` variant, indicating a static vs. shared Ruby build), which moved where bundler expects compiled native extensions to live. Since the cache key didn't change, the old cache was restored into the new image and its extensions were no longer found, breaking every job identically.

**Change log entry**
None.

**Additional Notes:**
This unblocks CI for the current image republish. It doesn't address whether the underlying static-build change in `images-rb` was intentional -- that's a question for whoever owns image publishing, separate from this repo.

**How to test the change?**
This is a CI-only workflow change; validated by inspecting the currently-published image directly (`docker run ... ruby -e "puts Gem.extension_api_version"` returned `4.0.0-static`, confirming the new key differs from the old one) and by tracing the exact failure in the linked job log. Will be further confirmed by this PR's own CI run producing a clean cache miss/rebuild instead of the `bundle check` failure.