### PR TITLE
[APMS-20023] Add fallback for hidden URI in JDBC

### DIFF
--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -137,9 +137,19 @@ module Datadog
               if is_jdbc
                 parsed = parse_jdbc_uri(conn)
 
+                # JNDI/DataSource-managed connections keep only a lookup name in opts (e.g.
+                # "jdbc:jndi:..."), so nothing can be parsed from it. Recover the real driver URL
+                # from the live connection's JDBC metadata, the same way Sequel resolves JNDI. This
+                # stays a fallback rather than the primary source: it requires a connection checkout
+                # and some drivers report no URL, whereas the opts URL is free and already present
+                # for direct connections (and non-JDBC adapters have no such metadata at all).
+                if parsed[:host].nil? && parsed[:database].nil? && (resolved = jdbc_connection_url(db))
+                  parsed = parse_jdbc_uri(resolved)
+                end
+
                 # Sequel's JDBC adapter connects with the URL and ignores separate
                 # :host/:port options, unlike native adapters where those options take precedence.
-                if !parsed[:host].nil? || !parsed[:port].nil? || !parsed[:database].nil?
+                if parsed[:host] || parsed[:port] || parsed[:database]
                   host = parsed[:host]
                   port = parsed[:port]
                 end
@@ -150,6 +160,28 @@ module Datadog
             end
 
             private
+
+            # Resolves the real JDBC connection URL from the live connection's metadata
+            # (java.sql.DatabaseMetaData#getURL), for JNDI/DataSource connections whose opts hold
+            # only a lookup name. Memoized on the Database since the URL is stable for its lifetime,
+            # and rescued so tracing degrades gracefully -- returns nil when the connection object
+            # exposes no JDBC metadata, the driver reports no URL, or the connection can't be reached.
+            def jdbc_connection_url(db)
+              return db.instance_variable_get(:@datadog_jdbc_url) if db.instance_variable_defined?(:@datadog_jdbc_url)
+
+              url =
+                begin
+                  db.synchronize do |conn|
+                    conn.get_meta_data.get_url if conn.respond_to?(:get_meta_data)
+                  end
+                rescue => e
+                  Datadog.logger.debug { "Sequel: unable to resolve JDBC URL from connection metadata (#{e.class}: #{e.message})" }
+                  nil
+                end
+
+              db.instance_variable_set(:@datadog_jdbc_url, url)
+              url
+            end
 
             def database_from_path(path)
               return unless path&.start_with?("/")

--- a/lib/datadog/tracing/contrib/sequel/utils.rb
+++ b/lib/datadog/tracing/contrib/sequel/utils.rb
@@ -138,13 +138,13 @@ module Datadog
                 parsed = parse_jdbc_uri(conn)
 
                 # JNDI/DataSource-managed connections keep only a lookup name in opts (e.g.
-                # "jdbc:jndi:..."), so nothing can be parsed from it. Recover the real driver URL
-                # from the live connection's JDBC metadata, the same way Sequel resolves JNDI. This
-                # stays a fallback rather than the primary source: it requires a connection checkout
-                # and some drivers report no URL, whereas the opts URL is free and already present
-                # for direct connections (and non-JDBC adapters have no such metadata at all).
-                if parsed[:host].nil? && parsed[:database].nil? && (resolved = jdbc_connection_url(db))
-                  parsed = parse_jdbc_uri(resolved)
+                # "jdbc:jndi:..."), so nothing can be parsed from it. Recover the endpoint from the
+                # live connection's JDBC metadata, the same way Sequel resolves JNDI. This stays a
+                # fallback rather than the primary source: it requires a connection checkout and
+                # some drivers report no URL, whereas the opts URL is free and already present for
+                # direct connections (and non-JDBC adapters have no such metadata at all).
+                if parsed[:host].nil? && parsed[:port].nil? && parsed[:database].nil?
+                  parsed = jdbc_metadata_from_connection(db) || parsed
                 end
 
                 # Sequel's JDBC adapter connects with the URL and ignores separate
@@ -161,13 +161,18 @@ module Datadog
 
             private
 
-            # Resolves the real JDBC connection URL from the live connection's metadata
+            # Resolves host/port/database from the live connection's JDBC metadata
             # (java.sql.DatabaseMetaData#getURL), for JNDI/DataSource connections whose opts hold
-            # only a lookup name. Memoized on the Database since the URL is stable for its lifetime,
-            # and rescued so tracing degrades gracefully -- returns nil when the connection object
-            # exposes no JDBC metadata, the driver reports no URL, or the connection can't be reached.
-            def jdbc_connection_url(db)
-              return db.instance_variable_get(:@datadog_jdbc_url) if db.instance_variable_defined?(:@datadog_jdbc_url)
+            # only a lookup name. Returns the parsed metadata, or nil when it can't be resolved.
+            #
+            # Only *parsed, credential-free* metadata is memoized -- the raw URL (which can carry a
+            # user/password) is used transiently and never stored or logged. A completed lookup that
+            # yields no usable URL is a permanent property of the connection, so it is cached to avoid
+            # re-checking out a connection on every query. A raised error is treated as transient
+            # (pool checkout timeout, dropped connection, ...) and left uncached, so a later query
+            # can retry once connectivity recovers.
+            def jdbc_metadata_from_connection(db)
+              return db.instance_variable_get(:@datadog_jdbc_metadata) if db.instance_variable_defined?(:@datadog_jdbc_metadata)
 
               url =
                 begin
@@ -175,12 +180,13 @@ module Datadog
                     conn.get_meta_data.get_url if conn.respond_to?(:get_meta_data)
                   end
                 rescue => e
-                  Datadog.logger.debug { "Sequel: unable to resolve JDBC URL from connection metadata (#{e.class}: #{e.message})" }
-                  nil
+                  Datadog.logger.debug { "Sequel: unable to resolve JDBC connection metadata (#{e.class})" }
+                  return nil
                 end
 
-              db.instance_variable_set(:@datadog_jdbc_url, url)
-              url
+              metadata = url && parse_jdbc_uri(url)
+              db.instance_variable_set(:@datadog_jdbc_metadata, metadata)
+              metadata
             end
 
             def database_from_path(path)

--- a/sig/datadog/tracing/contrib/sequel/utils.rbs
+++ b/sig/datadog/tracing/contrib/sequel/utils.rbs
@@ -19,7 +19,7 @@ module Datadog
 
           private
 
-          def self.jdbc_connection_url: (::Sequel::Database db) -> String?
+          def self.jdbc_metadata_from_connection: (::Sequel::Database db) -> { host: String?, port: String?, database: String? }?
 
           def self.database_from_path: (String? path) -> String?
 

--- a/sig/datadog/tracing/contrib/sequel/utils.rbs
+++ b/sig/datadog/tracing/contrib/sequel/utils.rbs
@@ -31,6 +31,8 @@ module Datadog
 
           private
 
+          def self.jdbc_connection_url: (untyped db) -> String?
+
           def self.database_from_path: (String? path) -> String?
 
           def self.database_from_properties: (String? properties) -> String?

--- a/sig/datadog/tracing/contrib/sequel/utils.rbs
+++ b/sig/datadog/tracing/contrib/sequel/utils.rbs
@@ -3,18 +3,6 @@ module Datadog
     module Contrib
       module Sequel
         module Utils
-          type connection_options = {
-            ?host: String?,
-            ?port: (Integer | String)?,
-            ?database: String?,
-            ?uri: String?,
-            ?url: String?
-          }
-
-          interface _Database
-            def opts: () -> connection_options?
-          end
-
           JDBC_URI_PATTERN: Regexp
           DATABASE_PROPERTY_PATTERN: Regexp
 
@@ -25,13 +13,13 @@ module Datadog
 
           def self.parse_opts: (untyped sql, untyped opts, untyped db_opts, ?untyped? dataset) -> { name: untyped, query: untyped, prepared_name: untyped, database: untyped, host: untyped }
 
-          def self.connection_metadata: (_Database db) -> { host: String?, port: String?, database: String? }
+          def self.connection_metadata: (::Sequel::Database db) -> { host: String?, port: String?, database: String? }
 
           def self.set_common_tags: (untyped span, untyped db) -> untyped
 
           private
 
-          def self.jdbc_connection_url: (untyped db) -> String?
+          def self.jdbc_connection_url: (::Sequel::Database db) -> String?
 
           def self.database_from_path: (String? path) -> String?
 

--- a/spec/datadog/tracing/contrib/sequel/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/utils_spec.rb
@@ -255,27 +255,47 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
         described_class.connection_metadata(db)
         expect(db).to have_received(:synchronize).once
       end
-    end
 
-    context "when the JDBC driver reports no URL from metadata" do
-      let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+      it "memoizes only parsed, credential-free metadata (never the raw URL)" do
+        described_class.connection_metadata(db)
 
-      before { allow(db).to receive(:synchronize).and_return(nil) }
-
-      it "returns empty metadata without raising" do
-        expect { metadata }.not_to raise_error
-        expect(metadata).to eq(host: nil, port: nil, database: nil)
+        cached = db.instance_variable_get(:@datadog_jdbc_metadata)
+        expect(cached).to eq(host: "prod-host", port: "3111", database: "yds")
+        expect(cached.to_s).not_to include("password")
+        expect(cached.to_s).not_to include("jdbc:")
       end
     end
 
-    context "when resolving connection metadata raises" do
+    context "when the JDBC driver reports no URL (permanent)" do
       let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+      let(:metadata_obj) { double("java.sql.DatabaseMetaData", get_url: nil) }
+      let(:connection) { double("java.sql.Connection", get_meta_data: metadata_obj) }
 
-      before { allow(db).to receive(:synchronize).and_raise(StandardError, "connection unavailable") }
+      before { allow(db).to receive(:synchronize) { |&blk| blk.call(connection) } }
 
-      it "swallows the error and returns empty metadata" do
-        expect { metadata }.not_to raise_error
+      it "returns empty metadata and caches it (no re-checkout per query)" do
         expect(metadata).to eq(host: nil, port: nil, database: nil)
+        described_class.connection_metadata(db)
+        expect(db).to have_received(:synchronize).once
+      end
+    end
+
+    context "when metadata resolution fails transiently" do
+      let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+      let(:metadata_obj) { double("java.sql.DatabaseMetaData", get_url: "jdbc:mariadb://prod-host:3111/yds") }
+      let(:connection) { double("java.sql.Connection", get_meta_data: metadata_obj) }
+
+      it "does not cache the failure and recovers on a later call" do
+        calls = 0
+        allow(db).to receive(:synchronize) do |&blk|
+          calls += 1
+          raise "pool checkout timeout" if calls == 1
+          blk.call(connection)
+        end
+
+        expect(described_class.connection_metadata(db)).to eq(host: nil, port: nil, database: nil)
+        expect(described_class.connection_metadata(db)).to eq(host: "prod-host", port: "3111", database: "yds")
+        expect(db).to have_received(:synchronize).twice
       end
     end
   end

--- a/spec/datadog/tracing/contrib/sequel/utils_spec.rb
+++ b/spec/datadog/tracing/contrib/sequel/utils_spec.rb
@@ -221,9 +221,61 @@ RSpec.describe Datadog::Tracing::Contrib::Sequel::Utils do
       let(:uri) { "jdbc:mysql://h\xFF\xFEst/db".b.force_encoding("UTF-8") }
       let(:opts) { {host: "db-host", port: 3306, database: uri} }
 
+      # The opts URL yields nothing, so the metadata fallback runs; no URL is recoverable here.
+      before { allow(db).to receive(:synchronize).and_return(nil) }
+
       it "does not raise or emit the raw URL as the database name" do
         expect { metadata }.not_to raise_error
         expect(metadata).to eq(host: "db-host", port: "3306", database: nil)
+      end
+    end
+
+    # This is specific to JRuby which we don't support anymore, so we cannot test against a real connection
+    context "with a JNDI/DataSource connection that hides the endpoint from opts" do
+      # Sequel stores only the JNDI lookup name; the real driver URL lives on the connection.
+      let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+      let(:metadata_obj) do
+        double("java.sql.DatabaseMetaData", get_url: "jdbc:mariadb://prod-host:3111/yds?user=u&password=secret")
+      end
+      let(:connection) { double("java.sql.Connection", get_meta_data: metadata_obj) }
+
+      before { allow(db).to receive(:synchronize) { |&blk| blk.call(connection) } }
+
+      it "recovers host/port/database from the live connection's JDBC metadata" do
+        expect(metadata).to eq(host: "prod-host", port: "3111", database: "yds")
+      end
+
+      it "never emits the raw URL or its credentials as the database name" do
+        expect(metadata[:database]).to eq("yds")
+        expect(metadata[:database]).not_to include("password")
+      end
+
+      it "resolves the connection only once, then memoizes on the database" do
+        described_class.connection_metadata(db)
+        described_class.connection_metadata(db)
+        expect(db).to have_received(:synchronize).once
+      end
+    end
+
+    context "when the JDBC driver reports no URL from metadata" do
+      let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+
+      before { allow(db).to receive(:synchronize).and_return(nil) }
+
+      it "returns empty metadata without raising" do
+        expect { metadata }.not_to raise_error
+        expect(metadata).to eq(host: nil, port: nil, database: nil)
+      end
+    end
+
+    context "when resolving connection metadata raises" do
+      let(:opts) { {uri: "jdbc:jndi:java:comp/env/jdbc/ycs"} }
+
+      before { allow(db).to receive(:synchronize).and_raise(StandardError, "connection unavailable") }
+
+      it "swallows the error and returns empty metadata" do
+        expect { metadata }.not_to raise_error
+        expect(metadata).to eq(host: nil, port: nil, database: nil)
       end
     end
   end

--- a/vendor/rbs/sequel/0/sequel.rbs
+++ b/vendor/rbs/sequel/0/sequel.rbs
@@ -1,0 +1,11 @@
+module Sequel
+  class Database
+    def opts: () -> ::Hash[::Symbol, untyped]?
+
+    def synchronize: [T] (?untyped server) { (untyped connection) -> T } -> T
+
+    def database_type: () -> ::Symbol
+
+    def adapter_scheme: () -> ::Symbol
+  end
+end


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Add fallback for hidden URI in sequel with JDBC. With DataSource/JNDI-managed connection it is possible to have a hidden URI that can still be access through
```ruby
db.synchronize do |conn|
  conn.get_meta_data.get_url if conn.respond_to?(:get_meta_data)
end
```

**Motivation:**
<!-- What inspired you to submit this pull request? -->
APMS-20023

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None. We do not officially support JRuby anymore and this is specific to JRuby

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
The CI does not test this because we do not test on JRuby anymore. So the tests are best effort and reproduce what would happen on JRuby, in a Ruby env

<!-- Unsure? Have a question? Request a review! -->
