### PR TITLE
Synchronize native transport fork teardown

### DIFF
--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -6,18 +6,27 @@ module Datadog
       # Monkey patches `Kernel#fork` and similar functions, adding an `at_fork` callback mechanism which
       # is used to restart observability after the VM forks (e.g. in multiprocess Ruby apps).
       module AtForkMonkeyPatch
-        AT_FORK_BEFORE_BLOCKS = [] # rubocop:disable Style/MutableConstant -- Used to store blocks to run, mutable by design.
-        private_constant :AT_FORK_BEFORE_BLOCKS
+        class Callback
+          attr_reader :block
 
-        AT_FORK_PARENT_BLOCKS = [] # rubocop:disable Style/MutableConstant -- Used to store blocks to run, mutable by design.
-        private_constant :AT_FORK_PARENT_BLOCKS
+          def initialize(block)
+            @block = block
+            freeze
+          end
+        end
+        private_constant :Callback
 
-        AT_FORK_CHILD_BLOCKS = [] # rubocop:disable Style/MutableConstant -- Used to store blocks to run, mutable by design.
-        private_constant :AT_FORK_CHILD_BLOCKS
+        EMPTY_AT_FORK_BLOCKS = {
+          before: [].freeze,
+          parent: [].freeze,
+          child: [].freeze,
+        }.freeze
+        private_constant :EMPTY_AT_FORK_BLOCKS
 
-        # Keeps callback registration and removal atomic with the per-fork copy.
-        # Ruby mutexes cannot be acquired from signal traps, so calling fork
-        # directly from a Ruby signal handler is unsupported by this patch.
+        @at_fork_blocks = EMPTY_AT_FORK_BLOCKS
+
+        # Serializes copy-on-write registry updates. Fork dispatch only reads the
+        # latest immutable registry reference and never acquires this mutex.
         AT_FORK_REGISTRY_MUTEX = Mutex.new
         private_constant :AT_FORK_REGISTRY_MUTEX
 
@@ -46,14 +55,13 @@ module Datadog
         # Runs the callbacks copied for one fork lifecycle. Before callbacks
         # stop at the first failure; parent and child callbacks all run before
         # the first failure is re-raised.
-        def self.run_at_fork_blocks(stage, snapshot = nil)
-          blocks_for(stage) # Validate the stage before consulting a snapshot.
-          blocks = snapshot ? snapshot.fetch(stage) : snapshot_at_fork_blocks.fetch(stage)
-          return blocks.each(&:call) if stage == :before
+        def self.run_at_fork_blocks(stage, snapshot: nil)
+          callbacks = blocks_for(snapshot || snapshot_at_fork_blocks, stage)
+          return callbacks.each { |callback| callback.block.call } if stage == :before
 
           error = nil
-          blocks.each do |block|
-            block.call
+          callbacks.each do |callback|
+            callback.block.call
           rescue Exception => e # rubocop:disable Lint/RescueException -- finish cleanup, then re-raise the first failure
             error ||= e
           end
@@ -61,7 +69,7 @@ module Datadog
         end
 
         def self.run_parent_cleanup(snapshot, fork_error)
-          run_at_fork_blocks(:parent, snapshot)
+          run_at_fork_blocks(:parent, snapshot: snapshot)
         rescue Exception => cleanup_error # rubocop:disable Lint/RescueException -- preserve the original fork failure
           Datadog.logger.warn do
             "Parent at-fork cleanup failed while handling #{fork_error.class}: " \
@@ -78,7 +86,12 @@ module Datadog
         def self.at_fork(stage, &block)
           raise(ArgumentError, "Missing block argument") unless block
 
-          AT_FORK_REGISTRY_MUTEX.synchronize { blocks_for(stage) << block }
+          AT_FORK_REGISTRY_MUTEX.synchronize do
+            current = @at_fork_blocks
+            @at_fork_blocks = current.merge(
+              stage => (blocks_for(current, stage) + [Callback.new(block)]).freeze
+            ).freeze
+          end
 
           block
         end
@@ -88,7 +101,12 @@ module Datadog
         def self.at_fork_blocks(before:, parent:, child:)
           blocks = {before: before, parent: parent, child: child}
           AT_FORK_REGISTRY_MUTEX.synchronize do
-            blocks.each { |stage, block| blocks_for(stage) << block }
+            current = @at_fork_blocks
+            @at_fork_blocks = {
+              before: (current.fetch(:before) + [Callback.new(before)]).freeze,
+              parent: (current.fetch(:parent) + [Callback.new(parent)]).freeze,
+              child: (current.fetch(:child) + [Callback.new(child)]).freeze,
+            }.freeze
           end
           blocks
         end
@@ -98,28 +116,32 @@ module Datadog
         # registered (or was already removed). Raises +ArgumentError+ for an
         # unknown stage, matching the {.at_fork} contract.
         def self.remove_at_fork(stage, block)
-          AT_FORK_REGISTRY_MUTEX.synchronize { blocks_for(stage).delete(block) }
+          AT_FORK_REGISTRY_MUTEX.synchronize do
+            current = @at_fork_blocks
+            callbacks = blocks_for(current, stage)
+            @at_fork_blocks = current.merge(
+              stage => callbacks.reject { |callback| callback.block.equal?(block) }.freeze
+            ).freeze
+          end
 
           nil
         end
 
-        # Returns one per-fork copy of the blocks registered for every stage.
-        # Registrations made after the copy apply only to the next lifecycle.
+        # Returns the immutable callback registry for one fork lifecycle.
+        # Copy-on-write updates publish a new reference, so registrations made
+        # afterwards apply only to the next lifecycle without locking this read.
         def self.snapshot_at_fork_blocks
-          AT_FORK_REGISTRY_MUTEX.synchronize do
-            {
-              before: AT_FORK_BEFORE_BLOCKS.dup,
-              parent: AT_FORK_PARENT_BLOCKS.dup,
-              child: AT_FORK_CHILD_BLOCKS.dup,
-            }
-          end
+          @at_fork_blocks
         end
 
-        def self.blocks_for(stage)
+        def self.replace_at_fork_blocks(snapshot)
+          AT_FORK_REGISTRY_MUTEX.synchronize { @at_fork_blocks = snapshot }
+        end
+        private_class_method :replace_at_fork_blocks
+
+        def self.blocks_for(snapshot, stage)
           case stage
-          when :before then AT_FORK_BEFORE_BLOCKS
-          when :parent then AT_FORK_PARENT_BLOCKS
-          when :child then AT_FORK_CHILD_BLOCKS
+          when :before, :parent, :child then snapshot.fetch(stage)
           else raise(ArgumentError, "Unsupported stage #{stage}")
           end
         end
@@ -133,7 +155,7 @@ module Datadog
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
               proc do
-                AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
+                AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot: snapshot)
 
                 # Invoke original block
                 yield
@@ -142,7 +164,7 @@ module Datadog
 
             begin
               # Run pre-fork callbacks in the parent, just before forking.
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
 
               # Start fork. If a block is provided, use the wrapped version.
               result = child_block.nil? ? super : super(&child_block)
@@ -158,9 +180,9 @@ module Datadog
             # If we're in the parent, result = pid: trigger parent callbacks.
             # (If it gets called with a block, it only returns on the parent)
             if result.nil?
-              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot: snapshot)
             else
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot: snapshot)
             end
 
             result
@@ -174,7 +196,7 @@ module Datadog
           def _fork
             snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
               pid = super
             rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed, so no child was
@@ -184,9 +206,9 @@ module Datadog
             end
 
             if pid == 0
-              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot: snapshot)
             else
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot: snapshot)
             end
 
             pid
@@ -198,7 +220,7 @@ module Datadog
           def daemon(*args)
             snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
               result = super
             rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # `daemon` or a before-fork callback failed, so the original
@@ -209,7 +231,7 @@ module Datadog
 
             # `daemon` kills the parent, so there is no surviving parent to run
             # `:parent` callbacks in; only the child continues executing.
-            AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
+            AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot: snapshot)
 
             result
           end

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -15,6 +15,9 @@ module Datadog
         AT_FORK_CHILD_BLOCKS = [] # rubocop:disable Style/MutableConstant -- Used to store blocks to run, mutable by design.
         private_constant :AT_FORK_CHILD_BLOCKS
 
+        # Keeps callback registration and removal atomic with the per-fork copy.
+        # Ruby mutexes cannot be acquired from signal traps, so calling fork
+        # directly from a Ruby signal handler is unsupported by this patch.
         AT_FORK_REGISTRY_MUTEX = Mutex.new
         private_constant :AT_FORK_REGISTRY_MUTEX
 
@@ -100,8 +103,8 @@ module Datadog
           nil
         end
 
-        # Captures all stages under one lock. Registrations made after this
-        # point apply only to the next fork lifecycle.
+        # Returns one per-fork copy of the blocks registered for every stage.
+        # Registrations made after the copy apply only to the next lifecycle.
         def self.snapshot_at_fork_blocks
           AT_FORK_REGISTRY_MUTEX.synchronize do
             {

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -38,7 +38,9 @@ module Datadog
         end
 
         def self.run_at_fork_blocks(stage)
-          blocks_for(stage).each(&:call)
+          # A callback may deregister itself while it runs. Iterate a snapshot
+          # so every callback selected for this stage still gets its turn.
+          blocks_for(stage).dup.each(&:call)
         end
 
         # Registers a block to run at the given fork +stage+ (+:before+,
@@ -87,16 +89,15 @@ module Datadog
               end
             end
 
-            # Run pre-fork callbacks in the parent, just before forking.
-            AtForkMonkeyPatch.run_at_fork_blocks(:before)
-
-            # Start fork
-            # If a block is provided, use the wrapped version.
             begin
+              # Run pre-fork callbacks in the parent, just before forking.
+              AtForkMonkeyPatch.run_at_fork_blocks(:before)
+
+              # Start fork. If a block is provided, use the wrapped version.
               result = child_block.nil? ? super : super(&child_block)
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
-              # The fork failed and we are still in the parent; run `:parent` to
-              # restore any state the `:before` blocks set up, then re-raise.
+              # The fork or a before-fork callback failed and we are still in
+              # the parent. Restore any state set up by earlier callbacks.
               AtForkMonkeyPatch.run_at_fork_blocks(:parent)
               raise
             end
@@ -120,15 +121,12 @@ module Datadog
           # Hook provided by Ruby 3.1+ for observability libraries that want to know about fork, see
           # https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
           def _fork
-            AtForkMonkeyPatch.run_at_fork_blocks(:before)
-
             begin
+              AtForkMonkeyPatch.run_at_fork_blocks(:before)
               pid = super
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
-              # The fork failed, so no child was created and we are still in the
-              # parent. The `:before` blocks already ran (and may hold resources,
-              # e.g. a locked mutex); run the `:parent` blocks so that state is
-              # restored, then re-raise.
+              # The fork or a before-fork callback failed, so no child was
+              # created. Restore state set up by any earlier callbacks.
               AtForkMonkeyPatch.run_at_fork_blocks(:parent)
               raise
             end
@@ -146,13 +144,12 @@ module Datadog
           # keeps executing code in the child process, killing off the parent, thus effectively replacing it.
           # This is not covered by `_fork` and thus we have some extra code for it.
           def daemon(*args)
-            AtForkMonkeyPatch.run_at_fork_blocks(:before)
-
             begin
+              AtForkMonkeyPatch.run_at_fork_blocks(:before)
               result = super
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
-              # `daemon` failed, so the original process survives; run `:parent`
-              # to restore state the `:before` blocks set up, then re-raise.
+              # `daemon` or a before-fork callback failed, so the original
+              # process survives. Restore state set up by earlier callbacks.
               AtForkMonkeyPatch.run_at_fork_blocks(:parent)
               raise
             end

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -56,8 +56,8 @@ module Datadog
         # Runs the callbacks copied for one fork lifecycle. Before callbacks
         # stop at the first failure; parent and child callbacks all run before
         # the first failure is re-raised.
-        def self.run_at_fork_blocks(stage, snapshot: nil, started: nil)
-          callbacks = blocks_for(snapshot || snapshot_at_fork_blocks, stage)
+        def self.run_at_fork_blocks(stage, snapshot:, started: nil)
+          callbacks = blocks_for(snapshot, stage)
           if stage == :before
             return callbacks.each do |callback|
               started[callback.group] = true if started && callback.group

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -7,10 +7,11 @@ module Datadog
       # is used to restart observability after the VM forks (e.g. in multiprocess Ruby apps).
       module AtForkMonkeyPatch
         class Callback
-          attr_reader :block
+          attr_reader :block, :group
 
-          def initialize(block)
+          def initialize(block, group = nil)
             @block = block
+            @group = group
             freeze
           end
         end
@@ -55,12 +56,19 @@ module Datadog
         # Runs the callbacks copied for one fork lifecycle. Before callbacks
         # stop at the first failure; parent and child callbacks all run before
         # the first failure is re-raised.
-        def self.run_at_fork_blocks(stage, snapshot: nil)
+        def self.run_at_fork_blocks(stage, snapshot: nil, started: nil)
           callbacks = blocks_for(snapshot || snapshot_at_fork_blocks, stage)
-          return callbacks.each { |callback| callback.block.call } if stage == :before
+          if stage == :before
+            return callbacks.each do |callback|
+              started[callback.group] = true if started && callback.group
+              callback.block.call
+            end
+          end
 
           error = nil
           callbacks.each do |callback|
+            next if started && callback.group && !started.key?(callback.group)
+
             callback.block.call
           rescue Exception => e # rubocop:disable Lint/RescueException -- finish cleanup, then re-raise the first failure
             error ||= e
@@ -68,8 +76,8 @@ module Datadog
           raise error if error
         end
 
-        def self.run_parent_cleanup(snapshot, fork_error)
-          run_at_fork_blocks(:parent, snapshot: snapshot)
+        def self.run_parent_cleanup(snapshot, started, fork_error)
+          run_at_fork_blocks(:parent, snapshot: snapshot, started: started)
         rescue Exception => cleanup_error # rubocop:disable Lint/RescueException -- preserve the original fork failure
           Datadog.logger.warn do
             "Parent at-fork cleanup failed while handling #{fork_error.class}: " \
@@ -100,12 +108,13 @@ module Datadog
         # to the snapshots taken by fork dispatch.
         def self.at_fork_blocks(before:, parent:, child:)
           blocks = {before: before, parent: parent, child: child}
+          group = Object.new.freeze
           AT_FORK_REGISTRY_MUTEX.synchronize do
             current = @at_fork_blocks
             @at_fork_blocks = {
-              before: (current.fetch(:before) + [Callback.new(before)]).freeze,
-              parent: (current.fetch(:parent) + [Callback.new(parent)]).freeze,
-              child: (current.fetch(:child) + [Callback.new(child)]).freeze,
+              before: (current.fetch(:before) + [Callback.new(before, group)]).freeze,
+              parent: (current.fetch(:parent) + [Callback.new(parent, group)]).freeze,
+              child: (current.fetch(:child) + [Callback.new(child, group)]).freeze,
             }.freeze
           end
           blocks
@@ -151,6 +160,7 @@ module Datadog
         module KernelMonkeyPatch
           def fork
             snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
+            started = {}
 
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
@@ -164,14 +174,14 @@ module Datadog
 
             begin
               # Run pre-fork callbacks in the parent, just before forking.
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot, started: started)
 
               # Start fork. If a block is provided, use the wrapped version.
               result = child_block.nil? ? super : super(&child_block)
             rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed and we are still in
               # the parent. Restore any state set up by earlier callbacks.
-              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, started, e)
               raise
             end
 
@@ -195,13 +205,14 @@ module Datadog
           # https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
           def _fork
             snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
+            started = {}
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot, started: started)
               pid = super
             rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed, so no child was
               # created. Restore state set up by any earlier callbacks.
-              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, started, e)
               raise
             end
 
@@ -219,13 +230,14 @@ module Datadog
           # This is not covered by `_fork` and thus we have some extra code for it.
           def daemon(*args)
             snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
+            started = {}
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot: snapshot, started: started)
               result = super
             rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # `daemon` or a before-fork callback failed, so the original
               # process survives. Restore state set up by earlier callbacks.
-              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, started, e)
               raise
             end
 

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -40,6 +40,9 @@ module Datadog
           true
         end
 
+        # Runs the callbacks copied for one fork lifecycle. Before callbacks
+        # stop at the first failure; parent and child callbacks all run before
+        # the first failure is re-raised.
         def self.run_at_fork_blocks(stage, snapshot = nil)
           blocks_for(stage) # Validate the stage before consulting a snapshot.
           blocks = snapshot ? snapshot.fetch(stage) : snapshot_at_fork_blocks.fetch(stage)
@@ -53,6 +56,16 @@ module Datadog
           end
           raise error if error
         end
+
+        def self.run_parent_cleanup(snapshot, fork_error)
+          run_at_fork_blocks(:parent, snapshot)
+        rescue Exception => cleanup_error # rubocop:disable Lint/RescueException -- preserve the original fork failure
+          Datadog.logger.warn do
+            "Parent at-fork cleanup failed while handling #{fork_error.class}: " \
+              "#{cleanup_error.class}: #{cleanup_error.message}"
+          end
+        end
+        private_class_method :run_parent_cleanup
 
         # Registers a block to run at the given fork +stage+ (+:before+,
         # +:parent+, or +:child+).
@@ -130,10 +143,10 @@ module Datadog
 
               # Start fork. If a block is provided, use the wrapped version.
               result = child_block.nil? ? super : super(&child_block)
-            rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
+            rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed and we are still in
               # the parent. Restore any state set up by earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
               raise
             end
 
@@ -160,10 +173,10 @@ module Datadog
             begin
               AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
               pid = super
-            rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
+            rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed, so no child was
               # created. Restore state set up by any earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
               raise
             end
 
@@ -184,10 +197,10 @@ module Datadog
             begin
               AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
               result = super
-            rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
+            rescue Exception => e # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # `daemon` or a before-fork callback failed, so the original
               # process survives. Restore state set up by earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
+              AtForkMonkeyPatch.send(:run_parent_cleanup, snapshot, e)
               raise
             end
 

--- a/lib/datadog/core/utils/at_fork_monkey_patch.rb
+++ b/lib/datadog/core/utils/at_fork_monkey_patch.rb
@@ -15,6 +15,9 @@ module Datadog
         AT_FORK_CHILD_BLOCKS = [] # rubocop:disable Style/MutableConstant -- Used to store blocks to run, mutable by design.
         private_constant :AT_FORK_CHILD_BLOCKS
 
+        AT_FORK_REGISTRY_MUTEX = Mutex.new
+        private_constant :AT_FORK_REGISTRY_MUTEX
+
         def self.supported?
           Process.respond_to?(:fork)
         end
@@ -37,10 +40,18 @@ module Datadog
           true
         end
 
-        def self.run_at_fork_blocks(stage)
-          # A callback may deregister itself while it runs. Iterate a snapshot
-          # so every callback selected for this stage still gets its turn.
-          blocks_for(stage).dup.each(&:call)
+        def self.run_at_fork_blocks(stage, snapshot = nil)
+          blocks_for(stage) # Validate the stage before consulting a snapshot.
+          blocks = snapshot ? snapshot.fetch(stage) : snapshot_at_fork_blocks.fetch(stage)
+          return blocks.each(&:call) if stage == :before
+
+          error = nil
+          blocks.each do |block|
+            block.call
+          rescue Exception => e # rubocop:disable Lint/RescueException -- finish cleanup, then re-raise the first failure
+            error ||= e
+          end
+          raise error if error
         end
 
         # Registers a block to run at the given fork +stage+ (+:before+,
@@ -51,9 +62,19 @@ module Datadog
         def self.at_fork(stage, &block)
           raise(ArgumentError, "Missing block argument") unless block
 
-          blocks_for(stage) << block
+          AT_FORK_REGISTRY_MUTEX.synchronize { blocks_for(stage) << block }
 
           block
+        end
+
+        # Registers one before/parent/child callback triplet atomically relative
+        # to the snapshots taken by fork dispatch.
+        def self.at_fork_blocks(before:, parent:, child:)
+          blocks = {before: before, parent: parent, child: child}
+          AT_FORK_REGISTRY_MUTEX.synchronize do
+            blocks.each { |stage, block| blocks_for(stage) << block }
+          end
+          blocks
         end
 
         # Deregisters a block previously registered with {.at_fork} for the given
@@ -61,9 +82,21 @@ module Datadog
         # registered (or was already removed). Raises +ArgumentError+ for an
         # unknown stage, matching the {.at_fork} contract.
         def self.remove_at_fork(stage, block)
-          blocks_for(stage).delete(block)
+          AT_FORK_REGISTRY_MUTEX.synchronize { blocks_for(stage).delete(block) }
 
           nil
+        end
+
+        # Captures all stages under one lock. Registrations made after this
+        # point apply only to the next fork lifecycle.
+        def self.snapshot_at_fork_blocks
+          AT_FORK_REGISTRY_MUTEX.synchronize do
+            {
+              before: AT_FORK_BEFORE_BLOCKS.dup,
+              parent: AT_FORK_PARENT_BLOCKS.dup,
+              child: AT_FORK_CHILD_BLOCKS.dup,
+            }
+          end
         end
 
         def self.blocks_for(stage)
@@ -79,10 +112,12 @@ module Datadog
         # Adds `at_fork` behavior; see parent module for details.
         module KernelMonkeyPatch
           def fork
+            snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
+
             # If a block is provided, it must be wrapped to trigger callbacks.
             child_block = if block_given?
               proc do
-                AtForkMonkeyPatch.run_at_fork_blocks(:child)
+                AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
 
                 # Invoke original block
                 yield
@@ -91,14 +126,14 @@ module Datadog
 
             begin
               # Run pre-fork callbacks in the parent, just before forking.
-              AtForkMonkeyPatch.run_at_fork_blocks(:before)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
 
               # Start fork. If a block is provided, use the wrapped version.
               result = child_block.nil? ? super : super(&child_block)
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed and we are still in
               # the parent. Restore any state set up by earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
               raise
             end
 
@@ -107,9 +142,9 @@ module Datadog
             # If we're in the parent, result = pid: trigger parent callbacks.
             # (If it gets called with a block, it only returns on the parent)
             if result.nil?
-              AtForkMonkeyPatch.run_at_fork_blocks(:child)
+              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
             else
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
             end
 
             result
@@ -121,20 +156,21 @@ module Datadog
           # Hook provided by Ruby 3.1+ for observability libraries that want to know about fork, see
           # https://github.com/ruby/ruby/pull/5017 and https://bugs.ruby-lang.org/issues/17795
           def _fork
+            snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
               pid = super
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # The fork or a before-fork callback failed, so no child was
               # created. Restore state set up by any earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
               raise
             end
 
             if pid == 0
-              AtForkMonkeyPatch.run_at_fork_blocks(:child)
+              AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
             else
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
             end
 
             pid
@@ -144,19 +180,20 @@ module Datadog
           # keeps executing code in the child process, killing off the parent, thus effectively replacing it.
           # This is not covered by `_fork` and thus we have some extra code for it.
           def daemon(*args)
+            snapshot = AtForkMonkeyPatch.snapshot_at_fork_blocks
             begin
-              AtForkMonkeyPatch.run_at_fork_blocks(:before)
+              AtForkMonkeyPatch.run_at_fork_blocks(:before, snapshot)
               result = super
             rescue Exception # rubocop:disable Lint/RescueException -- re-raised unchanged; we only need to run parent cleanup first
               # `daemon` or a before-fork callback failed, so the original
               # process survives. Restore state set up by earlier callbacks.
-              AtForkMonkeyPatch.run_at_fork_blocks(:parent)
+              AtForkMonkeyPatch.run_at_fork_blocks(:parent, snapshot)
               raise
             end
 
             # `daemon` kills the parent, so there is no surviving parent to run
             # `:parent` callbacks in; only the child continues executing.
-            AtForkMonkeyPatch.run_at_fork_blocks(:child)
+            AtForkMonkeyPatch.run_at_fork_blocks(:child, snapshot)
 
             result
           end

--- a/lib/datadog/tracing/transport/native.rb
+++ b/lib/datadog/tracing/transport/native.rb
@@ -65,6 +65,12 @@ module Datadog
             # fork-safety note below.
             @send_mutex = Mutex.new
 
+            # Serializes fork-hook execution with close/finalization. Unlike
+            # @send_mutex, this is held for the complete fork lifecycle so the
+            # matching parent/child hooks cannot be deregistered mid-fork.
+            @fork_mutex = Mutex.new
+            @fork_state = {closed: false, pending: 0}
+
             url = agent_settings.url
             tracer_version = tracer_version_string
             language = Core::Environment::Ext::LANG
@@ -106,8 +112,16 @@ module Datadog
             # also tears down and replaces the runtime, so it must not run while
             # a send is still using that runtime.
             #
-            # `@send_mutex` serializes sends (see #send_traces) and is held
-            # across the fork. The `:before` hook first calls
+            # `@fork_mutex` prevents close/finalization from deregistering the
+            # completion hooks after `:before` has started. The `:before` hook
+            # locks it first, then calls `_native_before_fork`, and finally
+            # locks `@send_mutex`, which serializes sends and is held across the
+            # fork. This lock order is also used by #close; sends only acquire
+            # `@send_mutex`, so there is no inverse path.
+            #
+            # `_native_before_fork` must run before locking `@send_mutex` to
+            # pause the runtime before waiting for an in-flight send to drain.
+            # The hook first calls
             # `_native_before_fork` to pause the runtime, THEN locks the mutex.
             # This ordering minimizes the serialized section and is safe to run
             # concurrently with an in-flight send: `block_on` (used by
@@ -137,24 +151,42 @@ module Datadog
             # the closures keep the exporter -- and its runtime threads -- alive
             # forever, and every later fork runs them against every
             # historically-created exporter. The closures intentionally capture
-            # only the `exporter`/`send_mutex` locals (NOT `self`), so the
-            # Transport stays GC-eligible and its finalizer can fire even when
-            # #close was not called explicitly.
+            # only locals (NOT `self`), so the Transport stays GC-eligible and
+            # its finalizer can fire even when #close was not called explicitly.
             send_mutex = @send_mutex
+            fork_mutex = @fork_mutex
+            fork_state = @fork_state
             before_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:before) do
-              # Pause the runtime first (safe to run concurrently with an
-              # in-flight send), then drain by locking the mutex. The lock must
-              # happen even if `_native_before_fork` raises, so the in-flight
-              # send has returned (dropping the runtime's last `Arc`) before the
-              # fork. Held across the fork; released in :parent/:child.
-              exporter._native_before_fork
-            rescue => e
-              Datadog.logger.warn { "Native transport before-fork preparation failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
-            ensure
-              send_mutex.lock
+              # Announce before blocking: close may already hold @fork_mutex
+              # while it waits for a send, and must yield to this hook rather
+              # than deregistering its matching parent/child hooks.
+              fork_state[:pending] += 1
+              begin
+                fork_mutex.lock
+              ensure
+                fork_state[:pending] -= 1
+              end
+
+              if fork_state[:closed]
+                fork_mutex.unlock
+                next
+              end
+
+              begin
+                # Pause the runtime first (safe to run concurrently with an
+                # in-flight send), then drain by locking the mutex. The lock
+                # must happen even if `_native_before_fork` raises, so the
+                # in-flight send has returned before the fork. Held across the
+                # fork; released in :parent/:child.
+                exporter._native_before_fork
+              rescue => e
+                Datadog.logger.warn { "Native transport before-fork preparation failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
+              ensure
+                send_mutex.lock
+              end
             end
             parent_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:parent) do
-              exporter._native_after_fork_in_parent
+              exporter._native_after_fork_in_parent if fork_mutex.owned?
             rescue => e
               Datadog.logger.warn { "Native transport after-fork reset failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
             ensure
@@ -164,9 +196,10 @@ module Datadog
               # between `_native_before_fork` and the lock). Released even if the
               # native call raised, so a failure can't leave the mutex locked.
               send_mutex.unlock if send_mutex.owned?
+              fork_mutex.unlock if fork_mutex.owned?
             end
             child_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:child) do
-              exporter._native_after_fork_in_child
+              exporter._native_after_fork_in_child if fork_mutex.owned?
             rescue => e
               Datadog.logger.warn { "Native transport after-fork reset failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
             ensure
@@ -174,6 +207,7 @@ module Datadog
               # lone survivor in the child); the guard only covers `:before`
               # being interrupted mid-lock.
               send_mutex.unlock if send_mutex.owned?
+              fork_mutex.unlock if fork_mutex.owned?
             end
 
             @fork_hooks = {before: before_hook, parent: parent_hook, child: child_hook}
@@ -184,34 +218,60 @@ module Datadog
             # stage->block handles, never `self` -- a finalizer that closed over
             # the object it is attached to would keep that object reachable and
             # never run.
-            ObjectSpace.define_finalizer(self, self.class.send(:finalizer_for, @fork_hooks))
+            ObjectSpace.define_finalizer(
+              self,
+              self.class.send(:finalizer_for, @fork_hooks, fork_mutex, fork_state)
+            )
           end
 
           # Deregister this transport's process-global fork hooks and release the
           # native exporter so its runtime can shut down. Idempotent: safe to
           # call multiple times and safe to call after the finalizer has run.
           def close
+            # Acquire both locks only when no before-fork hook is already
+            # waiting. A hook can announce itself while we wait for an active
+            # send, so check again after acquiring @send_mutex.
+            loop do
+              @fork_mutex.lock
+              if @fork_state[:pending] > 0
+                @fork_mutex.unlock
+                Thread.pass
+                next
+              end
+
+              @send_mutex.lock
+              break if @fork_state[:pending] == 0
+
+              @send_mutex.unlock
+              @fork_mutex.unlock
+              Thread.pass
+            end
+
             fork_hooks = @fork_hooks
-            @fork_hooks = nil
             return if fork_hooks.nil?
+
+            @fork_state[:closed] = true
+            @fork_hooks = nil
 
             fork_hooks.each do |stage, block|
               Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
             end
 
-            # Drop our reference to the exporter so that, once the hooks above no
-            # longer pin it, it can be collected and its runtime shut down
+            # Drop our reference to the exporter so that, once the hooks above
+            # no longer pin it, it can be collected and its runtime shut down
             # cleanly in this (parent) process.
             @exporter = nil
 
             # The finalizer only exists to deregister the hooks for a transport
             # dropped without #close. We have just done that, so remove it;
-            # otherwise its captured hook blocks keep the exporter (and its
-            # runtime threads) alive until this still-reachable transport is
-            # itself collected.
+            # otherwise its captured hook blocks keep the exporter alive until
+            # this transport is itself collected.
             ObjectSpace.undefine_finalizer(self)
 
             nil
+          ensure
+            @send_mutex.unlock if @send_mutex.owned?
+            @fork_mutex.unlock if @fork_mutex.owned?
           end
 
           # Builds the finalizer proc for a transport's fork hooks.
@@ -221,10 +281,23 @@ module Datadog
           # (which would keep the instance reachable and prevent the finalizer
           # from ever running). Removing the hooks unpins the exporter captured
           # by those closures, allowing it (and its runtime) to be freed.
-          def self.finalizer_for(fork_hooks)
+          def self.finalizer_for(fork_hooks, fork_mutex, fork_state)
             proc do
-              fork_hooks.each do |stage, block|
-                Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
+              loop do
+                fork_mutex.lock
+                break if fork_state[:pending] == 0
+
+                fork_mutex.unlock
+                Thread.pass
+              end
+
+              begin
+                fork_state[:closed] = true
+                fork_hooks.each do |stage, block|
+                  Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
+                end
+              ensure
+                fork_mutex.unlock if fork_mutex.owned?
               end
             end
           end
@@ -239,12 +312,6 @@ module Datadog
           # @return [Array<Response>] one response per batch sent
           def send_traces(traces)
             return [] if traces.empty?
-
-            # A closed transport has released its exporter; there is nothing to
-            # send through. Raising here is caught below and surfaced as an
-            # InternalErrorResponse, matching the other failure paths.
-            exporter = @exporter
-            raise "Native transport has been closed" if exporter.nil?
 
             # Apply trace-level tags to root spans (same as the HTTP transport)
             traces.each { |trace| TraceFormatter.format!(trace) }
@@ -263,7 +330,14 @@ module Datadog
             # (and `_native_before_fork` cannot tear down the runtime mid-send).
             # `Mutex#synchronize` releases on exception / `rb_jump_tag` via its
             # ensure, so interrupt propagation stays correct.
-            responses = @send_mutex.synchronize { exporter._native_send_traces(chunks) }
+            responses = @send_mutex.synchronize do
+              # Resolve the exporter under the same lock used by #close, so
+              # close either drains this send or prevents it from starting.
+              exporter = @exporter
+              raise "Native transport has been closed" if exporter.nil?
+
+              exporter._native_send_traces(chunks)
+            end
 
             # Update statistics from the response
             responses.each { |response| update_stats_from_response!(response) }

--- a/lib/datadog/tracing/transport/native.rb
+++ b/lib/datadog/tracing/transport/native.rb
@@ -65,11 +65,9 @@ module Datadog
             # fork-safety note below.
             @send_mutex = Mutex.new
 
-            # Serializes fork-hook execution with close/finalization. Unlike
-            # @send_mutex, this is held for the complete fork lifecycle so the
-            # matching parent/child hooks cannot be deregistered mid-fork.
+            # Serializes concurrent fork-hook lifecycles. Unlike @send_mutex,
+            # this is held across the fork through the matching completion hook.
             @fork_mutex = Mutex.new
-            @fork_state = {closed: false, pending: 0, forking: false, finalize: false}
 
             url = agent_settings.url
             tracer_version = tracer_version_string
@@ -112,12 +110,11 @@ module Datadog
             # also tears down and replaces the runtime, so it must not run while
             # a send is still using that runtime.
             #
-            # `@fork_mutex` prevents close/finalization from deregistering the
-            # completion hooks after `:before` has started. The `:before` hook
-            # locks it first, then calls `_native_before_fork`, and finally
-            # locks `@send_mutex`, which serializes sends and is held across the
-            # fork. This lock order is also used by #close; sends only acquire
-            # `@send_mutex`, so there is no inverse path.
+            # `@fork_mutex` serializes concurrent forks for this exporter. The
+            # `:before` hook locks it first, then calls `_native_before_fork`,
+            # and finally locks `@send_mutex`, which serializes sends and is
+            # held across the fork. Sends and #close only acquire @send_mutex,
+            # so there is no lock-order inversion.
             #
             # `_native_before_fork` must run before locking `@send_mutex` to
             # pause the runtime before waiting for an in-flight send to drain.
@@ -155,24 +152,8 @@ module Datadog
             # its finalizer can fire even when #close was not called explicitly.
             send_mutex = @send_mutex
             fork_mutex = @fork_mutex
-            fork_state = @fork_state
-            remove_fork_hooks = nil
             before_hook = proc do
-              # Announce before blocking: close may already hold @fork_mutex
-              # while it waits for a send, and must yield to this hook rather
-              # than deregistering its matching parent/child hooks.
-              fork_state[:pending] += 1
-              begin
-                fork_mutex.lock
-              ensure
-                fork_state[:pending] -= 1
-              end
-
-              if fork_state[:closed]
-                fork_mutex.unlock
-                next
-              end
-              fork_state[:forking] = true
+              fork_mutex.lock
 
               begin
                 # Pause the runtime first (safe to run concurrently with an
@@ -198,13 +179,9 @@ module Datadog
               # between `_native_before_fork` and the lock). Released even if the
               # native call raised, so a failure can't leave the mutex locked.
               send_mutex.unlock if send_mutex.owned?
-              fork_state[:forking] = false
-              remove_fork_hooks.call if fork_state[:finalize]
               fork_mutex.unlock if fork_mutex.owned?
             end
             child_hook = proc do
-              # Other threads waiting to fork do not survive into the child.
-              fork_state[:pending] = 0
               exporter._native_after_fork_in_child if fork_mutex.owned?
             rescue => e
               Datadog.logger.warn { "Native transport after-fork reset failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
@@ -213,8 +190,6 @@ module Datadog
               # lone survivor in the child); the guard only covers `:before`
               # being interrupted mid-lock.
               send_mutex.unlock if send_mutex.owned?
-              fork_state[:forking] = false
-              remove_fork_hooks.call if fork_state[:finalize]
               fork_mutex.unlock if fork_mutex.owned?
             end
 
@@ -223,17 +198,18 @@ module Datadog
               parent: parent_hook,
               child: child_hook
             )
-            remove_fork_hooks = self.class.send(:fork_hooks_remover, @fork_hooks, fork_state)
+            remove_fork_hooks = self.class.send(:fork_hooks_remover, @fork_hooks)
 
             # Fallback so a dropped (un-#close'd) transport doesn't leak its
             # global fork hooks (and, through them, the exporter/runtime). The
-            # finalizer proc is built by a class method capturing ONLY the
+            # removal proc is built by a class method capturing ONLY the
             # stage->block handles, never `self` -- a finalizer that closed over
             # the object it is attached to would keep that object reachable and
-            # never run.
+            # never run. A fork that already copied these callbacks still owns
+            # them through its matching completion stage.
             ObjectSpace.define_finalizer(
               self,
-              self.class.send(:finalizer_for, fork_mutex, fork_state, remove_fork_hooks)
+              remove_fork_hooks
             )
           end
 
@@ -241,47 +217,18 @@ module Datadog
           # native exporter so its runtime can shut down. Idempotent: safe to
           # call multiple times and safe to call after the finalizer has run.
           def close
-            fork_locked = false
-            send_locked = false
+            fork_hooks = @send_mutex.synchronize do
+              hooks = @fork_hooks
+              return if hooks.nil?
 
-            # Acquire both locks only when no before-fork hook is already
-            # waiting. A hook can announce itself while we wait for an active
-            # send, so check again after acquiring @send_mutex.
-            loop do
-              @fork_mutex.lock
-              fork_locked = true
-              if @fork_state[:pending] > 0
-                @fork_mutex.unlock
-                fork_locked = false
-                Thread.pass
-                next
-              end
-
-              @send_mutex.lock
-              send_locked = true
-              break if @fork_state[:pending] == 0
-
-              @send_mutex.unlock
-              send_locked = false
-              @fork_mutex.unlock
-              fork_locked = false
-              Thread.pass
+              @fork_hooks = nil
+              @exporter = nil
+              hooks
             end
-
-            fork_hooks = @fork_hooks
-            return if fork_hooks.nil?
-
-            @fork_state[:closed] = true
-            @fork_hooks = nil
 
             fork_hooks.each do |stage, block|
               Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
             end
-
-            # Drop our reference to the exporter so that, once the hooks above
-            # no longer pin it, it can be collected and its runtime shut down
-            # cleanly in this (parent) process.
-            @exporter = nil
 
             # The finalizer only exists to deregister the hooks for a transport
             # dropped without #close. We have just done that, so remove it;
@@ -290,61 +237,23 @@ module Datadog
             ObjectSpace.undefine_finalizer(self)
 
             nil
-          ensure
-            @send_mutex.unlock if send_locked && @send_mutex.owned?
-            @fork_mutex.unlock if fork_locked && @fork_mutex.owned?
           end
 
-          # Builds the finalizer proc for a transport's fork hooks.
+          # Builds the proc that deregisters a transport's fork hooks.
           #
           # Defined as a class method so the proc closes over ONLY the
           # stage->block handles passed in and never over a Transport instance
           # (which would keep the instance reachable and prevent the finalizer
           # from ever running). Removing the hooks unpins the exporter captured
           # by those closures, allowing it (and its runtime) to be freed.
-          def self.fork_hooks_remover(fork_hooks, fork_state)
+          def self.fork_hooks_remover(fork_hooks)
             proc do
-              fork_state[:closed] = true
-              fork_state[:finalize] = false
               fork_hooks.each do |stage, block|
                 Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
               end
             end
           end
           private_class_method :fork_hooks_remover
-
-          def self.finalizer_for(fork_mutex, fork_state, remove_fork_hooks)
-            proc do
-              # Mutex is not reentrant. A finalizer can run at a safe point on
-              # the owning thread, so either remove directly or let the active
-              # fork's completion callback restore state before removing.
-              if fork_mutex.owned?
-                if fork_state[:forking]
-                  # The matching parent/child callback must restore the runtime
-                  # and release both locks before deregistering its own hooks.
-                  fork_state[:finalize] = true
-                else
-                  remove_fork_hooks.call
-                end
-                next
-              end
-
-              loop do
-                fork_mutex.lock
-                break if fork_state[:pending] == 0
-
-                fork_mutex.unlock
-                Thread.pass
-              end
-
-              begin
-                remove_fork_hooks.call
-              ensure
-                fork_mutex.unlock if fork_mutex.owned?
-              end
-            end
-          end
-          private_class_method :finalizer_for
 
           # Send a list of traces to the agent.
           #

--- a/lib/datadog/tracing/transport/native.rb
+++ b/lib/datadog/tracing/transport/native.rb
@@ -147,8 +147,8 @@ module Datadog
             # hooks when it goes away (see #close and the finalizer): otherwise
             # the closures keep the exporter -- and its runtime threads -- alive
             # forever, and every later fork runs them against every
-            # historically-created exporter. The closures intentionally capture
-            # only locals (NOT `self`), so the Transport stays GC-eligible and
+            # historically-created exporter. The closures intentionally close
+            # over only locals (NOT `self`), so the Transport stays GC-eligible and
             # its finalizer can fire even when #close was not called explicitly.
             send_mutex = @send_mutex
             fork_mutex = @fork_mutex
@@ -157,8 +157,8 @@ module Datadog
 
               begin
                 # Pause the runtime first (safe to run concurrently with an
-                # in-flight send), then drain by locking the mutex. The lock
-                # must happen even if `_native_before_fork` raises, so the
+                # in-flight send), then wait for it to drain by acquiring the
+                # mutex. The lock must happen even if `_native_before_fork` raises, so the
                 # in-flight send has returned before the fork. Held across the
                 # fork; released in :parent/:child.
                 exporter._native_before_fork
@@ -232,7 +232,7 @@ module Datadog
 
             # The finalizer only exists to deregister the hooks for a transport
             # dropped without #close. We have just done that, so remove it;
-            # otherwise its captured hook blocks keep the exporter alive until
+            # otherwise its closed-over hook blocks keep the exporter alive until
             # this transport is itself collected.
             ObjectSpace.undefine_finalizer(self)
 

--- a/lib/datadog/tracing/transport/native.rb
+++ b/lib/datadog/tracing/transport/native.rb
@@ -69,7 +69,7 @@ module Datadog
             # @send_mutex, this is held for the complete fork lifecycle so the
             # matching parent/child hooks cannot be deregistered mid-fork.
             @fork_mutex = Mutex.new
-            @fork_state = {closed: false, pending: 0}
+            @fork_state = {closed: false, pending: 0, forking: false, finalize: false}
 
             url = agent_settings.url
             tracer_version = tracer_version_string
@@ -156,6 +156,7 @@ module Datadog
             send_mutex = @send_mutex
             fork_mutex = @fork_mutex
             fork_state = @fork_state
+            remove_fork_hooks = nil
             before_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:before) do
               # Announce before blocking: close may already hold @fork_mutex
               # while it waits for a send, and must yield to this hook rather
@@ -171,6 +172,7 @@ module Datadog
                 fork_mutex.unlock
                 next
               end
+              fork_state[:forking] = true
 
               begin
                 # Pause the runtime first (safe to run concurrently with an
@@ -196,6 +198,8 @@ module Datadog
               # between `_native_before_fork` and the lock). Released even if the
               # native call raised, so a failure can't leave the mutex locked.
               send_mutex.unlock if send_mutex.owned?
+              fork_state[:forking] = false
+              remove_fork_hooks.call if fork_state[:finalize]
               fork_mutex.unlock if fork_mutex.owned?
             end
             child_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:child) do
@@ -207,10 +211,13 @@ module Datadog
               # lone survivor in the child); the guard only covers `:before`
               # being interrupted mid-lock.
               send_mutex.unlock if send_mutex.owned?
+              fork_state[:forking] = false
+              remove_fork_hooks.call if fork_state[:finalize]
               fork_mutex.unlock if fork_mutex.owned?
             end
 
             @fork_hooks = {before: before_hook, parent: parent_hook, child: child_hook}
+            remove_fork_hooks = self.class.send(:fork_hooks_remover, @fork_hooks, fork_state)
 
             # Fallback so a dropped (un-#close'd) transport doesn't leak its
             # global fork hooks (and, through them, the exporter/runtime). The
@@ -220,7 +227,7 @@ module Datadog
             # never run.
             ObjectSpace.define_finalizer(
               self,
-              self.class.send(:finalizer_for, @fork_hooks, fork_mutex, fork_state)
+              self.class.send(:finalizer_for, fork_mutex, fork_state, remove_fork_hooks)
             )
           end
 
@@ -281,8 +288,33 @@ module Datadog
           # (which would keep the instance reachable and prevent the finalizer
           # from ever running). Removing the hooks unpins the exporter captured
           # by those closures, allowing it (and its runtime) to be freed.
-          def self.finalizer_for(fork_hooks, fork_mutex, fork_state)
+          def self.fork_hooks_remover(fork_hooks, fork_state)
             proc do
+              fork_state[:closed] = true
+              fork_state[:finalize] = false
+              fork_hooks.each do |stage, block|
+                Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
+              end
+            end
+          end
+          private_class_method :fork_hooks_remover
+
+          def self.finalizer_for(fork_mutex, fork_state, remove_fork_hooks)
+            proc do
+              # Mutex is not reentrant. A finalizer can run at a safe point on
+              # the owning thread, so either remove directly or let the active
+              # fork's completion callback restore state before removing.
+              if fork_mutex.owned?
+                if fork_state[:forking]
+                  # The matching parent/child callback must restore the runtime
+                  # and release both locks before deregistering its own hooks.
+                  fork_state[:finalize] = true
+                else
+                  remove_fork_hooks.call
+                end
+                next
+              end
+
               loop do
                 fork_mutex.lock
                 break if fork_state[:pending] == 0
@@ -292,10 +324,7 @@ module Datadog
               end
 
               begin
-                fork_state[:closed] = true
-                fork_hooks.each do |stage, block|
-                  Core::Utils::AtForkMonkeyPatch.remove_at_fork(stage, block)
-                end
+                remove_fork_hooks.call
               ensure
                 fork_mutex.unlock if fork_mutex.owned?
               end

--- a/lib/datadog/tracing/transport/native.rb
+++ b/lib/datadog/tracing/transport/native.rb
@@ -157,7 +157,7 @@ module Datadog
             fork_mutex = @fork_mutex
             fork_state = @fork_state
             remove_fork_hooks = nil
-            before_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:before) do
+            before_hook = proc do
               # Announce before blocking: close may already hold @fork_mutex
               # while it waits for a send, and must yield to this hook rather
               # than deregistering its matching parent/child hooks.
@@ -187,7 +187,7 @@ module Datadog
                 send_mutex.lock
               end
             end
-            parent_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:parent) do
+            parent_hook = proc do
               exporter._native_after_fork_in_parent if fork_mutex.owned?
             rescue => e
               Datadog.logger.warn { "Native transport after-fork reset failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
@@ -202,7 +202,9 @@ module Datadog
               remove_fork_hooks.call if fork_state[:finalize]
               fork_mutex.unlock if fork_mutex.owned?
             end
-            child_hook = Core::Utils::AtForkMonkeyPatch.at_fork(:child) do
+            child_hook = proc do
+              # Other threads waiting to fork do not survive into the child.
+              fork_state[:pending] = 0
               exporter._native_after_fork_in_child if fork_mutex.owned?
             rescue => e
               Datadog.logger.warn { "Native transport after-fork reset failed; traces may not be sent to Datadog: #{e.class}: #{e.message}" }
@@ -216,7 +218,11 @@ module Datadog
               fork_mutex.unlock if fork_mutex.owned?
             end
 
-            @fork_hooks = {before: before_hook, parent: parent_hook, child: child_hook}
+            @fork_hooks = Core::Utils::AtForkMonkeyPatch.at_fork_blocks(
+              before: before_hook,
+              parent: parent_hook,
+              child: child_hook
+            )
             remove_fork_hooks = self.class.send(:fork_hooks_remover, @fork_hooks, fork_state)
 
             # Fallback so a dropped (un-#close'd) transport doesn't leak its
@@ -235,22 +241,30 @@ module Datadog
           # native exporter so its runtime can shut down. Idempotent: safe to
           # call multiple times and safe to call after the finalizer has run.
           def close
+            fork_locked = false
+            send_locked = false
+
             # Acquire both locks only when no before-fork hook is already
             # waiting. A hook can announce itself while we wait for an active
             # send, so check again after acquiring @send_mutex.
             loop do
               @fork_mutex.lock
+              fork_locked = true
               if @fork_state[:pending] > 0
                 @fork_mutex.unlock
+                fork_locked = false
                 Thread.pass
                 next
               end
 
               @send_mutex.lock
+              send_locked = true
               break if @fork_state[:pending] == 0
 
               @send_mutex.unlock
+              send_locked = false
               @fork_mutex.unlock
+              fork_locked = false
               Thread.pass
             end
 
@@ -277,8 +291,8 @@ module Datadog
 
             nil
           ensure
-            @send_mutex.unlock if @send_mutex.owned?
-            @fork_mutex.unlock if @fork_mutex.owned?
+            @send_mutex.unlock if send_locked && @send_mutex.owned?
+            @fork_mutex.unlock if fork_locked && @fork_mutex.owned?
           end
 
           # Builds the finalizer proc for a transport's fork hooks.

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -3,15 +3,19 @@ module Datadog
   module Core
     module Utils
       module AtForkMonkeyPatch
-        AT_FORK_CHILD_BLOCKS: ::Array[untyped]
+        class Callback
+          attr_reader block: Proc
+
+          def initialize: (Proc block) -> void
+        end
 
         def self.supported?: () -> (false | true)
 
         def self.apply!: () -> (false | true)
 
-        def self.run_at_fork_blocks: (Symbol stage, ?Hash[Symbol, Array[Proc]] snapshot) -> void
+        def self.run_at_fork_blocks: (Symbol stage, ?snapshot: Hash[Symbol, Array[Callback]]) -> void
 
-        def self.run_parent_cleanup: (Hash[Symbol, Array[Proc]] snapshot, Exception fork_error) -> void
+        def self.run_parent_cleanup: (Hash[Symbol, Array[Callback]] snapshot, Exception fork_error) -> void
 
         def self.at_fork: (Symbol stage) { () -> untyped } -> Proc
 
@@ -19,7 +23,9 @@ module Datadog
 
         def self.remove_at_fork: (Symbol stage, Proc block) -> void
 
-        def self.snapshot_at_fork_blocks: () -> Hash[Symbol, Array[Proc]]
+        def self.snapshot_at_fork_blocks: () -> Hash[Symbol, Array[Callback]]
+
+        def self.replace_at_fork_blocks: (Hash[Symbol, Array[Callback]] snapshot) -> void
 
         module KernelMonkeyPatch
           def fork: () ?{ () -> untyped } -> untyped

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -11,6 +11,8 @@ module Datadog
 
         def self.run_at_fork_blocks: (Symbol stage, ?Hash[Symbol, Array[Proc]] snapshot) -> void
 
+        def self.run_parent_cleanup: (Hash[Symbol, Array[Proc]] snapshot, Exception fork_error) -> void
+
         def self.at_fork: (Symbol stage) { () -> untyped } -> Proc
 
         def self.at_fork_blocks: (before: Proc, parent: Proc, child: Proc) -> Hash[Symbol, Proc]

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -9,11 +9,15 @@ module Datadog
 
         def self.apply!: () -> (false | true)
 
-        def self.run_at_fork_blocks: (Symbol stage) -> void
+        def self.run_at_fork_blocks: (Symbol stage, ?Hash[Symbol, Array[Proc]] snapshot) -> void
 
         def self.at_fork: (Symbol stage) { () -> untyped } -> Proc
 
+        def self.at_fork_blocks: (before: Proc, parent: Proc, child: Proc) -> Hash[Symbol, Proc]
+
         def self.remove_at_fork: (Symbol stage, Proc block) -> void
+
+        def self.snapshot_at_fork_blocks: () -> Hash[Symbol, Array[Proc]]
 
         module KernelMonkeyPatch
           def fork: () ?{ () -> untyped } -> untyped

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -16,7 +16,7 @@ module Datadog
 
         def self.apply!: () -> (false | true)
 
-        def self.run_at_fork_blocks: (Symbol stage, ?snapshot: Hash[Symbol, Array[Callback]], ?started: Hash[Object, bool]) -> void
+        def self.run_at_fork_blocks: (Symbol stage, snapshot: Hash[Symbol, Array[Callback]], ?started: Hash[Object, bool]) -> void
 
         def self.run_parent_cleanup: (Hash[Symbol, Array[Callback]] snapshot, Hash[Object, bool] started, Exception fork_error) -> void
 

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -5,17 +5,18 @@ module Datadog
       module AtForkMonkeyPatch
         class Callback
           attr_reader block: Proc
+          attr_reader group: Object?
 
-          def initialize: (Proc block) -> void
+          def initialize: (Proc block, ?Object? group) -> void
         end
 
         def self.supported?: () -> (false | true)
 
         def self.apply!: () -> (false | true)
 
-        def self.run_at_fork_blocks: (Symbol stage, ?snapshot: Hash[Symbol, Array[Callback]]) -> void
+        def self.run_at_fork_blocks: (Symbol stage, ?snapshot: Hash[Symbol, Array[Callback]], ?started: Hash[Object, bool]) -> void
 
-        def self.run_parent_cleanup: (Hash[Symbol, Array[Callback]] snapshot, Exception fork_error) -> void
+        def self.run_parent_cleanup: (Hash[Symbol, Array[Callback]] snapshot, Hash[Object, bool] started, Exception fork_error) -> void
 
         def self.at_fork: (Symbol stage) { () -> untyped } -> Proc
 

--- a/sig/datadog/core/utils/at_fork_monkey_patch.rbs
+++ b/sig/datadog/core/utils/at_fork_monkey_patch.rbs
@@ -3,6 +3,8 @@ module Datadog
   module Core
     module Utils
       module AtForkMonkeyPatch
+        @at_fork_blocks: Hash[Symbol, Array[Callback]]
+
         class Callback
           attr_reader block: Proc
           attr_reader group: Object?

--- a/sig/datadog/tracing/transport/native.rbs
+++ b/sig/datadog/tracing/transport/native.rbs
@@ -31,13 +31,14 @@ module Datadog
           @logger: Datadog::Core::Logger
           @exporter: TraceExporter?
           @send_mutex: Thread::Mutex
+          @fork_mutex: Thread::Mutex
           @fork_hooks: Hash[Symbol, Proc]?
           @unsupported_fields_warned: bool
 
           attr_reader logger: Datadog::Core::Logger
 
           def initialize: (agent_settings: Datadog::Core::Configuration::AgentSettings, logger: Datadog::Core::Logger) -> void
-          def self.finalizer_for: (Hash[Symbol, Proc] fork_hooks) -> Proc
+          def self.fork_hooks_remover: (Hash[Symbol, Proc] fork_hooks) -> Proc
           def close: () -> void
           def send_traces: (Array[Datadog::Tracing::TraceSegment] traces) -> Array[Response | InternalErrorResponse]
 

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -377,6 +377,24 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
           expect { process_module._fork }.to raise_error(error)
         end
 
+        it "cleans up only callback triplets whose before stage started" do
+          calls = []
+          error = RuntimeError.new("before failed")
+          at_fork = Datadog::Core::Utils::AtForkMonkeyPatch
+          at_fork.at_fork_blocks(
+            before: proc { calls << :started_before; raise error },
+            parent: proc { calls << :started_parent },
+            child: proc { calls << :started_child }
+          )
+          at_fork.at_fork_blocks(
+            before: proc { calls << :skipped_before },
+            parent: proc { calls << :skipped_parent },
+            child: proc { calls << :skipped_child }
+          )
+
+          expect { process_module._fork }.to raise_error(error)
+          expect(calls).to eq(%i[started_before started_parent])
+        end
       end
     end
   end

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -293,6 +293,28 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         it "returns the result from _fork" do
           expect(process_module._fork).to be _fork_result
         end
+
+        it "uses one callback snapshot for the complete fork lifecycle" do
+          calls = []
+          registered = false
+          at_fork = Datadog::Core::Utils::AtForkMonkeyPatch
+          at_fork.at_fork(:before) do
+            next if registered
+
+            registered = true
+            at_fork.at_fork_blocks(
+              before: proc { calls << :late_before },
+              parent: proc { calls << :late_parent },
+              child: proc { calls << :late_child }
+            )
+          end
+
+          process_module._fork
+          expect(calls).to eq([])
+
+          process_module._fork
+          expect(calls).to eq(%i[late_before late_child])
+        end
       end
 
       context "in the parent process" do
@@ -361,6 +383,51 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         described_class.run_at_fork_blocks(stage)
 
         expect(calls).to eq(%i[first second])
+      end
+    end
+
+    %i[parent child].each do |stage|
+      it "runs every #{stage} callback before re-raising the first failure" do
+        calls = []
+        error = RuntimeError.new("first #{stage} failed")
+        described_class.at_fork(stage) do
+          calls << :first
+          raise error
+        end
+        described_class.at_fork(stage) do
+          calls << :second
+          raise "second #{stage} failed"
+        end
+
+        expect { described_class.run_at_fork_blocks(stage) }.to raise_error(error)
+        expect(calls).to eq(%i[first second])
+      end
+    end
+
+    it "stops before callbacks at the first failure" do
+      calls = []
+      described_class.at_fork(:before) do
+        calls << :first
+        raise "before failed"
+      end
+      described_class.at_fork(:before) { calls << :second }
+
+      expect { described_class.run_at_fork_blocks(:before) }.to raise_error("before failed")
+      expect(calls).to eq([:first])
+    end
+
+    it "registers a callback triplet together" do
+      blocks = {
+        before: proc {},
+        parent: proc {},
+        child: proc {},
+      }
+
+      expect(described_class.at_fork_blocks(**blocks)).to eq(blocks)
+
+      snapshot = described_class.snapshot_at_fork_blocks
+      blocks.each do |stage, block|
+        expect(snapshot.fetch(stage)).to include(block)
       end
     end
 

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -187,6 +187,23 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
             end
           end
         end
+
+        context "when a later before callback raises" do
+          include_context "at_fork callbacks"
+
+          it "runs parent cleanup and does not fork" do
+            error = RuntimeError.new("before failed")
+            described_module = Datadog::Core::Utils::AtForkMonkeyPatch
+            described_module.at_fork(:before) { raise error }
+
+            expect(before_fork).to receive(:call).ordered
+            expect(parent).to receive(:call).ordered
+            expect(child).to_not receive(:call)
+            expect(Kernel).to_not receive(:fork)
+
+            expect { fork_class.fork }.to raise_error(error)
+          end
+        end
       end
     end
   end
@@ -248,6 +265,17 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
       it "passes any arguments to Process.daemon and returns its results" do
         expect(process_module.daemon(:arg1, :arg2)).to eq([:arg1, :arg2])
       end
+
+      it "runs parent cleanup when a later before callback raises" do
+        error = RuntimeError.new("before failed")
+        Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:before) { raise error }
+
+        expect(before_callback).to receive(:call).ordered
+        expect(parent_callback).to receive(:call).ordered
+        expect(child_callback).to_not receive(:call)
+
+        expect { process_module.daemon }.to raise_error(error)
+      end
     end
 
     describe "_fork" do
@@ -301,6 +329,19 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
           expect { process_module._fork }.to raise_error(Errno::EAGAIN)
         end
       end
+
+      context "when a later before callback raises" do
+        it "runs parent cleanup and does not run child callbacks" do
+          error = RuntimeError.new("before failed")
+          Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:before) { raise error }
+
+          expect(before_callback).to receive(:call).ordered
+          expect(parent_callback).to receive(:call).ordered
+          expect(child_callback).to_not receive(:call)
+
+          expect { process_module._fork }.to raise_error(error)
+        end
+      end
     end
   end
 
@@ -334,6 +375,20 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
       described_class.run_at_fork_blocks(:child)
       expect(calls).to eq(%i[before child])
+    end
+
+    it "runs every selected callback when one deregisters itself" do
+      calls = []
+      first = nil
+      first = described_class.at_fork(:parent) do
+        calls << :first
+        described_class.remove_at_fork(:parent, first)
+      end
+      described_class.at_fork(:parent) { calls << :second }
+
+      described_class.run_at_fork_blocks(:parent)
+
+      expect(calls).to eq(%i[first second])
     end
 
     it "raises ArgumentError for an unknown stage when registering" do

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -350,6 +350,16 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
           expect { process_module._fork }.to raise_error(Errno::EAGAIN)
         end
+
+        it "does not replace the fork failure when parent cleanup also fails" do
+          cleanup_error = RuntimeError.new("parent cleanup failed")
+          allow(parent_callback).to receive(:call).and_raise(cleanup_error)
+          expect(Datadog.logger).to receive(:warn) do |&message|
+            expect(message.call).to include("Parent at-fork cleanup failed", "RuntimeError: parent cleanup failed")
+          end
+
+          expect { process_module._fork }.to raise_error(Errno::EAGAIN)
+        end
       end
 
       context "when a later before callback raises" do

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -1,7 +1,15 @@
 require "datadog/core/utils/at_fork_monkey_patch"
+require "timeout"
 
 RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
   before { skip "Forking not supported" unless Datadog::Core::Utils::AtForkMonkeyPatch.supported? } # rubocop:disable RSpec/DescribedClass
+
+  def clear_at_fork_blocks
+    Datadog::Core::Utils::AtForkMonkeyPatch.send(
+      :replace_at_fork_blocks,
+      {before: [].freeze, parent: [].freeze, child: [].freeze}.freeze
+    )
+  end
 
   describe "::apply!" do
     subject(:apply!) { described_class.apply! }
@@ -117,9 +125,7 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
       end
 
       after do
-        Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_BEFORE_BLOCKS).clear
-        Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_PARENT_BLOCKS).clear
-        Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_CHILD_BLOCKS).clear
+        clear_at_fork_blocks
       end
     end
 
@@ -233,9 +239,7 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
     end
 
     after do
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_BEFORE_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_PARENT_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_CHILD_BLOCKS).clear
+      clear_at_fork_blocks
     end
 
     describe ".daemon" do
@@ -252,8 +256,7 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
       it "runs the before callback before the child callback" do
         calls = []
         described_class_blocks = Datadog::Core::Utils::AtForkMonkeyPatch
-        described_class_blocks.const_get(:AT_FORK_BEFORE_BLOCKS).clear
-        described_class_blocks.const_get(:AT_FORK_CHILD_BLOCKS).clear
+        clear_at_fork_blocks
         described_class_blocks.at_fork(:before) { calls << :before }
         described_class_blocks.at_fork(:child) { calls << :child }
 
@@ -373,15 +376,14 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
           expect { process_module._fork }.to raise_error(error)
         end
+
       end
     end
   end
 
   describe "::at_fork and ::run_at_fork_blocks" do
     after do
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_BEFORE_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_PARENT_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_CHILD_BLOCKS).clear
+      clear_at_fork_blocks
     end
 
     %i[before parent child].each do |stage|
@@ -437,8 +439,44 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
       snapshot = described_class.snapshot_at_fork_blocks
       blocks.each do |stage, block|
-        expect(snapshot.fetch(stage)).to include(block)
+        expect(snapshot.fetch(stage).map(&:block)).to include(block)
       end
+    end
+
+    it "publishes a new immutable registry without changing an active snapshot" do
+      described_class.at_fork(:before) {}
+      snapshot = described_class.snapshot_at_fork_blocks
+
+      described_class.at_fork(:before) {}
+
+      expect(snapshot).to be_frozen
+      expect(snapshot.fetch(:before)).to be_frozen
+      expect(snapshot.fetch(:before).length).to eq(1)
+      expect(described_class.snapshot_at_fork_blocks.fetch(:before).length).to eq(2)
+    end
+
+    it "dispatches an empty fork lifecycle from a signal trap without locking" do
+      at_fork = described_class
+      clear_at_fork_blocks
+      process_module = Module.new do
+        define_singleton_method(:_fork) { 1234 }
+      end
+      process_module.singleton_class.prepend(at_fork::ProcessMonkeyPatch)
+      result = nil
+      error = nil
+      previous_handler = Signal.trap("USR1") do
+        result = process_module._fork
+      rescue => e
+        error = e
+      end
+
+      Process.kill("USR1", Process.pid)
+      Timeout.timeout(1) { Thread.pass until result || error }
+
+      expect(error).to be_nil
+      expect(result).to eq(1234)
+    ensure
+      Signal.trap("USR1", previous_handler) if previous_handler
     end
 
     it "keeps the stages independent" do
@@ -488,9 +526,7 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
   describe "::remove_at_fork" do
     after do
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_BEFORE_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_PARENT_BLOCKS).clear
-      Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_CHILD_BLOCKS).clear
+      clear_at_fork_blocks
     end
 
     %i[before parent child].each do |stage|

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -382,7 +382,10 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
           error = RuntimeError.new("before failed")
           at_fork = Datadog::Core::Utils::AtForkMonkeyPatch
           at_fork.at_fork_blocks(
-            before: proc { calls << :started_before; raise error },
+            before: proc do
+              calls << :started_before
+              raise error
+            end,
             parent: proc { calls << :started_parent },
             child: proc { calls << :started_child }
           )

--- a/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
+++ b/spec/datadog/core/utils/at_fork_monkey_patch_spec.rb
@@ -409,8 +409,9 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         calls = []
         described_class.at_fork(stage) { calls << :first }
         described_class.at_fork(stage) { calls << :second }
+        snapshot = described_class.snapshot_at_fork_blocks
 
-        described_class.run_at_fork_blocks(stage)
+        described_class.run_at_fork_blocks(stage, snapshot: snapshot)
 
         expect(calls).to eq(%i[first second])
       end
@@ -428,8 +429,9 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
           calls << :second
           raise "second #{stage} failed"
         end
+        snapshot = described_class.snapshot_at_fork_blocks
 
-        expect { described_class.run_at_fork_blocks(stage) }.to raise_error(error)
+        expect { described_class.run_at_fork_blocks(stage, snapshot: snapshot) }.to raise_error(error)
         expect(calls).to eq(%i[first second])
       end
     end
@@ -441,8 +443,9 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         raise "before failed"
       end
       described_class.at_fork(:before) { calls << :second }
+      snapshot = described_class.snapshot_at_fork_blocks
 
-      expect { described_class.run_at_fork_blocks(:before) }.to raise_error("before failed")
+      expect { described_class.run_at_fork_blocks(:before, snapshot: snapshot) }.to raise_error("before failed")
       expect(calls).to eq([:first])
     end
 
@@ -502,11 +505,12 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
       described_class.at_fork(:before) { calls << :before }
       described_class.at_fork(:parent) { calls << :parent }
       described_class.at_fork(:child) { calls << :child }
+      snapshot = described_class.snapshot_at_fork_blocks
 
-      described_class.run_at_fork_blocks(:before)
+      described_class.run_at_fork_blocks(:before, snapshot: snapshot)
       expect(calls).to eq(%i[before])
 
-      described_class.run_at_fork_blocks(:child)
+      described_class.run_at_fork_blocks(:child, snapshot: snapshot)
       expect(calls).to eq(%i[before child])
     end
 
@@ -518,8 +522,9 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         described_class.remove_at_fork(:parent, first)
       end
       described_class.at_fork(:parent) { calls << :second }
+      snapshot = described_class.snapshot_at_fork_blocks
 
-      described_class.run_at_fork_blocks(:parent)
+      described_class.run_at_fork_blocks(:parent, snapshot: snapshot)
 
       expect(calls).to eq(%i[first second])
     end
@@ -529,7 +534,10 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
     end
 
     it "raises ArgumentError for an unknown stage when running" do
-      expect { described_class.run_at_fork_blocks(:nonsense) }.to raise_error(ArgumentError, /Unsupported stage nonsense/)
+      snapshot = described_class.snapshot_at_fork_blocks
+
+      expect { described_class.run_at_fork_blocks(:nonsense, snapshot: snapshot) }
+        .to raise_error(ArgumentError, /Unsupported stage nonsense/)
     end
 
     it "raises ArgumentError when no block is given" do
@@ -554,7 +562,8 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
         removed = described_class.at_fork(stage) { calls << :removed }
 
         described_class.remove_at_fork(stage, removed)
-        described_class.run_at_fork_blocks(stage)
+        snapshot = described_class.snapshot_at_fork_blocks
+        described_class.run_at_fork_blocks(stage, snapshot: snapshot)
 
         expect(calls).to eq(%i[kept])
         # The handle returned by at_fork is the one that was removed.
@@ -570,7 +579,8 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
 
       expect { described_class.remove_at_fork(:child, never_registered) }.to_not raise_error
 
-      described_class.run_at_fork_blocks(:child)
+      snapshot = described_class.snapshot_at_fork_blocks
+      described_class.run_at_fork_blocks(:child, snapshot: snapshot)
       expect(calls).to eq(%i[kept])
     end
 
@@ -581,7 +591,8 @@ RSpec.describe Datadog::Core::Utils::AtForkMonkeyPatch do
       described_class.remove_at_fork(:child, block)
       expect { described_class.remove_at_fork(:child, block) }.to_not raise_error
 
-      described_class.run_at_fork_blocks(:child)
+      snapshot = described_class.snapshot_at_fork_blocks
+      described_class.run_at_fork_blocks(:child, snapshot: snapshot)
       expect(calls).to eq([])
     end
 

--- a/spec/datadog/tracing/transport/native/fork_spec.rb
+++ b/spec/datadog/tracing/transport/native/fork_spec.rb
@@ -344,12 +344,51 @@ RSpec.describe "Native transport fork safety and cancellation" do
       expect(transport.send_traces([build_trace]).first.ok?).to be(true)
     end
 
+    it "discards pending fork waiters that vanished in the child" do
+      hooks = transport.instance_variable_get(:@fork_hooks)
+      fork_state = transport.instance_variable_get(:@fork_state)
+      waiter = nil
+      Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:before) do
+        waiter = Thread.new do
+          hooks[:before].call
+          hooks[:parent].call
+        end
+        Timeout.timeout(5) { Thread.pass until fork_state[:pending] > 0 }
+      end
+
+      read_io, write_io = IO.pipe
+      pid = fork do
+        read_io.close
+        result = begin
+          Timeout.timeout(5) { transport.close }
+          "OK"
+        rescue => e
+          "RAISED:#{e.class}:#{e.message}"
+        end
+        write_io.write(result)
+        write_io.close
+        exit!(0)
+      end
+      write_io.close
+
+      child_result = Timeout.timeout(10) { read_io.read }
+      read_io.close
+      _, status = Process.wait2(pid)
+      expect(waiter.join(10)).to be(waiter)
+
+      expect(child_result).to eq("OK")
+      expect(status.success?).to be(true)
+      expect(transport.send_traces([build_trace(name: "parent-after-pending-fork.op")]).first.ok?).to be(true)
+    ensure
+      waiter&.join(10)
+      read_io&.close unless read_io&.closed?
+      write_io&.close unless write_io&.closed?
+    end
+
     it "restores the parent and unlocks sends when fork fails" do
       hooks = transport.instance_variable_get(:@fork_hooks)
       saved_at_fork = AtForkRegistryHelpers.snapshot_and_clear
-      hooks.each do |stage, block|
-        Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(stage, &block)
-      end
+      Datadog::Core::Utils::AtForkMonkeyPatch.at_fork_blocks(**hooks)
 
       allow(exporter).to receive(:_native_before_fork).and_call_original
       allow(exporter).to receive(:_native_after_fork_in_parent).and_call_original

--- a/spec/datadog/tracing/transport/native/fork_spec.rb
+++ b/spec/datadog/tracing/transport/native/fork_spec.rb
@@ -370,6 +370,31 @@ RSpec.describe "Native transport fork safety and cancellation" do
     ensure
       AtForkRegistryHelpers.restore(saved_at_fork) if saved_at_fork
     end
+
+    it "restores the parent when a later global before-fork hook raises" do
+      error = RuntimeError.new("later before-fork hook failed")
+      fork_called = Queue.new
+      Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:before) { raise error }
+
+      allow(exporter).to receive(:_native_before_fork).and_call_original
+      allow(exporter).to receive(:_native_after_fork_in_parent).and_call_original
+
+      process_module = Module.new do
+        define_singleton_method(:_fork) do
+          fork_called << true
+          1234
+        end
+      end
+      process_module.singleton_class.prepend(
+        Datadog::Core::Utils::AtForkMonkeyPatch::ProcessMonkeyPatch
+      )
+
+      expect { process_module._fork }.to raise_error(error)
+      expect(fork_called).to be_empty
+      expect(exporter).to have_received(:_native_before_fork).once
+      expect(exporter).to have_received(:_native_after_fork_in_parent).once
+      expect(transport.send_traces([build_trace(name: "after-before-failure.op")]).first.ok?).to be(true)
+    end
   end
 
   # ===========================================================================

--- a/spec/datadog/tracing/transport/native/fork_spec.rb
+++ b/spec/datadog/tracing/transport/native/fork_spec.rb
@@ -344,47 +344,6 @@ RSpec.describe "Native transport fork safety and cancellation" do
       expect(transport.send_traces([build_trace]).first.ok?).to be(true)
     end
 
-    it "discards pending fork waiters that vanished in the child" do
-      hooks = transport.instance_variable_get(:@fork_hooks)
-      fork_state = transport.instance_variable_get(:@fork_state)
-      waiter = nil
-      Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(:before) do
-        waiter = Thread.new do
-          hooks[:before].call
-          hooks[:parent].call
-        end
-        Timeout.timeout(5) { Thread.pass until fork_state[:pending] > 0 }
-      end
-
-      read_io, write_io = IO.pipe
-      pid = fork do
-        read_io.close
-        result = begin
-          Timeout.timeout(5) { transport.close }
-          "OK"
-        rescue => e
-          "RAISED:#{e.class}:#{e.message}"
-        end
-        write_io.write(result)
-        write_io.close
-        exit!(0)
-      end
-      write_io.close
-
-      child_result = Timeout.timeout(10) { read_io.read }
-      read_io.close
-      _, status = Process.wait2(pid)
-      expect(waiter.join(10)).to be(waiter)
-
-      expect(child_result).to eq("OK")
-      expect(status.success?).to be(true)
-      expect(transport.send_traces([build_trace(name: "parent-after-pending-fork.op")]).first.ok?).to be(true)
-    ensure
-      waiter&.join(10)
-      read_io&.close unless read_io&.closed?
-      write_io&.close unless write_io&.closed?
-    end
-
     it "restores the parent and unlocks sends when fork fails" do
       hooks = transport.instance_variable_get(:@fork_hooks)
       saved_at_fork = AtForkRegistryHelpers.snapshot_and_clear
@@ -606,25 +565,35 @@ RSpec.describe "Native transport fork safety and cancellation" do
       end
       expect(closer).to be_alive
 
-      # Start the fork only after close is waiting for the send. Its before hook
-      # announces itself before waiting for the lifecycle mutex, forcing close
-      # to yield rather than removing the matching parent/child hooks.
+      # Start the fork only after close is waiting for the send. The fork keeps
+      # its callback snapshot even if close deregisters the global hooks first.
+      fork_prepared = Queue.new
+      exporter = transport.instance_variable_get(:@exporter)
+      allow(exporter).to receive(:_native_before_fork).and_wrap_original do |method|
+        result = method.call
+        fork_prepared << true
+        result
+      end
       read_io, write_io = IO.pipe
       forker = Thread.new do
         pid = fork do
           read_io.close
           response = transport.send_traces([build_trace(name: "child-after-close-race.op")]).first
-          write_io.write(response.ok? ? "OK" : "NOT_OK:#{response.inspect}")
+          result = if response.ok?
+            "OK"
+          elsif response.internal_error?
+            "CLOSED"
+          else
+            "NOT_OK:#{response.inspect}"
+          end
+          write_io.write(result)
           write_io.close
           exit!(0)
         end
         fork_result << pid
       end
 
-      Timeout.timeout(5) do
-        fork_state = transport.instance_variable_get(:@fork_state)
-        Thread.pass until fork_state[:pending] > 0
-      end
+      Timeout.timeout(5) { fork_prepared.pop }
 
       mock_agent.release
       expect(sender.join(10)).to be(sender)
@@ -637,7 +606,7 @@ RSpec.describe "Native transport fork safety and cancellation" do
       _, status = Process.wait2(fork_result.pop)
 
       expect(sender_result.pop.first.ok?).to be(true)
-      expect(child_result).to eq("OK")
+      expect(child_result).to match(/\A(?:OK|CLOSED)\z/)
       expect(status.success?).to be(true)
       expect(transport.send_traces([build_trace(name: "parent-after-close.op")]).first).to be_internal_error
     ensure

--- a/spec/datadog/tracing/transport/native/fork_spec.rb
+++ b/spec/datadog/tracing/transport/native/fork_spec.rb
@@ -129,24 +129,24 @@ RSpec.describe "Native transport fork safety and cancellation" do
     end
   end
 
-  # Accepts connections, signals (via a pipe) that a request has arrived and is
-  # in-flight, waits a fixed delay, then answers with `200 OK`. The delay lets a
-  # test fork WHILE a send is mid-flight (the agent has received the request but
-  # not yet replied), so the fork's `:before` hook must wait for the in-flight
-  # send to drain before tearing down the runtime.
-  class DelayingMockAgent # rubocop:disable Lint/ConstantDefinitionInBlock
+  # Holds the first trace request until the parent explicitly releases it. This
+  # gives the tests a deterministic in-flight send without timing sleeps.
+  class BlockingMockAgent # rubocop:disable Lint/ConstantDefinitionInBlock
     attr_reader :port
 
-    def initialize(delay:)
-      @read_io, @write_io = IO.pipe
+    def initialize
+      @request_read, @request_write = IO.pipe
+      @release_read, @release_write = IO.pipe
       server = TCPServer.new("127.0.0.1", 0)
       @port = server.addr[1]
 
       @pid = fork do
-        @read_io.close
+        @request_read.close
+        @release_write.close
         body = '{"rate_by_service":{"service:,env:":1.0}}'
         response = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n" \
                    "Content-Type: application/json\r\n\r\n#{body}"
+        blocked_trace = false
 
         loop do
           client = begin
@@ -164,14 +164,11 @@ RSpec.describe "Native transport fork safety and cancellation" do
             end
             c.read(content_length) if content_length > 0
 
-            # Signal that the request has arrived and is in-flight, THEN delay
-            # before replying so the send stays in-flight for `delay` seconds.
-            begin
-              @write_io.write("x")
-            rescue
-              nil
+            if !blocked_trace && request_line.include?("/v0.")
+              blocked_trace = true
+              @request_write.write("x")
+              @release_read.read(1)
             end
-            sleep delay
 
             c.print response
           rescue # rubocop:disable Lint/SuppressedException
@@ -186,24 +183,26 @@ RSpec.describe "Native transport fork safety and cancellation" do
       end
 
       server.close
-      @write_io.close
+      @request_write.close
+      @release_read.close
     end
 
     # Block until the agent has received at least one request (send in-flight).
     def wait_for_connection(timeout: 5)
-      ready = IO.select([@read_io], nil, nil, timeout)
+      ready = IO.select([@request_read], nil, nil, timeout)
       raise "Timed out waiting for the native send to reach the mock agent" unless ready
 
-      @read_io.read(1)
+      @request_read.read(1)
+    end
+
+    def release
+      @release_write.write("x")
     end
 
     def stop
       NativeTransportForkIsolation.reap_process(@pid)
-      begin
-        @read_io.close
-      rescue
-        nil
-      end
+      @request_read.close unless @request_read.closed?
+      @release_write.close unless @release_write.closed?
     end
   end
 
@@ -344,6 +343,33 @@ RSpec.describe "Native transport fork safety and cancellation" do
       # Parent still works after the fork.
       expect(transport.send_traces([build_trace]).first.ok?).to be(true)
     end
+
+    it "restores the parent and unlocks sends when fork fails" do
+      hooks = transport.instance_variable_get(:@fork_hooks)
+      saved_at_fork = AtForkRegistryHelpers.snapshot_and_clear
+      hooks.each do |stage, block|
+        Datadog::Core::Utils::AtForkMonkeyPatch.at_fork(stage, &block)
+      end
+
+      allow(exporter).to receive(:_native_before_fork).and_call_original
+      allow(exporter).to receive(:_native_after_fork_in_parent).and_call_original
+      allow(exporter).to receive(:_native_after_fork_in_child).and_call_original
+
+      failing_process = Module.new do
+        define_singleton_method(:_fork) { raise Errno::EAGAIN }
+      end
+      failing_process.singleton_class.prepend(
+        Datadog::Core::Utils::AtForkMonkeyPatch::ProcessMonkeyPatch
+      )
+
+      expect { failing_process._fork }.to raise_error(Errno::EAGAIN)
+      expect(exporter).to have_received(:_native_before_fork).once
+      expect(exporter).to have_received(:_native_after_fork_in_parent).once
+      expect(exporter).to_not have_received(:_native_after_fork_in_child)
+      expect(transport.send_traces([build_trace(name: "after-failed-fork.op")]).first.ok?).to be(true)
+    ensure
+      AtForkRegistryHelpers.restore(saved_at_fork) if saved_at_fork
+    end
   end
 
   # ===========================================================================
@@ -403,21 +429,26 @@ RSpec.describe "Native transport fork safety and cancellation" do
   # releases the GVL, and `_native_before_fork` tears down/replaces the runtime,
   # so forking mid-send would leave the child with a half-completed send and
   # Rust-internal locks (deadlock/crash). The transport guards this with a
-  # per-transport mutex held across the fork: the `:before` hook blocks until
-  # any in-flight send drains before `_native_before_fork` runs.
+  # per-transport mutex held across the fork: the `:before` hook pauses the
+  # shared runtime, then blocks until any in-flight send drains.
   describe "fork while a send is in-flight" do
-    # Keep the delay comfortably larger than the slack we allow when asserting
-    # the fork blocked for the send to drain.
-    AGENT_DELAY = 1.0 # rubocop:disable Lint/ConstantDefinitionInBlock
-
     around do |example|
-      run_with_transport(example, fork_hooks: true) { DelayingMockAgent.new(delay: AGENT_DELAY) }
+      run_with_transport(example, fork_hooks: true) { BlockingMockAgent.new }
     end
 
     let(:transport) { @transport }
     let(:mock_agent) { @mock_agent }
 
     it "drains the in-flight send before the fork, and both child and parent send succeed" do
+      exporter = transport.instance_variable_get(:@exporter)
+      fork_prepared = Queue.new
+
+      allow(exporter).to receive(:_native_before_fork).and_wrap_original do |method|
+        result = method.call
+        fork_prepared << true
+        result
+      end
+
       # The background send's result, pushed only when send_traces returns.
       sender_result = Queue.new
 
@@ -427,16 +458,18 @@ RSpec.describe "Native transport fork safety and cancellation" do
       end
 
       # Wait until the send has actually reached the agent (is in-flight). The
-      # agent then sleeps AGENT_DELAY before replying, so the send is still
-      # holding @send_mutex when we fork below.
+      # agent does not reply until explicitly released below.
       mock_agent.wait_for_connection(timeout: 10)
 
       # Fork through the real AtForkMonkeyPatch path so the transport's
       # :before/:parent/:child hooks run. The :before hook locks @send_mutex,
       # which BLOCKS until the in-flight send finishes, so `fork` itself blocks
-      # here for ~AGENT_DELAY.
+      # until the releaser below allows the agent to answer.
+      releaser = Thread.new do
+        fork_prepared.pop
+        mock_agent.release
+      end
       read_io, write_io = IO.pipe
-      fork_started = Datadog::Core::Utils::Time.get_time
       pid = Timeout.timeout(15) do
         fork do
           read_io.close
@@ -452,8 +485,8 @@ RSpec.describe "Native transport fork safety and cancellation" do
           exit!(0)
         end
       end
-      fork_elapsed = Datadog::Core::Utils::Time.get_time - fork_started
       write_io.close
+      expect(releaser.join(5)).to be(releaser)
 
       child_result =
         begin
@@ -463,14 +496,8 @@ RSpec.describe "Native transport fork safety and cancellation" do
         end
       _, status = Process.wait2(pid)
 
-      # The fork's :before hook must have waited for the in-flight send to
-      # drain before tearing down the runtime. Because the agent holds the
-      # request for AGENT_DELAY before replying, `fork` blocks for at least
-      # that long (minus generous slack to stay non-flaky). The background send
-      # must therefore have completed by the time the child ran.
-      expect(fork_elapsed).to be >= (AGENT_DELAY * 0.5),
-        "expected fork to block until the in-flight send drained (>= #{AGENT_DELAY * 0.5}s), " \
-        "but it returned after #{fork_elapsed}s"
+      # The fork call cannot return until the agent releases the in-flight send,
+      # so the background send must have completed before the child runs.
       expect(sender_result).to_not be_empty,
         "expected the in-flight send to have completed before the child started"
 
@@ -485,6 +512,81 @@ RSpec.describe "Native transport fork safety and cancellation" do
 
       # The parent transport still works after the fork.
       expect(transport.send_traces([build_trace(name: "after.op")]).first.ok?).to be(true)
+    ensure
+      begin
+        mock_agent.release
+      rescue IOError, Errno::EPIPE
+        nil
+      end
+      releaser&.join(5)
+    end
+
+    it "serializes close with an in-flight send and fork in both processes" do
+      sender_result = Queue.new
+      fork_result = Queue.new
+      close_started = Queue.new
+
+      sender = Thread.new do
+        sender_result << transport.send_traces([build_trace(name: "inflight-close.op")])
+      end
+      mock_agent.wait_for_connection(timeout: 10)
+
+      # Close acquires the lifecycle mutex, then blocks on the in-flight send.
+      closer = Thread.new do
+        close_started << true
+        transport.close
+      end
+      close_started.pop
+      Timeout.timeout(5) do
+        Thread.pass until closer.status == "sleep" || !closer.alive?
+      end
+      expect(closer).to be_alive
+
+      # Start the fork only after close is waiting for the send. Its before hook
+      # announces itself before waiting for the lifecycle mutex, forcing close
+      # to yield rather than removing the matching parent/child hooks.
+      read_io, write_io = IO.pipe
+      forker = Thread.new do
+        pid = fork do
+          read_io.close
+          response = transport.send_traces([build_trace(name: "child-after-close-race.op")]).first
+          write_io.write(response.ok? ? "OK" : "NOT_OK:#{response.inspect}")
+          write_io.close
+          exit!(0)
+        end
+        fork_result << pid
+      end
+
+      Timeout.timeout(5) do
+        fork_state = transport.instance_variable_get(:@fork_state)
+        Thread.pass until fork_state[:pending] > 0
+      end
+
+      mock_agent.release
+      expect(sender.join(10)).to be(sender)
+      expect(forker.join(10)).to be(forker)
+      expect(closer.join(10)).to be(closer)
+      write_io.close
+
+      child_result = Timeout.timeout(15) { read_io.read }
+      read_io.close
+      _, status = Process.wait2(fork_result.pop)
+
+      expect(sender_result.pop.first.ok?).to be(true)
+      expect(child_result).to eq("OK")
+      expect(status.success?).to be(true)
+      expect(transport.send_traces([build_trace(name: "parent-after-close.op")]).first).to be_internal_error
+    ensure
+      begin
+        mock_agent.release
+      rescue IOError, Errno::EPIPE
+        nil
+      end
+      sender&.join(5)
+      forker&.join(5)
+      closer&.join(5)
+      read_io&.close unless read_io&.closed?
+      write_io&.close unless write_io&.closed?
     end
   end
 end

--- a/spec/datadog/tracing/transport/native/fork_spec.rb
+++ b/spec/datadog/tracing/transport/native/fork_spec.rb
@@ -214,24 +214,18 @@ RSpec.describe "Native transport fork safety and cancellation" do
   module AtForkRegistryHelpers # rubocop:disable Lint/ConstantDefinitionInBlock
     module_function
 
-    STAGES = {
-      before: :AT_FORK_BEFORE_BLOCKS,
-      parent: :AT_FORK_PARENT_BLOCKS,
-      child: :AT_FORK_CHILD_BLOCKS,
-    }.freeze
-
     def snapshot_and_clear
-      STAGES.each_with_object({}) do |(stage, const), saved|
-        array = Datadog::Core::Utils::AtForkMonkeyPatch.const_get(const)
-        saved[stage] = array.dup
-        array.clear
-      end
+      registry = Datadog::Core::Utils::AtForkMonkeyPatch
+      snapshot = registry.snapshot_at_fork_blocks
+      registry.send(
+        :replace_at_fork_blocks,
+        {before: [].freeze, parent: [].freeze, child: [].freeze}.freeze
+      )
+      snapshot
     end
 
     def restore(saved)
-      STAGES.each do |stage, const|
-        Datadog::Core::Utils::AtForkMonkeyPatch.const_get(const).replace(saved[stage])
-      end
+      Datadog::Core::Utils::AtForkMonkeyPatch.send(:replace_at_fork_blocks, saved)
     end
   end
 

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -273,6 +273,18 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
     end
 
     describe "finalizer fallback" do
+      def build_finalizer(transport)
+        hooks = transport.instance_variable_get(:@fork_hooks)
+        fork_state = transport.instance_variable_get(:@fork_state)
+        remove_fork_hooks = transport_class.send(:fork_hooks_remover, hooks, fork_state)
+        transport_class.send(
+          :finalizer_for,
+          transport.instance_variable_get(:@fork_mutex),
+          fork_state,
+          remove_fork_hooks
+        )
+      end
+
       it "registers a finalizer on the transport at construction" do
         # The finalizer guards against a transport that is dropped without
         # #close: it must still deregister the global fork hooks.
@@ -285,13 +297,7 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         # keep that object reachable, so it would never fire. Building it in a
         # class method guarantees its binding receiver is the class, not an
         # instance.
-        hooks = transport.instance_variable_get(:@fork_hooks)
-        finalizer = transport_class.send(
-          :finalizer_for,
-          hooks,
-          transport.instance_variable_get(:@fork_mutex),
-          transport.instance_variable_get(:@fork_state)
-        )
+        finalizer = build_finalizer(transport)
 
         expect(finalizer.binding.receiver).to be(transport_class)
         expect(finalizer.binding.receiver).to_not be(transport)
@@ -299,12 +305,7 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
 
       it "removes all the hooks when the finalizer runs" do
         hooks = transport.instance_variable_get(:@fork_hooks)
-        finalizer = transport_class.send(
-          :finalizer_for,
-          hooks,
-          transport.instance_variable_get(:@fork_mutex),
-          transport.instance_variable_get(:@fork_state)
-        )
+        finalizer = build_finalizer(transport)
 
         # Assert the hooks are registered first, so the post-run absence check
         # cannot pass vacuously.
@@ -319,6 +320,44 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         hooks.each do |stage, block|
           expect(registry_contains?(stage, block)).to be(false)
         end
+      end
+
+      it "removes hooks without relocking a lifecycle mutex owned outside a fork" do
+        hooks = transport.instance_variable_get(:@fork_hooks)
+        fork_mutex = transport.instance_variable_get(:@fork_mutex)
+        finalizer = build_finalizer(transport)
+        fork_mutex.lock
+
+        expect { Timeout.timeout(1) { finalizer.call(transport.object_id) } }.to_not raise_error
+
+        hooks.each do |stage, block|
+          expect(registry_contains?(stage, block)).to be(false)
+        end
+      ensure
+        fork_mutex&.unlock if fork_mutex&.owned?
+      end
+
+      it "defers hook removal to the completion callback during a fork lifecycle" do
+        hooks = transport.instance_variable_get(:@fork_hooks)
+        fork_mutex = transport.instance_variable_get(:@fork_mutex)
+        finalizer = build_finalizer(transport)
+
+        hooks[:before].call
+        expect(fork_mutex).to be_owned
+
+        expect { Timeout.timeout(1) { finalizer.call(transport.object_id) } }.to_not raise_error
+        hooks.each do |stage, block|
+          expect(registry_contains?(stage, block)).to be(true)
+        end
+
+        hooks[:parent].call
+
+        expect(fork_mutex).to_not be_owned
+        hooks.each do |stage, block|
+          expect(registry_contains?(stage, block)).to be(false)
+        end
+      ensure
+        hooks&.dig(:parent)&.call if fork_mutex&.owned?
       end
     end
 

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -230,6 +230,43 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         closer&.join(5)
       end
 
+      it "does not release fork locks owned before a reentrant close" do
+        hooks = transport.instance_variable_get(:@fork_hooks)
+        exporter = transport.instance_variable_get(:@exporter)
+        fork_mutex = transport.instance_variable_get(:@fork_mutex)
+        send_mutex = transport.instance_variable_get(:@send_mutex)
+        allow(exporter).to receive(:_native_after_fork_in_parent).and_call_original
+
+        hooks[:before].call
+
+        expect { transport.close }.to raise_error(ThreadError)
+        expect(fork_mutex).to be_owned
+        expect(send_mutex).to be_owned
+
+        hooks[:parent].call
+
+        expect(exporter).to have_received(:_native_after_fork_in_parent).once
+        expect(fork_mutex).to_not be_owned
+        expect(send_mutex).to_not be_owned
+        expect(transport.send_traces([make_trace_segment("after-reentrant-close")]).first).to be_ok
+      ensure
+        hooks&.dig(:parent)&.call if fork_mutex&.owned?
+      end
+
+      it "releases its lifecycle lock but retains a pre-owned send lock" do
+        fork_mutex = transport.instance_variable_get(:@fork_mutex)
+        send_mutex = transport.instance_variable_get(:@send_mutex)
+        send_mutex.lock
+
+        expect { transport.close }.to raise_error(ThreadError)
+
+        expect(fork_mutex).to_not be_owned
+        expect(send_mutex).to be_owned
+        expect(transport.instance_variable_get(:@exporter)).to_not be_nil
+      ensure
+        send_mutex&.unlock if send_mutex&.owned?
+      end
+
       it "stops the exporter native fork hooks from firing on a later fork" do
         exporter = transport.instance_variable_get(:@exporter)
         # If our hooks were still registered, running the blocks would invoke

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -312,14 +312,7 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
     describe "finalizer fallback" do
       def build_finalizer(transport)
         hooks = transport.instance_variable_get(:@fork_hooks)
-        fork_state = transport.instance_variable_get(:@fork_state)
-        remove_fork_hooks = transport_class.send(:fork_hooks_remover, hooks, fork_state)
-        transport_class.send(
-          :finalizer_for,
-          transport.instance_variable_get(:@fork_mutex),
-          fork_state,
-          remove_fork_hooks
-        )
+        transport_class.send(:fork_hooks_remover, hooks)
       end
 
       it "registers a finalizer on the transport at construction" do
@@ -359,7 +352,7 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         end
       end
 
-      it "removes hooks without relocking a lifecycle mutex owned outside a fork" do
+      it "removes hooks while a lifecycle mutex is owned outside a fork" do
         hooks = transport.instance_variable_get(:@fork_hooks)
         fork_mutex = transport.instance_variable_get(:@fork_mutex)
         finalizer = build_finalizer(transport)
@@ -374,22 +367,27 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         fork_mutex&.unlock if fork_mutex&.owned?
       end
 
-      it "defers hook removal to the completion callback during a fork lifecycle" do
+      it "keeps snapshotted completion callbacks alive after removing their hooks" do
         hooks = transport.instance_variable_get(:@fork_hooks)
+        exporter = transport.instance_variable_get(:@exporter)
         fork_mutex = transport.instance_variable_get(:@fork_mutex)
+        send_mutex = transport.instance_variable_get(:@send_mutex)
         finalizer = build_finalizer(transport)
+        allow(exporter).to receive(:_native_after_fork_in_parent).and_call_original
 
         hooks[:before].call
         expect(fork_mutex).to be_owned
 
         expect { Timeout.timeout(1) { finalizer.call(transport.object_id) } }.to_not raise_error
         hooks.each do |stage, block|
-          expect(registry_contains?(stage, block)).to be(true)
+          expect(registry_contains?(stage, block)).to be(false)
         end
 
         hooks[:parent].call
 
+        expect(exporter).to have_received(:_native_after_fork_in_parent).once
         expect(fork_mutex).to_not be_owned
+        expect(send_mutex).to_not be_owned
         hooks.each do |stage, block|
           expect(registry_contains?(stage, block)).to be(false)
         end

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -8,6 +8,7 @@ require "datadog/tracing/transport/trace_formatter"
 require "datadog/core/utils/at_fork_monkey_patch"
 require "socket"
 require "json"
+require "timeout"
 
 RSpec.describe Datadog::Tracing::Transport::Native::Transport do
   before do
@@ -197,6 +198,38 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
           .to(be_nil)
       end
 
+      it "waits for an in-flight send before closing" do
+        exporter = transport.instance_variable_get(:@exporter)
+        send_started = Queue.new
+        release_send = Queue.new
+
+        allow(exporter).to receive(:_native_send_traces) do
+          send_started << true
+          release_send.pop
+          []
+        end
+
+        sender = Thread.new { transport.send_traces([make_trace_segment("web.request")]) }
+        send_started.pop
+        closer = Thread.new { transport.close }
+
+        Timeout.timeout(5) do
+          Thread.pass until closer.status == "sleep" || !closer.alive?
+        end
+
+        expect(closer).to be_alive
+        expect(transport.instance_variable_get(:@exporter)).to be(exporter)
+
+        release_send << true
+        expect(sender.join(5)).to be(sender)
+        expect(closer.join(5)).to be(closer)
+        expect(transport.instance_variable_get(:@exporter)).to be_nil
+      ensure
+        release_send << true if release_send&.empty?
+        sender&.join(5)
+        closer&.join(5)
+      end
+
       it "stops the exporter native fork hooks from firing on a later fork" do
         exporter = transport.instance_variable_get(:@exporter)
         # If our hooks were still registered, running the blocks would invoke
@@ -253,7 +286,12 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         # class method guarantees its binding receiver is the class, not an
         # instance.
         hooks = transport.instance_variable_get(:@fork_hooks)
-        finalizer = transport_class.send(:finalizer_for, hooks)
+        finalizer = transport_class.send(
+          :finalizer_for,
+          hooks,
+          transport.instance_variable_get(:@fork_mutex),
+          transport.instance_variable_get(:@fork_state)
+        )
 
         expect(finalizer.binding.receiver).to be(transport_class)
         expect(finalizer.binding.receiver).to_not be(transport)
@@ -261,7 +299,12 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
 
       it "removes all the hooks when the finalizer runs" do
         hooks = transport.instance_variable_get(:@fork_hooks)
-        finalizer = transport_class.send(:finalizer_for, hooks)
+        finalizer = transport_class.send(
+          :finalizer_for,
+          hooks,
+          transport.instance_variable_get(:@fork_mutex),
+          transport.instance_variable_get(:@fork_state)
+        )
 
         # Assert the hooks are registered first, so the post-run absence check
         # cannot pass vacuously.

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -152,8 +152,7 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
     let(:at_fork) { Datadog::Core::Utils::AtForkMonkeyPatch }
 
     def registry(stage)
-      const = {before: :AT_FORK_BEFORE_BLOCKS, parent: :AT_FORK_PARENT_BLOCKS, child: :AT_FORK_CHILD_BLOCKS}.fetch(stage)
-      at_fork.const_get(const)
+      at_fork.snapshot_at_fork_blocks.fetch(stage).map(&:block)
     end
 
     # Identity membership check. We must NOT use RSpec's `include(block)` here:

--- a/spec/datadog/tracing/transport/native/transport_spec.rb
+++ b/spec/datadog/tracing/transport/native/transport_spec.rb
@@ -275,10 +275,11 @@ RSpec.describe Datadog::Tracing::Transport::Native::Transport do
         allow(exporter).to receive(:_native_after_fork_in_child)
 
         transport.close
+        snapshot = at_fork.snapshot_at_fork_blocks
 
-        at_fork.run_at_fork_blocks(:before)
-        at_fork.run_at_fork_blocks(:parent)
-        at_fork.run_at_fork_blocks(:child)
+        at_fork.run_at_fork_blocks(:before, snapshot: snapshot)
+        at_fork.run_at_fork_blocks(:parent, snapshot: snapshot)
+        at_fork.run_at_fork_blocks(:child, snapshot: snapshot)
 
         expect(exporter).to_not have_received(:_native_before_fork)
         expect(exporter).to_not have_received(:_native_after_fork_in_parent)

--- a/spec/support/core_helpers.rb
+++ b/spec/support/core_helpers.rb
@@ -153,7 +153,12 @@ module CoreHelpers
         # In this case the handlers that are already registered would be
         # executed twice which is 1) probably not good and 2) would fail
         # our assertions.
-        Datadog::Core::Utils::AtForkMonkeyPatch.const_get(:AT_FORK_CHILD_BLOCKS).clear
+        at_fork = Datadog::Core::Utils::AtForkMonkeyPatch
+        snapshot = at_fork.snapshot_at_fork_blocks
+        at_fork.send(
+          :replace_at_fork_blocks,
+          snapshot.merge(child: [].freeze).freeze
+        )
       end
     end
   end

--- a/spec/support/native_transport_fork_isolation.rb
+++ b/spec/support/native_transport_fork_isolation.rb
@@ -25,12 +25,6 @@
 # is collected in the PARENT process -- where its runtime can shut down cleanly
 # -- before the next group forks.
 module NativeTransportForkIsolation
-  STAGES = {
-    before: :AT_FORK_BEFORE_BLOCKS,
-    parent: :AT_FORK_PARENT_BLOCKS,
-    child: :AT_FORK_CHILD_BLOCKS,
-  }.freeze
-
   module_function
 
   # Deterministically release a native transport so its exporter -- and the
@@ -89,19 +83,18 @@ module NativeTransportForkIsolation
   end
 
   def push_snapshot
-    snapshot = STAGES.each_with_object({}) do |(stage, const), saved|
-      saved[stage] = registry.const_get(const).dup
-    end
-    stack << snapshot
+    stack << registry.snapshot_at_fork_blocks
+    registry.send(
+      :replace_at_fork_blocks,
+      {before: [].freeze, parent: [].freeze, child: [].freeze}.freeze
+    )
   end
 
   def pop_and_restore
     snapshot = stack.pop
     return unless snapshot
 
-    STAGES.each do |stage, const|
-      registry.const_get(const).replace(snapshot[stage])
-    end
+    registry.send(:replace_at_fork_blocks, snapshot)
   end
 
   def stack


### PR DESCRIPTION
AI-generated code disclosure: this PR was implemented with substantial AI assistance and manually reviewed and validated.

**What does this PR do?**

Makes native transport fork lifecycle dispatch atomic and failure-safe. It coordinates `close` with in-flight sends and forks, runs every completion callback before re-raising the first error, and prevents finalizer and reentrant-lock deadlocks.

**Motivation:**

Native transport teardown can race with sends or fork handling, and exceptional callbacks can otherwise leave lifecycle work incomplete. This is the internal safety work tracked by [APMSP-3823](https://datadoghq.atlassian.net/browse/APMSP-3823).

**Change log entry**

No.

**Additional Notes:**

- This is R0, the fork-safety change [dd-trace-rb#6127](https://github.com/DataDog/dd-trace-rb/pull/6127). R0 and R1, the exception-safety change [dd-trace-rb#6128](https://github.com/DataDog/dd-trace-rb/pull/6128), are independent and can be reviewed and merged in either order.
- Packaging must proceed with [libdatadog-rb#65](https://github.com/DataDog/libdatadog-rb/pull/65) merging and publishing v37, followed by [libdatadog-rb#66](https://github.com/DataDog/libdatadog-rb/pull/66) merging and publishing v38. R2, the v38 runtime uptake [dd-trace-rb#6131](https://github.com/DataDog/dd-trace-rb/pull/6131), can then be finalized and merged.
- The libdatadog L0-L5 train consists of [libdatadog#2302](https://github.com/DataDog/libdatadog/pull/2302), [libdatadog#2303](https://github.com/DataDog/libdatadog/pull/2303), [libdatadog#2305](https://github.com/DataDog/libdatadog/pull/2305), [libdatadog#2301](https://github.com/DataDog/libdatadog/pull/2301), [libdatadog#2304](https://github.com/DataDog/libdatadog/pull/2304), and [libdatadog#2300](https://github.com/DataDog/libdatadog/pull/2300). Those changes must merge into v39 and be published by a matching future libdatadog-rb package before R3, the v39 payload API uptake [dd-trace-rb#6143](https://github.com/DataDog/dd-trace-rb/pull/6143), can be finalized.
- R4 M1 [dd-trace-rb#6130](https://github.com/DataDog/dd-trace-rb/pull/6130), R5 links [dd-trace-rb#6129](https://github.com/DataDog/dd-trace-rb/pull/6129), and R6 events [dd-trace-rb#6134](https://github.com/DataDog/dd-trace-rb/pull/6134) are parallel branches on R3, with recommended review and merge order M1, then links, then events. R7 M2 [dd-trace-rb#6132](https://github.com/DataDog/dd-trace-rb/pull/6132) is based on R4, and R8 M3 [dd-trace-rb#6133](https://github.com/DataDog/dd-trace-rb/pull/6133) is based on R7.
- Recommended overall merge order: independent R0/R1; libdatadog-rb v37 then v38; R2; libdatadog L0-L5 and the matching future libdatadog-rb package; R3; parallel R4-R6 in the recommended M1, links, events order; then R7 and R8.

**How to test the change?**

- Ran the core/main suite: 6,320 examples, 0 failures.
- Ran the native transport suite: 120 examples, 0 failures, including repeated seeded runs covering concurrent send, fork, close, callback failure, finalizer, and reentrant lifecycle paths.
- Ran Standard and Steep successfully.


[APMSP-3823]: https://datadoghq.atlassian.net/browse/APMSP-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ