### PR TITLE
Add distributed tracing propagation policy for AI Guard

### DIFF
--- a/lib/datadog/tracing/distributed/propagation_policy.rb
+++ b/lib/datadog/tracing/distributed/propagation_policy.rb
@@ -28,6 +28,10 @@ module Datadog
               return true
             end
 
+            if ::Datadog.configuration.ai_guard.enabled && (trace_source & ::Datadog::AIGuard::Ext::PRODUCT_BIT) != 0
+              return true
+            end
+
             return false
           end
 

--- a/lib/datadog/tracing/distributed/propagation_policy.rb
+++ b/lib/datadog/tracing/distributed/propagation_policy.rb
@@ -28,7 +28,8 @@ module Datadog
               return true
             end
 
-            if ::Datadog.configuration.ai_guard.enabled && (trace_source & ::Datadog::AIGuard::Ext::PRODUCT_BIT) != 0
+            if ::Datadog.configuration.respond_to?(:ai_guard) && ::Datadog.configuration.ai_guard.enabled &&
+                (trace_source & ::Datadog::AIGuard::Ext::PRODUCT_BIT) != 0
               return true
             end
 

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -628,6 +628,10 @@ module Datadog
           appsec_bit = upstream_tags[Tracing::Metadata::Ext::Distributed::TAG_TRACE_SOURCE].to_i(16) &
             Datadog::AppSec::Ext::PRODUCT_BIT
           return appsec_enabled if appsec_bit != 0
+
+          ai_guard_bit = upstream_tags[Tracing::Metadata::Ext::Distributed::TAG_TRACE_SOURCE].to_i(16) &
+            Datadog::AIGuard::Ext::PRODUCT_BIT
+          return Datadog.configuration.respond_to?(:ai_guard) && Datadog.configuration.ai_guard.enabled if ai_guard_bit != 0
         end
 
         false

--- a/lib/datadog/tracing/tracer.rb
+++ b/lib/datadog/tracing/tracer.rb
@@ -631,7 +631,7 @@ module Datadog
 
           ai_guard_bit = upstream_tags[Tracing::Metadata::Ext::Distributed::TAG_TRACE_SOURCE].to_i(16) &
             Datadog::AIGuard::Ext::PRODUCT_BIT
-          return Datadog.configuration.respond_to?(:ai_guard) && Datadog.configuration.ai_guard.enabled if ai_guard_bit != 0
+          return ai_guard_enabled if ai_guard_bit != 0
         end
 
         false
@@ -644,6 +644,10 @@ module Datadog
 
       def appsec_enabled
         @appsec_enabled ||= Datadog.configuration.appsec.enabled
+      end
+
+      def ai_guard_enabled
+        @ai_guard_enabled ||= Datadog.configuration.respond_to?(:ai_guard) && Datadog.configuration.ai_guard.enabled
       end
 
       # Due to APM Tracing (the product) and Tracing (the transport) being intertwined, we cannot completely disabled APM

--- a/sig/datadog/tracing/tracer.rbs
+++ b/sig/datadog/tracing/tracer.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Tracing
     class Tracer
-      
+
       @logger: Core::Logger
 
       attr_reader logger: Core::Logger
@@ -15,6 +15,8 @@ module Datadog
       def propagate_sampling_priority?: (upstream_tags: Hash[String, String]) -> bool
 
       def appsec_enabled: -> bool
+
+      def ai_guard_enabled: -> bool
 
       def apm_tracing_enabled: -> bool
     end

--- a/spec/datadog/tracing/distributed/propagation_policy_spec.rb
+++ b/spec/datadog/tracing/distributed/propagation_policy_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe Datadog::Tracing::Distributed::PropagationPolicy do
             it { expect(result).to be true }
           end
         end
+
+        context "when there is a distributed ai_guard event" do
+          before do
+            allow(Datadog.configuration.apm.tracing).to receive(:enabled).and_return(false)
+            allow(Datadog.configuration.ai_guard).to receive(:enabled).and_return(true)
+          end
+
+          let(:trace) { Datadog::Tracing::TraceOperation.new(tags: {"_dd.p.ts" => "20"}) }
+          let(:result) { described_class.enabled?(trace: trace) }
+
+          it { expect(result).to be true }
+        end
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
This PR changes distributed propagation policy to take AI Guard into account.

**Motivation:**
We want to have distributed tracing work properly when a trace has `_dd.p.ts` tag set to AI Guard product bit.

**Change log entry**
None. This change is internal.

**Additional Notes:**
Follow-up for #6081

**How to test the change?**
CI