### PR TITLE
Type the untyped Rack header and HTTP quantization RBS signatures

### DIFF
--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -23,16 +23,14 @@ module Datadog
             def url(url, options = {})
               url!(url, options)
             rescue
-              placeholder = (options[:placeholder] || PLACEHOLDER).to_s
+              placeholder = options[:placeholder] || PLACEHOLDER
 
               (options[:base] == :exclude) ? placeholder : "#{base_url(url)}/#{placeholder}"
             end
 
             def base_url(url, options = {})
               if (m = RFC3986_URL_BASE.match(url))
-                # MatchData#[] is nil-typed; capture group 1 always participates on
-                # a successful match, so to_s is a no-op that yields a String.
-                m[1].to_s
+                m[1]
               else
                 ""
               end
@@ -43,10 +41,9 @@ module Datadog
 
               URI.parse(url).tap do |uri|
                 # Format the query string
-                if (query_string = uri.query)
-                  sub_options = options[:query]
-                  quantized = query(query_string, sub_options.is_a?(::Hash) ? sub_options : {})
-                  uri.query = (quantized.empty? ? nil : quantized)
+                if uri.query
+                  query = query(uri.query, options[:query])
+                  uri.query = ((!query.nil? && query.empty?) ? nil : query)
                 end
 
                 # Remove any URI fragments
@@ -63,7 +60,7 @@ module Datadog
             def query(query, options = {})
               query!(query, options)
             rescue
-              (options[:placeholder] || PLACEHOLDER).to_s
+              options[:placeholder] || PLACEHOLDER
             end
 
             def query!(query, options = {})
@@ -76,22 +73,18 @@ module Datadog
               # or if the query string is meant to include everything
               return "" if options[:exclude] == :all
 
-              show = options[:show]
-              exclude = options[:exclude]
-              obfuscate = options[:obfuscate]
-
-              unless show == :all && !(obfuscate && exclude)
+              unless options[:show] == :all && !(options[:obfuscate] && options[:exclude])
                 query = collect_query(query, uniq: true) do |key, value|
-                  if exclude.is_a?(::Array) && exclude.include?(key)
+                  if options[:exclude].include?(key)
                     [nil, nil]
                   else
-                    value = (show == :all || (show.is_a?(::Array) && show.include?(key))) ? value : nil
+                    value = (options[:show] == :all || options[:show].include?(key)) ? value : nil
                     [key, value]
                   end
                 end
               end
 
-              obfuscate.is_a?(::Hash) ? obfuscate_query(query, obfuscate) : query
+              options[:obfuscate] ? obfuscate_query(query, options[:obfuscate]) : query
             end
 
             # Iterate over each key value pair, yielding to the block given.
@@ -126,10 +119,9 @@ module Datadog
             # Scans over the query string and obfuscates sensitive data by
             # replacing matches with an opaque value
             def obfuscate_query(query, options = {})
-              regex = options[:regex]
-              re = regex.is_a?(::Regexp) ? regex : OBFUSCATOR_REGEX
-              with = options[:with]
-              with = with.is_a?(::String) ? with : OBFUSCATOR_WITH
+              options[:regex] = nil if options[:regex] == :internal
+              re = options[:regex] || OBFUSCATOR_REGEX
+              with = options[:with] || OBFUSCATOR_WITH
 
               query.gsub(re, with)
             end

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -23,7 +23,7 @@ module Datadog
             def url(url, options = {})
               url!(url, options)
             rescue
-              placeholder = options[:placeholder] || PLACEHOLDER
+              placeholder = (options[:placeholder] || PLACEHOLDER).to_s
 
               (options[:base] == :exclude) ? placeholder : "#{base_url(url)}/#{placeholder}"
             end
@@ -43,9 +43,10 @@ module Datadog
 
               URI.parse(url).tap do |uri|
                 # Format the query string
-                if uri.query
-                  query = query(uri.query, options[:query])
-                  uri.query = ((!query.nil? && query.empty?) ? nil : query)
+                if (query_string = uri.query)
+                  sub_options = options[:query]
+                  quantized = query(query_string, sub_options.is_a?(::Hash) ? sub_options : {})
+                  uri.query = (quantized.empty? ? nil : quantized)
                 end
 
                 # Remove any URI fragments
@@ -62,7 +63,7 @@ module Datadog
             def query(query, options = {})
               query!(query, options)
             rescue
-              options[:placeholder] || PLACEHOLDER
+              (options[:placeholder] || PLACEHOLDER).to_s
             end
 
             def query!(query, options = {})
@@ -75,18 +76,22 @@ module Datadog
               # or if the query string is meant to include everything
               return "" if options[:exclude] == :all
 
-              unless options[:show] == :all && !(options[:obfuscate] && options[:exclude])
+              show = options[:show]
+              exclude = options[:exclude]
+              obfuscate = options[:obfuscate]
+
+              unless show == :all && !(obfuscate && exclude)
                 query = collect_query(query, uniq: true) do |key, value|
-                  if options[:exclude].include?(key)
+                  if exclude.is_a?(::Array) && exclude.include?(key)
                     [nil, nil]
                   else
-                    value = (options[:show] == :all || options[:show].include?(key)) ? value : nil
+                    value = (show == :all || (show.is_a?(::Array) && show.include?(key))) ? value : nil
                     [key, value]
                   end
                 end
               end
 
-              options[:obfuscate] ? obfuscate_query(query, options[:obfuscate]) : query
+              obfuscate.is_a?(::Hash) ? obfuscate_query(query, obfuscate) : query
             end
 
             # Iterate over each key value pair, yielding to the block given.
@@ -121,9 +126,10 @@ module Datadog
             # Scans over the query string and obfuscates sensitive data by
             # replacing matches with an opaque value
             def obfuscate_query(query, options = {})
-              options[:regex] = nil if options[:regex] == :internal
-              re = options[:regex] || OBFUSCATOR_REGEX
-              with = options[:with] || OBFUSCATOR_WITH
+              regex = options[:regex]
+              re = regex.is_a?(::Regexp) ? regex : OBFUSCATOR_REGEX
+              with = options[:with]
+              with = with.is_a?(::String) ? with : OBFUSCATOR_WITH
 
               query.gsub(re, with)
             end

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -30,7 +30,9 @@ module Datadog
 
             def base_url(url, options = {})
               if (m = RFC3986_URL_BASE.match(url))
-                m[1]
+                # MatchData#[] is nil-typed; capture group 1 always participates on
+                # a successful match, so to_s is a no-op that yields a String.
+                m[1].to_s
               else
                 ""
               end

--- a/lib/datadog/tracing/contrib/utils/quantization/http.rb
+++ b/lib/datadog/tracing/contrib/utils/quantization/http.rb
@@ -23,14 +23,14 @@ module Datadog
             def url(url, options = {})
               url!(url, options)
             rescue
-              placeholder = options[:placeholder] || PLACEHOLDER
+              placeholder = options[:placeholder] || PLACEHOLDER #: ::String
 
               (options[:base] == :exclude) ? placeholder : "#{base_url(url)}/#{placeholder}"
             end
 
             def base_url(url, options = {})
               if (m = RFC3986_URL_BASE.match(url))
-                m[1]
+                m[1] #: ::String
               else
                 ""
               end
@@ -60,7 +60,7 @@ module Datadog
             def query(query, options = {})
               query!(query, options)
             rescue
-              options[:placeholder] || PLACEHOLDER
+              options[:placeholder] || PLACEHOLDER #: ::String
             end
 
             def query!(query, options = {})
@@ -119,9 +119,9 @@ module Datadog
             # Scans over the query string and obfuscates sensitive data by
             # replacing matches with an opaque value
             def obfuscate_query(query, options = {})
-              options[:regex] = nil if options[:regex] == :internal
-              re = options[:regex] || OBFUSCATOR_REGEX
-              with = options[:with] || OBFUSCATOR_WITH
+              regex = (options[:regex] == :internal) ? nil : options[:regex]
+              re = regex || OBFUSCATOR_REGEX #: ::Regexp
+              with = options[:with] || OBFUSCATOR_WITH #: ::String
 
               query.gsub(re, with)
             end

--- a/sig/datadog/core/utils/hash.rbs
+++ b/sig/datadog/core/utils/hash.rbs
@@ -1,0 +1,18 @@
+module Datadog
+  module Core
+    module Utils
+      module Hash
+        class CaseInsensitiveWrapper[V]
+          @hash: ::Hash[::String, V]
+
+          def initialize: (::Hash[::String, V] hash) -> void
+          def []: (::String key) -> V?
+          def key?: (::String key) -> bool
+          def empty?: () -> bool
+          def length: () -> ::Integer
+          def original_hash: () -> ::Hash[::String, V]
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/tracing/contrib/rack/header_collection.rbs
+++ b/sig/datadog/tracing/contrib/rack/header_collection.rbs
@@ -5,12 +5,12 @@ module Datadog
         module Header
           class RequestHeaderCollection < Datadog::Core::HeaderCollection
             def initialize: (::Rack::env env) -> void
-            def get: (untyped header_name) -> untyped
+            def get: (::String header_name) -> ::String?
             alias [] get
-            def key?: (untyped header_name) -> untyped
+            def key?: (::String header_name) -> bool
           end
 
-          def self.to_rack_header: (untyped name) -> ::String
+          def self.to_rack_header: (::String name) -> ::String
         end
       end
     end

--- a/sig/datadog/tracing/contrib/utils/quantization/http.rbs
+++ b/sig/datadog/tracing/contrib/utils/quantization/http.rbs
@@ -4,20 +4,25 @@ module Datadog
       module Utils
         module Quantization
           module HTTP
+            type option_value = ::String | ::Symbol | bool | ::Array[::String] | ::Regexp | ::Hash[::Symbol, option_value]
+            type quantize_options = ::Hash[::Symbol, option_value]
+
             PLACEHOLDER: "?"
             RFC3986_URL_BASE: ::Regexp
 
-            def self?.url: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.url: (::String url, ?quantize_options options) -> ::String
 
-            def self?.base_url: (untyped url, ?::Hash[untyped, untyped] options) -> (untyped | "")
+            def self?.base_url: (::String url, ?quantize_options options) -> ::String
 
-            def self?.url!: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.url!: (::String url, ?quantize_options options) -> ::String
 
-            def self?.query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.query: (::String query, ?quantize_options options) -> ::String
 
-            def self?.query!: (untyped query, ?::Hash[untyped, untyped] options) -> ("" | untyped)
-            def self?.collect_query: (untyped query, ?::Hash[untyped, untyped] options) { (untyped, untyped, untyped) -> untyped } -> untyped
-            def self?.obfuscate_query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.query!: (::String query, ?quantize_options options) -> ::String
+
+            def self?.collect_query: (::String query, ?quantize_options options) { (::String?, ::String?, ::String?) -> [::String?, ::String?] } -> ::String
+
+            def self?.obfuscate_query: (::String query, ?quantize_options options) -> ::String
 
             OBFUSCATOR_WITH: "<redacted>"
             OBFUSCATOR_REGEX: ::Regexp

--- a/sig/datadog/tracing/contrib/utils/quantization/http.rbs
+++ b/sig/datadog/tracing/contrib/utils/quantization/http.rbs
@@ -4,24 +4,25 @@ module Datadog
       module Utils
         module Quantization
           module HTTP
+            type option_value = ::String | ::Symbol | bool | ::Array[::String] | ::Regexp | ::Hash[::Symbol, option_value]
+            type quantize_options = ::Hash[::Symbol, option_value]
+
             PLACEHOLDER: "?"
             RFC3986_URL_BASE: ::Regexp
 
-            def self?.url: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
+            def self?.url: (::String url, ?quantize_options options) -> ::String
 
-            def self?.base_url: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
+            def self?.base_url: (::String url, ?quantize_options options) -> ::String
 
-            def self?.url!: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
+            def self?.url!: (::String url, ?quantize_options options) -> ::String
 
-            def self?.query: (::String? query, ?::Hash[::Symbol, untyped] options) -> ::String?
+            def self?.query: (::String query, ?quantize_options options) -> ::String
 
-            def self?.query!: (::String? query, ?::Hash[::Symbol, untyped] options) -> ::String?
-            # query is passed to String#scan / String#split after a
-            # `return query unless block_given?` guard that Steep does not narrow,
-            # so the parameter stays untyped; the internal callers always pass a
-            # non-nil query string with a block.
-            def self?.collect_query: (untyped query, ?::Hash[::Symbol, untyped] options) { (::String?, ::String?, ::String?) -> [::String?, ::String?] } -> ::String
-            def self?.obfuscate_query: (untyped query, ?::Hash[::Symbol, untyped] options) -> ::String
+            def self?.query!: (::String query, ?quantize_options options) -> ::String
+
+            def self?.collect_query: (::String query, ?quantize_options options) { (::String?, ::String?, ::String?) -> [::String?, ::String?] } -> ::String
+
+            def self?.obfuscate_query: (::String query, ?quantize_options options) -> ::String
 
             OBFUSCATOR_WITH: "<redacted>"
             OBFUSCATOR_REGEX: ::Regexp

--- a/sig/datadog/tracing/contrib/utils/quantization/http.rbs
+++ b/sig/datadog/tracing/contrib/utils/quantization/http.rbs
@@ -4,25 +4,20 @@ module Datadog
       module Utils
         module Quantization
           module HTTP
-            type option_value = ::String | ::Symbol | bool | ::Array[::String] | ::Regexp | ::Hash[::Symbol, option_value]
-            type quantize_options = ::Hash[::Symbol, option_value]
-
             PLACEHOLDER: "?"
             RFC3986_URL_BASE: ::Regexp
 
-            def self?.url: (::String url, ?quantize_options options) -> ::String
+            def self?.url: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
 
-            def self?.base_url: (::String url, ?quantize_options options) -> ::String
+            def self?.base_url: (untyped url, ?::Hash[untyped, untyped] options) -> (untyped | "")
 
-            def self?.url!: (::String url, ?quantize_options options) -> ::String
+            def self?.url!: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
 
-            def self?.query: (::String query, ?quantize_options options) -> ::String
+            def self?.query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
 
-            def self?.query!: (::String query, ?quantize_options options) -> ::String
-
-            def self?.collect_query: (::String query, ?quantize_options options) { (::String?, ::String?, ::String?) -> [::String?, ::String?] } -> ::String
-
-            def self?.obfuscate_query: (::String query, ?quantize_options options) -> ::String
+            def self?.query!: (untyped query, ?::Hash[untyped, untyped] options) -> ("" | untyped)
+            def self?.collect_query: (untyped query, ?::Hash[untyped, untyped] options) { (untyped, untyped, untyped) -> untyped } -> untyped
+            def self?.obfuscate_query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
 
             OBFUSCATOR_WITH: "<redacted>"
             OBFUSCATOR_REGEX: ::Regexp

--- a/sig/datadog/tracing/contrib/utils/quantization/http.rbs
+++ b/sig/datadog/tracing/contrib/utils/quantization/http.rbs
@@ -7,17 +7,21 @@ module Datadog
             PLACEHOLDER: "?"
             RFC3986_URL_BASE: ::Regexp
 
-            def self?.url: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.url: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
 
-            def self?.base_url: (untyped url, ?::Hash[untyped, untyped] options) -> (untyped | "")
+            def self?.base_url: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
 
-            def self?.url!: (untyped url, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.url!: (::String url, ?::Hash[::Symbol, untyped] options) -> ::String
 
-            def self?.query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.query: (::String? query, ?::Hash[::Symbol, untyped] options) -> ::String?
 
-            def self?.query!: (untyped query, ?::Hash[untyped, untyped] options) -> ("" | untyped)
-            def self?.collect_query: (untyped query, ?::Hash[untyped, untyped] options) { (untyped, untyped, untyped) -> untyped } -> untyped
-            def self?.obfuscate_query: (untyped query, ?::Hash[untyped, untyped] options) -> untyped
+            def self?.query!: (::String? query, ?::Hash[::Symbol, untyped] options) -> ::String?
+            # query is passed to String#scan / String#split after a
+            # `return query unless block_given?` guard that Steep does not narrow,
+            # so the parameter stays untyped; the internal callers always pass a
+            # non-nil query string with a block.
+            def self?.collect_query: (untyped query, ?::Hash[::Symbol, untyped] options) { (::String?, ::String?, ::String?) -> [::String?, ::String?] } -> ::String
+            def self?.obfuscate_query: (untyped query, ?::Hash[::Symbol, untyped] options) -> ::String
 
             OBFUSCATOR_WITH: "<redacted>"
             OBFUSCATOR_REGEX: ::Regexp


### PR DESCRIPTION
**What does this PR do?**

Adds more typing to rack integration.

**Motivation:**

In https://github.com/DataDog/dd-trace-rb/pull/6109 LLM argued to put untyped in the rbs files due to existing untyped usage in the codebase. This PR deletes the untyped usage that is in the adjacent code.

**Change log entry**

None.


**How to test the change?**
Existing CI