### PR TITLE
[APMS-20023] Parse Connector/J failover URLs in Sequel JDBC metadata

### DIFF
--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -14,7 +14,9 @@ module Datadog
       module Sequel
         # General purpose functions for Sequel
         module Utils
-          JDBC_URI_PATTERN = %r{\Ajdbc:(?<vendor>[a-z][a-z0-9+.-]*):(?<location>//[^\r\n]*)\z}i
+          # Matches an optional Connector/J sub-protocol (e.g. the "replication" in
+          # jdbc:mysql:replication://...) between the vendor and the // authority.
+          JDBC_URI_PATTERN = %r{\Ajdbc:(?<vendor>[a-z][a-z0-9+.-]*)(?::[a-z][a-z0-9+.-]*)?:(?<location>//[^\r\n]*)\z}i
           DATABASE_PROPERTY_PATTERN =
             /(?:\A|[&;])(?<key>databaseName|database|libraries)=(?<value>[^&;]+)/i
           private_constant :JDBC_URI_PATTERN, :DATABASE_PROPERTY_PATTERN
@@ -43,8 +45,9 @@ module Datadog
             end
 
             # Parses URI-style JDBC connection strings, extracting host, port, and
-            # (best-effort) database name. Unsupported or ambiguous forms return empty
-            # metadata rather than potentially incorrect tags.
+            # (best-effort) database name. Handles Connector/J failover forms (an
+            # optional sub-protocol and comma-separated host lists). Unsupported or
+            # ambiguous forms return empty metadata rather than potentially incorrect tags.
             def parse_jdbc_uri(uri)
               result = {host: nil, port: nil, database: nil}
               return result unless uri.is_a?(String) && uri.valid_encoding?
@@ -55,12 +58,18 @@ module Datadog
               vendor = match[:vendor].downcase
               location, properties = match[:location].split(";", 2)
 
+              # Failover/load-balancing drivers (e.g. MySQL/MariaDB Connector/J) list
+              # several comma-separated hosts in the authority; keep only the first so
+              # the value parses as a standard URI.
+              location = single_host_location(location)
+
               # Several JDBC vendors append properties with semicolons, outside the URI
               # grammar. Parse the URI-compatible location separately from those properties.
               parsed = URI.parse("#{vendor}:#{location}")
 
               host = parsed.hostname
-              port = parsed.port
+              host = nil unless valid_host?(host)
+              port = parsed.port if host
 
               database = database_from_path(parsed.path) ||
                 database_from_properties(properties) || database_from_properties(parsed.query)
@@ -150,6 +159,32 @@ module Datadog
             end
 
             private
+
+            # Reduces a comma-separated host list in the authority to its first host
+            # (the primary/master for Connector/J failover URLs), preserving any path,
+            # query, or user-info. Non-list authorities are returned unchanged.
+            def single_host_location(location)
+              return location unless location.start_with?("//")
+
+              authority_end = location.index(%r{[/?#]}, 2)
+              authority = authority_end ? location[2...authority_end] : location[2..-1]
+              remainder = authority_end ? location[authority_end..-1] : ""
+
+              return location unless authority.include?(",")
+
+              userinfo, separator, hosts = authority.rpartition("@")
+              first_host = hosts.split(",", 2).first
+              authority = separator.empty? ? first_host : "#{userinfo}#{separator}#{first_host}"
+
+              "//#{authority}#{remainder}"
+            end
+
+            # Rejects authority values that are not plausible hostnames or IP addresses
+            # (e.g. MySQL's "address=(host=..)(port=..)" form), which would otherwise
+            # surface as a misleading peer.hostname tag.
+            def valid_host?(host)
+              !host.nil? && !host.empty? && host.match?(/\A[\w.\-:]+\z/)
+            end
 
             def database_from_path(path)
               return unless path&.start_with?("/")

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -67,7 +67,7 @@ module Datadog
               # Failover drivers (e.g. MySQL/MariaDB Connector/J) list several
               # comma-separated hosts in the authority; keep only the first so the value
               # parses as a standard URI and to recover the database name from its path.
-              location = single_host_location(location)
+              location, multiple_hosts = single_host_location(location)
 
               # Several JDBC vendors append properties with semicolons, outside the URI
               # grammar. Parse the URI-compatible location separately from those properties.
@@ -75,9 +75,10 @@ module Datadog
 
               host = parsed.hostname
               host = nil unless valid_host?(host)
-              # Load-balancing/replication sub-protocols do not pin a query to a single
-              # host, so any one host would be a misleading peer; drop it (keep database).
-              host = nil if HOST_AGNOSTIC_SUBPROTOCOLS.include?(subprotocol)
+              # With multiple hosts, load-balancing/replication sub-protocols do not pin a
+              # query to a single host, so any one host would be a misleading peer; drop it
+              # (keep database). A single host is unambiguous regardless of sub-protocol.
+              host = nil if multiple_hosts && HOST_AGNOSTIC_SUBPROTOCOLS.include?(subprotocol)
               port = parsed.port if host
 
               database = database_from_path(parsed.path) ||
@@ -170,19 +171,19 @@ module Datadog
             private
 
             def single_host_location(location)
-              return location unless location.start_with?("//")
+              return [location, false] unless location.start_with?("//")
 
               authority_end = location.index(%r{[/?#]}, 2)
               authority = authority_end ? location[2...authority_end] : location[2..-1]
               remainder = authority_end ? location[authority_end..-1] : ""
 
-              return location unless authority.include?(",")
+              return [location, false] unless authority.include?(",")
 
               userinfo, separator, hosts = authority.rpartition("@")
               first_host = hosts.split(",", 2).first
               authority = separator.empty? ? first_host : "#{userinfo}#{separator}#{first_host}"
 
-              "//#{authority}#{remainder}"
+              ["//#{authority}#{remainder}", true]
             end
 
             # Rejects authority values that are not plausible hostnames or IP addresses

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -14,12 +14,17 @@ module Datadog
       module Sequel
         # General purpose functions for Sequel
         module Utils
-          # Matches an optional Connector/J sub-protocol (e.g. the "replication" in
+          # Captures an optional Connector/J sub-protocol (e.g. "replication" in
           # jdbc:mysql:replication://...) between the vendor and the // authority.
-          JDBC_URI_PATTERN = %r{\Ajdbc:(?<vendor>[a-z][a-z0-9+.-]*)(?::[a-z][a-z0-9+.-]*)?:(?<location>//[^\r\n]*)\z}i
+          JDBC_URI_PATTERN =
+            %r{\Ajdbc:(?<vendor>[a-z][a-z0-9+.-]*)(?::(?<subprotocol>[a-z][a-z0-9+.-]*))?:(?<location>//[^\r\n]*)\z}i
           DATABASE_PROPERTY_PATTERN =
             /(?:\A|[&;])(?<key>databaseName|database|libraries)=(?<value>[^&;]+)/i
-          private_constant :JDBC_URI_PATTERN, :DATABASE_PROPERTY_PATTERN
+          # Connector/J sub-protocols that spread queries across hosts (load balancing)
+          # or route them by role (read/write splitting), so no single host identifies
+          # the peer a query reached. The database name is still meaningful.
+          HOST_AGNOSTIC_SUBPROTOCOLS = %w[loadbalance replication].freeze
+          private_constant :JDBC_URI_PATTERN, :DATABASE_PROPERTY_PATTERN, :HOST_AGNOSTIC_SUBPROTOCOLS
 
           class << self
             # Ruby database connector library
@@ -56,11 +61,12 @@ module Datadog
               return result unless match
 
               vendor = match[:vendor].downcase
+              subprotocol = match[:subprotocol]&.downcase
               location, properties = match[:location].split(";", 2)
 
-              # Failover/load-balancing drivers (e.g. MySQL/MariaDB Connector/J) list
-              # several comma-separated hosts in the authority; keep only the first so
-              # the value parses as a standard URI.
+              # Failover drivers (e.g. MySQL/MariaDB Connector/J) list several
+              # comma-separated hosts in the authority; keep only the first so the value
+              # parses as a standard URI and to recover the database name from its path.
               location = single_host_location(location)
 
               # Several JDBC vendors append properties with semicolons, outside the URI
@@ -69,6 +75,9 @@ module Datadog
 
               host = parsed.hostname
               host = nil unless valid_host?(host)
+              # Load-balancing/replication sub-protocols do not pin a query to a single
+              # host, so any one host would be a misleading peer; drop it (keep database).
+              host = nil if HOST_AGNOSTIC_SUBPROTOCOLS.include?(subprotocol)
               port = parsed.port if host
 
               database = database_from_path(parsed.path) ||
@@ -160,9 +169,6 @@ module Datadog
 
             private
 
-            # Reduces a comma-separated host list in the authority to its first host
-            # (the primary/master for Connector/J failover URLs), preserving any path,
-            # query, or user-info. Non-list authorities are returned unchanged.
             def single_host_location(location)
               return location unless location.start_with?("//")
 

--- a/sig/datadog/tracing/contrib/sequel/utils.rbs
+++ b/sig/datadog/tracing/contrib/sequel/utils.rbs
@@ -31,6 +31,10 @@ module Datadog
 
           private
 
+          def self.single_host_location: (String location) -> String
+
+          def self.valid_host?: (String? host) -> bool
+
           def self.database_from_path: (String? path) -> String?
 
           def self.database_from_properties: (String? properties) -> String?

--- a/spec/datadog/tracing/contrib/sequel/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/utils_spec.rb
@@ -125,11 +125,67 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
       end
     end
 
-    context "multi-host authority" do
+    context "multi-host authority with ports" do
       let(:uri) { "jdbc:postgresql://host1:5432,host2:5432/analytics" }
 
-      it "returns all-nil rather than selecting incorrect metadata" do
-        expect(parsed).to eq(host: nil, port: nil, database: nil)
+      it "uses the first host in the failover list" do
+        expect(parsed).to eq(host: "host1", port: "5432", database: "analytics")
+      end
+    end
+
+    context "multi-host authority without ports" do
+      let(:uri) { "jdbc:mysql://host1,host2,host3/orders" }
+
+      it "uses the first host in the failover list" do
+        expect(parsed).to eq(host: "host1", port: nil, database: "orders")
+      end
+    end
+
+    context "multi-host authority with user-info" do
+      let(:uri) { "jdbc:mysql://user:password@host1:3306,host2:3306/orders" }
+
+      it "uses the first host without exposing credentials" do
+        expect(parsed).to eq(host: "host1", port: "3306", database: "orders")
+      end
+    end
+
+    context "mysql replication sub-protocol" do
+      let(:uri) { "jdbc:mysql:replication://master:3306,slave1:3306,slave2:3306/orders" }
+
+      it "strips the sub-protocol and uses the first host" do
+        expect(parsed).to eq(host: "master", port: "3306", database: "orders")
+      end
+    end
+
+    context "mysql loadbalance sub-protocol without ports" do
+      let(:uri) { "jdbc:mysql:loadbalance://host1,host2/orders" }
+
+      it "strips the sub-protocol and uses the first host" do
+        expect(parsed).to eq(host: "host1", port: nil, database: "orders")
+      end
+    end
+
+    context "mariadb replication sub-protocol" do
+      let(:uri) { "jdbc:mariadb:replication://master:3306,slave1:3306/orders" }
+
+      it "strips the sub-protocol and uses the first host" do
+        expect(parsed).to eq(host: "master", port: "3306", database: "orders")
+      end
+    end
+
+    context "mysql aurora sub-protocol single host" do
+      let(:uri) { "jdbc:mysql:aurora://cluster.example.com:3306/orders" }
+
+      it "strips the sub-protocol" do
+        expect(parsed).to eq(host: "cluster.example.com", port: "3306", database: "orders")
+      end
+    end
+
+    context "mysql address-equals authority form" do
+      let(:uri) { "jdbc:mysql://address=(protocol=tcp)(host=db-host)(port=3306)/orders" }
+
+      it "returns a nil host rather than an unparseable authority string" do
+        expect(parsed[:host]).to be_nil
       end
     end
 

--- a/spec/datadog/tracing/contrib/sequel/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/utils_spec.rb
@@ -152,31 +152,31 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
     context "mysql replication sub-protocol" do
       let(:uri) { "jdbc:mysql:replication://master:3306,slave1:3306,slave2:3306/orders" }
 
-      it "strips the sub-protocol and uses the first host" do
-        expect(parsed).to eq(host: "master", port: "3306", database: "orders")
+      it "keeps the database but drops the host, which does not identify the queried peer" do
+        expect(parsed).to eq(host: nil, port: nil, database: "orders")
       end
     end
 
     context "mysql loadbalance sub-protocol without ports" do
       let(:uri) { "jdbc:mysql:loadbalance://host1,host2/orders" }
 
-      it "strips the sub-protocol and uses the first host" do
-        expect(parsed).to eq(host: "host1", port: nil, database: "orders")
+      it "keeps the database but drops the load-balanced host" do
+        expect(parsed).to eq(host: nil, port: nil, database: "orders")
       end
     end
 
     context "mariadb replication sub-protocol" do
       let(:uri) { "jdbc:mariadb:replication://master:3306,slave1:3306/orders" }
 
-      it "strips the sub-protocol and uses the first host" do
-        expect(parsed).to eq(host: "master", port: "3306", database: "orders")
+      it "keeps the database but drops the host" do
+        expect(parsed).to eq(host: nil, port: nil, database: "orders")
       end
     end
 
     context "mysql aurora sub-protocol single host" do
       let(:uri) { "jdbc:mysql:aurora://cluster.example.com:3306/orders" }
 
-      it "strips the sub-protocol" do
+      it "strips the sub-protocol and keeps the single host" do
         expect(parsed).to eq(host: "cluster.example.com", port: "3306", database: "orders")
       end
     end
@@ -184,8 +184,8 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
     context "mysql address-equals authority form" do
       let(:uri) { "jdbc:mysql://address=(protocol=tcp)(host=db-host)(port=3306)/orders" }
 
-      it "returns a nil host rather than an unparseable authority string" do
-        expect(parsed[:host]).to be_nil
+      it "rejects the unparseable authority as a host but still recovers the database" do
+        expect(parsed).to eq(host: nil, port: nil, database: "orders")
       end
     end
 

--- a/spec/datadog/tracing/contrib/sequel/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/utils_spec.rb
@@ -173,6 +173,14 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
       end
     end
 
+    context "mysql replication sub-protocol with a single host" do
+      let(:uri) { "jdbc:mysql:replication://master:3306/orders" }
+
+      it "keeps the unambiguous single host" do
+        expect(parsed).to eq(host: "master", port: "3306", database: "orders")
+      end
+    end
+
     context "mysql aurora sub-protocol single host" do
       let(:uri) { "jdbc:mysql:aurora://cluster.example.com:3306/orders" }
 


### PR DESCRIPTION
**What does this PR do?**

Extends the Sequel integration's JDBC connection-string parser to recover the database host and name from MySQL/MariaDB Connector/J failover URLs, which the previous parser silently dropped: an optional sub-protocol (`jdbc:mysql:replication://…`) and comma-separated multi-host authorities (`jdbc:mysql://host1:3306,host2:3306/db`).

Plain failover and single-host sub-protocols (e.g. `aurora`) report the first/primary host; `loadbalance://` and `replication://` report the database name but not `peer.hostname`, because those drivers spread or role-route queries and no single host identifies the peer a query reached.

Authority forms that are not plausible hostnames, such as MySQL's `address=(host=..)`, are rejected so they never surface as a misleading `peer.hostname`.

**Motivation:**

Since #6072 added database metadata to Sequel spans, apps whose datastores use Connector/J failover URLs still produced spans without `peer.hostname`, `peer.db.name`, or inferred `peer.service`, so those datastore dependencies were absent from the service map.

**Change log entry**

Yes. Tracing: The Sequel integration now reads the database name and host from JDBC failover and multi-host connection URLs (MySQL/MariaDB Connector/J), so those datastore dependencies appear in the service map; load-balancing and replication URLs report the database name without a host.

**Additional Notes:**

Canonical single-host JDBC URLs and native (non-JDBC) adapters are unaffected. This replaces the prior all-nil-on-multi-host behavior with best-effort metadata that still avoids emitting a host it cannot attribute to one peer.

**How to test the change?**

Unit specs in `spec/datadog/tracing/contrib/sequel/utils_spec.rb` cover each URL form: multi-host with and without ports, user-info, the `replication`/`loadbalance`/`aurora` sub-protocols, and the rejected `address=` form. Verified on Ruby 2.5 and 3.4.
