### PR TITLE
[IGNORE] 🪞 #6108 - Honor DD_DOGSTATSD_URL/DD_DOGSTATSD_SOCKET for the runtime metrics statsd client

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2855,6 +2855,8 @@ end
 
 See the [Dogstatsd documentation](https://www.rubydoc.info/github/DataDog/dogstatsd-ruby/master/frames) for more details about configuring `Datadog::Statsd`.
 
+When runtime metrics must be sent over a Unix Domain Socket, or to a host and port that differ from the trace Agent, set `DD_DOGSTATSD_URL` (for example `unix:///var/run/datadog/dsd.socket` or `udp://127.0.0.1:8125`) or `DD_DOGSTATSD_SOCKET` (a UDS path). These are read by `dogstatsd-ruby` (>= 5.6) and apply only when neither `DD_AGENT_HOST` nor `DD_METRIC_AGENT_PORT` is set; setting either of those keeps host/port resolution. This is how workloads instrumented by the Datadog Admission Controller reach the local DogStatsD socket without an explicit `DD_AGENT_HOST`.
+
 The stats are VM specific and will include:
 
 | Name                                        | Type    | Description                                                                                           | Available on                                                                                    |

--- a/lib/datadog/core/configuration/ext.rb
+++ b/lib/datadog/core/configuration/ext.rb
@@ -15,6 +15,8 @@ module Datadog
 
         module Metrics
           ENV_DEFAULT_PORT = "DD_METRIC_AGENT_PORT"
+          ENV_DOGSTATSD_URL = "DD_DOGSTATSD_URL"
+          ENV_DOGSTATSD_SOCKET = "DD_DOGSTATSD_SOCKET"
         end
 
         module APM

--- a/lib/datadog/core/configuration/supported_configurations.rb
+++ b/lib/datadog/core/configuration/supported_configurations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'set'
+require "set"
 
 # This file is auto-generated from `supported-configurations.json` by `rake local_config_map:generate`.
 # Do not change manually! Please refer to `docs/AccessEnvironmentVariables.md` for more information.

--- a/lib/datadog/core/configuration/supported_configurations.rb
+++ b/lib/datadog/core/configuration/supported_configurations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "set"
+require 'set'
 
 # This file is auto-generated from `supported-configurations.json` by `rake local_config_map:generate`.
 # Do not change manually! Please refer to `docs/AccessEnvironmentVariables.md` for more information.
@@ -49,6 +49,8 @@ module Datadog
           "DD_DBM_INJECT_SQL_BASEHASH",
           "DD_DBM_PROPAGATION_MODE",
           "DD_DISABLE_DATADOG_RAILS",
+          "DD_DOGSTATSD_SOCKET",
+          "DD_DOGSTATSD_URL",
           "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
           "DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE",
           "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE",

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -97,6 +97,8 @@ module Datadog
         # Whether transport resolution should be left to dogstatsd-ruby's own environment
         # handling (DD_DOGSTATSD_URL / DD_DOGSTATSD_SOCKET). An explicit DD_AGENT_HOST or
         # DD_METRIC_AGENT_PORT keeps the historical host/port behavior.
+        #
+        # @return [Boolean]
         def statsd_transport_from_env?
           dogstatsd_version >= Gem::Version.new("5.6") &&
             !DATADOG_ENV.key?(Configuration::Ext::Agent::ENV_DEFAULT_HOST) &&

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -94,19 +94,6 @@ module Datadog
           end
         end
 
-        # Whether transport resolution should be left to dogstatsd-ruby's own environment
-        # handling (DD_DOGSTATSD_URL / DD_DOGSTATSD_SOCKET). An explicit DD_AGENT_HOST or
-        # DD_METRIC_AGENT_PORT keeps the historical host/port behavior.
-        #
-        # @return [Boolean]
-        def statsd_transport_from_env?
-          dogstatsd_version >= Gem::Version.new("5.6") &&
-            !DATADOG_ENV.key?(Configuration::Ext::Agent::ENV_DEFAULT_HOST) &&
-            !DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DEFAULT_PORT) &&
-            (DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_URL) ||
-              DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_SOCKET))
-        end
-
         def configure(options = {})
           @statsd = options[:statsd] if options.key?(:statsd)
           self.enabled = options[:enabled] if options.key?(:enabled)
@@ -201,6 +188,19 @@ module Datadog
         end
 
         private
+
+        # Whether transport resolution should be left to dogstatsd-ruby's own environment
+        # handling (DD_DOGSTATSD_URL / DD_DOGSTATSD_SOCKET). An explicit DD_AGENT_HOST or
+        # DD_METRIC_AGENT_PORT keeps the historical host/port behavior.
+        #
+        # @return [Boolean]
+        def statsd_transport_from_env?
+          dogstatsd_version >= Gem::Version.new("5.6") &&
+            !DATADOG_ENV.key?(Configuration::Ext::Agent::ENV_DEFAULT_HOST) &&
+            !DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DEFAULT_PORT) &&
+            (DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_URL) ||
+              DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_SOCKET))
+        end
 
         def dogstatsd_version
           return @dogstatsd_version if instance_variable_defined?(:@dogstatsd_version)

--- a/lib/datadog/core/metrics/client.rb
+++ b/lib/datadog/core/metrics/client.rb
@@ -80,7 +80,29 @@ module Datadog
             {}
           end
 
-          Datadog::Statsd.new(default_hostname, default_port, **options)
+          # DD_DOGSTATSD_URL and DD_DOGSTATSD_SOCKET can configure a UDS transport that an
+          # explicit host and port pair cannot express, but passing explicit arguments
+          # bypasses dogstatsd-ruby's environment resolution entirely — runtime metrics
+          # were silently sent to the UDP default on UDS-only setups (for example pods
+          # configured by the Datadog Admission Controller, which injects DD_DOGSTATSD_URL
+          # but not DD_AGENT_HOST). When only those variables describe the transport,
+          # delegate the resolution to dogstatsd-ruby, which understands them since 5.6.
+          if statsd_transport_from_env?
+            Datadog::Statsd.new(**options)
+          else
+            Datadog::Statsd.new(default_hostname, default_port, **options)
+          end
+        end
+
+        # Whether transport resolution should be left to dogstatsd-ruby's own environment
+        # handling (DD_DOGSTATSD_URL / DD_DOGSTATSD_SOCKET). An explicit DD_AGENT_HOST or
+        # DD_METRIC_AGENT_PORT keeps the historical host/port behavior.
+        def statsd_transport_from_env?
+          dogstatsd_version >= Gem::Version.new("5.6") &&
+            !DATADOG_ENV.key?(Configuration::Ext::Agent::ENV_DEFAULT_HOST) &&
+            !DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DEFAULT_PORT) &&
+            (DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_URL) ||
+              DATADOG_ENV.key?(Configuration::Ext::Metrics::ENV_DOGSTATSD_SOCKET))
         end
 
         def configure(options = {})

--- a/sig/datadog/core/metrics/client.rbs
+++ b/sig/datadog/core/metrics/client.rbs
@@ -27,8 +27,6 @@ module Datadog
 
         def default_statsd_client: () -> untyped
 
-        def statsd_transport_from_env?: () -> bool
-
         def configure: (?::Hash[untyped, untyped] options) -> untyped
 
         def send_stats?: () -> untyped
@@ -48,6 +46,8 @@ module Datadog
         def close: () -> (untyped | nil)
 
         private
+
+        def statsd_transport_from_env?: () -> bool
 
         def dogstatsd_version: () -> untyped
 

--- a/sig/datadog/core/metrics/client.rbs
+++ b/sig/datadog/core/metrics/client.rbs
@@ -27,6 +27,8 @@ module Datadog
 
         def default_statsd_client: () -> untyped
 
+        def statsd_transport_from_env?: () -> bool
+
         def configure: (?::Hash[untyped, untyped] options) -> untyped
 
         def send_stats?: () -> untyped

--- a/spec/datadog/core/metrics/client_spec.rb
+++ b/spec/datadog/core/metrics/client_spec.rb
@@ -321,9 +321,12 @@ RSpec.describe Datadog::Core::Metrics::Client do
       # run with both ~> 4.0 and latest dogstatsd-ruby.
       if Gem::Version.new(Datadog::Statsd::VERSION) >= Gem::Version.new("5.6.0")
         before do
-          # Build the client first: initialize itself instantiates a statsd
-          # client, and the expectation below must only observe the explicit
+          # Client#initialize also instantiates a statsd client. Stub that call so
+          # it returns a double instead of opening a real env-based (UDS) transport,
+          # and so the expectation below only observes the explicit
           # #default_statsd_client call under test.
+          allow(Datadog::Statsd).to receive(:new).and_return(statsd_client)
+          allow(statsd_client).to receive(:close)
           metrics
 
           expect(Datadog::Statsd).to receive(:new)
@@ -383,9 +386,12 @@ RSpec.describe Datadog::Core::Metrics::Client do
         end
 
         before do
-          # Build the client first: initialize itself instantiates a statsd
-          # client, and the expectation below must only observe the explicit
+          # Client#initialize also instantiates a statsd client. Stub that call so
+          # it returns a double instead of opening a real env-based (UDS) transport,
+          # and so the expectation below only observes the explicit
           # #default_statsd_client call under test.
+          allow(Datadog::Statsd).to receive(:new).and_return(statsd_client)
+          allow(statsd_client).to receive(:close)
           metrics
 
           expect(Datadog::Statsd).to receive(:new)

--- a/spec/datadog/core/metrics/client_spec.rb
+++ b/spec/datadog/core/metrics/client_spec.rb
@@ -278,26 +278,124 @@ RSpec.describe Datadog::Core::Metrics::Client do
       end
     end
 
-    before do
-      expect(Datadog::Statsd).to receive(:new)
-        .with(metrics.default_hostname, metrics.default_port, **options)
-        .and_return(statsd_client)
+    context "without DogStatsD transport environment variables" do
+      with_env Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_URL => nil,
+        Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_SOCKET => nil
+
+      before do
+        expect(Datadog::Statsd).to receive(:new)
+          .with(metrics.default_hostname, metrics.default_port, **options)
+          .and_return(statsd_client)
+      end
+
+      it { is_expected.to be(statsd_client) }
+
+      context "with Datadog::Statsd not loaded" do
+        before do
+          const = Datadog::Statsd
+          hide_const("Datadog::Statsd")
+
+          expect(metrics).to receive(:require).with("datadog/statsd") do
+            stub_const("Datadog::Statsd", const)
+          end
+        end
+
+        it "loads Datadog::Statsd library" do
+          is_expected.to be(statsd_client)
+        end
+      end
     end
 
-    it { is_expected.to be(statsd_client) }
-
-    context "with Datadog::Statsd not loaded" do
-      before do
-        const = Datadog::Statsd
-        hide_const("Datadog::Statsd")
-
-        expect(metrics).to receive(:require).with("datadog/statsd") do
-          stub_const("Datadog::Statsd", const)
+    context "when DD_DOGSTATSD_URL is set" do
+      around do |example|
+        ClimateControl.modify(
+          Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_URL => "unix:///var/run/datadog/dsd.socket",
+          Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_HOST => nil,
+          Datadog::Core::Configuration::Ext::Metrics::ENV_DEFAULT_PORT => nil
+        ) do
+          example.run
         end
       end
 
-      it "loads Datadog::Statsd library" do
+      # dogstatsd-ruby resolves DD_DOGSTATSD_URL itself since 5.6; this test is
+      # run with both ~> 4.0 and latest dogstatsd-ruby.
+      if Gem::Version.new(Datadog::Statsd::VERSION) >= Gem::Version.new("5.6.0")
+        before do
+          # Build the client first: initialize itself instantiates a statsd
+          # client, and the expectation below must only observe the explicit
+          # #default_statsd_client call under test.
+          metrics
+
+          expect(Datadog::Statsd).to receive(:new)
+            .with(**options)
+            .and_return(statsd_client)
+        end
+
+        it "delegates transport resolution to dogstatsd-ruby" do
+          is_expected.to be(statsd_client)
+        end
+      else
+        before do
+          expect(Datadog::Statsd).to receive(:new)
+            .with(metrics.default_hostname, metrics.default_port, **options)
+            .and_return(statsd_client)
+        end
+
+        it "keeps the explicit host and port" do
+          is_expected.to be(statsd_client)
+        end
+      end
+    end
+
+    context "when DD_DOGSTATSD_URL and DD_AGENT_HOST are both set" do
+      around do |example|
+        ClimateControl.modify(
+          Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_URL => "unix:///var/run/datadog/dsd.socket",
+          Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_HOST => "agent-host",
+          Datadog::Core::Configuration::Ext::Metrics::ENV_DEFAULT_PORT => nil
+        ) do
+          example.run
+        end
+      end
+
+      before do
+        expect(Datadog::Statsd).to receive(:new)
+          .with(metrics.default_hostname, metrics.default_port, **options)
+          .and_return(statsd_client)
+      end
+
+      it "keeps the explicit host and port" do
         is_expected.to be(statsd_client)
+      end
+    end
+
+    if Gem::Version.new(Datadog::Statsd::VERSION) >= Gem::Version.new("5.6.0")
+      context "when DD_DOGSTATSD_SOCKET is set" do
+        around do |example|
+          ClimateControl.modify(
+            Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_SOCKET => "/var/run/datadog/dsd.socket",
+            Datadog::Core::Configuration::Ext::Metrics::ENV_DOGSTATSD_URL => nil,
+            Datadog::Core::Configuration::Ext::Agent::ENV_DEFAULT_HOST => nil,
+            Datadog::Core::Configuration::Ext::Metrics::ENV_DEFAULT_PORT => nil
+          ) do
+            example.run
+          end
+        end
+
+        before do
+          # Build the client first: initialize itself instantiates a statsd
+          # client, and the expectation below must only observe the explicit
+          # #default_statsd_client call under test.
+          metrics
+
+          expect(Datadog::Statsd).to receive(:new)
+            .with(**options)
+            .and_return(statsd_client)
+        end
+
+        it "delegates transport resolution to dogstatsd-ruby" do
+          is_expected.to be(statsd_client)
+        end
       end
     end
   end

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -287,6 +287,20 @@
         "default": null
       }
     ],
+    "DD_DOGSTATSD_SOCKET": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null
+      }
+    ],
+    "DD_DOGSTATSD_URL": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null
+      }
+    ],
     "DD_DYNAMIC_INSTRUMENTATION_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-rb/pull/6108
**Original Author:** @ollym
**Original Branch:** ollym/dd-trace-rb:fix/runtime-metrics-dogstatsd-url
**Mirror Type:** exact mirror (preserves original commits and signatures)

Closes #6108

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*