### PR TITLE
Install upstream Nix in CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Print ruby version
         run: |
           nix develop --command which ruby


### PR DESCRIPTION
**What does this PR do?**

Replaces Determinate's Nix installer action with the SHA-pinned Cachix installer, which installs upstream Nix.

**Motivation:**

Determinate action v22 now defaults to Determinate Nix, so the workflow no longer validates the upstream Nix environment it is intended to cover.

**Change log entry**

Nope.

**Additional Notes:**

I used AI assistance and reviewed and understood this change.

**How to test the change?**

- `nix run nixpkgs#actionlint -- .github/workflows/nix.yml`
- Confirm the GitHub Actions Nix matrix passes on Linux and macOS.