### PR TITLE
[NO-TICKET] Add new changelog/add.rb nano tool

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 <!--
-Check out the
-https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
+Check out the https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
 for guidance on how to set up your development environment,
 run the test suite, write new integrations, and more.
 -->
@@ -11,22 +10,7 @@ run the test suite, write new integrations, and more.
 **Motivation:**
 <!-- What inspired you to submit this pull request? -->
 
-**Change log entry**
-<!--
-If you are a Datadog employee:
-
-If this is a customer-visible change, use:
-`Yes. A brief summary to be placed into the CHANGELOG.md`
-Or opt out with `None/No/Nope`.
-
-This will be the ONLY mention of the change in the release notes;
-it should be self-contained and understandable by customers.
-
-If you are not a Datadog employee:
-
-You can skip this section and it will be filled or deleted during PR review.
-Please do not remove this section from the PR though.
--->
+<!-- (Changelogs are now kept in-tree using the `changelog/add.rb` nano tool) -->
 
 **Additional Notes:**
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,6 @@ run the test suite, write new integrations, and more.
 **Motivation:**
 <!-- What inspired you to submit this pull request? -->
 
-<!-- (Changelogs are now kept in-tree using the `changelog/add.rb` nano tool) -->
-
 **Additional Notes:**
 <!--
 If you used AI, have you read and understood what AI wrote?

--- a/.github/workflows/ensure-changelog-entry.yml
+++ b/.github/workflows/ensure-changelog-entry.yml
@@ -2,7 +2,7 @@ name: Check change log entry
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   check:
@@ -29,7 +29,7 @@ jobs:
             try {
               response = await github.rest.orgs.checkMembershipForUser({
                 org: context.repo.owner,
-                username: context.payload.sender.login
+                username: context.payload.pull_request.user.login
               })
 
               isMember = response.status == 204
@@ -66,17 +66,32 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const regex = /\*\*Change log entry\*\*\s+(?:<!--.*?-->\s*)?(?:(?<answer_yes>yes|yep|yeah)(?:\s?[.,:-]\s?(?<yes_message>[^\r\n<!-]+))?|(?<answer_no>no|nope|none)\.?.*?)/ims
-            const entry = context.payload.pull_request.body.match(regex)
+            // Branches of automated pull requests that never carry a customer-facing entry.
+            const SKIPPED_BRANCH_PREFIXES = [
+              "bump_to_version_", // See `release-prep.yml`
+              "auto-generate/update-system-tests", // See `update-system-tests.yml`
+            ]
 
-            const isWriteComment =
-              null === entry
-                || (undefined === entry.groups.answer_yes && undefined === entry.groups.answer_no)
-                || (undefined !== entry.groups.answer_yes && undefined === entry.groups.yes_message)
-                || (undefined !== entry.groups.answer_yes && "" === entry.groups.yes_message.trim())
-              ? true : false
+            const branchRef = context.payload.pull_request.head.ref
 
-            return isWriteComment
+            if (SKIPPED_BRANCH_PREFIXES.some((prefix) => branchRef.startsWith(prefix))) {
+              return false
+            }
+
+            // Matches the sanitization `changelog/add.rb` applies to the branch name.
+            const branch = branchRef.replace(/[^a-zA-Z0-9_-]/g, ".")
+            const expectedPath = `changelog/unreleased-${branch}.md`
+
+            const options = github.rest.pulls.listFiles.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            })
+            const files = await github.paginate(options)
+
+            const hasEntry = files.some((file) => file.filename === expectedPath && file.status !== "removed")
+
+            return !hasEntry
 
       - name: Write comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -84,28 +99,24 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const isMember = ${{steps.membership.outputs.result}}
-            const username = !isMember ? "@DataDog/ruby-guild" : `@${context.payload.sender.login}`
+            const username = !isMember ? "@DataDog/ruby-guild" : `@${context.payload.pull_request.user.login}`
 
-            const thankYouMessage = "Thank you for updating **Change log entry** section :clap:"
-            const warningMessage = `:wave: Hey ${username}, please fill "Change log entry" section in the pull request description.
+            const thankYouMessage = "Thank you for adding a changelog entry :clap:"
+            const warningMessage = `:wave: Hey ${username}, this PR is missing a changelog entry.
 
-            If changes need to be present in [CHANGELOG.md](https://github.com/DataDog/dd-trace-rb/blob/master/CHANGELOG.md) you can state it this way
+            Generate one with [\`changelog/add.rb\`](https://github.com/DataDog/dd-trace-rb/blob/master/changelog/add.rb), then commit and push it:
 
-            \`\`\`md
-            **Change log entry**
-
-            Yes. A brief summary to be placed into the CHANGELOG.md
+            \`\`\`sh
+            ruby changelog/add.rb --category Added --label Tracing --entry "A one-sentence description of a user-visible change"
             \`\`\`
-            _(possible answers Yes/Yep/Yeah)_
 
-            Or you can opt out like that
+            Or opt out if this PR doesn't need a changelog entry:
 
-            \`\`\`md
-            **Change log entry**
-
-            None.
+            \`\`\`sh
+            ruby changelog/add.rb --category None
             \`\`\`
-            _(possible answers No/Nope/None)_`
+
+            Run \`ruby changelog/add.rb --help\` for the valid categories and labels.`
 
             const comment = ${{steps.comment.outputs.result}}
             const isWriteWarningComment = ${{steps.condition.outputs.result}}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -77,6 +77,7 @@ jobs:
           sign-commits: true
           add-paths: |
             CHANGELOG.md
+            changelog/
             docs/integration_versions.md
             docs/integration_versions.json
             lib/datadog/version.rb

--- a/.github/workflows/update-system-tests.yml
+++ b/.github/workflows/update-system-tests.yml
@@ -112,7 +112,4 @@ jobs:
             - Source repo: ${{ github.event.client_payload.source_repo || 'N/A' }}
             - Source commit: ${{ github.event.client_payload.source_commit || 'N/A' }}
 
-            **Change log entry**
-            None.
-
             Please review the changes and merge when ready.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,13 @@
 - Write for the developer performing code review; be concise
 - Use one sentence per relevant point in summary/motivation sections
 - Changelog entries are written for customers only; consider changes from user/customer POV
-- Internal changes (CI, tooling, tracer-internal telemetry consumed only by Datadog engineering) = "None" for changelog
-- Telemetry that powers customer-facing Datadog product features (symbol database → DI autocomplete UI, profiling data → Profiler UI, AppSec events → AppSec UI, etc.) = "Yes" with a customer-facing summary, even though the data flow is tracer → Datadog backend
-- Changelog entry format: MUST start with "Yes." or "None."
-  - If changes need CHANGELOG: `Yes. Brief customer-facing summary.`
-  - If no CHANGELOG needed: `None.`
-  - Never write just the summary without "Yes." prefix
+- Internal changes (CI, tooling, tracer-internal telemetry consumed only by Datadog engineering) use category `None`
+- Telemetry that powers customer-facing Datadog product features (symbol database → DI autocomplete UI, profiling data → Profiler UI, AppSec events → AppSec UI, etc.) needs a customer-facing changelog entry, even though the data flow is tracer → Datadog backend
+- Generate the changelog entry with `changelog/add.rb`, non-interactively — never hand-write the `changelog/unreleased-*.md` fragment file:
+  - No entry needed: `ruby changelog/add.rb --category None`
+  - Entry needed: `ruby changelog/add.rb --category <category> --label <label> --entry "<brief customer-facing summary>"`
+  - Run `ruby changelog/add.rb --help` for the valid `--category`/`--label` values
+  - `git add` the resulting `changelog/unreleased-<branch>.md` file before opening the PR
 - Add `--label "AI Generated"` when creating PRs (do not mention AI in description; label is sufficient)
 
 ## Never

--- a/changelog/add.rb
+++ b/changelog/add.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Nano tool to generate a changelog entry for the current branch in the `changelog/` directory.
+#
+# Run interactively: `ruby changelog/add.rb`
+# Run non-interactively: `ruby changelog/add.rb --category Added --label Profiling --entry "Add Matz conference talks profiling"`
+# Run non-interactively with no entry needed: `ruby changelog/add.rb --category None`
+
+require "optparse"
+
+CATEGORIES = ["Added", "Changed", "Fixed", "Removed", "Uncategorized", "None"].freeze
+LABELS = [
+  "Core",
+  "Tracing",
+  "Tracing: Integrations",
+  "Profiling",
+  "AppSec",
+  "AI Guard",
+  "Dynamic Instrumentation",
+  "Data Streams",
+  "Error Tracking",
+  "OpenFeature",
+  "OpenTelemetry",
+  "SSI",
+  "Uncategorized",
+].freeze
+
+def main
+  options = {}
+
+  OptionParser.new do |parser|
+    parser.banner = "Usage: ruby changelog/add.rb [options]\n" \
+      "Example: ruby changelog/add.rb --category Added --label Profiling --entry 'Add Matz conference talks profiling'"
+    parser.on("-c", "--category CATEGORY", "One of: #{CATEGORIES.join(", ")}") { |v| options[:category] = v }
+    parser.on("-l", "--label LABEL", "One of: #{LABELS.join(", ")}") { |v| options[:label] = v }
+    parser.on("-e", "--entry ENTRY", "Short customer-facing sentence describing the change") { |v| options[:entry] = v }
+  end.parse!
+
+  puts "Welcome to `changelog/add.rb`. This tool automates generating a changelog entry for the current branch." if options.empty?
+
+  category = options[:category] || prompt("Pick a category:", choices: CATEGORIES)
+  abort "Invalid category #{category.inspect}, must be one of: #{CATEGORIES.join(", ")}" unless CATEGORIES.include?(category)
+
+  line =
+    if category == "None"
+      "* [None] (No changelog entry needed)"
+    else
+      label = options[:label] || prompt("Pick a label:", choices: LABELS)
+      abort "Invalid label #{label.inspect}, must be one of: #{LABELS.join(", ")}" unless LABELS.include?(label)
+
+      entry = options[:entry] || prompt("Enter the changelog entry. This should be a short sentence to be read and understood by customers:")
+      abort "Changelog entry cannot be blank" if entry.to_s.strip.empty?
+      abort "Changelog entry cannot contain newlines" if entry.include?("\n")
+
+      "* [#{category}] #{label}: #{entry}"
+    end
+
+  path = File.join(__dir__, "unreleased-#{sanitized_branch_name}.md")
+  already_existed = File.exist?(path)
+
+  File.open(path, "a") { |file| file.puts(line) }
+
+  puts "This file already existed, so the entry has been appended to it." if already_existed
+  puts "Done! Saved entry in changelog/#{File.basename(path)} (Remember to `git add` it!)"
+end
+
+def prompt(question, choices: nil)
+  abort "Missing required option for #{question.inspect} (see --help)." unless $stdin.tty?
+
+  loop do
+    print "#{question} "
+    print "[#{choices.join(", ")}] " if choices
+    answer = $stdin.gets&.strip
+    abort "No input received." if answer.nil?
+    return answer if choices.nil? || choices.include?(answer)
+    puts "Invalid value #{answer.inspect}, must be one of: #{choices.join(", ")}"
+  end
+end
+
+def sanitized_branch_name
+  branch = `git rev-parse --abbrev-ref HEAD`.strip
+  abort "Could not detect the current git branch." unless $?.success?
+  abort "Could not detect the current git branch, is HEAD detached?" if branch.empty? || branch == "HEAD"
+
+  branch.gsub(/[^a-zA-Z0-9_-]/, ".")
+end
+
+main

--- a/changelog/unreleased-ivoanjo.changelog-in-tree.md
+++ b/changelog/unreleased-ivoanjo.changelog-in-tree.md
@@ -1,0 +1,1 @@
+* [None] (No changelog entry needed)

--- a/lib/datadog/open_feature/AGENTS.md
+++ b/lib/datadog/open_feature/AGENTS.md
@@ -6,9 +6,8 @@ This guide applies to contributors and their AI coding tools working under `lib/
 
 ## Must follow
 
-- Keep each PR focused on one thing, under ~1000 added lines, and include tests for the change (see [Pull requests](#pull-requests)).
+- Keep each PR focused on one thing, under ~1000 added lines, and include tests for the change.
 - PR description follows `.github/PULL_REQUEST_TEMPLATE.md`, at most three sentences per section — high-level intent, not a file-by-file list.
-- Change log entry starts with `Yes.` or `None.` — `Yes.` only for changes to customer-observable provider behavior (see [Pull requests](#pull-requests)).
 - Full, descriptive names. Single letters only for block indices, `rescue => e`, or an ignored `_arg` (see [Naming](#naming)).
 - Comment the *why* in as few words as possible; delete a comment that only restates the code (see [Comments](#comments)).
 - Files and modules follow [Zeitwerk conventions](#file-and-directory-structure): `FlagEvaluation` lives in `flag_evaluation.rb`.
@@ -32,7 +31,6 @@ The sections below explain the reasoning and show the tricky cases. Skim the "ba
 - **Tests.** Every behavior change ships with test coverage in the same PR. A PR that changes code without a corresponding test change is incomplete, not a follow-up to file later.
 - **Size.** If the resulting diff would exceed roughly 1000 lines of additions, stop and propose a split into smaller, stackable PRs before generating any code.
 - **Description.** Use `.github/PULL_REQUEST_TEMPLATE.md` as the structure. At most three sentences per section — high-level intent, not a file-by-file list. Answer *what* and *why*, and call out any non-obvious trade-off; the reviewer reads the diff for the rest. Before opening the PR, count the sentences in each section; if a section runs longer, cut it or move the detail to Additional Notes.
-- **Change log entry.** Start with `Yes.` plus a one-sentence customer-facing summary if the change affects observable provider behavior (flag evaluation results, hooks, the public `OpenFeature` API); otherwise `None.` Refactors, tests, and tooling changes internal are always `None.`
 - Respond to every review comment with either a fix or an explanation of why the change is not being made. Do not re-request review with open threads unresolved.
 
 ---

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "gem release process" do
             |lib-injection
             |appraisal
             |benchmarks
+            |changelog
             |gemfiles
             |integration
             |tasks

--- a/tasks/release_prep.rake
+++ b/tasks/release_prep.rake
@@ -71,6 +71,15 @@ module ReleasePrep
     File.write(CHANGELOG_FILE, content.sub(pattern, replacement))
   end
 
+  # Clean up individual unreleased changelog entries, as fast castle will have already used them to prepare the release draft
+  def delete_changelog_fragments
+    Dir.glob("changelog/unreleased-*.md").sort.each do |fragment|
+      puts "Deleting #{fragment}:"
+      puts File.read(fragment).lines.map { |line| "  #{line}" }.join
+      File.delete(fragment)
+    end
+  end
+
   def fail!(message)
     abort "::error::#{message}"
   end
@@ -103,5 +112,7 @@ namespace :release_prep do
 
     # `version:bump` also asserts the resulting gemspec matches the version.
     Rake::Task["version:bump"].invoke(version)
+
+    ReleasePrep.delete_changelog_fragments
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR adds the a new `changelog/add.rb` nano tool to help us maintain changelog entries for the next release in-repo, rather than in PR descriptions as we've been doing so far.

The envisioned workflow is:

* _Adding an entry_: `ruby changelog/add.rb --category Added --label Profiling --entry "Add Matz conference talks profiling"` (or interactively: run `ruby changelog/add.rb` and follow along)

  This will create a `changelog/unreleased-branchname.md` file with the change

* _Updating an entry_: Just open the markdown file and change!

* _At release time_: Fast castle will flush all unreleased entries in the `changelog/` directory into the release draft. Then the `release_prep` rake task will delete them (as part of the PR that updates `CHANGELOG.md`)

**Motivation:**

For a while we've wanted a in-repo mechanism to keep changelogs, so that we can comment on them, do PRs to update them, etc.

This nano tool is my proposal to do such a thing.

**Additional Notes:**

This PR includes:
* The nano tool
* An update to `CLAUDE.md` and to `PULL_REQUEST_TEMPLATE.md` to mention use of the tool
* An update to the `ensure-changelog-entry.yml` workflow to now check for a file in-repo, rather than the PR description + a lightweight exclusion list for branches which aren't expected to have changelog entries
* An update to `release_prep` to delete the entries as part of the release process

We're still missing the https://github.com/DataDog/fast_castle changes. Once we're happy with this approach, I plan to open a PR on the `fast_castle` side to handle the new format.

I propose that, if we like this change, we merge it as the first PR after the next/a future release: this way we simplify the migration. I'll then go around merging master to recent existing PRs so the new "you're missing the changelog" check runs for them.

**How to test the change?**

Run the tool and check it out!