### PR TITLE
DI: capture real positional parameter names in non-virtual method probes

### DIFF
--- a/docs/DynamicInstrumentation.md
+++ b/docs/DynamicInstrumentation.md
@@ -137,6 +137,11 @@ the entire method execution.
   `method_missing` or similar metaprogramming will be omitted from the
   call chain because they don't have a source location in Ruby's
   internal representation
+- Method arguments are captured under their source parameter names.
+  Arguments without an available name — positions absorbed by a splat,
+  parameters of generated methods (such as `attr_writer`), and arguments
+  to virtual or C-implemented methods — fall back to the `arg1`, `arg2`,
+  ... labels
 
 **Use method probes when:**
 - You want to understand method inputs and outputs

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -78,12 +78,8 @@ module Datadog
       # the whole process.
       GLOBAL_LOG_RATE_LIMIT = 5000
 
-      # Extended into every method-probe wrapper module before it is
-      # prepended. #hook_method uses it to recognize wrapper modules that
-      # earlier probes on this method have prepended and resolve past them
-      # to the user's original method (see #original_target_method), so
-      # parameter names and source location are read from the original
-      # definition.
+      # Extended into each method-probe wrapper module so #original_target_method
+      # recognizes DI wrappers when resolving a method's original definition.
       module InstrumentedMethodMarker
       end
 
@@ -182,8 +178,6 @@ module Datadog
           nil
         end
 
-        # Resolve past wrappers prepended by earlier probes on this method so
-        # the checks below read the user's original definition.
         target_method = original_target_method(target_method)
 
         # Reject method probes whose target method resolves to Kernel#lambda,
@@ -490,10 +484,8 @@ module Datadog
       # ancestor chain, so each step drops one prepended wrapper. Returns nil
       # when only wrappers underlie the target (e.g. a virtual method that an
       # earlier probe instrumented), matching the nil that #hook_method assigns
-      # for a method it cannot resolve.
-      #
-      # @param target_method [UnboundMethod, nil]
-      # @return [UnboundMethod, nil]
+      # for a method it cannot resolve. Called at hook time so the source
+      # location and parameter names read below come from the user's method.
       def original_target_method(target_method)
         return target_method unless target_method
         return target_method unless target_method.owner.is_a?(InstrumentedMethodMarker)

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -467,7 +467,7 @@ module Datadog
           end
         end
         names
-      rescue StandardError => e
+      rescue => e
         logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
         nil
       end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -77,6 +77,10 @@ module Datadog
       # Maximum number of non-capturing probe emissions admitted per second across
       # the whole process.
       GLOBAL_LOG_RATE_LIMIT = 5000
+
+      # Marker module extended into each method-probe wrapper module so
+      # #original_target_method can distinguish DI wrappers from other
+      # prepended modules when resolving a method's original definition.
       module InstrumentedMethodMarker
       end
 
@@ -576,7 +580,7 @@ module Datadog
               # We do not need the stack for condition evaluation, therefore
               # stack is not passed to Context here.
               context = Context.new(
-                locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
+                locals: serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names),
                 target_self: target_self,
                 probe: probe, settings: settings, serializer: serializer,
               )
@@ -625,7 +629,7 @@ module Datadog
             # Arguments may be mutated by the method, therefore
             # they need to be serialized prior to method invocation.
             serialized_entry_args = if probe.capture_snapshot?
-              serializer.serialize_args(args, kwargs, target_self, positional_param_names,
+              serializer.serialize_args(args, kwargs, target_self, param_names: positional_param_names,
                 **probe.snapshot_serializer_limits(settings))
             end
 
@@ -636,7 +640,7 @@ module Datadog
                 entry_context = Context.new(
                   probe: probe, settings: settings, serializer: serializer,
                   target_self: target_self,
-                  locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
+                  locals: serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names),
                 )
                 entry_capture_expressions, entry_capture_evaluation_errors =
                   capture_expression_evaluator.evaluate(probe, entry_context)
@@ -710,7 +714,7 @@ module Datadog
             # TODO capture arguments at exit
 
             capture_expression_locals = if probe.capture_expressions_only?
-              serializer.combine_args(args, kwargs, target_self, positional_param_names)
+              serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names)
             end
             context = Context.new(locals: capture_expression_locals, target_self: target_self,
               probe: probe, settings: settings, serializer: serializer,

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -77,9 +77,6 @@ module Datadog
       # Maximum number of non-capturing probe emissions admitted per second across
       # the whole process.
       GLOBAL_LOG_RATE_LIMIT = 5000
-
-      # Extended into each method-probe wrapper module so #original_target_method
-      # recognizes DI wrappers when resolving a method's original definition.
       module InstrumentedMethodMarker
       end
 

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -498,7 +498,7 @@ module Datadog
           end
         end
         names
-      rescue StandardError => e
+      rescue => e
         logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
         nil
       end

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -190,6 +190,7 @@ module Datadog
         end
 
         loc = target_method&.source_location
+        positional_param_names = extract_positional_param_names(target_method)
         # @type var instrumenter: Instrumenter
         instrumenter = self
 
@@ -236,7 +237,7 @@ module Datadog
                 args, kwargs, target_block, # steep:ignore FallbackAny
                 self,
                 probe, responder,
-                loc, method_name,
+                loc, method_name, positional_param_names,
               ) do
                 super(*args, **kwargs, &target_block) # steep:ignore FallbackAny
               end
@@ -256,7 +257,7 @@ module Datadog
                 pos_args, kwargs, target_block,
                 self,
                 probe, responder,
-                loc, method_name,
+                loc, method_name, positional_param_names,
               ) do
                 super(*args, &target_block)
               end
@@ -469,6 +470,41 @@ module Datadog
 
       attr_reader :lock
 
+      # Real names of the target method's leading fixed positional parameters
+      # (+:req+ and +:opt+), in declaration order, used to label captured
+      # positional arguments with their source names instead of the synthetic
+      # arg1, arg2, ... labels. Uses the same Method#parameters reflection that
+      # the symbol database extractor relies on.
+      #
+      # Stops at a rest (+*+) parameter: values absorbed by a splat, and any
+      # positional parameters declared after it, cannot be mapped to a name by
+      # index, so they fall back to arg-N labels in #combine_args. A name entry
+      # may be nil (e.g. attr_writer-generated methods expose no parameter
+      # name); #combine_args falls back to arg-N for those too.
+      #
+      # Returns nil when no UnboundMethod is available (virtual or C methods),
+      # in which case all positional arguments fall back to arg-N labels.
+      #
+      # @param target_method [UnboundMethod, nil]
+      # @return [Array<Symbol, nil>, nil]
+      def extract_positional_param_names(target_method)
+        return unless target_method
+
+        names = []
+        target_method.parameters.each do |type, name|
+          case type
+          when :req, :opt
+            names << name
+          when :rest
+            break
+          end
+        end
+        names
+      rescue StandardError => e
+        logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
+        nil
+      end
+
       # Body of the method probe wrapper. Extracted from the define_method
       # block in #hook_method so the begin/ensure structure can use normal
       # indentation. The original method is invoked with yield, calling the
@@ -476,11 +512,11 @@ module Datadog
       # from inside the define_method block, the only place super resolves
       # to the prepended-on class's method.
       #
-      # Performance: this method takes eight positional parameters, not
+      # Performance: this method takes nine positional parameters, not
       # keyword parameters, deliberately. Every probed method invocation
       # passes through here on the firing/disabled/rate-limited paths.
       # Keyword-argument calls in Ruby allocate a fresh Hash on every call
-      # to materialize the keyword bindings; with eight keyword arguments
+      # to materialize the keyword bindings; with that many keyword arguments
       # (~300-1000 ns of allocation per invocation), that hash dominated
       # the wrapper's per-call overhead. Positional parameters skip the
       # allocation entirely. The cost is a long unlabeled signature and
@@ -497,10 +533,11 @@ module Datadog
       # @param responder [#probe_executed_callback, #probe_condition_evaluation_failed_callback] callback target invoked with the built Context
       # @param loc [Array(String, Integer), nil] source location of the probed method, or nil for virtual/lazily-defined methods
       # @param method_name [String] name of the probed method, used as the synthetic top stack frame label
+      # @param positional_param_names [Array<Symbol, nil>, nil] real names of the target method's leading fixed positional parameters, for labeling captured positional arguments
       # @yield invokes the original method via super and returns its value
       # @return [Object] the original method's return value, or re-raises its exception
       def run_method_probe(args, kwargs, target_block, target_self,
-        probe, responder, loc, method_name)
+        probe, responder, loc, method_name, positional_param_names = nil)
         # Disabled probe: skip DI processing entirely. enter_probe is not
         # called on this path so the guard is never set — there is no DI
         # work to guard, and any nested probed methods invoked by the
@@ -519,7 +556,7 @@ module Datadog
               # We do not need the stack for condition evaluation, therefore
               # stack is not passed to Context here.
               context = Context.new(
-                locals: serializer.combine_args(args, kwargs, target_self),
+                locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
                 target_self: target_self,
                 probe: probe, settings: settings, serializer: serializer,
               )
@@ -568,7 +605,7 @@ module Datadog
             # Arguments may be mutated by the method, therefore
             # they need to be serialized prior to method invocation.
             serialized_entry_args = if probe.capture_snapshot?
-              serializer.serialize_args(args, kwargs, target_self,
+              serializer.serialize_args(args, kwargs, target_self, positional_param_names,
                 **probe.snapshot_serializer_limits(settings))
             end
 
@@ -579,7 +616,7 @@ module Datadog
                 entry_context = Context.new(
                   probe: probe, settings: settings, serializer: serializer,
                   target_self: target_self,
-                  locals: serializer.combine_args(args, kwargs, target_self),
+                  locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
                 )
                 entry_capture_expressions, entry_capture_evaluation_errors =
                   capture_expression_evaluator.evaluate(probe, entry_context)
@@ -653,7 +690,7 @@ module Datadog
             # TODO capture arguments at exit
 
             capture_expression_locals = if probe.capture_expressions_only?
-              serializer.combine_args(args, kwargs, target_self)
+              serializer.combine_args(args, kwargs, target_self, positional_param_names)
             end
             context = Context.new(locals: capture_expression_locals, target_self: target_self,
               probe: probe, settings: settings, serializer: serializer,

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -160,7 +160,7 @@ module Datadog
         end
 
         loc = target_method&.source_location
-        positional_param_names = extract_positional_param_names(target_method)
+        positional_param_names = target_method && extract_positional_param_names(target_method)
         instrumenter = self
 
         mod = Module.new do
@@ -451,14 +451,12 @@ module Datadog
       # may be nil (e.g. attr_writer-generated methods expose no parameter
       # name); #combine_args falls back to arg-N for those too.
       #
-      # Returns nil when no UnboundMethod is available (virtual or C methods),
-      # in which case all positional arguments fall back to arg-N labels.
+      # Only called with a resolved UnboundMethod; virtual and C methods have
+      # no UnboundMethod and skip this at the call site.
       #
-      # @param target_method [UnboundMethod, nil]
+      # @param target_method [UnboundMethod]
       # @return [Array<Symbol, nil>, nil]
       def extract_positional_param_names(target_method)
-        return unless target_method
-
         names = []
         target_method.parameters.each do |type, name|
           case type

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -190,7 +190,7 @@ module Datadog
         end
 
         loc = target_method&.source_location
-        positional_param_names = extract_positional_param_names(target_method)
+        positional_param_names = target_method && extract_positional_param_names(target_method)
         # @type var instrumenter: Instrumenter
         instrumenter = self
 
@@ -482,14 +482,12 @@ module Datadog
       # may be nil (e.g. attr_writer-generated methods expose no parameter
       # name); #combine_args falls back to arg-N for those too.
       #
-      # Returns nil when no UnboundMethod is available (virtual or C methods),
-      # in which case all positional arguments fall back to arg-N labels.
+      # Only called with a resolved UnboundMethod; virtual and C methods have
+      # no UnboundMethod and skip this at the call site.
       #
-      # @param target_method [UnboundMethod, nil]
+      # @param target_method [UnboundMethod]
       # @return [Array<Symbol, nil>, nil]
       def extract_positional_param_names(target_method)
-        return unless target_method
-
         names = []
         target_method.parameters.each do |type, name|
           case type

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -78,6 +78,15 @@ module Datadog
       # the whole process.
       GLOBAL_LOG_RATE_LIMIT = 5000
 
+      # Extended into every method-probe wrapper module before it is
+      # prepended. #hook_method uses it to recognize wrapper modules that
+      # earlier probes on this method have prepended and resolve past them
+      # to the user's original method (see #original_target_method), so
+      # parameter names and source location are read from the original
+      # definition.
+      module InstrumentedMethodMarker
+      end
+
       def initialize(settings, serializer, logger, code_tracker: nil, telemetry: nil)
         @settings = settings
         @serializer = serializer
@@ -172,6 +181,10 @@ module Datadog
           # target method here.
           nil
         end
+
+        # Resolve past wrappers prepended by earlier probes on this method so
+        # the checks below read the user's original definition.
+        target_method = original_target_method(target_method)
 
         # Reject method probes whose target method resolves to Kernel#lambda,
         # including inherited targets. Every class inherits Kernel#lambda, so a
@@ -272,6 +285,7 @@ module Datadog
             return
           end
 
+          mod.extend(InstrumentedMethodMarker)
           probe.instrumentation_module = mod
           cls.send(:prepend, mod)
 
@@ -469,6 +483,23 @@ module Datadog
       private
 
       attr_reader :lock
+
+      # Resolves +target_method+ past any method-probe wrapper modules that
+      # earlier probes on the same method have prepended, returning the user's
+      # original method. Ruby resolves UnboundMethod#super_method along the
+      # ancestor chain, so each step drops one prepended wrapper. Returns nil
+      # when only wrappers underlie the target (e.g. a virtual method that an
+      # earlier probe instrumented), matching the nil that #hook_method assigns
+      # for a method it cannot resolve.
+      #
+      # @param target_method [UnboundMethod, nil]
+      # @return [UnboundMethod, nil]
+      def original_target_method(target_method)
+        return target_method unless target_method
+        return target_method unless target_method.owner.is_a?(InstrumentedMethodMarker)
+
+        original_target_method(target_method.super_method)
+      end
 
       # Real names of the target method's leading fixed positional parameters
       # (+:req+ and +:opt+), in declaration order, used to label captured

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -487,6 +487,9 @@ module Datadog
       # earlier probe instrumented), matching the nil that #hook_method assigns
       # for a method it cannot resolve. Called at hook time so the source
       # location and parameter names read below come from the user's method.
+      #
+      # @param target_method [UnboundMethod, nil]
+      # @return [UnboundMethod, nil]
       def original_target_method(target_method)
         return target_method unless target_method
         return target_method unless target_method.owner.is_a?(InstrumentedMethodMarker)
@@ -561,7 +564,7 @@ module Datadog
       # @yield invokes the original method via super and returns its value
       # @return [Object] the original method's return value, or re-raises its exception
       def run_method_probe(args, kwargs, target_block, target_self,
-        probe, responder, loc, method_name, positional_param_names = nil)
+        probe, responder, loc, method_name, positional_param_names)
         # Disabled probe: skip DI processing entirely. enter_probe is not
         # called on this path so the guard is never set — there is no DI
         # work to guard, and any nested probed methods invoked by the
@@ -580,7 +583,7 @@ module Datadog
               # We do not need the stack for condition evaluation, therefore
               # stack is not passed to Context here.
               context = Context.new(
-                locals: serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names),
+                locals: serializer.combine_args(args, kwargs, target_self, positional_param_names: positional_param_names),
                 target_self: target_self,
                 probe: probe, settings: settings, serializer: serializer,
               )
@@ -629,7 +632,7 @@ module Datadog
             # Arguments may be mutated by the method, therefore
             # they need to be serialized prior to method invocation.
             serialized_entry_args = if probe.capture_snapshot?
-              serializer.serialize_args(args, kwargs, target_self, param_names: positional_param_names,
+              serializer.serialize_args(args, kwargs, target_self, positional_param_names: positional_param_names,
                 **probe.snapshot_serializer_limits(settings))
             end
 
@@ -640,7 +643,7 @@ module Datadog
                 entry_context = Context.new(
                   probe: probe, settings: settings, serializer: serializer,
                   target_self: target_self,
-                  locals: serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names),
+                  locals: serializer.combine_args(args, kwargs, target_self, positional_param_names: positional_param_names),
                 )
                 entry_capture_expressions, entry_capture_evaluation_errors =
                   capture_expression_evaluator.evaluate(probe, entry_context)
@@ -714,7 +717,7 @@ module Datadog
             # TODO capture arguments at exit
 
             capture_expression_locals = if probe.capture_expressions_only?
-              serializer.combine_args(args, kwargs, target_self, param_names: positional_param_names)
+              serializer.combine_args(args, kwargs, target_self, positional_param_names: positional_param_names)
             end
             context = Context.new(locals: capture_expression_locals, target_self: target_self,
               probe: probe, settings: settings, serializer: serializer,

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -160,6 +160,7 @@ module Datadog
         end
 
         loc = target_method&.source_location
+        positional_param_names = extract_positional_param_names(target_method)
         instrumenter = self
 
         mod = Module.new do
@@ -205,7 +206,7 @@ module Datadog
                 args, kwargs, target_block, # steep:ignore FallbackAny
                 self,
                 probe, responder,
-                loc, method_name,
+                loc, method_name, positional_param_names,
               ) do
                 super(*args, **kwargs, &target_block) # steep:ignore FallbackAny
               end
@@ -225,7 +226,7 @@ module Datadog
                 pos_args, kwargs, target_block,
                 self,
                 probe, responder,
-                loc, method_name,
+                loc, method_name, positional_param_names,
               ) do
                 super(*args, &target_block)
               end
@@ -438,6 +439,41 @@ module Datadog
 
       attr_reader :lock
 
+      # Real names of the target method's leading fixed positional parameters
+      # (+:req+ and +:opt+), in declaration order, used to label captured
+      # positional arguments with their source names instead of the synthetic
+      # arg1, arg2, ... labels. Uses the same Method#parameters reflection that
+      # the symbol database extractor relies on.
+      #
+      # Stops at a rest (+*+) parameter: values absorbed by a splat, and any
+      # positional parameters declared after it, cannot be mapped to a name by
+      # index, so they fall back to arg-N labels in #combine_args. A name entry
+      # may be nil (e.g. attr_writer-generated methods expose no parameter
+      # name); #combine_args falls back to arg-N for those too.
+      #
+      # Returns nil when no UnboundMethod is available (virtual or C methods),
+      # in which case all positional arguments fall back to arg-N labels.
+      #
+      # @param target_method [UnboundMethod, nil]
+      # @return [Array<Symbol, nil>, nil]
+      def extract_positional_param_names(target_method)
+        return unless target_method
+
+        names = []
+        target_method.parameters.each do |type, name|
+          case type
+          when :req, :opt
+            names << name
+          when :rest
+            break
+          end
+        end
+        names
+      rescue StandardError => e
+        logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
+        nil
+      end
+
       # Body of the method probe wrapper. Extracted from the define_method
       # block in #hook_method so the begin/ensure structure can use normal
       # indentation. The original method is invoked with yield, calling the
@@ -445,11 +481,11 @@ module Datadog
       # from inside the define_method block, the only place super resolves
       # to the prepended-on class's method.
       #
-      # Performance: this method takes eight positional parameters, not
+      # Performance: this method takes nine positional parameters, not
       # keyword parameters, deliberately. Every probed method invocation
       # passes through here on the firing/disabled/rate-limited paths.
       # Keyword-argument calls in Ruby allocate a fresh Hash on every call
-      # to materialize the keyword bindings; with eight keyword arguments
+      # to materialize the keyword bindings; with that many keyword arguments
       # (~300-1000 ns of allocation per invocation), that hash dominated
       # the wrapper's per-call overhead. Positional parameters skip the
       # allocation entirely. The cost is a long unlabeled signature and
@@ -466,10 +502,11 @@ module Datadog
       # @param responder [#probe_executed_callback, #probe_condition_evaluation_failed_callback] callback target invoked with the built Context
       # @param loc [Array(String, Integer), nil] source location of the probed method, or nil for virtual/lazily-defined methods
       # @param method_name [String] name of the probed method, used as the synthetic top stack frame label
+      # @param positional_param_names [Array<Symbol, nil>, nil] real names of the target method's leading fixed positional parameters, for labeling captured positional arguments
       # @yield invokes the original method via super and returns its value
       # @return [Object] the original method's return value, or re-raises its exception
       def run_method_probe(args, kwargs, target_block, target_self,
-        probe, responder, loc, method_name)
+        probe, responder, loc, method_name, positional_param_names = nil)
         # Disabled probe: skip DI processing entirely. enter_probe is not
         # called on this path so the guard is never set — there is no DI
         # work to guard, and any nested probed methods invoked by the
@@ -488,7 +525,7 @@ module Datadog
               # We do not need the stack for condition evaluation, therefore
               # stack is not passed to Context here.
               context = Context.new(
-                locals: serializer.combine_args(args, kwargs, target_self),
+                locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
                 target_self: target_self,
                 probe: probe, settings: settings, serializer: serializer,
               )
@@ -532,7 +569,7 @@ module Datadog
             # Arguments may be mutated by the method, therefore
             # they need to be serialized prior to method invocation.
             serialized_entry_args = if probe.capture_snapshot?
-              serializer.serialize_args(args, kwargs, target_self,
+              serializer.serialize_args(args, kwargs, target_self, positional_param_names,
                 **probe.snapshot_serializer_limits(settings))
             end
 
@@ -543,7 +580,7 @@ module Datadog
                 entry_context = Context.new(
                   probe: probe, settings: settings, serializer: serializer,
                   target_self: target_self,
-                  locals: serializer.combine_args(args, kwargs, target_self),
+                  locals: serializer.combine_args(args, kwargs, target_self, positional_param_names),
                 )
                 entry_capture_expressions, entry_capture_evaluation_errors =
                   capture_expression_evaluator.evaluate(probe, entry_context)
@@ -617,7 +654,7 @@ module Datadog
             # TODO capture arguments at exit
 
             capture_expression_locals = if probe.capture_expressions_only?
-              serializer.combine_args(args, kwargs, target_self)
+              serializer.combine_args(args, kwargs, target_self, positional_param_names)
             end
             context = Context.new(locals: capture_expression_locals, target_self: target_self,
               probe: probe, settings: settings, serializer: serializer,

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -498,8 +498,10 @@ module Datadog
           end
         end
         names
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
+        telemetry&.report(e, description: "Error extracting positional parameter names")
         nil
       end
 

--- a/lib/datadog/di/instrumenter.rb
+++ b/lib/datadog/di/instrumenter.rb
@@ -467,8 +467,10 @@ module Datadog
           end
         end
         names
-      rescue => e
+      rescue Exception => e # standard:disable Lint/RescueException
+        Datadog::DI.reraise_if_fatal(e)
         logger.debug { "di: failed to extract positional parameter names: #{e.class}: #{e.message}" }
+        telemetry&.report(e, description: "Error extracting positional parameter names")
         nil
       end
 

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -131,7 +131,7 @@ module Datadog
       #   argument key, falls back to the arg-N label. nil means no names are
       #   available and every position uses arg-N.
       # @return [Hash{Symbol=>Object}] argument values keyed by name, plus :self
-      def combine_args(args, kwargs, target_self, param_names = nil)
+      def combine_args(args, kwargs, target_self, param_names: nil)
         combined = {}
         args.each_with_index do |value, index|
           name = param_names && param_names[index]
@@ -169,12 +169,12 @@ module Datadog
       # @param length [Integer, nil] maximum string length before truncation
       # @param collection_size [Integer, nil] maximum collection entries
       # @return [Hash{Symbol=>Hash}] serialized argument values keyed by name
-      def serialize_args(args, kwargs, target_self, param_names = nil,
+      def serialize_args(args, kwargs, target_self, param_names: nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,
         length: nil,
         collection_size: nil)
-        combined = combine_args(args, kwargs, target_self, param_names)
+        combined = combine_args(args, kwargs, target_self, param_names: param_names)
         serialize_vars(combined, depth: depth, attribute_count: attribute_count,
           length: length, collection_size: collection_size)
       end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -113,11 +113,23 @@ module Datadog
       attr_reader :redactor
       attr_reader :telemetry
 
-      # +param_names+, when provided, is the ordered list of the method's
-      # leading fixed positional parameter names (from Method#parameters).
-      # Each positional argument is keyed by its real name; an argument with
-      # no available name (generated methods, splat overflow, virtual/C
-      # methods) falls back to the positional label arg1, arg2, ...
+      # Combines positional arguments, keyword arguments, and the receiver into
+      # a single name-keyed hash for serialization.
+      #
+      # Positional arguments are keyed by their real parameter name when
+      # +param_names+ provides one, otherwise by the positional label arg1,
+      # arg2, ... . Keyword arguments keep their own names; the receiver is
+      # added under :self. Symbol keys keep positional arguments ahead of the
+      # symbol-keyed keyword arguments merged after them.
+      #
+      # @param args [Array<Object>] positional argument values, in call order
+      # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
+      # @param target_self [Object] the receiver of the probed method
+      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
+      #   fixed positional parameters; a nil entry (generated methods, splat
+      #   overflow, virtual/C methods) falls back to the arg-N label. nil means
+      #   no names are available and every position uses arg-N.
+      # @return [Hash{Symbol=>Object}] argument values keyed by name, plus :self
       def combine_args(args, kwargs, target_self, param_names = nil)
         combined = {}
         args.each_with_index do |value, index|
@@ -131,18 +143,26 @@ module Datadog
         combined
       end
 
-      # Serializes positional and keyword arguments to a method,
-      # as obtained by a method probe.
+      # Serializes positional and keyword arguments to a method, as obtained by
+      # a method probe.
       #
-      # UI supports a single argument list only and does not distinguish
-      # between positional and keyword arguments. Positional arguments are
-      # keyed by their real parameter names when available (see
-      # +combine_args+), falling back to "arg1", "arg2", ...; positional
-      # arguments are listed first.
+      # UI supports a single argument list only and does not distinguish between
+      # positional and keyword arguments. Positional arguments are keyed by their
+      # real parameter names when available (see #combine_args), falling back to
+      # arg1, arg2, ...; positional arguments are listed first. The receiver is
+      # serialized under :self so its instance variables are captured without an
+      # extra hash merge in the caller.
       #
-      # Instance variables are technically a hash just like kwargs,
-      # we take them as a separate parameter to avoid a hash merge
-      # in upstream code.
+      # @param args [Array<Object>] positional argument values, in call order
+      # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
+      # @param target_self [Object] the receiver of the probed method
+      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
+      #   fixed positional parameters (see #combine_args), or nil for arg-N labels
+      # @param depth [Integer] maximum object graph depth to serialize
+      # @param attribute_count [Integer, nil] maximum attributes per object
+      # @param length [Integer, nil] maximum string length before truncation
+      # @param collection_size [Integer, nil] maximum collection entries
+      # @return [Hash{Symbol=>Hash}] serialized argument values keyed by name
       def serialize_args(args, kwargs, target_self, param_names = nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -106,14 +106,20 @@ module Datadog
       attr_reader :redactor
       attr_reader :telemetry
 
-      def combine_args(args, kwargs, target_self)
-        counter = 0
-        combined = args.each_with_object({}) do |value, c|
-          counter += 1
-          # Conversion to symbol is needed here to put args ahead of
-          # kwargs when they are merged below.
-          c[:"arg#{counter}"] = value
-        end.update(kwargs)
+      # +param_names+, when provided, is the ordered list of the method's
+      # leading fixed positional parameter names (from Method#parameters).
+      # Each positional argument is keyed by its real name; an argument with
+      # no available name (generated methods, splat overflow, virtual/C
+      # methods) falls back to the positional label arg1, arg2, ...
+      def combine_args(args, kwargs, target_self, param_names = nil)
+        combined = {}
+        args.each_with_index do |value, index|
+          name = param_names && param_names[index]
+          # Symbol keys put positional args ahead of the symbol-keyed kwargs
+          # merged below.
+          combined[name || :"arg#{index + 1}"] = value
+        end
+        combined.update(kwargs)
         combined[:self] = target_self
         combined
       end
@@ -122,19 +128,20 @@ module Datadog
       # as obtained by a method probe.
       #
       # UI supports a single argument list only and does not distinguish
-      # between positional and keyword arguments. We convert positional
-      # arguments to keyword arguments ("arg1", "arg2", ...) and ensure
-      # the positional arguments are listed first.
+      # between positional and keyword arguments. Positional arguments are
+      # keyed by their real parameter names when available (see
+      # +combine_args+), falling back to "arg1", "arg2", ...; positional
+      # arguments are listed first.
       #
       # Instance variables are technically a hash just like kwargs,
       # we take them as a separate parameter to avoid a hash merge
       # in upstream code.
-      def serialize_args(args, kwargs, target_self,
+      def serialize_args(args, kwargs, target_self, param_names = nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,
         length: nil,
         collection_size: nil)
-        combined = combine_args(args, kwargs, target_self)
+        combined = combine_args(args, kwargs, target_self, param_names)
         serialize_vars(combined, depth: depth, attribute_count: attribute_count,
           length: length, collection_size: collection_size)
       end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -106,11 +106,23 @@ module Datadog
       attr_reader :redactor
       attr_reader :telemetry
 
-      # +param_names+, when provided, is the ordered list of the method's
-      # leading fixed positional parameter names (from Method#parameters).
-      # Each positional argument is keyed by its real name; an argument with
-      # no available name (generated methods, splat overflow, virtual/C
-      # methods) falls back to the positional label arg1, arg2, ...
+      # Combines positional arguments, keyword arguments, and the receiver into
+      # a single name-keyed hash for serialization.
+      #
+      # Positional arguments are keyed by their real parameter name when
+      # +param_names+ provides one, otherwise by the positional label arg1,
+      # arg2, ... . Keyword arguments keep their own names; the receiver is
+      # added under :self. Symbol keys keep positional arguments ahead of the
+      # symbol-keyed keyword arguments merged after them.
+      #
+      # @param args [Array<Object>] positional argument values, in call order
+      # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
+      # @param target_self [Object] the receiver of the probed method
+      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
+      #   fixed positional parameters; a nil entry (generated methods, splat
+      #   overflow, virtual/C methods) falls back to the arg-N label. nil means
+      #   no names are available and every position uses arg-N.
+      # @return [Hash{Symbol=>Object}] argument values keyed by name, plus :self
       def combine_args(args, kwargs, target_self, param_names = nil)
         combined = {}
         args.each_with_index do |value, index|
@@ -124,18 +136,26 @@ module Datadog
         combined
       end
 
-      # Serializes positional and keyword arguments to a method,
-      # as obtained by a method probe.
+      # Serializes positional and keyword arguments to a method, as obtained by
+      # a method probe.
       #
-      # UI supports a single argument list only and does not distinguish
-      # between positional and keyword arguments. Positional arguments are
-      # keyed by their real parameter names when available (see
-      # +combine_args+), falling back to "arg1", "arg2", ...; positional
-      # arguments are listed first.
+      # UI supports a single argument list only and does not distinguish between
+      # positional and keyword arguments. Positional arguments are keyed by their
+      # real parameter names when available (see #combine_args), falling back to
+      # arg1, arg2, ...; positional arguments are listed first. The receiver is
+      # serialized under :self so its instance variables are captured without an
+      # extra hash merge in the caller.
       #
-      # Instance variables are technically a hash just like kwargs,
-      # we take them as a separate parameter to avoid a hash merge
-      # in upstream code.
+      # @param args [Array<Object>] positional argument values, in call order
+      # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
+      # @param target_self [Object] the receiver of the probed method
+      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
+      #   fixed positional parameters (see #combine_args), or nil for arg-N labels
+      # @param depth [Integer] maximum object graph depth to serialize
+      # @param attribute_count [Integer, nil] maximum attributes per object
+      # @param length [Integer, nil] maximum string length before truncation
+      # @param collection_size [Integer, nil] maximum collection entries
+      # @return [Hash{Symbol=>Hash}] serialized argument values keyed by name
       def serialize_args(args, kwargs, target_self, param_names = nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -117,31 +117,32 @@ module Datadog
       # a single name-keyed hash for serialization.
       #
       # Positional arguments are keyed by their real parameter name when
-      # +param_names+ provides one, otherwise by the positional label arg1,
-      # arg2, ... . Keyword arguments keep their own names; the receiver is
-      # added under :self. Symbol keys keep positional arguments ahead of the
-      # symbol-keyed keyword arguments merged after them.
+      # +positional_param_names+ provides one, otherwise by the positional
+      # label arg1, arg2, ... . Keyword arguments keep their own names; the
+      # receiver is added under :self. Symbol keys keep positional arguments
+      # ahead of the symbol-keyed keyword arguments merged after them.
       #
       # @param args [Array<Object>] positional argument values, in call order
       # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
       # @param target_self [Object] the receiver of the probed method
-      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
-      #   fixed positional parameters; a nil entry (generated methods, splat
-      #   overflow, virtual/C methods), or a name that collides with a keyword
-      #   argument key, falls back to the arg-N label. nil means no names are
-      #   available and every position uses arg-N.
+      # @param positional_param_names [Array<Symbol, nil>, nil] real names of
+      #   the leading fixed positional parameters; a nil entry (generated
+      #   methods, splat overflow, virtual/C methods), or a name that collides
+      #   with a keyword argument key or with the synthetic arg-N label of
+      #   another position, falls back to the arg-N label. nil means no names
+      #   are available and every position uses arg-N.
       # @return [Hash{Symbol=>Object}] argument values keyed by name, plus :self
-      def combine_args(args, kwargs, target_self, param_names: nil)
+      def combine_args(args, kwargs, target_self, positional_param_names: nil)
         combined = {}
         args.each_with_index do |value, index|
-          name = param_names && param_names[index]
-          # A real parameter name can coincide with a keyword argument key;
-          # the #update below would then overwrite the positional value with
-          # the keyword value, silently dropping the positional. Fall back to
-          # the positional arg-N label in that case so both values are kept.
-          # Symbol keys put positional args ahead of the symbol-keyed kwargs
-          # merged below.
-          name = nil if name && kwargs.key?(name)
+          name = positional_param_names && positional_param_names[index]
+          # A real parameter name can coincide with a keyword argument key, or
+          # be shaped like the synthetic arg-N label of a later splat-absorbed
+          # position; either would silently drop a value in the assignment
+          # below. Fall back to the arg-N label in both cases so every position
+          # keeps a distinct key. Symbol keys put positional args ahead of the
+          # symbol-keyed kwargs merged below.
+          name = nil if name && (kwargs.key?(name) || name.to_s.match?(/\Aarg\d+\z/))
           combined[name || :"arg#{index + 1}"] = value
         end
         combined.update(kwargs)
@@ -162,19 +163,20 @@ module Datadog
       # @param args [Array<Object>] positional argument values, in call order
       # @param kwargs [Hash{Symbol=>Object}] keyword arguments by name
       # @param target_self [Object] the receiver of the probed method
-      # @param param_names [Array<Symbol, nil>, nil] real names of the leading
-      #   fixed positional parameters (see #combine_args), or nil for arg-N labels
+      # @param positional_param_names [Array<Symbol, nil>, nil] real names of
+      #   the leading fixed positional parameters (see #combine_args), or nil
+      #   for arg-N labels
       # @param depth [Integer] maximum object graph depth to serialize
       # @param attribute_count [Integer, nil] maximum attributes per object
       # @param length [Integer, nil] maximum string length before truncation
       # @param collection_size [Integer, nil] maximum collection entries
       # @return [Hash{Symbol=>Hash}] serialized argument values keyed by name
-      def serialize_args(args, kwargs, target_self, param_names: nil,
+      def serialize_args(args, kwargs, target_self, positional_param_names: nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,
         length: nil,
         collection_size: nil)
-        combined = combine_args(args, kwargs, target_self, param_names: param_names)
+        combined = combine_args(args, kwargs, target_self, positional_param_names: positional_param_names)
         serialize_vars(combined, depth: depth, attribute_count: attribute_count,
           length: length, collection_size: collection_size)
       end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -113,14 +113,20 @@ module Datadog
       attr_reader :redactor
       attr_reader :telemetry
 
-      def combine_args(args, kwargs, target_self)
-        counter = 0
-        combined = args.each_with_object({}) do |value, c|
-          counter += 1
-          # Conversion to symbol is needed here to put args ahead of
-          # kwargs when they are merged below.
-          c[:"arg#{counter}"] = value
-        end.update(kwargs)
+      # +param_names+, when provided, is the ordered list of the method's
+      # leading fixed positional parameter names (from Method#parameters).
+      # Each positional argument is keyed by its real name; an argument with
+      # no available name (generated methods, splat overflow, virtual/C
+      # methods) falls back to the positional label arg1, arg2, ...
+      def combine_args(args, kwargs, target_self, param_names = nil)
+        combined = {}
+        args.each_with_index do |value, index|
+          name = param_names && param_names[index]
+          # Symbol keys put positional args ahead of the symbol-keyed kwargs
+          # merged below.
+          combined[name || :"arg#{index + 1}"] = value
+        end
+        combined.update(kwargs)
         combined[:self] = target_self
         combined
       end
@@ -129,19 +135,20 @@ module Datadog
       # as obtained by a method probe.
       #
       # UI supports a single argument list only and does not distinguish
-      # between positional and keyword arguments. We convert positional
-      # arguments to keyword arguments ("arg1", "arg2", ...) and ensure
-      # the positional arguments are listed first.
+      # between positional and keyword arguments. Positional arguments are
+      # keyed by their real parameter names when available (see
+      # +combine_args+), falling back to "arg1", "arg2", ...; positional
+      # arguments are listed first.
       #
       # Instance variables are technically a hash just like kwargs,
       # we take them as a separate parameter to avoid a hash merge
       # in upstream code.
-      def serialize_args(args, kwargs, target_self,
+      def serialize_args(args, kwargs, target_self, param_names = nil,
         depth: settings.dynamic_instrumentation.max_capture_depth,
         attribute_count: settings.dynamic_instrumentation.max_capture_attribute_count,
         length: nil,
         collection_size: nil)
-        combined = combine_args(args, kwargs, target_self)
+        combined = combine_args(args, kwargs, target_self, param_names)
         serialize_vars(combined, depth: depth, attribute_count: attribute_count,
           length: length, collection_size: collection_size)
       end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -127,15 +127,21 @@ module Datadog
       # @param target_self [Object] the receiver of the probed method
       # @param param_names [Array<Symbol, nil>, nil] real names of the leading
       #   fixed positional parameters; a nil entry (generated methods, splat
-      #   overflow, virtual/C methods) falls back to the arg-N label. nil means
-      #   no names are available and every position uses arg-N.
+      #   overflow, virtual/C methods), or a name that collides with a keyword
+      #   argument key, falls back to the arg-N label. nil means no names are
+      #   available and every position uses arg-N.
       # @return [Hash{Symbol=>Object}] argument values keyed by name, plus :self
       def combine_args(args, kwargs, target_self, param_names = nil)
         combined = {}
         args.each_with_index do |value, index|
           name = param_names && param_names[index]
+          # A real parameter name can coincide with a keyword argument key;
+          # the #update below would then overwrite the positional value with
+          # the keyword value, silently dropping the positional. Fall back to
+          # the positional arg-N label in that case so both values are kept.
           # Symbol keys put positional args ahead of the symbol-keyed kwargs
           # merged below.
+          name = nil if name && kwargs.key?(name)
           combined[name || :"arg#{index + 1}"] = value
         end
         combined.update(kwargs)

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -9,6 +9,9 @@ module Datadog
         def label: () -> String?
       end
 
+      # Marker module extended into each method-probe wrapper module so
+      # #original_target_method can distinguish DI wrappers from other
+      # prepended modules when resolving a method's original definition.
       module InstrumentedMethodMarker
       end
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -84,7 +84,7 @@ module Datadog
 
       attr_reader lock: Mutex
 
-      def extract_positional_param_names: (UnboundMethod? target_method) -> ::Array[::Symbol?]?
+      def extract_positional_param_names: (UnboundMethod target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -9,6 +9,9 @@ module Datadog
         def label: () -> String?
       end
 
+      module InstrumentedMethodMarker
+      end
+
       DATADOG_NAMESPACE_TYPE_NAME: ::Regexp
 
       GLOBAL_SNAPSHOT_RATE_LIMIT: ::Integer
@@ -83,6 +86,8 @@ module Datadog
       private
 
       attr_reader lock: Mutex
+
+      def original_target_method: (::UnboundMethod? target_method) -> ::UnboundMethod?
 
       def extract_positional_param_names: (::UnboundMethod target_method) -> ::Array[::Symbol?]?
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module DI
     class Instrumenter
+      type positional_param_names_type = ::Array[::Symbol?]?
+
       class Location
         def initialize: (String path, Integer lineno, String? label) -> void
 
@@ -80,7 +82,7 @@ module Datadog
       # at this layer. responder is a duck-typed interface
       # (#probe_executed_callback, #probe_condition_evaluation_failed_callback,
       # #probe_disabled_callback) with no shared base class to name.
-      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, any target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name, ?::Array[::Symbol?]? positional_param_names) { () -> untyped } -> untyped
+      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, any target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name, positional_param_names_type positional_param_names) { () -> untyped } -> untyped
 
       # Ruby < 3 only. Splits a splat-captured argument list into
       # [positional_args, kwargs]; the trailing hash, if any, becomes kwargs.
@@ -92,7 +94,7 @@ module Datadog
 
       def original_target_method: (::UnboundMethod? target_method) -> ::UnboundMethod?
 
-      def extract_positional_param_names: (::UnboundMethod target_method) -> ::Array[::Symbol?]?
+      def extract_positional_param_names: (::UnboundMethod target_method) -> positional_param_names_type
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -74,7 +74,7 @@ module Datadog
       # at this layer. responder is a duck-typed interface
       # (#probe_executed_callback, #probe_condition_evaluation_failed_callback,
       # #probe_disabled_callback) with no shared base class to name.
-      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, any target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name) { () -> untyped } -> untyped
+      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, any target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name, ?::Array[::Symbol?]? positional_param_names) { () -> untyped } -> untyped
 
       # Ruby < 3 only. Splits a splat-captured argument list into
       # [positional_args, kwargs]; the trailing hash, if any, becomes kwargs.
@@ -83,6 +83,8 @@ module Datadog
       private
 
       attr_reader lock: Mutex
+
+      def extract_positional_param_names: (UnboundMethod? target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -70,7 +70,7 @@ module Datadog
 
       attr_reader lock: Mutex
 
-      def extract_positional_param_names: (UnboundMethod? target_method) -> ::Array[::Symbol?]?
+      def extract_positional_param_names: (UnboundMethod target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -70,7 +70,7 @@ module Datadog
 
       attr_reader lock: Mutex
 
-      def extract_positional_param_names: (UnboundMethod target_method) -> ::Array[::Symbol?]?
+      def extract_positional_param_names: (::UnboundMethod target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -60,7 +60,7 @@ module Datadog
       # at this layer. responder is a duck-typed interface
       # (#probe_executed_callback, #probe_condition_evaluation_failed_callback,
       # #probe_disabled_callback) with no shared base class to name.
-      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, Object target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name) { () -> untyped } -> untyped
+      def run_method_probe: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Proc? target_block, Object target_self, Probe probe, untyped responder, [::String, ::Integer]? loc, ::String method_name, ?::Array[::Symbol?]? positional_param_names) { () -> untyped } -> untyped
 
       # Ruby < 3 only. Splits a splat-captured argument list into
       # [positional_args, kwargs]; the trailing hash, if any, becomes kwargs.
@@ -69,6 +69,8 @@ module Datadog
       private
 
       attr_reader lock: Mutex
+
+      def extract_positional_param_names: (UnboundMethod? target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/instrumenter.rbs
+++ b/sig/datadog/di/instrumenter.rbs
@@ -84,7 +84,7 @@ module Datadog
 
       attr_reader lock: Mutex
 
-      def extract_positional_param_names: (UnboundMethod target_method) -> ::Array[::Symbol?]?
+      def extract_positional_param_names: (::UnboundMethod target_method) -> ::Array[::Symbol?]?
 
       def line_trace_point_callback: (Probe probe, RubyVM::InstructionSequence? iseq, untyped responder, TracePoint tp) -> void
 

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -22,8 +22,8 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, Object target_self) -> Hash[Symbol, untyped]
-      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
+      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, Object target_self, ?Array[Symbol?]? param_names) -> Hash[Symbol, untyped]
+      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?Array[Symbol?]? param_names, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
       def serialize_value_for_message: (any value, ?depth: ::Integer, ?name: (::Symbol | ::String)?) -> String?

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -21,8 +21,8 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, Object target_self) -> Hash[Symbol, untyped]
-      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
+      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, Object target_self, ?Array[Symbol?]? param_names) -> Hash[Symbol, untyped]
+      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?Array[Symbol?]? param_names, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
       def serialize_value_for_message: (any value, ?::Integer depth) -> String?

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -1,6 +1,8 @@
 module Datadog
   module DI
     class Serializer
+      type positional_param_names_type = ::Array[::Symbol?]?
+
       MAX_MESSAGE_COLLECTION_SIZE: Integer
       MAX_MESSAGE_ATTRIBUTE_COUNT: Integer
       SERIALIZABLE_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
@@ -22,8 +24,8 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, Object target_self, ?param_names: ::Array[::Symbol?]?) -> ::Hash[::Symbol, untyped]
-      def serialize_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, untyped instance_vars, ?param_names: ::Array[::Symbol?]?, ?depth: ::Integer, ?attribute_count: ::Integer?, ?length: ::Integer?, ?collection_size: ::Integer?) -> ::Hash[::Symbol, untyped]
+      def combine_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, ::Object target_self, ?positional_param_names: positional_param_names_type) -> ::Hash[::Symbol, untyped]
+      def serialize_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, untyped instance_vars, ?positional_param_names: positional_param_names_type, ?depth: ::Integer, ?attribute_count: ::Integer?, ?length: ::Integer?, ?collection_size: ::Integer?) -> ::Hash[::Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
       def serialize_value_for_message: (any value, ?depth: ::Integer, ?name: (::Symbol | ::String)?) -> String?

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -22,8 +22,8 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, Object target_self, ?::Array[::Symbol?]? param_names) -> ::Hash[::Symbol, untyped]
-      def serialize_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, untyped instance_vars, ?::Array[::Symbol?]? param_names, ?depth: ::Integer, ?attribute_count: ::Integer?, ?length: ::Integer?, ?collection_size: ::Integer?) -> ::Hash[::Symbol, untyped]
+      def combine_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, Object target_self, ?param_names: ::Array[::Symbol?]?) -> ::Hash[::Symbol, untyped]
+      def serialize_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, untyped instance_vars, ?param_names: ::Array[::Symbol?]?, ?depth: ::Integer, ?attribute_count: ::Integer?, ?length: ::Integer?, ?collection_size: ::Integer?) -> ::Hash[::Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
       def serialize_value_for_message: (any value, ?depth: ::Integer, ?name: (::Symbol | ::String)?) -> String?

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -22,8 +22,8 @@ module Datadog
 
       attr_reader telemetry: Core::Telemetry::Component?
 
-      def combine_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, Object target_self, ?Array[Symbol?]? param_names) -> Hash[Symbol, untyped]
-      def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?Array[Symbol?]? param_names, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
+      def combine_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, Object target_self, ?::Array[::Symbol?]? param_names) -> ::Hash[::Symbol, untyped]
+      def serialize_args: (::Array[untyped] args, ::Hash[::Symbol, untyped] kwargs, untyped instance_vars, ?::Array[::Symbol?]? param_names, ?depth: ::Integer, ?attribute_count: ::Integer?, ?length: ::Integer?, ?collection_size: ::Integer?) -> ::Hash[::Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
       def serialize_value_for_message: (any value, ?depth: ::Integer, ?name: (::Symbol | ::String)?) -> String?

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -70,6 +70,10 @@ class HookTestClass
     [arg, options]
   end
 
+  def method_with_splat(first, *rest)
+    [first, rest]
+  end
+
   def exception_method
     raise TestException, "Test exception"
   end

--- a/spec/datadog/di/hook_method.rb
+++ b/spec/datadog/di/hook_method.rb
@@ -74,6 +74,10 @@ class HookTestClass
     [first, rest]
   end
 
+  def method_kwarg_name_collision(path, **opts)
+    [path, opts]
+  end
+
   def exception_method
     raise TestException, "Test exception"
   end

--- a/spec/datadog/di/instrumenter_circuit_breaker_spec.rb
+++ b/spec/datadog/di/instrumenter_circuit_breaker_spec.rb
@@ -170,9 +170,9 @@ RSpec.describe "Datadog::DI::Instrumenter circuit breaker" do
         context = observed_calls.first
         expect(context).to be_a(Datadog::DI::Context)
         expect(context.serialized_entry_args).to be_a(Hash)
-        expect(context.serialized_entry_args).to have_key(:arg1)
+        expect(context.serialized_entry_args).to have_key(:arg)
 
-        arg_data = context.serialized_entry_args[:arg1]
+        arg_data = context.serialized_entry_args[:arg]
         expect(arg_data).to be_a(Hash)
         expect(arg_data[:type]).to eq("Array")
         expect(arg_data[:elements]).to be_a(Array)

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -366,7 +366,6 @@ RSpec.describe Datadog::DI::Instrumenter do
           expect(observed_calls.first).to be_a(Datadog::DI::Context)
           expect(observed_calls.first.return_value).to eq 2
           expect(observed_calls.first.duration).to be_a(Float)
-          # expect(observed_calls.first.serialized_entry_args).to eq(arg: 2)
         end
       end
 
@@ -622,12 +621,18 @@ RSpec.describe Datadog::DI::Instrumenter do
 
       let(:first_calls) { [] }
 
+      before do
+        hook_method(first_probe) { |payload| first_calls << payload }
+        # Establish the precondition: the method is already instrumented
+        # by the earlier probe.
+        expect(first_probe.instrumentation_module).not_to be_nil
+      end
+
       after do
         instrumenter.unhook(first_probe)
       end
 
       it "captures positional args under their real names for the later probe" do
-        hook_method(first_probe) { |payload| first_calls << payload }
         hook_method(probe) { |payload| observed_calls << payload }
 
         expect(HookTestClass.new.hook_test_method_with_arg(2)).to eq 2
@@ -2418,40 +2423,42 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
-    def names_for(method_name)
+    def positional_param_names(method_name)
       instrumenter.send(:extract_positional_param_names, target_class.instance_method(method_name))
     end
 
     it "returns required positional names in order" do
-      expect(names_for(:only_req)).to eq([:a, :b])
+      expect(positional_param_names(:only_req)).to eq([:a, :b])
     end
 
     it "includes optional positional parameters" do
-      expect(names_for(:req_and_opt)).to eq([:a, :b])
+      expect(positional_param_names(:req_and_opt)).to eq([:a, :b])
     end
 
     it "stops at a rest parameter, keeping the leading fixed positionals" do
-      expect(names_for(:leading_req_then_rest)).to eq([:a, :b])
+      expect(positional_param_names(:leading_req_then_rest)).to eq([:a, :b])
     end
 
     it "stops at a leading rest parameter, dropping post-splat positionals" do
-      expect(names_for(:rest_first)).to eq([])
+      expect(positional_param_names(:rest_first)).to eq([])
     end
 
     it "ignores keyword and keyword-splat parameters" do
-      expect(names_for(:kwargs_only)).to eq([])
+      expect(positional_param_names(:kwargs_only)).to eq([])
     end
 
     it "ignores block parameters" do
-      expect(names_for(:block_only)).to eq([])
+      expect(positional_param_names(:block_only)).to eq([])
     end
 
     it "returns an empty array for a method with no parameters" do
-      expect(names_for(:no_params)).to eq([])
+      expect(positional_param_names(:no_params)).to eq([])
     end
 
     it "returns a nil name for a generated method (attr_writer) with no parameter name" do
-      expect(names_for(:written=)).to eq([nil])
+      # attr_writer-generated methods expose a nameless [:req] parameter; this
+      # shape is a stable MRI attribute contract across the supported range.
+      expect(positional_param_names(:written=)).to eq([nil])
     end
 
     it "returns nil and logs when parameter extraction raises" do

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           expect(observed_calls.first).to be_a(Datadog::DI::Context)
           expect(observed_calls.first.return_value).to eq 2
           expect(observed_calls.first.duration).to be_a(Float)
-          # expect(observed_calls.first.serialized_entry_args).to eq(arg1: 2)
+          # expect(observed_calls.first.serialized_entry_args).to eq(arg: 2)
         end
       end
 
@@ -395,7 +395,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              arg1: {type: "Integer", value: "2"},
+              arg: {type: "Integer", value: "2"},
               self: {type: "HookTestClass", fields: {}},
             )
           end
@@ -423,7 +423,7 @@ RSpec.describe Datadog::DI::Instrumenter do
               expect(observed_calls.first.duration).to be_a(Float)
 
               expect(observed_calls.first.serialized_entry_args).to eq(
-                arg1: {type: "Integer", value: "2"},
+                arg: {type: "Integer", value: "2"},
                 self: {
                   type: "HookIvarTestClass",
                   fields: {
@@ -575,9 +575,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              # TODO actual argument name not captured yet,
-              # requires method call trace point.
-              arg1: {type: "Integer", value: "41"},
+              arg: {type: "Integer", value: "41"},
               kwarg: {type: "Integer", value: "42"},
               self: {type: "HookTestClass", fields: {}},
             )
@@ -711,7 +709,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              arg1: {type: "String", value: "hello"},
+              arg: {type: "String", value: "hello"},
               kwarg: {type: "Integer", value: "42"},
               self: {type: "HookTestClass", fields: {}},
             )
@@ -1180,8 +1178,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           let(:condition) do
             Datadog::DI::EL::Expression.new(
               "(expression)",
-              # We use "arg1" here, actual variable name is not currently available
-              "ref('arg1') == 41"
+              "ref('arg') == 41"
             )
           end
 
@@ -1192,8 +1189,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           let(:condition) do
             Datadog::DI::EL::Expression.new(
               "(expression)",
-              # We use "arg1" here, actual variable name is not currently available
-              "ref('arg1') == 42"
+              "ref('arg') == 42"
             )
           end
 

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -2282,4 +2282,70 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
   end
+
+  describe "#extract_positional_param_names" do
+    let(:target_class) do
+      Class.new do
+        def only_req(a, b)
+          [a, b]
+        end
+
+        def req_and_opt(a, b = 1)
+          [a, b]
+        end
+
+        def leading_req_then_rest(a, b, *rest)
+          [a, b, rest]
+        end
+
+        def rest_first(*rest, a)
+          [rest, a]
+        end
+
+        def kwargs_only(x:, y: 1, **opts)
+          [x, y, opts]
+        end
+
+        def block_only(&blk)
+          blk
+        end
+
+        def no_params
+          nil
+        end
+      end
+    end
+
+    def names_for(method_name)
+      instrumenter.send(:extract_positional_param_names, target_class.instance_method(method_name))
+    end
+
+    it "returns required positional names in order" do
+      expect(names_for(:only_req)).to eq([:a, :b])
+    end
+
+    it "includes optional positional parameters" do
+      expect(names_for(:req_and_opt)).to eq([:a, :b])
+    end
+
+    it "stops at a rest parameter, keeping the leading fixed positionals" do
+      expect(names_for(:leading_req_then_rest)).to eq([:a, :b])
+    end
+
+    it "stops at a leading rest parameter, dropping post-splat positionals" do
+      expect(names_for(:rest_first)).to eq([])
+    end
+
+    it "ignores keyword and keyword-splat parameters" do
+      expect(names_for(:kwargs_only)).to eq([])
+    end
+
+    it "ignores block parameters" do
+      expect(names_for(:block_only)).to eq([])
+    end
+
+    it "returns an empty array for a method with no parameters" do
+      expect(names_for(:no_params)).to eq([])
+    end
+  end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -607,6 +607,40 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "when the method is already instrumented by an earlier probe" do
+      let(:probe_args) do
+        {type_name: "HookTestClass", method_name: "hook_test_method_with_arg",
+         capture_snapshot: true}
+      end
+
+      let(:first_probe) do
+        Datadog::DI::Probe.new(**base_probe_args.merge(
+          id: "first", type_name: "HookTestClass",
+          method_name: "hook_test_method_with_arg", capture_snapshot: true
+        ))
+      end
+
+      let(:first_calls) { [] }
+
+      after do
+        instrumenter.unhook(first_probe)
+      end
+
+      it "captures positional args under their real names for the later probe" do
+        hook_method(first_probe) { |payload| first_calls << payload }
+        hook_method(probe) { |payload| observed_calls << payload }
+
+        expect(HookTestClass.new.hook_test_method_with_arg(2)).to eq 2
+
+        expect(first_calls.length).to eq 1
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          arg: {type: "Integer", value: "2"},
+          self: {type: "HookTestClass", fields: {}},
+        )
+      end
+    end
+
     context "positional args with a splat parameter" do
       let(:probe_args) do
         {type_name: "HookTestClass", method_name: "method_with_splat",
@@ -2431,6 +2465,76 @@ RSpec.describe Datadog::DI::Instrumenter do
 
       expect(instrumenter.send(:extract_positional_param_names, broken)).to be_nil
       expect(logged).to include("failed to extract positional parameter names")
+    end
+  end
+
+  describe "#original_target_method" do
+    let(:target_class) do
+      Class.new do
+        def method_with_args(account, action, count)
+          [account, action, count]
+        end
+      end
+    end
+
+    def build_wrapper
+      Module.new do
+        define_method(:method_with_args) { |*args, **kwargs, &blk| super(*args, **kwargs, &blk) }
+      end
+    end
+
+    def wrapper_module
+      mod = build_wrapper
+      mod.extend(Datadog::DI::Instrumenter::InstrumentedMethodMarker)
+      mod
+    end
+
+    def resolve
+      instrumenter.send(:original_target_method, target_class.instance_method(:method_with_args))
+    end
+
+    it "returns the method unchanged when it is not a wrapper" do
+      expect(resolve.parameters).to eq([[:req, :account], [:req, :action], [:req, :count]])
+    end
+
+    it "resolves past a single prepended wrapper to the original method" do
+      target_class.prepend(wrapper_module)
+      expect(resolve.parameters).to eq([[:req, :account], [:req, :action], [:req, :count]])
+    end
+
+    it "resolves past multiple stacked wrappers to the original method" do
+      target_class.prepend(wrapper_module)
+      target_class.prepend(wrapper_module)
+      expect(resolve.parameters).to eq([[:req, :account], [:req, :action], [:req, :count]])
+    end
+
+    it "stops at a non-DI wrapper installed by module prepend" do
+      plain = build_wrapper
+      target_class.prepend(plain)
+      target_class.prepend(wrapper_module)
+
+      resolved = resolve
+      expect(resolved.owner).to eq(plain)
+      expect(resolved.parameters).to eq([[:rest, :args], [:keyrest, :kwargs], [:block, :blk]])
+    end
+
+    it "returns nil when only wrappers underlie the target (virtual method)" do
+      virtual_class = Class.new do
+        def method_missing(name, *args, **kwargs, &blk)
+          [args, kwargs]
+        end
+
+        def respond_to_missing?(name, include_private = false)
+          true
+        end
+      end
+      virtual_class.prepend(wrapper_module)
+      resolved = instrumenter.send(:original_target_method, virtual_class.instance_method(:method_with_args))
+      expect(resolved).to be_nil
+    end
+
+    it "returns nil when given nil" do
+      expect(instrumenter.send(:original_target_method, nil)).to be_nil
     end
   end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -608,6 +608,50 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "positional args with a splat parameter" do
+      let(:probe_args) do
+        {type_name: "HookTestClass", method_name: "method_with_splat",
+         capture_snapshot: true}
+      end
+
+      it "names the leading fixed positionals and falls back to arg-N for splat values" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect(HookTestClass.new.method_with_splat(1, 2, 3)).to eq [1, [2, 3]]
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          first: {type: "Integer", value: "1"},
+          arg2: {type: "Integer", value: "2"},
+          arg3: {type: "Integer", value: "3"},
+          self: {type: "HookTestClass", fields: {}},
+        )
+      end
+    end
+
+    context "when method is virtual (defined via method_missing) with snapshot capture" do
+      let(:probe_args) do
+        {type_name: "YieldingMethodMissingHookTestClass", method_name: "yielding",
+         capture_snapshot: true}
+      end
+
+      it "captures positional args as arg-N because no parameter names are available" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect(YieldingMethodMissingHookTestClass.new.yielding("hello") { |_| }).to eq [["hello"], {}]
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          arg1: {type: "String", value: "hello"},
+          self: {type: "YieldingMethodMissingHookTestClass", fields: {}},
+        )
+      end
+    end
+
     context "empty hash as last argument" do
       let(:probe_args) do
         {type_name: "HookTestClass", method_name: "positional_and_squashed"}

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -2074,4 +2074,70 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
   end
+
+  describe "#extract_positional_param_names" do
+    let(:target_class) do
+      Class.new do
+        def only_req(a, b)
+          [a, b]
+        end
+
+        def req_and_opt(a, b = 1)
+          [a, b]
+        end
+
+        def leading_req_then_rest(a, b, *rest)
+          [a, b, rest]
+        end
+
+        def rest_first(*rest, a)
+          [rest, a]
+        end
+
+        def kwargs_only(x:, y: 1, **opts)
+          [x, y, opts]
+        end
+
+        def block_only(&blk)
+          blk
+        end
+
+        def no_params
+          nil
+        end
+      end
+    end
+
+    def names_for(method_name)
+      instrumenter.send(:extract_positional_param_names, target_class.instance_method(method_name))
+    end
+
+    it "returns required positional names in order" do
+      expect(names_for(:only_req)).to eq([:a, :b])
+    end
+
+    it "includes optional positional parameters" do
+      expect(names_for(:req_and_opt)).to eq([:a, :b])
+    end
+
+    it "stops at a rest parameter, keeping the leading fixed positionals" do
+      expect(names_for(:leading_req_then_rest)).to eq([:a, :b])
+    end
+
+    it "stops at a leading rest parameter, dropping post-splat positionals" do
+      expect(names_for(:rest_first)).to eq([])
+    end
+
+    it "ignores keyword and keyword-splat parameters" do
+      expect(names_for(:kwargs_only)).to eq([])
+    end
+
+    it "ignores block parameters" do
+      expect(names_for(:block_only)).to eq([])
+    end
+
+    it "returns an empty array for a method with no parameters" do
+      expect(names_for(:no_params)).to eq([])
+    end
+  end
 end

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -607,6 +607,50 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "positional args with a splat parameter" do
+      let(:probe_args) do
+        {type_name: "HookTestClass", method_name: "method_with_splat",
+         capture_snapshot: true}
+      end
+
+      it "names the leading fixed positionals and falls back to arg-N for splat values" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect(HookTestClass.new.method_with_splat(1, 2, 3)).to eq [1, [2, 3]]
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          first: {type: "Integer", value: "1"},
+          arg2: {type: "Integer", value: "2"},
+          arg3: {type: "Integer", value: "3"},
+          self: {type: "HookTestClass", fields: {}},
+        )
+      end
+    end
+
+    context "when method is virtual (defined via method_missing) with snapshot capture" do
+      let(:probe_args) do
+        {type_name: "YieldingMethodMissingHookTestClass", method_name: "yielding",
+         capture_snapshot: true}
+      end
+
+      it "captures positional args as arg-N because no parameter names are available" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect(YieldingMethodMissingHookTestClass.new.yielding("hello") { |_| }).to eq [["hello"], {}]
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          arg1: {type: "String", value: "hello"},
+          self: {type: "YieldingMethodMissingHookTestClass", fields: {}},
+        )
+      end
+    end
+
     context "empty hash as last argument" do
       let(:probe_args) do
         {type_name: "HookTestClass", method_name: "positional_and_squashed"}

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           expect(observed_calls.first).to be_a(Datadog::DI::Context)
           expect(observed_calls.first.return_value).to eq 2
           expect(observed_calls.first.duration).to be_a(Float)
-          # expect(observed_calls.first.serialized_entry_args).to eq(arg1: 2)
+          # expect(observed_calls.first.serialized_entry_args).to eq(arg: 2)
         end
       end
 
@@ -394,7 +394,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              arg1: {type: "Integer", value: "2"},
+              arg: {type: "Integer", value: "2"},
               self: {type: "HookTestClass", fields: {}},
             )
           end
@@ -422,7 +422,7 @@ RSpec.describe Datadog::DI::Instrumenter do
               expect(observed_calls.first.duration).to be_a(Float)
 
               expect(observed_calls.first.serialized_entry_args).to eq(
-                arg1: {type: "Integer", value: "2"},
+                arg: {type: "Integer", value: "2"},
                 self: {
                   type: "HookIvarTestClass",
                   fields: {
@@ -574,9 +574,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              # TODO actual argument name not captured yet,
-              # requires method call trace point.
-              arg1: {type: "Integer", value: "41"},
+              arg: {type: "Integer", value: "41"},
               kwarg: {type: "Integer", value: "42"},
               self: {type: "HookTestClass", fields: {}},
             )
@@ -710,7 +708,7 @@ RSpec.describe Datadog::DI::Instrumenter do
             expect(observed_calls.first.duration).to be_a(Float)
 
             expect(observed_calls.first.serialized_entry_args).to eq(
-              arg1: {type: "String", value: "hello"},
+              arg: {type: "String", value: "hello"},
               kwarg: {type: "Integer", value: "42"},
               self: {type: "HookTestClass", fields: {}},
             )
@@ -1179,8 +1177,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           let(:condition) do
             Datadog::DI::EL::Expression.new(
               "(expression)",
-              # We use "arg1" here, actual variable name is not currently available
-              "ref('arg1') == 41"
+              "ref('arg') == 41"
             )
           end
 
@@ -1191,8 +1188,7 @@ RSpec.describe Datadog::DI::Instrumenter do
           let(:condition) do
             Datadog::DI::EL::Expression.new(
               "(expression)",
-              # We use "arg1" here, actual variable name is not currently available
-              "ref('arg1') == 42"
+              "ref('arg') == 42"
             )
           end
 

--- a/spec/datadog/di/instrumenter_spec.rb
+++ b/spec/datadog/di/instrumenter_spec.rb
@@ -630,6 +630,28 @@ RSpec.describe Datadog::DI::Instrumenter do
       end
     end
 
+    context "positional arg whose name collides with a keyword key" do
+      let(:probe_args) do
+        {type_name: "HookTestClass", method_name: "method_kwarg_name_collision",
+         capture_snapshot: true}
+      end
+
+      it "keeps the positional under arg-N and the keyword under its own name" do
+        hook_method(probe) do |payload|
+          observed_calls << payload
+        end
+
+        expect(HookTestClass.new.method_kwarg_name_collision("/a", path: "override")).to eq ["/a", {path: "override"}]
+
+        expect(observed_calls.length).to eq 1
+        expect(observed_calls.first.serialized_entry_args).to eq(
+          arg1: {type: "String", value: "/a"},
+          path: {type: "String", value: "override"},
+          self: {type: "HookTestClass", fields: {}},
+        )
+      end
+    end
+
     context "when method is virtual (defined via method_missing) with snapshot capture" do
       let(:probe_args) do
         {type_name: "YieldingMethodMissingHookTestClass", method_name: "yielding",
@@ -2357,6 +2379,8 @@ RSpec.describe Datadog::DI::Instrumenter do
         def no_params
           nil
         end
+
+        attr_writer :written
       end
     end
 
@@ -2390,6 +2414,23 @@ RSpec.describe Datadog::DI::Instrumenter do
 
     it "returns an empty array for a method with no parameters" do
       expect(names_for(:no_params)).to eq([])
+    end
+
+    it "returns a nil name for a generated method (attr_writer) with no parameter name" do
+      expect(names_for(:written=)).to eq([nil])
+    end
+
+    it "returns nil and logs when parameter extraction raises" do
+      broken = instance_double(UnboundMethod)
+      allow(broken).to receive(:parameters).and_raise(RuntimeError.new("boom"))
+
+      logged = nil
+      expect(logger).to receive(:debug) do |&blk|
+        logged = blk.call
+      end
+
+      expect(instrumenter.send(:extract_positional_param_names, broken)).to be_nil
+      expect(logged).to include("failed to extract positional parameter names")
     end
   end
 end

--- a/spec/datadog/di/integration/instrumentation_spec.rb
+++ b/spec/datadog/di/integration/instrumentation_spec.rb
@@ -465,7 +465,7 @@ RSpec.describe "Instrumentation integration" do
             {
               entry: {
                 arguments: {
-                  arg1: {type: "String", value: "hello world"},
+                  greeting: {type: "String", value: "hello world"},
                   self: {
                     type: "InstrumentationSpecTestClass",
                     fields: {
@@ -575,7 +575,7 @@ RSpec.describe "Instrumentation integration" do
             type: "LOG_PROBE",
             where: {typeName: "InstrumentationSpecTestClass", methodName: "test_method"},
             captureExpressions: [
-              {name: "arg1", expr: {dsl: "arg1", json: {ref: "arg1"}}},
+              {name: "a", expr: {dsl: "a", json: {ref: "a"}}},
             ],
           }
         end
@@ -593,7 +593,7 @@ RSpec.describe "Instrumentation integration" do
 
           captures = payload.fetch(:debugger).fetch(:snapshot).fetch(:captures)
           expect(captures.fetch(:return).fetch(:captureExpressions)).to eq(
-            "arg1" => {type: "Integer", value: "7"},
+            "a" => {type: "Integer", value: "7"},
           )
           expect(captures).not_to have_key(:entry)
         end
@@ -611,7 +611,7 @@ RSpec.describe "Instrumentation integration" do
             where: {typeName: "InstrumentationSpecTestClass", methodName: "mutating_method"},
             evaluateAt: "ENTRY",
             captureExpressions: [
-              {name: "greeting_at_entry", expr: {dsl: "arg1", json: {ref: "arg1"}}},
+              {name: "greeting_at_entry", expr: {dsl: "greeting", json: {ref: "greeting"}}},
             ],
           }
         end
@@ -687,7 +687,7 @@ RSpec.describe "Instrumentation integration" do
             where: {typeName: "InstrumentationSpecTestClass", methodName: "mutating_method"},
             evaluateAt: "EXIT",
             captureExpressions: [
-              {name: "greeting_at_exit", expr: {dsl: "arg1", json: {ref: "arg1"}}},
+              {name: "greeting_at_exit", expr: {dsl: "greeting", json: {ref: "greeting"}}},
             ],
           }
         end
@@ -723,7 +723,7 @@ RSpec.describe "Instrumentation integration" do
             where: {typeName: "InstrumentationSpecTestClass", methodName: "test_method"},
             captureSnapshot: true,
             captureExpressions: [
-              {name: "arg1", expr: {dsl: "arg1", json: {ref: "arg1"}}},
+              {name: "arg1", expr: {dsl: "a", json: {ref: "a"}}},
             ],
           }
         end
@@ -762,7 +762,7 @@ RSpec.describe "Instrumentation integration" do
             type: "LOG_PROBE",
             where: {typeName: "InstrumentationSpecTestClass", methodName: "test_method"},
             captureExpressions: [
-              {name: "arg1", expr: {dsl: "arg1", json: {ref: "arg1"}}},
+              {name: "arg1", expr: {dsl: "a", json: {ref: "a"}}},
             ],
           }
         end
@@ -845,7 +845,7 @@ RSpec.describe "Instrumentation integration" do
           component.probe_notifier_worker.flush
 
           captures = payload.fetch(:debugger).fetch(:snapshot).fetch(:captures)
-          expect(captures.fetch(:entry).fetch(:arguments).fetch(:arg1)).to include(
+          expect(captures.fetch(:entry).fetch(:arguments).fetch(:greeting)).to include(
             type: "String", value: "hell", truncated: true,
           )
           expect(captures.fetch(:return).fetch(:arguments).fetch(:@return)).to include(
@@ -878,9 +878,9 @@ RSpec.describe "Instrumentation integration" do
           component.probe_notifier_worker.flush
 
           captures = payload.fetch(:debugger).fetch(:snapshot).fetch(:captures)
-          arg1 = captures.fetch(:entry).fetch(:arguments).fetch(:arg1)
-          expect(arg1).to include(type: "Array", notCapturedReason: "collectionSize", size: 5)
-          expect(arg1.fetch(:elements).size).to eq(2)
+          items = captures.fetch(:entry).fetch(:arguments).fetch(:items)
+          expect(items).to include(type: "Array", notCapturedReason: "collectionSize", size: 5)
+          expect(items.fetch(:elements).size).to eq(2)
           ret = captures.fetch(:return).fetch(:arguments).fetch(:@return)
           expect(ret).to include(type: "Array", notCapturedReason: "collectionSize", size: 5)
           expect(ret.fetch(:elements).size).to eq(2)
@@ -1857,10 +1857,10 @@ RSpec.describe "Instrumentation integration" do
         expect(captured_snapshot[:debugger][:snapshot][:captures]).to have_key(:entry)
 
         entry_capture = captured_snapshot[:debugger][:snapshot][:captures][:entry]
-        expect(entry_capture[:arguments]).to have_key(:arg1)
+        expect(entry_capture[:arguments]).to have_key(:binary_param)
 
         # The binary string is escaped to b'...' format
-        binary_param_value = entry_capture[:arguments][:arg1][:value]
+        binary_param_value = entry_capture[:arguments][:binary_param][:value]
         expect(binary_param_value).to be_a(String)
         expect(binary_param_value).to eq("b'\\x80\\x81\\x82\\xff\\xfe'")
         expect(binary_param_value.encoding).to eq(Encoding::UTF_8)

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -464,6 +464,27 @@ RSpec.describe Datadog::DI::Serializer do
           self: {type: "Object", fields: {}},
         )
       end
+
+      it "falls back to arg-N when a positional name collides with a keyword key" do
+        # def foo(path, **opts) called foo("/a", path: "override"): the positional
+        # path and the keyword path are distinct values. Keying the positional
+        # by its real name would let the keyword overwrite it in the merge.
+        expect(serializer.serialize_args(["/a"], {path: "override"}, target_self, [:path])).to eq(
+          arg1: {type: "String", value: "/a"},
+          path: {type: "String", value: "override"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "redacts a positional arg whose real name is a redacted identifier" do
+        # Keying by real name routes positional args through identifier
+        # redaction; a positional named e.g. password is now redacted where
+        # the arg-N label previously captured it in the clear.
+        expect(serializer.serialize_args(["secret"], {}, target_self, [:password])).to eq(
+          password: {type: "String", notCapturedReason: "redactedIdent"},
+          self: {type: "Object", fields: {}},
+        )
+      end
     end
 
     context "when positional arg is frozen" do

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe Datadog::DI::Serializer do
       let(:target_self) { Object.new }
 
       it "labels positional args with their real names" do
-        expect(serializer.serialize_args([1, "x"], {}, target_self, param_names: [:count, :label])).to eq(
+        expect(serializer.serialize_args([1, "x"], {}, target_self, positional_param_names: [:count, :label])).to eq(
           count: {type: "Integer", value: "1"},
           label: {type: "String", value: "x"},
           self: {type: "Object", fields: {}},
@@ -447,9 +447,7 @@ RSpec.describe Datadog::DI::Serializer do
       end
 
       it "falls back to arg-N labels for positions without a name" do
-        # A nil name (e.g. attr_writer-generated methods) or a value absorbed
-        # by a splat has no name; those positions keep the arg-N label.
-        expect(serializer.serialize_args([1, "x", 2], {}, target_self, param_names: [:count, nil])).to eq(
+        expect(serializer.serialize_args([1, "x", 2], {}, target_self, positional_param_names: [:count, nil])).to eq(
           count: {type: "Integer", value: "1"},
           arg2: {type: "String", value: "x"},
           arg3: {type: "Integer", value: "2"},
@@ -458,7 +456,7 @@ RSpec.describe Datadog::DI::Serializer do
       end
 
       it "keeps arg-N labels when no names are given" do
-        expect(serializer.serialize_args([1, "x"], {}, target_self, param_names: nil)).to eq(
+        expect(serializer.serialize_args([1, "x"], {}, target_self, positional_param_names: nil)).to eq(
           arg1: {type: "Integer", value: "1"},
           arg2: {type: "String", value: "x"},
           self: {type: "Object", fields: {}},
@@ -466,12 +464,18 @@ RSpec.describe Datadog::DI::Serializer do
       end
 
       it "falls back to arg-N when a positional name collides with a keyword key" do
-        # def foo(path, **opts) called foo("/a", path: "override"): the positional
-        # path and the keyword path are distinct values. Keying the positional
-        # by its real name would let the keyword overwrite it in the merge.
-        expect(serializer.serialize_args(["/a"], {path: "override"}, target_self, param_names: [:path])).to eq(
+        expect(serializer.serialize_args(["/a"], {path: "override"}, target_self, positional_param_names: [:path])).to eq(
           arg1: {type: "String", value: "/a"},
           path: {type: "String", value: "override"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "falls back to arg-N when a positional name is shaped like the arg-N label" do
+        expect(serializer.serialize_args([10, 20, 30], {}, target_self, positional_param_names: [:arg3])).to eq(
+          arg1: {type: "Integer", value: "10"},
+          arg2: {type: "Integer", value: "20"},
+          arg3: {type: "Integer", value: "30"},
           self: {type: "Object", fields: {}},
         )
       end
@@ -480,7 +484,7 @@ RSpec.describe Datadog::DI::Serializer do
         # Keying by real name routes positional args through identifier
         # redaction; a positional named e.g. password is now redacted where
         # the arg-N label previously captured it in the clear.
-        expect(serializer.serialize_args(["secret"], {}, target_self, param_names: [:password])).to eq(
+        expect(serializer.serialize_args(["secret"], {}, target_self, positional_param_names: [:password])).to eq(
           password: {type: "String", notCapturedReason: "redactedIdent"},
           self: {type: "Object", fields: {}},
         )

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe Datadog::DI::Serializer do
       let(:target_self) { Object.new }
 
       it "labels positional args with their real names" do
-        expect(serializer.serialize_args([1, "x"], {}, target_self, [:count, :label])).to eq(
+        expect(serializer.serialize_args([1, "x"], {}, target_self, param_names: [:count, :label])).to eq(
           count: {type: "Integer", value: "1"},
           label: {type: "String", value: "x"},
           self: {type: "Object", fields: {}},
@@ -449,7 +449,7 @@ RSpec.describe Datadog::DI::Serializer do
       it "falls back to arg-N labels for positions without a name" do
         # A nil name (e.g. attr_writer-generated methods) or a value absorbed
         # by a splat has no name; those positions keep the arg-N label.
-        expect(serializer.serialize_args([1, "x", 2], {}, target_self, [:count, nil])).to eq(
+        expect(serializer.serialize_args([1, "x", 2], {}, target_self, param_names: [:count, nil])).to eq(
           count: {type: "Integer", value: "1"},
           arg2: {type: "String", value: "x"},
           arg3: {type: "Integer", value: "2"},
@@ -458,7 +458,7 @@ RSpec.describe Datadog::DI::Serializer do
       end
 
       it "keeps arg-N labels when no names are given" do
-        expect(serializer.serialize_args([1, "x"], {}, target_self, nil)).to eq(
+        expect(serializer.serialize_args([1, "x"], {}, target_self, param_names: nil)).to eq(
           arg1: {type: "Integer", value: "1"},
           arg2: {type: "String", value: "x"},
           self: {type: "Object", fields: {}},
@@ -469,7 +469,7 @@ RSpec.describe Datadog::DI::Serializer do
         # def foo(path, **opts) called foo("/a", path: "override"): the positional
         # path and the keyword path are distinct values. Keying the positional
         # by its real name would let the keyword overwrite it in the merge.
-        expect(serializer.serialize_args(["/a"], {path: "override"}, target_self, [:path])).to eq(
+        expect(serializer.serialize_args(["/a"], {path: "override"}, target_self, param_names: [:path])).to eq(
           arg1: {type: "String", value: "/a"},
           path: {type: "String", value: "override"},
           self: {type: "Object", fields: {}},
@@ -480,7 +480,7 @@ RSpec.describe Datadog::DI::Serializer do
         # Keying by real name routes positional args through identifier
         # redaction; a positional named e.g. password is now redacted where
         # the arg-N label previously captured it in the clear.
-        expect(serializer.serialize_args(["secret"], {}, target_self, [:password])).to eq(
+        expect(serializer.serialize_args(["secret"], {}, target_self, param_names: [:password])).to eq(
           password: {type: "String", notCapturedReason: "redactedIdent"},
           self: {type: "Object", fields: {}},
         )

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -429,6 +429,37 @@ RSpec.describe Datadog::DI::Serializer do
       end
     end
 
+    context "with positional parameter names" do
+      let(:target_self) { Object.new }
+
+      it "labels positional args with their real names" do
+        expect(serializer.serialize_args([1, "x"], {}, target_self, [:count, :label])).to eq(
+          count: {type: "Integer", value: "1"},
+          label: {type: "String", value: "x"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "falls back to arg-N labels for positions without a name" do
+        # A nil name (e.g. attr_writer-generated methods) or a value absorbed
+        # by a splat has no name; those positions keep the arg-N label.
+        expect(serializer.serialize_args([1, "x", 2], {}, target_self, [:count, nil])).to eq(
+          count: {type: "Integer", value: "1"},
+          arg2: {type: "String", value: "x"},
+          arg3: {type: "Integer", value: "2"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "keeps arg-N labels when no names are given" do
+        expect(serializer.serialize_args([1, "x"], {}, target_self, nil)).to eq(
+          arg1: {type: "Integer", value: "1"},
+          arg2: {type: "String", value: "x"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+    end
+
     context "when positional arg is frozen" do
       let(:frozen_string) { "hello".freeze }
 

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -435,6 +435,37 @@ RSpec.describe Datadog::DI::Serializer do
       end
     end
 
+    context "with positional parameter names" do
+      let(:target_self) { Object.new }
+
+      it "labels positional args with their real names" do
+        expect(serializer.serialize_args([1, "x"], {}, target_self, [:count, :label])).to eq(
+          count: {type: "Integer", value: "1"},
+          label: {type: "String", value: "x"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "falls back to arg-N labels for positions without a name" do
+        # A nil name (e.g. attr_writer-generated methods) or a value absorbed
+        # by a splat has no name; those positions keep the arg-N label.
+        expect(serializer.serialize_args([1, "x", 2], {}, target_self, [:count, nil])).to eq(
+          count: {type: "Integer", value: "1"},
+          arg2: {type: "String", value: "x"},
+          arg3: {type: "Integer", value: "2"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+
+      it "keeps arg-N labels when no names are given" do
+        expect(serializer.serialize_args([1, "x"], {}, target_self, nil)).to eq(
+          arg1: {type: "Integer", value: "1"},
+          arg2: {type: "String", value: "x"},
+          self: {type: "Object", fields: {}},
+        )
+      end
+    end
+
     context "when positional arg is frozen" do
       let(:frozen_string) { "hello".freeze }
 


### PR DESCRIPTION
**What does this PR do?**

Captures real positional parameter names in probes on methods explicitly defined in Ruby.

**Motivation:**

The `arg1` etc. placeholders are not discoverable by customers.

**Change log entry**

Yes. Dynamic Instrumentation: report positional method argument names for methods explicitly defined in Ruby

**Additional Notes:**

Scope applies to Ruby-defined methods, where `Method#parameters` exposes parameter names. Positions without an available name (splat overflow, generated methods such as `attr_writer`, and arguments to virtual or C-implemented methods) fall back to the `arg1`/`arg2` labels.

**How to test the change?**

Unit and integration tests added
