### PR TITLE
[PROF-15490] Profiling: Fix missing native filename for static Ruby binaries

### DIFF
--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -79,11 +79,11 @@ class ProfilerSampleLoopBenchmark
     if mode == :native
       unless Datadog::Profiling::Collectors::Stack._native_filenames_available?
         if OS.linux?
-          puts "Skipping benchmarking native_frames, not supported by this Ruby build"
+          raise "Native filenames are not available. This is not expected on Linux!"
         else
           puts "Skipping benchmarking native_frames, not supported outside of Linux"
+          return
         end
-        return
       end
 
       Datadog::Profiling::Collectors::ThreadContext.for_testing(

--- a/benchmarks/profiling_sample_loop_v2.rb
+++ b/benchmarks/profiling_sample_loop_v2.rb
@@ -4,7 +4,6 @@ VALIDATE_BENCHMARK_MODE = ENV["VALIDATE_BENCHMARK"] == "true"
 return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
 
 require_relative "benchmarks_helper"
-require "os"
 
 # This benchmark measures the performance of the main stack sampling loop of the profiler
 
@@ -77,15 +76,6 @@ class ProfilerSampleLoopBenchmark
     collector = Datadog::Profiling::Collectors::ThreadContext.for_testing(recorder: @recorder)
 
     if mode == :native
-      unless Datadog::Profiling::Collectors::Stack._native_filenames_available?
-        if OS.linux?
-          raise "Native filenames are not available. This is not expected on Linux!"
-        else
-          puts "Skipping benchmarking native_frames, not supported outside of Linux"
-          return
-        end
-      end
-
       Datadog::Profiling::Collectors::ThreadContext.for_testing(
         recorder: @recorder,
         native_filenames_enabled: false

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -5,14 +5,11 @@
 
 #include "extconf.h" // This is needed for the HAVE_DLADDR and friends below
 
-#if (defined(HAVE_DLADDR1) && HAVE_DLADDR1) || (defined(HAVE_DLADDR) && HAVE_DLADDR)
+#if defined(HAVE_DLADDR) && HAVE_DLADDR
   #ifndef _GNU_SOURCE
     #define _GNU_SOURCE
   #endif
   #include <dlfcn.h>
-  #if defined(HAVE_DLADDR1) && HAVE_DLADDR1
-    #include <link.h>
-  #endif
 #endif
 
 #include "datadog_ruby_common.h"
@@ -62,7 +59,7 @@ void collectors_stack_init(VALUE profiling_module) {
 
   rb_define_singleton_method(testing_module, "_native_sample", _native_sample, -1);
 
-  #if (defined(HAVE_DLADDR1) && HAVE_DLADDR1) || (defined(HAVE_DLADDR) && HAVE_DLADDR)
+  #if defined(HAVE_DLADDR) && HAVE_DLADDR
     // To be able to detect when a frame is coming from Ruby, we record here its filename as returned by dladdr.
     // We expect this same pointer to be returned by dladdr for all frames coming from Ruby.
     //
@@ -421,7 +418,7 @@ void sample_thread(
   );
 }
 
-#if (defined(HAVE_DLADDR1) && HAVE_DLADDR1) || (defined(HAVE_DLADDR) && HAVE_DLADDR)
+#if defined(HAVE_DLADDR) && HAVE_DLADDR
   static void set_file_info_for_cfunc(
     ddog_CharSlice *filename_slice,
     int *line,
@@ -468,17 +465,7 @@ void sample_thread(
     if (cached_filename != NULL) return cached_filename;
 
     Dl_info info;
-    const char *native_filename = NULL;
-    #if defined(HAVE_DLADDR1) && HAVE_DLADDR1
-      struct link_map *extra_info = NULL;
-      if (dladdr1(function, &info, (void **) &extra_info, RTLD_DL_LINKMAP) != 0 && extra_info != NULL) {
-        native_filename = extra_info->l_name != NULL ? extra_info->l_name : info.dli_fname;
-      }
-    #elif defined(HAVE_DLADDR) && HAVE_DLADDR
-      if (dladdr(function, &info) != 0) {
-        native_filename = info.dli_fname;
-      }
-    #endif
+    const char *native_filename = dladdr(function, &info) != 0 ? info.dli_fname : NULL;
 
     // We explicitly use an empty string here so as to cache lookups that somehow "failed". Otherwise we would keep trying them every time.
     if (native_filename == NULL) native_filename = "";

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -24,7 +24,6 @@
 // Gathers stack traces from running threads, storing them in a StackRecorder instance
 // This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
 
-static VALUE _native_filenames_available(DDTRACE_UNUSED VALUE self);
 static VALUE _native_ruby_native_filename(DDTRACE_UNUSED VALUE self);
 static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static VALUE native_sample_do(VALUE args);
@@ -56,7 +55,6 @@ void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
   VALUE collectors_stack_class = rb_define_class_under(collectors_module, "Stack", rb_cObject);
 
-  rb_define_singleton_method(collectors_stack_class, "_native_filenames_available?", _native_filenames_available, 0);
   rb_define_singleton_method(collectors_stack_class, "_native_ruby_native_filename", _native_ruby_native_filename, 0);
 
   // Hosts methods used for testing the native code using RSpec
@@ -77,14 +75,6 @@ void collectors_stack_init(VALUE profiling_module) {
       ruby_native_filename = native_filename;
     }
     st_free_table(temporary_cache);
-  #endif
-}
-
-static VALUE _native_filenames_available(DDTRACE_UNUSED VALUE self) {
-  #if (defined(HAVE_DLADDR1) && HAVE_DLADDR1) || (defined(HAVE_DLADDR) && HAVE_DLADDR)
-    return ruby_native_filename != NULL ? Qtrue : Qfalse;
-  #else
-    return Qfalse;
   #endif
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -3,14 +3,10 @@
 #include <ruby/st.h>
 #include <stdatomic.h>
 
-#include "extconf.h" // This is needed for the HAVE_DLADDR and friends below
-
-#if defined(HAVE_DLADDR) && HAVE_DLADDR
-  #ifndef _GNU_SOURCE
-    #define _GNU_SOURCE
-  #endif
-  #include <dlfcn.h>
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE // Needed for dlfcn.h/dladdr
 #endif
+#include <dlfcn.h>
 
 #include "datadog_ruby_common.h"
 #include "private_vm_api_access.h"
@@ -45,7 +41,7 @@ static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_Char
 extern VALUE rb_iseq_path(const VALUE);
 extern VALUE rb_iseq_base_label(const VALUE);
 
-// NULL if dladdr is not available or we weren't able to get the native filename for the Ruby VM
+// NULL if we weren't able to get the native filename for the Ruby VM
 static const char *ruby_native_filename = NULL;
 
 void collectors_stack_init(VALUE profiling_module) {
@@ -59,20 +55,18 @@ void collectors_stack_init(VALUE profiling_module) {
 
   rb_define_singleton_method(testing_module, "_native_sample", _native_sample, -1);
 
-  #if defined(HAVE_DLADDR) && HAVE_DLADDR
-    // To be able to detect when a frame is coming from Ruby, we record here its filename as returned by dladdr.
-    // We expect this same pointer to be returned by dladdr for all frames coming from Ruby.
-    //
-    // Small note: Creating/deleting the cache is a bit awkward here, but it seems like a bigger footgun to allow
-    // `get_or_compute_native_filename` to run without a cache, since we never expect that to happen during sampling. So it seems
-    // like a reasonable trade-off to force callers to always figure that out.
-    st_table *temporary_cache = st_init_numtable();
-    const char *native_filename = get_or_compute_native_filename(rb_ary_new, temporary_cache);
-    if (native_filename != NULL && native_filename[0] != '\0') {
-      ruby_native_filename = native_filename;
-    }
-    st_free_table(temporary_cache);
-  #endif
+  // To be able to detect when a frame is coming from Ruby, we record here its filename as returned by dladdr.
+  // We expect this same pointer to be returned by dladdr for all frames coming from Ruby.
+  //
+  // Small note: Creating/deleting the cache is a bit awkward here, but it seems like a bigger footgun to allow
+  // `get_or_compute_native_filename` to run without a cache, since we never expect that to happen during sampling. So it seems
+  // like a reasonable trade-off to force callers to always figure that out.
+  st_table *temporary_cache = st_init_numtable();
+  const char *native_filename = get_or_compute_native_filename(rb_ary_new, temporary_cache);
+  if (native_filename != NULL && native_filename[0] != '\0') {
+    ruby_native_filename = native_filename;
+  }
+  st_free_table(temporary_cache);
 }
 
 static VALUE _native_ruby_native_filename(DDTRACE_UNUSED VALUE self) {
@@ -418,83 +412,67 @@ void sample_thread(
   );
 }
 
-#if defined(HAVE_DLADDR) && HAVE_DLADDR
-  static void set_file_info_for_cfunc(
-    ddog_CharSlice *filename_slice,
-    int *line,
-    ddog_CharSlice last_ruby_frame_filename,
-    int last_ruby_line,
-    void *function,
-    bool top_of_the_stack,
-    bool native_filenames_enabled,
-    st_table *native_filenames_cache
-  ) {
-    if (native_filenames_enabled) {
-      const char *native_filename = get_or_compute_native_filename(function, native_filenames_cache);
-      if (native_filename && native_filename[0] != '\0' &&
-        // Using the ruby_native_filename at the top of the stack has a weird effect on the "top methods" table because
-        // e.g. we don't have classnames for methods. This is especially visible in the allocations profile, e.g.
-        // what a surprise, you're telling me "libruby.so:new" is the top method always?
-        //
-        // Until we have a better way of dealing with that, we don't do this replacement for the top frame.
-        //
-        // Also, dladdr is expected to always return the same pointer to the ruby_native_filename, so that's why we're
-        // comparing only pointer values and not the string contents.
-        (native_filename != ruby_native_filename || !top_of_the_stack)
-      ) {
-        *filename_slice = (ddog_CharSlice) {.ptr = native_filename, .len = strlen(native_filename)};
-        // Explicitly set the line to 0 as it has no meaning on a native library (e.g. an .so is built of many source files)
-        // and anyway often that debug info is not available.
-        *line = 0;
-        return;
-      }
+static void set_file_info_for_cfunc(
+  ddog_CharSlice *filename_slice,
+  int *line,
+  ddog_CharSlice last_ruby_frame_filename,
+  int last_ruby_line,
+  void *function,
+  bool top_of_the_stack,
+  bool native_filenames_enabled,
+  st_table *native_filenames_cache
+) {
+  if (native_filenames_enabled) {
+    const char *native_filename = get_or_compute_native_filename(function, native_filenames_cache);
+    if (native_filename && native_filename[0] != '\0' &&
+      // Using the ruby_native_filename at the top of the stack has a weird effect on the "top methods" table because
+      // e.g. we don't have classnames for methods. This is especially visible in the allocations profile, e.g.
+      // what a surprise, you're telling me "libruby.so:new" is the top method always?
+      //
+      // Until we have a better way of dealing with that, we don't do this replacement for the top frame.
+      //
+      // Also, dladdr is expected to always return the same pointer to the ruby_native_filename, so that's why we're
+      // comparing only pointer values and not the string contents.
+      (native_filename != ruby_native_filename || !top_of_the_stack)
+    ) {
+      *filename_slice = (ddog_CharSlice) {.ptr = native_filename, .len = strlen(native_filename)};
+      // Explicitly set the line to 0 as it has no meaning on a native library (e.g. an .so is built of many source files)
+      // and anyway often that debug info is not available.
+      *line = 0;
+      return;
     }
-
-    *filename_slice = last_ruby_frame_filename;
-    *line = last_ruby_line;
   }
 
-  // `native_filenames_cache` is used to cache native filename lookup results (Map[void *function_pointer, char *filename])
-  //
-  // Caching this information is safe because there's no API in Ruby to "unrequire" a native extension. Thus, if we see a
-  // frame on the **Ruby** stack with a given `function`, then that `function` was registered with the Ruby VM and
-  // belongs to a Ruby extension, so a lot of other bad things would happen if it was dlclosed.
-  static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache) {
-    const char *cached_filename = NULL;
-    st_lookup(native_filenames_cache, (st_data_t) function, (st_data_t *) &cached_filename);
-    if (cached_filename != NULL) return cached_filename;
+  *filename_slice = last_ruby_frame_filename;
+  *line = last_ruby_line;
+}
 
-    Dl_info info;
-    const char *native_filename = dladdr(function, &info) != 0 ? info.dli_fname : NULL;
+// `native_filenames_cache` is used to cache native filename lookup results (Map[void *function_pointer, char *filename])
+//
+// Caching this information is safe because there's no API in Ruby to "unrequire" a native extension. Thus, if we see a
+// frame on the **Ruby** stack with a given `function`, then that `function` was registered with the Ruby VM and
+// belongs to a Ruby extension, so a lot of other bad things would happen if it was dlclosed.
+static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache) {
+  const char *cached_filename = NULL;
+  st_lookup(native_filenames_cache, (st_data_t) function, (st_data_t *) &cached_filename);
+  if (cached_filename != NULL) return cached_filename;
 
-    // We explicitly use an empty string here so as to cache lookups that somehow "failed". Otherwise we would keep trying them every time.
-    if (native_filename == NULL) native_filename = "";
+  Dl_info info;
+  const char *native_filename = dladdr(function, &info) != 0 ? info.dli_fname : NULL;
 
-    // An st_table is what Ruby uses for its own hashtables. This allows us to get an easy estimate of the size of the cache:
-    // `ObjectSpace.memsize_of((0..100000).map { |it| [it, nil] }.to_h)` => 4194400 bytes as of Ruby 3.2 so that seems reasonable?
-    // Note: `st_table_size()` is available from Ruby 3.2+ but not before
-    if (native_filenames_cache->num_entries >= 100000) {
-      st_clear(native_filenames_cache);
-    }
+  // We explicitly use an empty string here so as to cache lookups that somehow "failed". Otherwise we would keep trying them every time.
+  if (native_filename == NULL) native_filename = "";
 
-    st_insert(native_filenames_cache, (st_data_t) function, (st_data_t) native_filename);
-    return native_filename;
+  // An st_table is what Ruby uses for its own hashtables. This allows us to get an easy estimate of the size of the cache:
+  // `ObjectSpace.memsize_of((0..100000).map { |it| [it, nil] }.to_h)` => 4194400 bytes as of Ruby 3.2 so that seems reasonable?
+  // Note: `st_table_size()` is available from Ruby 3.2+ but not before
+  if (native_filenames_cache->num_entries >= 100000) {
+    st_clear(native_filenames_cache);
   }
-#else
-  static void set_file_info_for_cfunc(
-    ddog_CharSlice *filename_slice,
-    int *line,
-    ddog_CharSlice last_ruby_frame_filename,
-    int last_ruby_line,
-    DDTRACE_UNUSED void *function,
-    DDTRACE_UNUSED bool top_of_the_stack,
-    DDTRACE_UNUSED bool native_filenames_enabled,
-    DDTRACE_UNUSED st_table *native_filenames_cache
-  ) {
-    *filename_slice = last_ruby_frame_filename;
-    *line = last_ruby_line;
-  }
-#endif
+
+  st_insert(native_filenames_cache, (st_data_t) function, (st_data_t) native_filename);
+  return native_filename;
+}
 
 // Rails's ActionView likes to dynamically generate method names with suffixed hashes/ids, resulting in methods with
 // names such as:

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -8,11 +8,6 @@
 #endif
 #include <dlfcn.h>
 
-#ifdef __APPLE__
-  #include <libproc.h> // Needed for proc_pidpath, used to find the path to a static Ruby's executable
-  #include <unistd.h> // Needed for getpid
-#endif
-
 #include "datadog_ruby_common.h"
 #include "private_vm_api_access.h"
 #include "ruby_helpers.h"
@@ -669,18 +664,13 @@ static void initialize_static_ruby_actual_filename(void) {
   bool ruby_is_static = rb_eval_string("require 'rbconfig'; (RbConfig::CONFIG['ENABLE_SHARED'] == 'no')") == Qtrue;
   if (!ruby_is_static) return;
 
-  VALUE actual_filename = Qnil;
-
-  #if defined(__linux__)
-    actual_filename = rb_eval_string("File.readlink('/proc/self/exe').delete_suffix(' (deleted)') rescue nil");
-  #elif defined(__APPLE__)
-    char path_buffer[PROC_PIDPATHINFO_MAXSIZE];
-    int path_length = proc_pidpath(getpid(), path_buffer, sizeof(path_buffer));
-    if (path_length > 0) actual_filename = rb_utf8_str_new(path_buffer, path_length);
-  #endif
-
-  if (!valid_looking_path(actual_filename)) actual_filename = rb_eval_string("RbConfig.ruby");
-  if (!valid_looking_path(actual_filename)) return;
+  VALUE actual_filename = rb_eval_string("RbConfig.ruby");
+  bool valid_looking_path =
+    actual_filename != Qnil &&
+    RB_TYPE_P(actual_filename, T_STRING) &&
+    RSTRING_LEN(actual_filename) > 0 &&
+    RSTRING_PTR(actual_filename)[0] == '/';
+  if (!valid_looking_path) return;
 
   static_ruby_actual_filename = rb_obj_freeze(actual_filename);
   rb_gc_register_mark_object(static_ruby_actual_filename); // Makes this object immortal + pinned in-place (no moving)

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -8,6 +8,11 @@
 #endif
 #include <dlfcn.h>
 
+#ifdef __APPLE__
+  #include <libproc.h> // Needed for proc_pidpath, used to find the path to a static Ruby's executable
+  #include <unistd.h> // Needed for getpid
+#endif
+
 #include "datadog_ruby_common.h"
 #include "private_vm_api_access.h"
 #include "ruby_helpers.h"
@@ -18,6 +23,7 @@
 // This file implements the native bits of the Datadog::Profiling::Collectors::Stack class
 
 static VALUE _native_ruby_native_filename(DDTRACE_UNUSED VALUE self);
+static VALUE _native_set_file_info_for_cfunc(DDTRACE_UNUSED VALUE self, VALUE new_static_ruby_actual_filename);
 static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self);
 static VALUE native_sample_do(VALUE args);
 static VALUE native_sample_ensure(VALUE args);
@@ -32,6 +38,7 @@ static void set_file_info_for_cfunc(
   st_table *native_filenames_cache
 );
 static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache);
+static void initialize_static_ruby_actual_filename(void);
 static void add_truncated_frames_placeholder(ddog_prof_Location *locations);
 static void record_placeholder_stack_in_native_code(VALUE recorder_instance, sample_values values, sample_labels labels);
 static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_CharSlice *filename_slice);
@@ -41,8 +48,12 @@ static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_Char
 extern VALUE rb_iseq_path(const VALUE);
 extern VALUE rb_iseq_base_label(const VALUE);
 
-// NULL if we weren't able to get the native filename for the Ruby VM
+// NULL if we weren't able to get the native filename for the Ruby VM.
+// On a static Ruby without libruby.so, `get_or_compute_native_filename` returns `ruby_native_filename` but
+// `static_ruby_actual_filename` (below) is what we want to show instead.
 static const char *ruby_native_filename = NULL;
+// Qnil unless we're running on a static Ruby
+static VALUE static_ruby_actual_filename = Qnil;
 
 void collectors_stack_init(VALUE profiling_module) {
   VALUE collectors_module = rb_define_module_under(profiling_module, "Collectors");
@@ -54,6 +65,7 @@ void collectors_stack_init(VALUE profiling_module) {
   VALUE testing_module = rb_define_module_under(collectors_stack_class, "Testing");
 
   rb_define_singleton_method(testing_module, "_native_sample", _native_sample, -1);
+  rb_define_singleton_method(testing_module, "_native_set_file_info_for_cfunc", _native_set_file_info_for_cfunc, 1);
 
   // To be able to detect when a frame is coming from Ruby, we record here its filename as returned by dladdr.
   // We expect this same pointer to be returned by dladdr for all frames coming from Ruby.
@@ -67,10 +79,16 @@ void collectors_stack_init(VALUE profiling_module) {
     ruby_native_filename = native_filename;
   }
   st_free_table(temporary_cache);
+
+  if (native_filename != NULL) initialize_static_ruby_actual_filename();
 }
 
 static VALUE _native_ruby_native_filename(DDTRACE_UNUSED VALUE self) {
-  return ruby_native_filename != NULL ? rb_utf8_str_new_cstr(ruby_native_filename) : Qnil;
+  if (static_ruby_actual_filename != Qnil) {
+    return static_ruby_actual_filename;
+  } else {
+    return ruby_native_filename != NULL ? rb_utf8_str_new_cstr(ruby_native_filename) : Qnil;
+  }
 }
 
 typedef struct {
@@ -424,18 +442,23 @@ static void set_file_info_for_cfunc(
 ) {
   if (native_filenames_enabled) {
     const char *native_filename = get_or_compute_native_filename(function, native_filenames_cache);
-    if (native_filename && native_filename[0] != '\0' &&
-      // Using the ruby_native_filename at the top of the stack has a weird effect on the "top methods" table because
+    if (native_filename[0] != '\0' &&
+      // TODO: Using the ruby_native_filename at the top of the stack has a weird effect on the "top methods" table because
       // e.g. we don't have classnames for methods. This is especially visible in the allocations profile, e.g.
       // what a surprise, you're telling me "libruby.so:new" is the top method always?
-      //
       // Until we have a better way of dealing with that, we don't do this replacement for the top frame.
+      // (Bonus TODO note: This might be fixed by using full class/module names in frames?)
       //
-      // Also, dladdr is expected to always return the same pointer to the ruby_native_filename, so that's why we're
+      // dladdr is expected to always return the same pointer to the ruby_native_filename, so that's why we're
       // comparing only pointer values and not the string contents.
       (native_filename != ruby_native_filename || !top_of_the_stack)
     ) {
-      *filename_slice = (ddog_CharSlice) {.ptr = native_filename, .len = strlen(native_filename)};
+      // On a static Ruby without libruby.so, we show `static_ruby_actual_filename` instead of `ruby_native_filename`
+      if (native_filename == ruby_native_filename && static_ruby_actual_filename != Qnil) {
+        *filename_slice = char_slice_from_ruby_string(static_ruby_actual_filename);
+      } else {
+        *filename_slice = (ddog_CharSlice) {.ptr = native_filename, .len = strlen(native_filename)};
+      }
       // Explicitly set the line to 0 as it has no meaning on a native library (e.g. an .so is built of many source files)
       // and anyway often that debug info is not available.
       *line = 0;
@@ -638,4 +661,54 @@ void sampling_buffer_mark(sampling_buffer *buffer) {
   // Make sure iteration completes before `is_marking` is unset...
   atomic_signal_fence(memory_order_seq_cst);
   buffer->is_marking = false;
+}
+
+// On a static Ruby without libruby.so the `ruby_native_filename` returned from `dladdr` is in practice `argv[0]`
+// (e.g. can be rspec, rake, etc), so here we find the actual Ruby binary to use instead
+static void initialize_static_ruby_actual_filename(void) {
+  bool ruby_is_static = rb_eval_string("require 'rbconfig'; (RbConfig::CONFIG['ENABLE_SHARED'] == 'no')") == Qtrue;
+  if (!ruby_is_static) return;
+
+  VALUE actual_filename = Qnil;
+
+  #if defined(__linux__)
+    actual_filename = rb_eval_string("File.readlink('/proc/self/exe').delete_suffix(' (deleted)') rescue nil");
+  #elif defined(__APPLE__)
+    char path_buffer[PROC_PIDPATHINFO_MAXSIZE];
+    int path_length = proc_pidpath(getpid(), path_buffer, sizeof(path_buffer));
+    if (path_length > 0) actual_filename = rb_utf8_str_new(path_buffer, path_length);
+  #endif
+
+  if (!valid_looking_path(actual_filename)) actual_filename = rb_eval_string("RbConfig.ruby");
+  if (!valid_looking_path(actual_filename)) return;
+
+  static_ruby_actual_filename = rb_obj_freeze(actual_filename);
+  rb_gc_register_mark_object(static_ruby_actual_filename); // Makes this object immortal + pinned in-place (no moving)
+}
+
+static VALUE _native_set_file_info_for_cfunc(DDTRACE_UNUSED VALUE self, VALUE new_static_ruby_actual_filename) {
+  if (new_static_ruby_actual_filename != Qnil) ENFORCE_TYPE(new_static_ruby_actual_filename, T_STRING);
+
+  VALUE previous_static_ruby_actual_filename = static_ruby_actual_filename;
+  static_ruby_actual_filename = new_static_ruby_actual_filename;
+
+  ddog_CharSlice filename_slice;
+  int line;
+  st_table *native_filenames_cache = st_init_numtable();
+
+  set_file_info_for_cfunc(
+    &filename_slice,
+    &line,
+    DDOG_CHARSLICE_C("(not used when testing)"),
+    0,
+    rb_ary_new, // Symbol inside Ruby VM to trigger comparison logic
+    false,
+    true,
+    native_filenames_cache
+  );
+
+  st_free_table(native_filenames_cache);
+  static_ruby_actual_filename = previous_static_ruby_actual_filename;
+
+  return rb_utf8_str_new(filename_slice.ptr, filename_slice.len);
 }

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -33,7 +33,7 @@ static void set_file_info_for_cfunc(
   st_table *native_filenames_cache
 );
 static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache);
-static void initialize_static_ruby_actual_filename(void);
+static void initialize_static_ruby_actual_filename(VALUE profiling_module);
 static void add_truncated_frames_placeholder(ddog_prof_Location *locations);
 static void record_placeholder_stack_in_native_code(VALUE recorder_instance, sample_values values, sample_labels labels);
 static void maybe_trim_template_random_ids(ddog_CharSlice *name_slice, ddog_CharSlice *filename_slice);
@@ -70,12 +70,11 @@ void collectors_stack_init(VALUE profiling_module) {
   // like a reasonable trade-off to force callers to always figure that out.
   st_table *temporary_cache = st_init_numtable();
   const char *native_filename = get_or_compute_native_filename(rb_ary_new, temporary_cache);
-  if (native_filename != NULL && native_filename[0] != '\0') {
+  if (native_filename[0] != '\0') {
     ruby_native_filename = native_filename;
+    initialize_static_ruby_actual_filename(profiling_module);
   }
   st_free_table(temporary_cache);
-
-  if (native_filename != NULL) initialize_static_ruby_actual_filename();
 }
 
 static VALUE _native_ruby_native_filename(DDTRACE_UNUSED VALUE self) {
@@ -470,6 +469,8 @@ static void set_file_info_for_cfunc(
 // Caching this information is safe because there's no API in Ruby to "unrequire" a native extension. Thus, if we see a
 // frame on the **Ruby** stack with a given `function`, then that `function` was registered with the Ruby VM and
 // belongs to a Ruby extension, so a lot of other bad things would happen if it was dlclosed.
+//
+// Returns "" if not found. Never returns NULL.
 static const char *get_or_compute_native_filename(void *function, st_table *native_filenames_cache) {
   const char *cached_filename = NULL;
   st_lookup(native_filenames_cache, (st_data_t) function, (st_data_t *) &cached_filename);
@@ -660,20 +661,13 @@ void sampling_buffer_mark(sampling_buffer *buffer) {
 
 // On a static Ruby without libruby.so the `ruby_native_filename` returned from `dladdr` is in practice `argv[0]`
 // (e.g. can be rspec, rake, etc), so here we find the actual Ruby binary to use instead
-static void initialize_static_ruby_actual_filename(void) {
-  bool ruby_is_static = rb_eval_string("require 'rbconfig'; (RbConfig::CONFIG['ENABLE_SHARED'] == 'no')") == Qtrue;
-  if (!ruby_is_static) return;
-
-  VALUE actual_filename = rb_eval_string("RbConfig.ruby");
-  bool valid_looking_path =
-    actual_filename != Qnil &&
-    RB_TYPE_P(actual_filename, T_STRING) &&
-    RSTRING_LEN(actual_filename) > 0 &&
-    RSTRING_PTR(actual_filename)[0] == '/';
-  if (!valid_looking_path) return;
-
-  static_ruby_actual_filename = rb_obj_freeze(actual_filename);
-  rb_gc_register_mark_object(static_ruby_actual_filename); // Makes this object immortal + pinned in-place (no moving)
+static void initialize_static_ruby_actual_filename(VALUE profiling_module) {
+  static_ruby_actual_filename = rb_const_get(profiling_module, rb_intern("STATIC_RUBY_PATH"));
+  if (NIL_P(static_ruby_actual_filename)) {
+    return;
+  }
+  // Makes this object immortal + pinned in-place (no moving)
+  rb_gc_register_mark_object(static_ruby_actual_filename);
 }
 
 static VALUE _native_set_file_info_for_cfunc(DDTRACE_UNUSED VALUE self, VALUE new_static_ruby_actual_filename) {

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -139,12 +139,9 @@ end
 
 have_func "malloc_stats"
 
-# Used to get native filenames (dladdr1 is preferred, so we only check for the other if not available)
-# Note it's possible none are available
-if have_header("dlfcn.h")
-  (have_struct_member("struct link_map", "l_name", "link.h") && have_func("dladdr1")) ||
-    have_func("dladdr")
-end
+# Used to get native filenames
+# Note it's possible it's not available
+have_func("dladdr") if have_header("dlfcn.h")
 
 # On older Rubies, there was no primitive mutex and condition variable implemented in `thread_sync.rb` (internal)
 $defs << "-DNO_PRIMITIVE_MUTEX_AND_CONDITION_VARIABLE" if RUBY_VERSION < "4"

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -139,10 +139,6 @@ end
 
 have_func "malloc_stats"
 
-# Used to get native filenames
-# Note it's possible it's not available
-have_func("dladdr") if have_header("dlfcn.h")
-
 # On older Rubies, there was no primitive mutex and condition variable implemented in `thread_sync.rb` (internal)
 $defs << "-DNO_PRIMITIVE_MUTEX_AND_CONDITION_VARIABLE" if RUBY_VERSION < "4"
 

--- a/lib/datadog/profiling.rb
+++ b/lib/datadog/profiling.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rbconfig"
 require_relative "core"
 require_relative "core/environment/variable_helpers"
 require_relative "core/utils/only_once"
@@ -7,6 +8,9 @@ require_relative "core/utils/only_once"
 module Datadog
   # Datadog Continuous Profiler implementation: https://docs.datadoghq.com/profiler/
   module Profiling
+    STATIC_RUBY_PATH = (RbConfig::CONFIG["ENABLE_SHARED"] == "no") ? RbConfig.ruby.freeze : nil
+    private_constant :STATIC_RUBY_PATH
+
     def self.supported?
       unsupported_reason.nil?
     end

--- a/lib/datadog/profiling/collectors/thread_context.rb
+++ b/lib/datadog/profiling/collectors/thread_context.rb
@@ -32,7 +32,7 @@ module Datadog
             endpoint_collection_enabled: endpoint_collection_enabled,
             waiting_for_gvl_threshold_ns: waiting_for_gvl_threshold_ns,
             otel_context_enabled: otel_context_enabled,
-            native_filenames_enabled: validate_native_filenames(native_filenames_enabled),
+            native_filenames_enabled: native_filenames_enabled,
             overhead_filename: __FILE__,
           )
         end
@@ -89,17 +89,6 @@ module Datadog
 
           context = provider.instance_variable_get(:@context)
           context&.instance_variable_get(:@key)
-        end
-
-        def validate_native_filenames(native_filenames_enabled)
-          if native_filenames_enabled && !Datadog::Profiling::Collectors::Stack._native_filenames_available?
-            Datadog.logger.debug(
-              "Native filenames are enabled, but the required dladdr API was not available. Disabling native filenames."
-            )
-            false
-          else
-            native_filenames_enabled
-          end
         end
       end
     end

--- a/sig/datadog/profiling.rbs
+++ b/sig/datadog/profiling.rbs
@@ -1,5 +1,7 @@
 module Datadog
   module Profiling
+    STATIC_RUBY_PATH: String?
+
     # Exception raised by native code when SIGPROF already has a handler (ext/datadog_profiling_native_extension/setup_signal_handler.c).
     class ExistingSignalHandler < ::RuntimeError
     end

--- a/sig/datadog/profiling/collectors/stack.rbs
+++ b/sig/datadog/profiling/collectors/stack.rbs
@@ -2,8 +2,6 @@ module Datadog
   module Profiling
     module Collectors
       class Stack
-        def self._native_filenames_available?: () -> bool
-
         def self._native_ruby_native_filename: () -> ::String?
       end
     end

--- a/sig/datadog/profiling/collectors/thread_context.rbs
+++ b/sig/datadog/profiling/collectors/thread_context.rbs
@@ -51,8 +51,6 @@ module Datadog
         private
 
         def safely_extract_context_key_from: (untyped tracer) -> ::Symbol?
-
-        def validate_native_filenames: (bool native_filenames_enabled) -> bool
       end
     end
   end

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         expect(gathered_stack).to eq reference_stack
       end
 
-      context "when native filenames are enabled", if: PlatformHelpers.linux? do
+      context "when native filenames are enabled" do
         let(:native_filenames_enabled) { true }
 
         it "matches the Ruby backtrace API after the 6th frame" do
@@ -284,11 +284,10 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
             have_attributes(base_label: "sleep", path: __FILE__, lineno: @expected_line),
             have_attributes(base_label: "<top (required)>", path: __FILE__, lineno: @expected_line),
             # Bigdecimal is a native extension shipped separately from Ruby
-            have_attributes(base_label: "save_rounding_mode", path: end_with("bigdecimal.so"), lineno: 0),
+            have_attributes(base_label: "save_rounding_mode", path: end_with("bigdecimal.so").or(end_with("bigdecimal.bundle")), lineno: 0),
             have_attributes(base_label: "<top (required)>", path: __FILE__, lineno: be_positive),
             # We expect the native filename for catch to be inside the Ruby VM -- either in the ruby binary or the libruby library
-            # Note that this may not apply everywhere (e.g. you can rename your Ruby), but it seems sane enough to require this when running tests
-            have_attributes(base_label: "catch", path: end_with("/ruby").or(include("libruby").and(include(".so"))), lineno: 0),
+            have_attributes(base_label: "catch", path: described_class._native_ruby_native_filename, lineno: 0),
           )
         end
       end
@@ -316,7 +315,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
         expect(gathered_stack).to eq reference_stack
       end
 
-      context "when native filenames are enabled", if: PlatformHelpers.linux? do
+      context "when native filenames are enabled" do
         let(:native_filenames_enabled) { true }
 
         it "matches the Ruby backtrace API after the 5th frame" do
@@ -328,7 +327,7 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
             have_attributes(base_label: "sleep", path: __FILE__, lineno: be_positive),
             have_attributes(base_label: "<top (required)>", path: __FILE__, lineno: be_positive),
             # Bigdecimal is a native extension shipped separately from Ruby
-            have_attributes(base_label: "save_rounding_mode", path: end_with("bigdecimal.so"), lineno: 0),
+            have_attributes(base_label: "save_rounding_mode", path: end_with("bigdecimal.so").or(end_with("bigdecimal.bundle")), lineno: 0),
             # This is the frame in module_calling_super.save_rounding_mode (the one that calls super)
             have_attributes(base_label: "save_rounding_mode", path: __FILE__, lineno: be_positive),
           )

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -909,6 +909,23 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
     end
   end
 
+  describe "Using static_ruby_actual_filename in static Rubies without libruby.so" do
+    def set_file_info_for_cfunc(static_ruby_actual_filename)
+      described_class::Testing._native_set_file_info_for_cfunc(static_ruby_actual_filename)
+    end
+
+    it "uses static_ruby_actual_filename when it is set" do
+      expect(set_file_info_for_cfunc("/static/ruby/path")).to eq("/static/ruby/path")
+    end
+
+    context "when static_ruby_actual_filename is unset" do
+      it "falls back to the raw dladdr-resolved filename for the Ruby VM" do
+        expect(set_file_info_for_cfunc(nil))
+          .to include("rspec").or(end_with("/ruby")).or(include("libruby"))
+      end
+    end
+  end
+
   def convert_reference_stack(raw_reference_stack)
     raw_reference_stack.map do |location|
       ProfileHelpers::Frame.new(location.base_label, location.path, location.lineno).freeze

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -910,16 +910,12 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
   describe "_native_filenames_available?" do
     it "returns true on linux and macOS" do
-      skip("Native filenames are unavailable for this Ruby build") unless described_class._native_filenames_available?
-
       expect(described_class._native_filenames_available?).to be true
     end
   end
 
   describe "_native_ruby_native_filename" do
     it "returns the correct filename", if: PlatformHelpers.linux? do
-      skip("Native filenames are unavailable for this Ruby build") unless described_class._native_filenames_available?
-
       expect(described_class._native_ruby_native_filename).to end_with("/ruby").or(include("libruby").and(include(".so")))
     end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -273,10 +273,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       context "when native filenames are enabled", if: PlatformHelpers.linux? do
         let(:native_filenames_enabled) { true }
 
-        before do
-          skip("Native filenames are only available on Linux") unless described_class._native_filenames_available?
-        end
-
         it "matches the Ruby backtrace API after the 6th frame" do
           expect(gathered_stack[5..-1]).to eq reference_stack[5..-1]
         end
@@ -322,10 +318,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
 
       context "when native filenames are enabled", if: PlatformHelpers.linux? do
         let(:native_filenames_enabled) { true }
-
-        before do
-          skip("Native filenames are only available on Linux") unless described_class._native_filenames_available?
-        end
 
         it "matches the Ruby backtrace API after the 5th frame" do
           expect(gathered_stack[4..-1]).to eq reference_stack[4..-1]
@@ -905,12 +897,6 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
       expect do
         sample(Thread.current, Datadog::Profiling::StackRecorder.for_testing, metric_values, labels, max_frames: 10_001)
       end.to raise_error(ArgumentError)
-    end
-  end
-
-  describe "_native_filenames_available?" do
-    it "returns true on linux and macOS" do
-      expect(described_class._native_filenames_available?).to be true
     end
   end
 

--- a/spec/datadog/profiling/collectors/stack_spec.rb
+++ b/spec/datadog/profiling/collectors/stack_spec.rb
@@ -924,6 +924,18 @@ RSpec.describe Datadog::Profiling::Collectors::Stack do
           .to include("rspec").or(end_with("/ruby")).or(include("libruby"))
       end
     end
+
+    context "on a static Ruby on Linux" do
+      before do
+        unless RbConfig::CONFIG["ENABLE_SHARED"] == "no" && PlatformHelpers.linux?
+          skip("Test only runs on static Ruby builds on linux")
+        end
+      end
+
+      it "matches the actual binary" do
+        expect(described_class._native_ruby_native_filename).to eq File.readlink("/proc/self/exe")
+      end
+    end
   end
 
   def convert_reference_stack(raw_reference_stack)

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -198,28 +198,6 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         }.to raise_error(ArgumentError, "Unexpected value for otel_context_enabled: :invalid")
       end
     end
-
-    context "when native filenames are enabled but feature is not available" do
-      let(:native_filenames_enabled) { true }
-
-      before do
-        allow(Datadog::Profiling::Collectors::Stack).to receive(:_native_filenames_available?).and_return(false)
-        allow(Datadog.logger).to receive(:debug)
-      end
-
-      it "disables native filenames" do
-        expect(described_class)
-          .to receive(:_native_initialize).with(hash_including(native_filenames_enabled: false)).and_call_original
-
-        thread_context_collector
-      end
-
-      it "logs a debug message" do
-        expect(Datadog.logger).to receive(:debug).with(/Disabling native filenames/)
-
-        thread_context_collector
-      end
-    end
   end
 
   describe "#sample" do


### PR DESCRIPTION
**What does this PR do?**

We recently changed our CI Ruby images to be static Ruby binaries (e.g. all Ruby VM code sits in the file called `ruby`, instead of split between `ruby` and `libruby.so/.bundle`).

This uncovered a bug that we were missing the native filename for such Rubies, and in https://github.com/DataDog/dd-trace-rb/pull/6089 we temporarily disabled our tests that were affected.

This PR:
* Reverts disabling the failing tests
* Fixes support for static Rubies (+ adds test coverage for it)
* Simplifies the code for getting native filenames under the assumption that on the platforms we care about (glibc linux, musl linux, macOS) `dladdr` is always available
* Fixes the tests so they work on macOS (the existing tests made it look like the native filenames feature didn't work on macOS, whereas it actually was working fine in reported profiles)

**Motivation:**

Support static Ruby binaries!

**Change log entry**

Yes. Profiling: Fix missing native filename for static Ruby binaries

**Additional Notes:**

The whole "replace the filename for static Rubies" thing is needed because `dladdr` returns the equivalent of `argv[0]` which in many cases will be `rspec` or `rake`, not the Ruby binary.

When reviewing, there's a bunch of whitespace noise, so I recommend looking at the diff with the "Hide whitespace" option enabled.

**How to test the change?**

I've included test coverage for this change. The CI images are static (as well as those from `rv`, if you use it), whereas most docker images you find online are non-static, so you can use those to test non-static Rubies.