### PR TITLE
DI: serialize BasicObject receivers and return values safely

### DIFF
--- a/lib/datadog/di/redactor.rb
+++ b/lib/datadog/di/redactor.rb
@@ -44,13 +44,18 @@ module Datadog
 
       attr_reader :settings
 
+      # Resolve the real class so a customer-overridden #class can't bypass
+      # type-based redaction, and BasicObject values redact by their real class.
+      KERNEL_CLASS = ::Kernel.instance_method(:class)
+      private_constant :KERNEL_CLASS
+
       def redact_identifier?(name)
         redacted_identifiers.include?(normalize(name))
       end
 
       def redact_type?(value)
         # Classses can be nameless, do not attempt to redact in that case.
-        if (cls_name = value.class.name)
+        if (cls_name = KERNEL_CLASS.bind(value).call.name)
           redacted_type_names_regexp.match?(cls_name)
         else
           false

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -50,6 +50,16 @@ module Datadog
       # return a safe stub rather than tear the process down.
       SERIALIZABLE_FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException].freeze
 
+      # Bind Kernel's reflective methods so serialization resolves the real
+      # implementations: customer-overridden #class/#instance_variables/
+      # #instance_variable_get can't intercept serialization, and blank-slate
+      # BasicObject receivers serialize instead of raising NoMethodError.
+      KERNEL_CLASS = ::Kernel.instance_method(:class)
+      KERNEL_INSTANCE_VARIABLES = ::Kernel.instance_method(:instance_variables)
+      KERNEL_INSTANCE_VARIABLE_GET = ::Kernel.instance_method(:instance_variable_get)
+      private_constant :KERNEL_CLASS, :KERNEL_INSTANCE_VARIABLES,
+        :KERNEL_INSTANCE_VARIABLE_GET
+
       # Placeholder emitted by #serialize_value_for_message in place of a value
       # whose identifier or type matches the redaction configuration. This
       # mirrors, for the human-readable log-probe message path, the
@@ -180,7 +190,7 @@ module Datadog
         collection_size: nil,
         type: nil)
         attribute_count ||= settings.dynamic_instrumentation.max_capture_attribute_count
-        cls = type || value.class
+        cls = type || KERNEL_CLASS.bind(value).call
         begin
           if redactor.redact_type?(value)
             return {type: class_name(cls), notCapturedReason: "redactedType"}
@@ -338,7 +348,7 @@ module Datadog
               # does not support JRuby, we don't handle JRuby's lack of ordering
               # of #instance_variables here, but if JRuby is supported in the
               # future this may need to be addressed.
-              ivars = value.instance_variables
+              ivars = KERNEL_INSTANCE_VARIABLES.bind(value).call
 
               ivars.each do |ivar|
                 if cur >= attribute_count
@@ -346,7 +356,7 @@ module Datadog
                   break
                 end
                 cur += 1
-                fields[ivar] = serialize_value(value.instance_variable_get(ivar), name: ivar, depth: depth - 1, length: length, collection_size: collection_size, attribute_count: attribute_count)
+                fields[ivar] = serialize_value(KERNEL_INSTANCE_VARIABLE_GET.bind(value).call(ivar), name: ivar, depth: depth - 1, length: length, collection_size: collection_size, attribute_count: attribute_count)
               end
               serialized.update(fields: fields)
             end
@@ -443,7 +453,7 @@ module Datadog
         else
           return "..." if depth <= 0
 
-          vars = value.instance_variables
+          vars = KERNEL_INSTANCE_VARIABLES.bind(value).call
           truncated = false
           max = max_capture_attribute_count_for_message
           if vars.length > max
@@ -458,7 +468,7 @@ module Datadog
             serialized_value = if redactor.redact_identifier?(var)
               REDACTED_VALUE_FOR_MESSAGE
             else
-              serialize_value_for_message(value.send(:instance_variable_get, var), depth: depth - 1)
+              serialize_value_for_message(KERNEL_INSTANCE_VARIABLE_GET.bind(value).call(var), depth: depth - 1)
             end
             "#{var}=#{serialized_value}"
           end
@@ -469,7 +479,7 @@ module Datadog
           serialized = if serialized.any?
             " " + serialized.join(" ")
           end
-          "#<#{class_name(value.class)}#{serialized}>"
+          "#<#{class_name(KERNEL_CLASS.bind(value).call)}#{serialized}>"
         end
       rescue Exception => exc # standard:disable Lint/RescueException
         raise if SERIALIZABLE_FATAL_EXCEPTION_CLASSES.any? { |klass| exc.is_a?(klass) }
@@ -477,7 +487,7 @@ module Datadog
         telemetry&.report(exc, description: "Error serializing for message")
         # TODO class_name(foo) can also fail, which we don't handle here.
         # Telemetry reporting could potentially also fail?
-        "#<#{class_name(value.class)}: serialization error>"
+        "#<#{class_name(KERNEL_CLASS.bind(value).call)}: serialization error>"
       end
 
       private

--- a/sig/datadog/di/redactor.rbs
+++ b/sig/datadog/di/redactor.rbs
@@ -11,6 +11,8 @@ module Datadog
 
       attr_reader settings: Datadog::Core::Configuration::Settings
 
+      KERNEL_CLASS: ::UnboundMethod
+
       def redact_identifier?: (Symbol | String name) -> bool
 
       def redact_type?: (any value) -> bool

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -5,6 +5,9 @@ module Datadog
       MAX_MESSAGE_ATTRIBUTE_COUNT: Integer
       SERIALIZABLE_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
       REDACTED_VALUE_FOR_MESSAGE: ::String
+      KERNEL_CLASS: ::UnboundMethod
+      KERNEL_INSTANCE_VARIABLES: ::UnboundMethod
+      KERNEL_INSTANCE_VARIABLE_GET: ::UnboundMethod
 
       @@flat_registry: ::Array[{condition: ::Proc?, proc: ^(Serializer serializer, any value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped}]
 

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -13,6 +13,10 @@ begin
   Object.send(:remove_const, :HookIvarTestClass)
 rescue NameError
 end
+begin
+  Object.send(:remove_const, :HookBasicObjectTestClass)
+rescue NameError
+end
 
 class HookTestClass
   class TestException < StandardError
@@ -84,6 +88,18 @@ class YieldingMethodMissingHookTestClass
   def method_missing(name, *args, **kwargs)
     yield [args, kwargs]
     [args, kwargs]
+  end
+end
+
+# A BasicObject subclass: instances are valid method receivers but do not
+# respond to Object/Kernel methods such as #class or #instance_variables.
+class HookBasicObjectTestClass < BasicObject
+  def initialize
+    @ivar = 2442
+  end
+
+  def hook_test_method
+    42
   end
 end
 

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -91,8 +91,6 @@ class YieldingMethodMissingHookTestClass
   end
 end
 
-# A BasicObject subclass: instances are valid method receivers but do not
-# respond to Object/Kernel methods such as #class or #instance_variables.
 class HookBasicObjectTestClass < BasicObject
   def initialize
     @ivar = 2442

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -350,6 +350,29 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "when the probed method is defined on a BasicObject subclass" do
+      let(:probe_args) do
+        {type_name: "HookBasicObjectTestClass", method_name: "hook_test_method",
+         capture_snapshot: true}
+      end
+
+      # Snapshot serialization calls Object/Kernel methods (e.g. #class,
+      # #instance_variables) on the receiver. A BasicObject provides none of
+      # them, so a snapshot of a BasicObject receiver cannot be captured; with
+      # propagate_all_exceptions enabled the underlying NoMethodError surfaces.
+      it "cannot serialize a BasicObject receiver" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect do
+          HookBasicObjectTestClass.new.hook_test_method
+        end.to raise_error(NoMethodError, /undefined method .class./)
+
+        expect(observed_calls).to be_empty
+      end
+    end
+
     context "positional args" do
       context "without snapshot capture" do
         let(:probe_args) do

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -355,18 +355,23 @@ RSpec.describe Datadog::DI::Instrumenter do
          capture_snapshot: true}
       end
 
-      # propagate_all_exceptions lets the NoMethodError from receiver
-      # serialization surface here; otherwise the probe boundary swallows it.
-      it "cannot serialize a BasicObject receiver" do
+      it "serializes a BasicObject receiver" do
         hook_method(probe) do |payload|
           observed_calls << payload
         end
 
-        expect do
-          HookBasicObjectTestClass.new.hook_test_method
-        end.to raise_error(NoMethodError, /undefined method .class./)
+        expect(HookBasicObjectTestClass.new.hook_test_method).to eq 42
 
-        expect(observed_calls).to be_empty
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first).to be_a(Datadog::DI::Context)
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          self: {
+            type: "HookBasicObjectTestClass",
+            fields: {
+              :@ivar => {type: "Integer", value: "2442"},
+            },
+          },
+        )
       end
     end
 

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -349,6 +349,29 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "when the probed method is defined on a BasicObject subclass" do
+      let(:probe_args) do
+        {type_name: "HookBasicObjectTestClass", method_name: "hook_test_method",
+         capture_snapshot: true}
+      end
+
+      # Snapshot serialization calls Object/Kernel methods (e.g. #class,
+      # #instance_variables) on the receiver. A BasicObject provides none of
+      # them, so a snapshot of a BasicObject receiver cannot be captured; with
+      # propagate_all_exceptions enabled the underlying NoMethodError surfaces.
+      it "cannot serialize a BasicObject receiver" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect do
+          HookBasicObjectTestClass.new.hook_test_method
+        end.to raise_error(NoMethodError, /undefined method .class./)
+
+        expect(observed_calls).to be_empty
+      end
+    end
+
     context "positional args" do
       context "without snapshot capture" do
         let(:probe_args) do

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -355,10 +355,8 @@ RSpec.describe Datadog::DI::Instrumenter do
          capture_snapshot: true}
       end
 
-      # Snapshot serialization calls Object/Kernel methods (e.g. #class,
-      # #instance_variables) on the receiver. A BasicObject provides none of
-      # them, so a snapshot of a BasicObject receiver cannot be captured; with
-      # propagate_all_exceptions enabled the underlying NoMethodError surfaces.
+      # propagate_all_exceptions lets the NoMethodError from receiver
+      # serialization surface here; otherwise the probe boundary swallows it.
       it "cannot serialize a BasicObject receiver" do
         hook_method(probe) do |payload|
           observed_calls << payload

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -430,6 +430,33 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
     end
   end
 
+  describe "#build_executed with a BasicObject return value" do
+    let(:probe) do
+      Datadog::DI::Probe.new(id: "123", type: :log,
+        type_name: "TestClass", method_name: "test_method",
+        capture_snapshot: true,)
+    end
+
+    let(:context) do
+      Datadog::DI::Context.new(
+        probe: probe,
+        settings: settings, serializer: serializer,
+        target_self: Object.new,
+        serialized_entry_args: {},
+        return_value: ::BasicObject.new, duration: 0.1,
+      )
+    end
+
+    # Snapshot serialization calls #class on the value being serialized, which
+    # a BasicObject does not provide, so a BasicObject return value cannot be
+    # serialized into the snapshot and the underlying NoMethodError surfaces.
+    it "cannot serialize a BasicObject return value" do
+      expect do
+        builder.build_executed(context)
+      end.to raise_error(NoMethodError, /undefined method .class./)
+    end
+  end
+
   describe "#build_executed for method probe with exception" do
     let(:probe) do
       Datadog::DI::Probe.new(id: "123", type: :log,

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -455,9 +455,8 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       )
     end
 
-    # Snapshot serialization calls #class on the value being serialized, which
-    # a BasicObject does not provide, so a BasicObject return value cannot be
-    # serialized into the snapshot and the underlying NoMethodError surfaces.
+    # build_executed serializes the return value with no error boundary, so the
+    # NoMethodError from #class propagates.
     it "cannot serialize a BasicObject return value" do
       expect do
         builder.build_executed(context)

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -438,6 +438,33 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
     end
   end
 
+  describe "#build_executed with a BasicObject return value" do
+    let(:probe) do
+      Datadog::DI::Probe.new(id: "123", type: :log,
+        type_name: "TestClass", method_name: "test_method",
+        capture_snapshot: true,)
+    end
+
+    let(:context) do
+      Datadog::DI::Context.new(
+        probe: probe,
+        settings: settings, serializer: serializer,
+        target_self: Object.new,
+        serialized_entry_args: {},
+        return_value: ::BasicObject.new, duration: 0.1,
+      )
+    end
+
+    # Snapshot serialization calls #class on the value being serialized, which
+    # a BasicObject does not provide, so a BasicObject return value cannot be
+    # serialized into the snapshot and the underlying NoMethodError surfaces.
+    it "cannot serialize a BasicObject return value" do
+      expect do
+        builder.build_executed(context)
+      end.to raise_error(NoMethodError, /undefined method .class./)
+    end
+  end
+
   describe "#build_executed for method probe with exception" do
     let(:probe) do
       Datadog::DI::Probe.new(id: "123", type: :log,

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -455,12 +455,11 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       )
     end
 
-    # build_executed serializes the return value with no error boundary, so the
-    # NoMethodError from #class propagates.
-    it "cannot serialize a BasicObject return value" do
-      expect do
-        builder.build_executed(context)
-      end.to raise_error(NoMethodError, /undefined method .class./)
+    it "serializes a BasicObject return value" do
+      payload = builder.build_executed(context)
+      expect(payload[:debugger][:snapshot][:captures][:return][:arguments][:"@return"]).to eq(
+        type: "BasicObject", fields: {}
+      )
     end
   end
 

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
 
     it "serializes a BasicObject return value" do
       payload = builder.build_executed(context)
-      expect(payload[:debugger][:snapshot][:captures][:return][:arguments][:"@return"]).to eq(
+      expect(payload[:debugger][:snapshot][:captures][:return][:arguments][:@return]).to eq(
         type: "BasicObject", fields: {}
       )
     end


### PR DESCRIPTION
**What does this PR do?**
Makes DI snapshot serialization safe for `BasicObject` receivers and return values, and adds tests covering both paths.

The serializer and redactor now resolve `#class`, `#instance_variables`, and `#instance_variable_get` through pre-bound `Kernel` unbound methods. This ensures `BasicObject` values (which lack `Kernel`) serialize correctly and customer-overridden methods cannot intercept serialization or bypass type-based redaction.

**Motivation:**
The snapshot serializer dispatched `#class`, `#instance_variables`, and `#instance_variable_get` on the captured value. A `BasicObject` lacks `Kernel` and provides none of these, so a `BasicObject` receiver or return value raised `NoMethodError` during serialization; in production the probe error boundary swallowed it, dropping the whole snapshot. Dispatching `#class` on the captured value also executed customer-overridden methods, running customer code during serialization.

**Change log entry**
No.

**Additional Notes:**
N/A

**How to test the change?**
Unit tests added
