### PR TITLE
[NO-TICKET] Profiling: Improve ENFORCE_TYPE error reporting

### DIFF
--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.c
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.c
@@ -6,19 +6,27 @@
 static ID telemetry_message_id;
 
 void raise_unexpected_type(VALUE value, const char *value_name, const char *type_name, const char *file, int line, const char *function_name) {
-  rb_exc_raise(
-    rb_exc_new_str(
-      rb_eTypeError,
-      rb_sprintf("wrong argument %"PRIsVALUE" for '%s' (expected a %s) at %s:%d:in `%s'",
-        rb_inspect(value),
-        value_name,
-        type_name,
-        file,
-        line,
-        function_name
-      )
+  // All of the below come from `ENFORCE_TYPE` and are constant for their call-site
+  VALUE simple_message = rb_sprintf("wrong argument for '%s' (expected a %s) at %s:%d:in `%s'",
+    value_name,
+    type_name,
+    file,
+    line,
+    function_name
+  );
+  VALUE exception = rb_exc_new_str(
+    rb_eTypeError,
+    rb_sprintf("wrong argument %"PRIsVALUE" for '%s' (expected a %s) at %s:%d:in `%s'",
+      rb_inspect(value),
+      value_name,
+      type_name,
+      file,
+      line,
+      function_name
     )
   );
+  rb_ivar_set(exception, telemetry_message_id, simple_message);
+  rb_exc_raise(exception);
 }
 
 // Raises an exception with separate telemetry-safe and detailed messages.

--- a/ext/libdatadog_api/datadog_ruby_common.c
+++ b/ext/libdatadog_api/datadog_ruby_common.c
@@ -6,19 +6,27 @@
 static ID telemetry_message_id;
 
 void raise_unexpected_type(VALUE value, const char *value_name, const char *type_name, const char *file, int line, const char *function_name) {
-  rb_exc_raise(
-    rb_exc_new_str(
-      rb_eTypeError,
-      rb_sprintf("wrong argument %"PRIsVALUE" for '%s' (expected a %s) at %s:%d:in `%s'",
-        rb_inspect(value),
-        value_name,
-        type_name,
-        file,
-        line,
-        function_name
-      )
+  // All of the below come from `ENFORCE_TYPE` and are constant for their call-site
+  VALUE simple_message = rb_sprintf("wrong argument for '%s' (expected a %s) at %s:%d:in `%s'",
+    value_name,
+    type_name,
+    file,
+    line,
+    function_name
+  );
+  VALUE exception = rb_exc_new_str(
+    rb_eTypeError,
+    rb_sprintf("wrong argument %"PRIsVALUE" for '%s' (expected a %s) at %s:%d:in `%s'",
+      rb_inspect(value),
+      value_name,
+      type_name,
+      file,
+      line,
+      function_name
     )
   );
+  rb_ivar_set(exception, telemetry_message_id, simple_message);
+  rb_exc_raise(exception);
 }
 
 // Raises an exception with separate telemetry-safe and detailed messages.


### PR DESCRIPTION
**What does this PR do?**

In #5076 we've improved our error reporting for telemetry, but at the time we didn't touch our `ENFORCE_TYPE`/`ENFORCE_BOOLEAN`/`ENFORCE_TYPED_DATA` macros which all use the `raise_unexpected_type` function which bypasses the telemetry extra information.

Yet, other than the Ruby `VALUE` (which can be an arbitrary object), all other arguments to that function *are* constant for a given call-site -- they're all things from **our** C code: variable name and built-ins such as `__FILE__`, `__LINE__`, `__func__` which are all constants provided by the compiler when the macro gets called.

This PR changes `raise_unexpected_type` to add these constant bits as telemetry, as by definition we know it's always safe to do so.

**Motivation:**

Improve debugging -- I'm seeing a `TypeError: IdleSamplingHelper thread error` and I'd really like to know where exactly did that `TypeError` came from.

**Change log entry**

None.

**Additional Notes:**

N/A

**How to test the change?**

We have existing coverage for the telemetry helpers. I've also tested this quickly by adding a `ENFORCE_TYPE(some_value, T_FLOAT)` to something that wasn't a float and saw the extra message came up:

```
TypeError: IdleSamplingHelper thread error (wrong argument for
'self_instance' (expected a RUBY_T_FLOAT) at
../../../../ext/datadog_profiling_native_extension/collectors_idle_sampling_helper.c:123:
in `idle_sampling_loop_body')
```