### PR TITLE
Remove sequel version check

### DIFF
--- a/lib/datadog/tracing/contrib/sequel/database.rb
+++ b/lib/datadog/tracing/contrib/sequel/database.rb
@@ -46,11 +46,7 @@ module Datadog
             end
 
             def parse_opts(sql, opts)
-              db_opts = if ::Sequel::VERSION < "3.41.0" && self.class.to_s !~ /Dataset$/
-                @opts
-              elsif instance_variable_defined?(:@pool) && @pool
-                @pool.db.opts
-              end
+              db_opts = @pool.db.opts if instance_variable_defined?(:@pool) && @pool
               sql = sql.is_a?(::Sequel::SQL::Expression) ? literal(sql) : sql.to_s
 
               Utils.parse_opts(sql, opts, db_opts)


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
The sequel integration requires version 3.41 or higher. This gem version check is always evaluating to `false` so it can be removed and the expression simplified.
 
**Motivation:**
I like a good code cleanup ♻️ 

**Change log entry**
None
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
All tests should pass, not expecting any breaking change from this.

<!-- Unsure? Have a question? Request a review! -->
