### PR TITLE
ci: add Dependabot docker ecosystem for container image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,16 @@ updates:
       - dependency-name: "DataDog/system-tests/.github/workflows/system-tests.yml"
     cooldown:
       default-days: 7
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/integration/images/ruby/*"
+      - "/integration/apps/*"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
**What does this PR do?**

Adds a `docker` package ecosystem to `.github/dependabot.yml`, covering the root `docker-compose.yml`, the integration base image Dockerfiles (`integration/images/ruby/*`), and the integration app images (`integration/apps/*`). It mirrors the existing `github-actions` Dependabot setup (weekly, grouped, 7-day cooldown).

**Motivation:**

dd-trace-rb's CI containers and integration images track **mutable** upstream tags, e.g. `ghcr.io/datadog/images-rb/engines/ruby:X.Y-gnu-gcc`. When those tags were re-aliased upstream ([DataDog/images-rb#99](https://github.com/DataDog/images-rb/pull/99)), the base image changed underneath every build — new statically-linked Ruby (`--disable-shared`) and no mysql client library — with no PR, no diff, and no review on our side. That single upstream retag red-walled master and every open PR simultaneously (bundle-cache extension-ABI mismatch, `mysql2` failing to compile, and profiling native-filename spec failures).

This PR adds the *maintenance half* of the durable fix: an update task that keeps container image references current through reviewed bump PRs, the same way Dependabot already manages our GitHub Actions pins.

**This is one of two pieces. It does not, by itself, pin anything.**

Digest-pinning the image references is the substantive companion change and is intentionally **not** in this PR:

- The pin must target a **known-good** digest. The current `…/ruby:X.Y-gnu-gcc` digest is the images-rb#99 build that is actively broken for us. Pinning to it would freeze the outage into the repo and disable the auto-recovery that happens the moment images-rb corrects the tag. So engine pins should land *after* the upstream fix, targeting the good digest.
- Several references are **templated** by matrix (`…:${{ inputs.version }}-gnu-gcc` in `.github/workflows/_unit_test.yml` and `update-latest-dependency.yml`); a digest can't be inlined on an interpolated tag, so those need a version→digest map (best carried by extending `update-latest-dependency.yml`, which already iterates every Ruby version).
- Scope of refs to pin (for the follow-up): `check.yml` (5), `yard.yml` (1), `docker-compose.yml` (9 engine tags), `integration/images/ruby/*/Dockerfile` (13 `FROM`), `_unit_test.yml` (engine matrix + 7 service images), plus `datadog/ci:vX` in `test.yml`. Pin the multi-arch **index** digest (`@sha256:<index>`), not a per-arch digest.

Once references carry `@sha256:` digests, the `docker` ecosystem added here maintains them.

**Change log entry**

None.

**Additional Notes:**

- CI on this branch will be red until images-rb#99 is resolved — the breakage is repo-wide and inherited from the mutable upstream tag, not caused by this change.
- Draft: opening for review of the ecosystem scope (directories/grouping) before wiring the digest-pin follow-up.

**How to test the change?**

`.github/dependabot.yml` parses as valid YAML (`ruby -ryaml -e 'YAML.load_file(...)'`). Dependabot behavior is validated by GitHub after merge (it will begin scanning the listed directories for Dockerfiles and compose files). No runtime code is affected.
