### PR TITLE
Type trace and span id signatures as Integer

### DIFF
--- a/lib/datadog/tracing/correlation.rb
+++ b/lib/datadog/tracing/correlation.rb
@@ -23,7 +23,6 @@ module Datadog
         attr_reader \
           :env,
           :service,
-          :span_id,
           :version
 
         # @!visibility private
@@ -37,7 +36,7 @@ module Datadog
           # Dup and freeze strings so they aren't modified by reference.
           @env = env || Datadog.configuration.env
           @service = service || Datadog.configuration.service
-          @span_id = (span_id || 0).to_s
+          @span_id = span_id || 0
           @trace_id = trace_id || 0
           @version = version || Datadog.configuration.version
         end
@@ -70,6 +69,10 @@ module Datadog
             attributes << "#{LOG_ATTR_SOURCE}=#{Core::Logging::Ext::DD_SOURCE}"
             attributes.join(" ")
           end
+        end
+
+        def span_id
+          @span_id.to_s
         end
 
         def trace_id

--- a/sig/datadog/tracing/correlation.rbs
+++ b/sig/datadog/tracing/correlation.rbs
@@ -8,7 +8,7 @@ module Datadog
 
         @span_id: String
 
-        @trace_id: String
+        @trace_id: Integer
 
         @version: String
 
@@ -35,18 +35,18 @@ module Datadog
         attr_reader span_id: String
 
         attr_reader version: String
-        def initialize: (?env: untyped?, ?service: untyped?, ?span_id: untyped?, ?trace_id: untyped?, ?version: untyped?) -> void
+        def initialize: (?env: untyped?, ?service: untyped?, ?span_id: Integer?, ?trace_id: Integer?, ?version: untyped?) -> void
 
         def to_h: () -> untyped
         def to_log_format: () -> untyped
 
-        def trace_id: () -> untyped
+        def trace_id: () -> String
       end
-      def self?.identifier_from_digest: (untyped digest) -> untyped
+      def self?.identifier_from_digest: (TraceDigest? digest) -> Identifier
 
-      def self?.format_trace_id: (untyped trace_id) -> untyped
+      def self?.format_trace_id: (::Integer trace_id) -> ::String
 
-      def self?.format_trace_id_128: (untyped trace_id) -> untyped
+      def self?.format_trace_id_128: (::Integer trace_id) -> ::String
     end
   end
 end

--- a/sig/datadog/tracing/correlation.rbs
+++ b/sig/datadog/tracing/correlation.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         @service: String
 
-        @span_id: String
+        @span_id: Integer
 
         @trace_id: Integer
 
@@ -32,13 +32,13 @@ module Datadog
 
         attr_reader service: String
 
-        attr_reader span_id: String
-
         attr_reader version: String
         def initialize: (?env: untyped?, ?service: untyped?, ?span_id: Integer?, ?trace_id: Integer?, ?version: untyped?) -> void
 
         def to_h: () -> untyped
         def to_log_format: () -> untyped
+
+        def span_id: () -> String
 
         def trace_id: () -> String
       end

--- a/sig/datadog/tracing/distributed/b3_multi.rbs
+++ b/sig/datadog/tracing/distributed/b3_multi.rbs
@@ -15,9 +15,9 @@ module Datadog
 
         def initialize: (fetcher: untyped, ?trace_id_key: untyped, ?span_id_key: untyped, ?sampled_key: untyped) -> void
 
-        def inject!: (untyped digest, ?::Hash[untyped, untyped] data) -> (nil | untyped)
+        def inject!: (TraceDigest? digest, ?::Hash[untyped, untyped] data) -> (nil | untyped)
 
-        def extract: (untyped data) -> (nil | untyped)
+        def extract: (untyped data) -> TraceDigest?
       end
     end
   end

--- a/sig/datadog/tracing/distributed/b3_single.rbs
+++ b/sig/datadog/tracing/distributed/b3_single.rbs
@@ -9,9 +9,9 @@ module Datadog
 
         def initialize: (fetcher: untyped, ?key: untyped) -> void
 
-        def inject!: (untyped digest, untyped env) -> (nil | untyped)
+        def inject!: (TraceDigest? digest, untyped env) -> (nil | untyped)
 
-        def extract: (untyped env) -> (nil | untyped)
+        def extract: (untyped env) -> TraceDigest?
       end
     end
   end

--- a/sig/datadog/tracing/distributed/helpers.rbs
+++ b/sig/datadog/tracing/distributed/helpers.rbs
@@ -4,9 +4,9 @@ module Datadog
       module Helpers
         def self.clamp_sampling_priority: (untyped sampling_priority) -> untyped
 
-        def self.parse_decimal_id: (untyped value) -> (nil | untyped)
+        def self.parse_decimal_id: (untyped value) -> ::Integer?
 
-        def self.parse_hex_id: (untyped value) -> (nil | untyped)
+        def self.parse_hex_id: (untyped value) -> ::Integer?
       end
     end
   end

--- a/sig/datadog/tracing/distributed/trace_context.rbs
+++ b/sig/datadog/tracing/distributed/trace_context.rbs
@@ -16,9 +16,9 @@ module Datadog
 
         def initialize: (fetcher: untyped, ?traceparent_key: untyped, ?tracestate_key: untyped) -> void
 
-        def inject!: (untyped digest, untyped data) -> (nil | untyped)
+        def inject!: (TraceDigest? digest, untyped data) -> (nil | untyped)
 
-        def extract: (untyped data) -> (nil | untyped)
+        def extract: (untyped data) -> TraceDigest?
 
         private
         def build_traceparent: (TraceDigest digest) -> ::String

--- a/sig/datadog/tracing/span_link.rbs
+++ b/sig/datadog/tracing/span_link.rbs
@@ -50,7 +50,7 @@ module Datadog
       #   @return [Integer]
       attr_reader dropped_attributes: untyped
 
-      def initialize: (untyped digest, ?attributes: untyped?) -> void
+      def initialize: (TraceDigest digest, ?attributes: untyped?) -> void
 
       def to_hash: () -> untyped
     end

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -156,13 +156,13 @@ module Datadog
 
       attr_reader events: untyped
 
-      attr_reader parent: untyped
+      attr_reader parent: SpanOperation?
 
       attr_reader span: untyped
 
       def build_span: () -> untyped
 
-      def parent=: (untyped parent) -> untyped
+      def parent=: (SpanOperation? parent) -> void
 
       def duration_marker: () -> untyped
 

--- a/sig/datadog/tracing/span_operation.rbs
+++ b/sig/datadog/tracing/span_operation.rbs
@@ -21,11 +21,11 @@ module Datadog
 
       attr_reader end_time: ::Time?
 
-      attr_reader id: untyped
+      attr_reader id: Integer
 
       attr_reader name: untyped
 
-      attr_reader parent_id: untyped
+      attr_reader parent_id: Integer
 
       attr_reader resource: untyped
 
@@ -33,7 +33,7 @@ module Datadog
 
       attr_reader start_time: ::Time?
 
-      attr_reader trace_id: untyped
+      attr_reader trace_id: Integer
 
       attr_reader type: untyped
 

--- a/sig/datadog/tracing/trace_digest.rbs
+++ b/sig/datadog/tracing/trace_digest.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module Tracing
     class TraceDigest
-      attr_reader span_id: untyped
+      attr_reader span_id: Integer?
       attr_reader span_name: untyped
       attr_reader span_resource: untyped
       attr_reader span_service: untyped
@@ -9,7 +9,7 @@ module Datadog
       attr_reader span_links: Array[SpanLink]?
       attr_reader trace_distributed_tags: untyped
       attr_reader trace_hostname: untyped
-      attr_reader trace_id: untyped
+      attr_reader trace_id: Integer?
       attr_reader trace_name: untyped
       attr_reader trace_origin: untyped
       attr_reader trace_process_id: untyped
@@ -24,7 +24,7 @@ module Datadog
       attr_reader span_remote: untyped
       attr_reader baggage: untyped
 
-      def initialize: (?span_id: untyped?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?span_links: ::Array[SpanLink]?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: untyped?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?span_remote: untyped?, ?baggage: untyped?) -> void
+      def initialize: (?span_id: Integer?, ?span_name: untyped?, ?span_resource: untyped?, ?span_service: untyped?, ?span_type: untyped?, ?span_links: ::Array[SpanLink]?, ?trace_distributed_tags: untyped?, ?trace_hostname: untyped?, ?trace_id: Integer?, ?trace_name: untyped?, ?trace_origin: untyped?, ?trace_process_id: untyped?, ?trace_resource: untyped?, ?trace_runtime_id: untyped?, ?trace_sampling_priority: untyped?, ?trace_service: untyped?, ?trace_distributed_id: untyped?, ?trace_flags: untyped?, ?trace_state: untyped?, ?trace_state_unknown_fields: untyped?, ?span_remote: untyped?, ?baggage: untyped?) -> void
 
       def merge: (Hash[String, String] field_value_pairs) -> Datadog::Tracing::TraceDigest
     end

--- a/sig/datadog/tracing/trace_operation.rbs
+++ b/sig/datadog/tracing/trace_operation.rbs
@@ -23,9 +23,9 @@ module Datadog
       attr_accessor baggage: untyped
       attr_reader active_span_count: untyped
       attr_reader active_span: untyped
-      attr_reader id: untyped
+      attr_reader id: Integer
       attr_reader max_length: untyped
-      attr_reader parent_span_id: untyped
+      attr_reader parent_span_id: Integer?
       attr_reader trace_state: untyped
       attr_reader trace_state_unknown_fields: untyped
       attr_writer name: untyped
@@ -38,11 +38,11 @@ module Datadog
         ?agent_sample_rate: untyped?,
         ?events: untyped?,
         ?hostname: untyped?,
-        ?id: untyped?,
+        ?id: Integer?,
         ?max_length: untyped,
         ?name: untyped?,
         ?origin: untyped?,
-        ?parent_span_id: untyped?,
+        ?parent_span_id: Integer?,
         ?span_links: ::Array[SpanLink]?,
         ?rate_limiter_rate: untyped?,
         ?resource: untyped?,

--- a/sig/datadog/tracing/trace_segment.rbs
+++ b/sig/datadog/tracing/trace_segment.rbs
@@ -1,9 +1,9 @@
 module Datadog
   module Tracing
     class TraceSegment
-      @id: untyped
+      @id: Integer?
 
-      @root_span_id: untyped
+      @root_span_id: Integer?
 
       @spans: untyped
       @meta: untyped
@@ -47,7 +47,7 @@ module Datadog
 
       TAG_SERVICE: "service"
 
-      attr_reader id: untyped
+      attr_reader id: Integer?
 
       attr_reader spans: untyped
 
@@ -82,7 +82,7 @@ module Datadog
       attr_reader profiling_enabled: untyped
 
       attr_reader apm_tracing_enabled: untyped
-      def initialize: (untyped spans, ?agent_sample_rate: untyped?, ?hostname: untyped?, ?id: untyped?, ?lang: untyped?, ?name: untyped?, ?origin: untyped?, ?process_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?root_span_id: untyped?, ?rule_sample_rate: untyped?, ?runtime_id: untyped?, ?sample_rate: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?profiling_enabled: untyped?, ?apm_tracing_enabled: untyped?) -> void
+      def initialize: (untyped spans, ?agent_sample_rate: untyped?, ?hostname: untyped?, ?id: Integer?, ?lang: untyped?, ?name: untyped?, ?origin: untyped?, ?process_id: untyped?, ?rate_limiter_rate: untyped?, ?resource: untyped?, ?root_span_id: Integer?, ?rule_sample_rate: untyped?, ?runtime_id: untyped?, ?sample_rate: untyped?, ?sampling_priority: untyped?, ?service: untyped?, ?tags: untyped?, ?metrics: untyped?, ?profiling_enabled: untyped?, ?apm_tracing_enabled: untyped?) -> void
 
       def any?: () -> untyped
 
@@ -99,7 +99,7 @@ module Datadog
       def sampled?: () -> untyped
       def high_order_tid: () -> untyped
 
-      attr_reader root_span_id: untyped
+      attr_reader root_span_id: Integer?
 
       attr_reader meta: untyped
 

--- a/sig/datadog/tracing/utils.rbs
+++ b/sig/datadog/tracing/utils.rbs
@@ -3,23 +3,23 @@ module Datadog
     module Utils
       extend Datadog::Core::Utils::Forking
 
-      RUBY_MAX_ID: untyped
+      RUBY_MAX_ID: ::Integer
       RUBY_ID_RANGE: ::Range[::Integer]
-      EXTERNAL_MAX_ID: untyped
+      EXTERNAL_MAX_ID: ::Integer
 
       self.@id_rng: Random
 
-      def self.next_id: () -> untyped
+      def self.next_id: () -> ::Integer
 
-      def self.id_rng: () -> untyped
+      def self.id_rng: () -> Random
 
-      def self.reset!: () -> untyped
+      def self.reset!: () -> Random
 
       def self.serialize_attribute: (untyped key, untyped value) -> (untyped | ::Array[::Array[untyped]])
 
       module TraceId
-        MAX: untyped
-        def self?.next_id: () -> untyped
+        MAX: ::Integer
+        def self?.next_id: () -> ::Integer
 
         def self?.to_high_order: (untyped trace_id) -> untyped
 


### PR DESCRIPTION
**What does this PR do?**

Types the trace/span id family in the RBS signatures.

The type is Integer. After LLM back and forth, the actual values appear to always be integers, and are converted to strings only when sent to agent. Hence, the type is integer and not string.

**Motivation:**

MOAR TYPES

**Change log entry**

None.


**How to test the change?**

Existing CI