### PR TITLE
[PROF-15045] Profling: Omit local root span id in reported profiles

### DIFF
--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -793,6 +793,13 @@ static void *call_serialize_without_gvl(void *call_args) {
   build_heap_profile_without_gvl(args->state, args->slot);
   args->heap_profile_build_time_ns = monotonic_wall_time_now_ns(DO_NOT_RAISE_ON_FAILURE) - serialize_no_gvl_start_time_ns;
 
+  ddog_prof_Profile_Result omit_result = ddog_prof_Profile_set_omit_local_root_span_id_when_serializing(&args->slot->profile, true);
+  if (omit_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
+    char error_msg[MAX_RAISE_MESSAGE_SIZE];
+    read_ddogerr_string_and_drop(&omit_result.err, error_msg, MAX_RAISE_MESSAGE_SIZE);
+    grab_gvl_and_raise(rb_eRuntimeError, "Failed to set_omit on profile: %s", error_msg);
+  }
+
   // Note: The profile gets reset by the serialize call
   args->result = ddog_prof_Profile_serialize(&args->slot->profile, &args->slot->start_timestamp, &args->finish_timestamp);
   args->advance_gen_result = ddog_prof_ManagedStringStorage_advance_gen(args->state->string_storage);

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -410,21 +410,24 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             end
           end
 
-          it 'includes "local root span id" and "span id" labels in the samples' do
+          it 'includes "span id" label in the samples' do
             expect(@t1_span_id).to_not be @t1_local_root_span_id
 
             sample
 
-            expect(t1_sample.labels).to include(
-              "local root span id": @t1_local_root_span_id.to_i,
-              "span id": @t1_span_id.to_i,
-            )
+            expect(t1_sample.labels).to include("span id": @t1_span_id.to_i)
           end
 
           it 'does not include the "trace endpoint" label' do
             sample
 
             expect(t1_sample.labels).to_not include("trace endpoint": anything)
+          end
+
+          it 'does not include the "local root span id" label' do
+            sample
+
+            expect(t1_sample.labels).to_not include("local root span id": anything)
           end
 
           shared_examples_for "samples with code hotspots information" do
@@ -437,13 +440,10 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             context "when endpoint_collection_enabled is false" do
               let(:endpoint_collection_enabled) { false }
 
-              it 'still includes "local root span id" and "span id" labels in the samples' do
+              it 'still includes the "span id" label in the samples' do
                 sample
 
-                expect(t1_sample.labels).to include(
-                  "local root span id": @t1_local_root_span_id.to_i,
-                  "span id": @t1_span_id.to_i,
-                )
+                expect(t1_sample.labels).to include("span id": @t1_span_id.to_i)
               end
 
               it 'does not include the "trace endpoint" label' do
@@ -1592,12 +1592,15 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
 
         after { Datadog::Tracing.shutdown! }
 
-        it 'gathers the "local root span id", "span id" and "trace endpoint"' do
+        it 'gathers the "span id" and "trace endpoint"' do
           expect(sample_for_thread(samples, t1).labels).to include(
-            "local root span id": @t1_local_root_span_id.to_i,
             "span id": @t1_span_id.to_i,
             "trace endpoint": "trace_resource",
           )
+        end
+
+        it 'does not include the "local root span id" label' do
+          expect(sample_for_thread(samples, t1).labels).to_not include("local root span id": anything)
         end
       end
     end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -342,23 +342,15 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         expect(samples).to have(6).items # Samples are guaranteed unique since each sample call is on a different line
 
+        # (Omitting the state makes the next asserts easier)
         labels_without_state = proc { |labels| labels.reject { |key| key == :state } }
 
-        # Other samples have not been changed
-        expect(samples.select { |it| labels_without_state.call(it.labels).empty? }).to have(2).items
-        expect(
-          samples.select do |it|
-            labels_without_state.call(it.labels) == {"local root span id": 456}
-          end
-        ).to have(2).items
+        # Samples without endpoint have not been changed
+        expect(samples.select { |it| labels_without_state.call(it.labels).empty? }).to have(4).items
 
         # Matching samples taken before and after recording the endpoint have been changed
-        expect(
-          samples.select do |it|
-            labels_without_state.call(it.labels) ==
-              {"local root span id": 123, "trace endpoint": "recorded-endpoint"}
-          end
-        ).to have(2).items
+        expected_label = {"trace endpoint": "recorded-endpoint"}
+        expect(samples.select { |it| labels_without_state.call(it.labels) == expected_label }).to have(2).items
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR uses the new libdatadog setting
`ddog_prof_Profile_set_omit_local_root_span_id_when_serializing` to omit the "local root span id" label in profiles.

**Motivation:**

The backend no longer uses this label, so we're experimenting with phasing it out.

**Change log entry**

None. (This is not a user-visible change)

**Additional Notes:**

I'm opening this as a draft until we make a decision if we want to ship it or not; the change is otherwise ready and working.

**How to test the change?**

I've updated the tests to match this new world. I've also manually reported profiles to staging and could spot no issues in the trace-to-profile integration (which is the feature that in the past required this information to work).

Here's my tiny test app:

```ruby
require "datadog"

def burn_cpu_for_n_millis(n)
  limit = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) + n * 1_000_000
  while Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) < limit
    # Do nothing
  end
end

Datadog::Tracing.trace("GET /foo", type: "web") do
  burn_cpu_for_n_millis(50)

  Datadog::Tracing.trace("child") do
    burn_cpu_for_n_millis(50)
  end
end

sleep 1
```