### PR TITLE
Type-check trace_context.rb (remove Steepfile ignore)

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -519,7 +519,6 @@ target :datadog do
   ignore "lib/datadog/tracing/distributed/datadog.rb"
   ignore "lib/datadog/tracing/distributed/datadog_tags_codec.rb"
   ignore "lib/datadog/tracing/distributed/propagation.rb"
-  ignore "lib/datadog/tracing/distributed/trace_context.rb"
   ignore "lib/datadog/tracing/event.rb"
   ignore "lib/datadog/tracing/metadata/errors.rb"
   ignore "lib/datadog/tracing/metadata/ext.rb"

--- a/lib/datadog/tracing/distributed/trace_context.rb
+++ b/lib/datadog/tracing/distributed/trace_context.rb
@@ -41,9 +41,11 @@ module Datadog
         def extract(data)
           fetcher = @fetcher.new(data)
 
-          trace_id, parent_id, sampled, trace_flags = extract_traceparent(fetcher[@traceparent_key])
+          traceparent_fields = extract_traceparent(fetcher[@traceparent_key])
 
-          return unless trace_id # Could not parse traceparent
+          return unless traceparent_fields # Could not parse traceparent
+
+          trace_id, parent_id, sampled, trace_flags = traceparent_fields
 
           tracestate, sampling_priority, origin, ts_parent_id, tags, unknown_fields = extract_tracestate(
             fetcher[@tracestate_key]
@@ -52,8 +54,7 @@ module Datadog
           sampling_priority = parse_priority_sampling(sampled, sampling_priority) do |decision|
             case decision
             when String
-              tags ||= {}
-              tags[Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER] = decision
+              (tags ||= {})[Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER] = decision
             when :drop
               tags&.delete(Tracing::Metadata::Ext::Distributed::TAG_DECISION_MAKER)
             end
@@ -80,8 +81,11 @@ module Datadog
 
         # @see https://www.w3.org/TR/trace-context/#traceparent-header
         def build_traceparent(digest)
+          trace_id = digest.trace_id
+          return unless trace_id
+
           build_traceparent_string(
-            digest.trace_id,
+            trace_id,
             digest.span_id || 0, # Fall back to zero (invalid) if not present
             build_trace_flags(digest)
           )
@@ -269,7 +273,11 @@ module Datadog
 
           return unless version && trace_id && parent_id && trace_flags
           return if version.size != 2 || trace_id.size != 32 || parent_id.size != 16 || trace_flags.size != 2
-          return if version[0] < "0" || version[0] > "f" || version[1] < "0" || version[1] > "f"
+
+          # `version.size == 2` above guarantees both chars are present; the nil checks narrow the type.
+          v0 = version[0]
+          v1 = version[1]
+          return if v0.nil? || v1.nil? || v0 < "0" || v0 > "f" || v1 < "0" || v1 > "f"
 
           return if version == INVALID_VERSION
 
@@ -286,10 +294,10 @@ module Datadog
         end
 
         # @return [nil] when the tracestate is absent or has no vendor entries.
-        # @return [String] when no `dd=` entry is present, the joined vendor list.
-        # @return [Array(String, Integer, String, String, Hash, String)] when a `dd=`
-        #   entry is present: [tracestate without `dd=`, sampling_priority, origin,
-        #   ts_parent_id, tags, unknown_fields]. All elements past the first may be nil.
+        # @return [Array(String, Integer, String, String, Hash, String)]
+        #   [tracestate without `dd=`, sampling_priority, origin, ts_parent_id, tags,
+        #   unknown_fields]. All elements past the first may be nil; when no `dd=` entry is
+        #   present only the first element (the joined vendor list) is populated.
         def extract_tracestate(tracestate)
           vendors = split_tracestate(tracestate)
           return unless vendors && !vendors.empty?
@@ -298,7 +306,7 @@ module Datadog
 
           # Find Datadog's `dd=` tracestate field.
           idx = vendors.index { |v| v.start_with?("dd=") }
-          return tracestate unless idx
+          return [tracestate, nil, nil, nil, nil, nil] unless idx
 
           # Delete `dd=` prefix
           dd_tracestate = vendors.delete_at(idx)
@@ -310,10 +318,15 @@ module Datadog
         end
 
         def extract_datadog_fields(dd_tracestate)
+          # @type var sampling_priority: ::Integer?
           sampling_priority = nil
+          # @type var origin: ::String?
           origin = nil
+          # @type var ts_parent_id: ::String?
           ts_parent_id = nil
+          # @type var tags: ::Hash[::String, ::String]?
           tags = nil
+          # @type var unknown_fields: ::String?
           unknown_fields = nil
 
           # DEV: Since Ruby 2.6 `split` can receive a block, so `each` can be removed then.
@@ -331,20 +344,23 @@ module Datadog
             when "p"
               ts_parent_id = value
             when /^t\./
+              # A regex match guarantees `key` is a non-nil String; the guard narrows the type.
+              next unless key
               key.slice!(0..1) # Delete `t.` prefix
 
               # Ignore the high order 64 bit trace id propagation tag to avoid confusion,
               # the single source of truth is from traceparent
               next if key == Tracing::Metadata::Ext::Distributed::TID
 
+              # Skip a malformed `t.` tag that carries no value.
+              next unless value
               value = deserialize_tag_value(value)
 
-              tags ||= {}
-              tags["#{Tracing::Metadata::Ext::Distributed::TAGS_PREFIX}#{key}"] = value
+              (tags ||= {})["#{Tracing::Metadata::Ext::Distributed::TAGS_PREFIX}#{key}"] = value
             else
-              unknown_fields ||= +""
-              unknown_fields << pair
-              unknown_fields << ";"
+              uf = (unknown_fields ||= +"")
+              uf << pair
+              uf << ";"
             end
           end
 

--- a/sig/datadog/tracing/distributed/trace_context.rbs
+++ b/sig/datadog/tracing/distributed/trace_context.rbs
@@ -14,14 +14,18 @@ module Datadog
 
         SPEC_VERSION: "00"
 
-        def initialize: (fetcher: untyped, ?traceparent_key: untyped, ?tracestate_key: untyped) -> void
+        @fetcher: singleton(Distributed::Fetcher)
+        @traceparent_key: ::String
+        @tracestate_key: ::String
+
+        def initialize: (fetcher: singleton(Distributed::Fetcher), ?traceparent_key: ::String, ?tracestate_key: ::String) -> void
 
         def inject!: (TraceDigest? digest, untyped data) -> (nil | untyped)
 
         def extract: (untyped data) -> TraceDigest?
 
         private
-        def build_traceparent: (TraceDigest digest) -> ::String
+        def build_traceparent: (TraceDigest digest) -> ::String?
         def build_traceparent_string: (::Integer trace_id, ::Integer parent_id, ::Integer trace_flags) -> ::String
         def build_trace_flags: (TraceDigest digest) -> ::Integer
         def build_tracestate: (TraceDigest digest) -> ::String?
@@ -36,7 +40,7 @@ module Datadog
         def parse_traceparent_string: (::String? traceparent) -> traceparent_fields?
 
         def parse_sampled_flag: (::Integer trace_flags) -> ::Integer
-        def extract_tracestate: (::String? tracestate) -> (::String | extracted_tracestate)?
+        def extract_tracestate: (::String? tracestate) -> extracted_tracestate?
 
         def extract_datadog_fields: (::String dd_tracestate) -> extracted_datadog_fields
         def deserialize_tag_value: (::String value) -> ::String

--- a/sig/datadog/tracing/metadata/ext.rbs
+++ b/sig/datadog/tracing/metadata/ext.rbs
@@ -34,7 +34,11 @@ module Datadog
           TAG_KNUTH_SAMPLING_RATE: ::String
           TAG_ORIGIN: ::String
           TAG_SAMPLING_PRIORITY: ::String
+          TAG_DD_PARENT_ID: ::String
+          DD_PARENT_ID_DEFAULT: ::String
           TAGS_PREFIX: ::String
+          TID: ::String
+          TAG_TID: ::String
         end
 
         module Errors


### PR DESCRIPTION
**What does this PR do?**

Removes the `Steepfile` ignore for `lib/datadog/tracing/distributed/trace_context.rb`
(the W3C trace-context propagator) and resolves all 32 resulting steep errors so the
file is type-checked. `rake steep:check` is clean.

Stacked on #6124 (branch `type-trace-span-id`): that PR types `TraceDigest#trace_id`
as `Integer?`, which is what forces the one id-related fix here
(`build_traceparent` guarding a nil `trace_id`).

Signature changes:

- Declare `@fetcher` / `@traceparent_key` / `@tracestate_key` and concrete
  `initialize` param types in `trace_context.rbs`.
- Declare the `Distributed` constants `TAG_DD_PARENT_ID`, `DD_PARENT_ID_DEFAULT`,
  `TID`, `TAG_TID` in `sig/datadog/tracing/metadata/ext.rbs` (present in the `.rb`,
  missing from the `.rbs`).
- `build_traceparent` returns `String?`; `extract_tracestate` returns the 6-tuple
  uniformly (drops the `String |` alternative).

Code changes (type-narrowing; no behavior change for well-formed input):

- Guard the `extract_traceparent` tuple before destructuring so `trace_id` /
  `parent_id` / `sampled` / `trace_flags` are non-nil `Integer`.
- Extract `version[0]` / `version[1]` into locals with a nil check (guaranteed
  non-nil by the preceding `version.size == 2`).
- `extract_tracestate` returns `[tracestate, nil, nil, nil, nil, nil]` instead of a
  bare `String` when there is no `dd=` entry (destructures identically at the call site).
- Annotate the `extract_datadog_fields` accumulators and narrow the `t.`-tag
  `key` / `value`.

Two behavior refinements (covered by the existing 478 distributed specs, all green):

- A malformed `t.` tracestate tag with no value is skipped instead of raising and
  discarding the entire tracestate for that propagator.
- A digest with a nil `trace_id` produces no `traceparent` header, without logging an
  error (previously it raised and was swallowed upstream — same header output).

**Motivation:**

`trace_context.rb` was ignored by steep purely due to accumulated type debt; the
signatures were otherwise already written. Un-ignoring it removes a checking gap on a
security/correctness-sensitive propagator.

**Change log entry**

None.

**Additional Notes:**

Signature/type-checking change plus small type-narrowing refactors. No public API change.

**How to test the change?**

`bundle exec rake steep:check` (clean) and `bundle exec rspec spec/datadog/tracing/distributed/`
(478 examples, 0 failures, 1 pre-existing pending).
