### PR TITLE
Pin Static Analysis action references immutably

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -180,11 +180,12 @@ jobs:
           scope: DataDog/dd-trace-rb
           policy: self.check
       - name: Run zizmor
-        uses: docker://ghcr.io/zizmorcore/zizmor:1.26.1
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
-          args: --min-severity low .
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          version: 1.26.1
+          min-severity: low
+          advanced-security: false
+          token: ${{ steps.generate-token.outputs.token }}
 
   actionlint:
     name: actionlint
@@ -194,9 +195,14 @@ jobs:
         with:
           persist-credentials: false
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:1.7.8
-        with:
-          args: -color
+        env:
+          ACTIONLINT_IMAGE: rhysd/actionlint@sha256:96d4a8c87dbbfb3bdd324f8fdc285fc3df5261e2decc619a4dd7e8ee52bbfd46 # 1.7.8
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/repo:ro" \
+            --workdir /repo \
+            "$ACTIONLINT_IMAGE" \
+            -color
 
   yaml-lint:
     name: yaml-lint


### PR DESCRIPTION
**What does this PR do?**

Makes both `uses:` references in the `Static Analysis` workflow immutably pinned, so the workflow starts again. zizmor now runs through its first-party action pinned to a commit SHA, and actionlint runs its digest-pinned image from a `run:` step.

**Motivation:**

`Require actions to be pinned to a full-length commit SHA` is now enabled on this repository, and the two tag-pinned `docker://` references in `check.yml` were the only `uses:` refs in the repo that were not SHA-pinned. The workflow was rejected before any job was created, so `Static Analysis (complete)` reported no status at all and every open pull request was blocked on it.

A `startup_failure` produces zero check-runs, so the required check sits at "Expected — Waiting for status to be reported" instead of showing a red X. That is why this looked like a hung job rather than a failing one.

**Change log entry**

None.

**Additional Notes:**

actionlint publishes no GitHub Action (`action.yml` 404s), so it cannot be referenced as `owner/repo@<sha>`. Digest-pinning it as `uses: docker://rhysd/actionlint@sha256:...` does not work either, because the allowed-actions list admits it only as `docker://rhysd/actionlint:*`, and a digest reference has `@` where that pattern requires `:`. The tag form is refused by the pinning policy and the digest form by the allow-list, so no `uses:` value satisfies both. Running the digest-pinned image from a `run:` step keeps the immutable reference, and matches what `docs/DevelopmentGuide.md` already tells developers to run locally.

Two entries already present in this repository's allowed-actions list are load-bearing here: `zizmorcore/zizmor-action@*`, and `github/codeql-action/upload-sarif@*` for a step inside that action which stays skipped while `advanced-security: false`.

The zizmor step keeps its previous behavior. `advanced-security: false` keeps findings failing the job rather than uploading SARIF, `version: 1.26.1` holds the previous version instead of the action's `latest` default, and the dd-octo-sts token still authenticates the online audits. Immutability improves, because the action resolves 1.26.1 to an image digest where the old reference pinned only a mutable tag.

Left alone as unrelated: `docs/DevelopmentGuide.md` still points at the pre-rename `ghcr.io/woodruffw/zizmor` image.

**How to test the change?**

Run locally against this branch: `yamllint --strict .`, `actionlint` 1.7.8, and `zizmor` 1.26.1 at `--min-severity low` all pass. I also ran the digest-pinned actionlint container exactly as the workflow invokes it: exit 0 on this tree, and exit 1 with a reported finding on a deliberately broken workflow, so a lint failure still fails the job.

The change that matters is that the workflow starts at all, and this PR exercises that on itself, since `pull_request` runs the workflow from the merge ref. Check the run object rather than the checks tab, because a startup failure reports no status to read:

```
gh api "repos/DataDog/dd-trace-rb/actions/runs?branch=brian.marks/fix-actions-sha-pinning" \
  --jq '.workflow_runs[] | select(.name=="Static Analysis") | {conclusion, status}'
```

Expect `conclusion` to be anything other than `startup_failure`, with the `zizmor` and `actionlint` jobs both present and passing.
