### PR TITLE
[APPSEC-69431] Add _dd.apm.enabled on every span when APM disabled

### DIFF
--- a/lib/datadog/tracing/transport/trace_formatter.rb
+++ b/lib/datadog/tracing/transport/trace_formatter.rb
@@ -213,7 +213,7 @@ module Datadog
         def tag_apm_tracing_disabled!
           return if trace.apm_tracing_enabled
 
-          root_span.set_tag(Tracing::Metadata::Ext::TAG_APM_ENABLED, 0)
+          trace.spans.each { |span| span.set_metric(Tracing::Metadata::Ext::TAG_APM_ENABLED, 0) }
         end
 
         def tag_git_repository_url!

--- a/spec/datadog/tracing/transport/trace_formatter_spec.rb
+++ b/spec/datadog/tracing/transport/trace_formatter_spec.rb
@@ -566,4 +566,41 @@ RSpec.describe Datadog::Tracing::Transport::TraceFormatter do
       end
     end
   end
+
+  describe "#format! _dd.apm.enabled marker" do
+    before { described_class.format!(trace) }
+
+    let(:span_markers) { spans.map { |span| span.get_metric(Datadog::Tracing::Metadata::Ext::TAG_APM_ENABLED) } }
+    let(:spans) { Array.new(3) { Datadog::Tracing::Span.new("my.job") } }
+
+    context "when APM tracing is disabled and the chunk contains its root span" do
+      let(:trace) do
+        Datadog::Tracing::TraceSegment.new(
+          spans, root_span_id: spans[1].id, apm_tracing_enabled: false, id: trace_id
+        )
+      end
+
+      it { expect(span_markers).to all(eq(0)) }
+    end
+
+    context "when APM tracing is disabled and the chunk has no root span (partial flush)" do
+      let(:trace) do
+        Datadog::Tracing::TraceSegment.new(
+          spans, root_span_id: Datadog::Tracing::Utils.next_id, apm_tracing_enabled: false, id: trace_id
+        )
+      end
+
+      it { expect(span_markers).to all(eq(0)) }
+    end
+
+    context "when APM tracing is enabled" do
+      let(:trace) do
+        Datadog::Tracing::TraceSegment.new(
+          spans, root_span_id: spans[1].id, apm_tracing_enabled: true, id: trace_id
+        )
+      end
+
+      it { expect(span_markers).to all(be_nil) }
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**

Fixes bug for standalone billing, backend can reshape chunk and we can miss on chunk APM disabled marker. Similar fixes in other libs:

1. https://github.com/DataDog/dd-trace-js/pull/9506
2. https://github.com/DataDog/dd-trace-java/pull/12068

**Motivation:**

This should fix wrong billing on standalone ASM

**Change log entry**

Yes. Fix standalone billing issues for partially flushed traces.

**Additional Notes:**

We are going to add ~25 bytes/span when APM is disabled, but save on some CPU time by immediately calling `set_metric` instead of `set_tag`

**How to test the change?**

CI