### PR TITLE
Add workflow to receive images-rb pin update dispatches

### DIFF
--- a/.github/chainguard/self.update-images.sts.yaml
+++ b/.github/chainguard/self.update-images.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/master"
 
 claim_pattern:
-  event_name: workflow_dispatch|repository_dispatch
+  event_name: repository_dispatch
   repository: DataDog/dd-trace-rb
   job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/update-images\.yml@refs/heads/master
 

--- a/.github/chainguard/self.update-images.sts.yaml
+++ b/.github/chainguard/self.update-images.sts.yaml
@@ -2,6 +2,9 @@ issuer: https://token.actions.githubusercontent.com
 
 subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/master"
 
+# The corresponding cross-repo grant (images-rb -> dd-trace-rb, provisioned
+# externally) must identify the caller as images-rb's notify-consumers.yml
+# (formerly notify-dd-trace-rb.yml).
 claim_pattern:
   event_name: repository_dispatch
   repository: DataDog/dd-trace-rb

--- a/.github/chainguard/self.update-images.sts.yaml
+++ b/.github/chainguard/self.update-images.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-rb:ref:refs/heads/master"
+
+claim_pattern:
+  event_name: workflow_dispatch|repository_dispatch
+  repository: DataDog/dd-trace-rb
+  job_workflow_ref: DataDog/dd-trace-rb/\.github/workflows/update-images\.yml@refs/heads/master
+
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,16 +1,16 @@
 name: Update Images
 
-# This workflow only starts via repository_dispatch (event_type: images-updated),
-# sent by images-rb's "Notify dd-trace-rb" workflow. There is no workflow_dispatch
-# here -- it cannot be run directly from this repo's Actions tab. Two scenarios
-# reach it:
-#   1. images-rb merges to `main` and its build succeeds -> notify-dd-trace-rb.yml
-#      fires automatically and dispatches the merged commit's SHA.
-#   2. Someone manually re-runs images-rb's "Notify dd-trace-rb" workflow (its own
-#      workflow_dispatch) to re-trigger a pin update, e.g. after a transient failure.
-# If the cross-repo dispatch link itself is broken (e.g. the dd-octo-sts grant is
-# missing), fall back to running `rake images:pin[<commit-sha>]` locally and
-# opening a PR by hand -- the same process this automation replaces.
+# When a change merges into images-rb's `main`, its build publishes a new
+# commit-tagged image. Once that build succeeds, images-rb sends this repo a
+# `repository_dispatch` event carrying the merged commit's SHA, which starts
+# this workflow. images-rb's "Notify dd-trace-rb" workflow can also be
+# triggered manually from any branch, before merging into `main`, to send the
+# same dispatch ahead of time.
+#
+# This workflow opens (or updates) a PR that pins dd-trace-rb to the new
+# images-rb images, and dd-trace-rb's own CI on that PR is the validation:
+# green means the images-rb change works with dd-trace-rb. Once it's green,
+# merge the PR to adopt the new images across the repo.
 
 on: # yamllint disable-line rule:truthy
   repository_dispatch:

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,0 +1,120 @@
+name: Update Images
+
+# To run this workflow manually, use the following command:
+#  `gh workflow run "Update Images" -f commit=<40-char-sha>`
+#
+# with additional arguments:
+#  `gh workflow run "Update Images" -f commit=<40-char-sha> -f is_preview=true`
+
+on: # yamllint disable-line rule:truthy
+  repository_dispatch:
+    types: [images-updated]
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: images-rb commit SHA to pin to (40-char hex)
+        required: true
+        type: string
+      is_preview:
+        description: Open a draft preview PR instead of updating the standard PR
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.client_payload.commit || github.event.inputs.commit }}
+  cancel-in-progress: true
+
+# Default permissions for all jobs
+permissions: {}
+
+jobs:
+  update-images:
+    name: "Update Images"
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Determine trigger inputs
+        id: inputs
+        run: |
+          COMMIT="${{ github.event.client_payload.commit || github.event.inputs.commit }}"
+          IS_PREVIEW="${{ github.event.client_payload.is_preview || github.event.inputs.is_preview || 'false' }}"
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "is_preview=${IS_PREVIEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Pin images
+        run: bundle exec rake "images:pin[${{ steps.inputs.outputs.commit }}]"
+
+      - run: git diff --color=always
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-rb
+          policy: self.update-images
+
+      # There appers to be a race condition; wait it out a bit
+      # See: https://datadoghq.atlassian.net/browse/APMLP-1305
+      - name: Wait for token propagation
+        run: sleep 30
+
+      - name: Create Pull Request (standard)
+        if: ${{ steps.inputs.outputs.is_preview != 'true' }}
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: auto-generate/update-images
+          title: '[🤖] Update images-rb pin'
+          base: master
+          labels: dev/internal
+          commit-message: "[🤖] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          delete-branch: true
+          sign-commits: true
+          body: |
+            _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
+            The PR pins images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
+
+            You can trigger this workflow manually from [here](https://github.com/DataDog/dd-trace-rb/actions/workflows/update-images.yml).
+
+            **Trigger Information:**
+            - Event: ${{ github.event_name }}
+            - Triggered by: ${{ github.event.client_payload.triggered_by || 'Manual' }}
+            - Source commit: [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
+            - Source run: ${{ github.event.client_payload.source_run_url || 'N/A' }}
+
+            Please review the changes and merge when ready.
+
+      - name: Create Pull Request (preview)
+        if: ${{ steps.inputs.outputs.is_preview == 'true' }}
+        id: cpr-preview
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: auto-generate/update-images-preview-${{ steps.inputs.outputs.commit }}
+          title: '[🤖] [Preview] Update images-rb pin to ${{ steps.inputs.outputs.commit }}'
+          base: master
+          labels: dev/internal, preview
+          draft: true
+          commit-message: "[🤖] [Preview] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          delete-branch: true
+          sign-commits: true
+          body: |
+            _This is an auto-generated PREVIEW PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
+            This previews the effect of pinning images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }}), which has not yet merged to images-rb's default branch.
+
+            **This PR's CI may fail if the source images-rb branch/PR has not published a commit-tagged image** (e.g. fork PRs without package-publish permission). This is expected for unpublished previews.
+
+            **Trigger Information:**
+            - Event: ${{ github.event_name }}
+            - Triggered by: ${{ github.event.client_payload.triggered_by || 'Manual' }}
+            - Source commit: [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
+            - Source run: ${{ github.event.client_payload.source_run_url || 'N/A' }}
+
+            Do not merge — this is for validation only, unless you intend to pin ahead of the images-rb merge.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -2,9 +2,6 @@ name: Update Images
 
 # To run this workflow manually, use the following command:
 #  `gh workflow run "Update Images" -f commit=<40-char-sha>`
-#
-# with additional arguments:
-#  `gh workflow run "Update Images" -f commit=<40-char-sha> -f is_preview=true`
 
 on: # yamllint disable-line rule:truthy
   repository_dispatch:
@@ -15,11 +12,6 @@ on: # yamllint disable-line rule:truthy
         description: images-rb commit SHA to pin to (40-char hex)
         required: true
         type: string
-      is_preview:
-        description: Open a draft preview PR instead of updating the standard PR
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.client_payload.commit || github.event.inputs.commit }}
@@ -52,18 +44,12 @@ jobs:
         id: inputs
         env:
           RAW_COMMIT: ${{ github.event.client_payload.commit || github.event.inputs.commit }}
-          RAW_IS_PREVIEW: ${{ github.event.client_payload.is_preview || github.event.inputs.is_preview || 'false' }}
         run: |
           if ! [[ "$RAW_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Invalid commit SHA: must be 40 lowercase hex characters"
             exit 1
           fi
-          if [[ "$RAW_IS_PREVIEW" != "true" && "$RAW_IS_PREVIEW" != "false" ]]; then
-            echo "::error::Invalid is_preview value: must be 'true' or 'false'"
-            exit 1
-          fi
           echo "commit=${RAW_COMMIT}" >> "$GITHUB_OUTPUT"
-          echo "is_preview=${RAW_IS_PREVIEW}" >> "$GITHUB_OUTPUT"
 
       - name: Pin images
         env:
@@ -84,8 +70,7 @@ jobs:
       - name: Wait for token propagation
         run: sleep 30
 
-      - name: Create Pull Request (standard)
-        if: ${{ steps.inputs.outputs.is_preview != 'true' }}
+      - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -116,37 +101,3 @@ jobs:
             - Source run: ${{ github.event.client_payload.source_run_url || 'N/A' }}
 
             Please review the changes and merge when ready.
-
-      - name: Create Pull Request (preview)
-        if: ${{ steps.inputs.outputs.is_preview == 'true' }}
-        id: cpr-preview
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          branch: auto-generate/update-images-preview-${{ steps.inputs.outputs.commit }}
-          title: '[🤖] [Preview] Update images-rb pin to ${{ steps.inputs.outputs.commit }}'
-          base: master
-          labels: dev/internal, preview
-          draft: true
-          commit-message: "[🤖] [Preview] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          delete-branch: true
-          sign-commits: true
-          add-paths: |
-            .github/
-            .gitlab/
-            docker-compose.yml
-            integration/images/
-            tools/yard.gemfile
-          body: |
-            _This is an auto-generated PREVIEW PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
-            This previews the effect of pinning images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }}), which has not yet merged to images-rb's default branch.
-
-            **This PR's CI may fail if the source images-rb branch/PR has not published a commit-tagged image** (e.g. fork PRs without package-publish permission). This is expected for unpublished previews.
-
-            **Trigger Information:**
-            - Event: ${{ github.event_name }}
-            - Triggered by: ${{ github.event.client_payload.triggered_by || 'Manual' }}
-            - Source commit: [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
-            - Source run: ${{ github.event.client_payload.source_run_url || 'N/A' }}
-
-            Do not merge — this is for validation only, unless you intend to pin ahead of the images-rb merge.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -17,8 +17,8 @@ on: # yamllint disable-line rule:truthy
     types: [images-updated]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.commit }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -35,20 +35,9 @@ jobs:
           ruby-version: "4.0.1"
           bundler-cache: true
 
-      - name: Determine trigger inputs
-        id: inputs
-        env:
-          RAW_COMMIT: ${{ github.event.client_payload.commit }}
-        run: |
-          if ! [[ "$RAW_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Invalid commit SHA: must be 40 lowercase hex characters"
-            exit 1
-          fi
-          echo "commit=${RAW_COMMIT}" >> "$GITHUB_OUTPUT"
-
       - name: Pin images
         env:
-          COMMIT: ${{ steps.inputs.outputs.commit }}
+          COMMIT: ${{ github.event.client_payload.commit }}
         run: bundle exec rake "images:pin[$COMMIT]"
 
       - run: git diff --color=always
@@ -85,11 +74,11 @@ jobs:
             tools/yard.gemfile
           body: |
             _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
-            The PR pins images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
+            The PR pins images-rb images to commit [${{ github.event.client_payload.commit }}](https://github.com/DataDog/images-rb/commit/${{ github.event.client_payload.commit }})
 
             **Trigger Information:**
             - Triggered by: ${{ github.event.client_payload.triggered_by }}
-            - Source commit: [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
+            - Source commit: [${{ github.event.client_payload.commit }}](https://github.com/DataDog/images-rb/commit/${{ github.event.client_payload.commit }})
             - Source run: ${{ github.event.client_payload.source_run_url }}
 
             Please review the changes and merge when ready.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -34,21 +34,37 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
+    env:
+      BUNDLE_GEMFILE: gemfiles/ruby-4.0.gemfile
+      BUNDLE_FROZEN: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@a30dfa457ad68707b8b910ac3a244714b61c0626 # v1.320.0
+        with:
+          ruby-version: "4.0.1"
+          bundler-cache: true
+
       - name: Determine trigger inputs
         id: inputs
+        env:
+          RAW_COMMIT: ${{ github.event.client_payload.commit || github.event.inputs.commit }}
+          RAW_IS_PREVIEW: ${{ github.event.client_payload.is_preview || github.event.inputs.is_preview || 'false' }}
         run: |
-          COMMIT="${{ github.event.client_payload.commit || github.event.inputs.commit }}"
-          IS_PREVIEW="${{ github.event.client_payload.is_preview || github.event.inputs.is_preview || 'false' }}"
-          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
-          echo "is_preview=${IS_PREVIEW}" >> "$GITHUB_OUTPUT"
+          if ! [[ "$RAW_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid commit SHA: must be 40 lowercase hex characters"
+            exit 1
+          fi
+          echo "commit=${RAW_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "is_preview=${RAW_IS_PREVIEW}" >> "$GITHUB_OUTPUT"
 
       - name: Pin images
-        run: bundle exec rake "images:pin[${{ steps.inputs.outputs.commit }}]"
+        env:
+          COMMIT: ${{ steps.inputs.outputs.commit }}
+        run: bundle exec rake "images:pin[$COMMIT]"
 
       - run: git diff --color=always
 
@@ -77,6 +93,9 @@ jobs:
           commit-message: "[🤖] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           delete-branch: true
           sign-commits: true
+          add-paths: |
+            .github/
+            docker-compose.yml
           body: |
             _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
             The PR pins images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
@@ -105,6 +124,9 @@ jobs:
           commit-message: "[🤖] [Preview] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           delete-branch: true
           sign-commits: true
+          add-paths: |
+            .github/
+            docker-compose.yml
           body: |
             _This is an auto-generated PREVIEW PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
             This previews the effect of pinning images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }}), which has not yet merged to images-rb's default branch.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -58,6 +58,10 @@ jobs:
             echo "::error::Invalid commit SHA: must be 40 lowercase hex characters"
             exit 1
           fi
+          if [[ "$RAW_IS_PREVIEW" != "true" && "$RAW_IS_PREVIEW" != "false" ]]; then
+            echo "::error::Invalid is_preview value: must be 'true' or 'false'"
+            exit 1
+          fi
           echo "commit=${RAW_COMMIT}" >> "$GITHUB_OUTPUT"
           echo "is_preview=${RAW_IS_PREVIEW}" >> "$GITHUB_OUTPUT"
 
@@ -95,7 +99,10 @@ jobs:
           sign-commits: true
           add-paths: |
             .github/
+            .gitlab/
             docker-compose.yml
+            integration/images/
+            tools/yard.gemfile
           body: |
             _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
             The PR pins images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
@@ -126,7 +133,10 @@ jobs:
           sign-commits: true
           add-paths: |
             .github/
+            .gitlab/
             docker-compose.yml
+            integration/images/
+            tools/yard.gemfile
           body: |
             _This is an auto-generated PREVIEW PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
             This previews the effect of pinning images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }}), which has not yet merged to images-rb's default branch.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,8 +1,16 @@
 name: Update Images
 
-# This workflow is only triggered by images-rb's "Notify dd-trace-rb" workflow
-# via repository_dispatch. If that link is broken, fall back to running
-# `rake images:pin[<commit-sha>]` locally and opening a PR by hand.
+# This workflow only starts via repository_dispatch (event_type: images-updated),
+# sent by images-rb's "Notify dd-trace-rb" workflow. There is no workflow_dispatch
+# here -- it cannot be run directly from this repo's Actions tab. Two scenarios
+# reach it:
+#   1. images-rb merges to `main` and its build succeeds -> notify-dd-trace-rb.yml
+#      fires automatically and dispatches the merged commit's SHA.
+#   2. Someone manually re-runs images-rb's "Notify dd-trace-rb" workflow (its own
+#      workflow_dispatch) to re-trigger a pin update, e.g. after a transient failure.
+# If the cross-repo dispatch link itself is broken (e.g. the dd-octo-sts grant is
+# missing), fall back to running `rake images:pin[<commit-sha>]` locally and
+# opening a PR by hand -- the same process this automation replaces.
 
 on: # yamllint disable-line rule:truthy
   repository_dispatch:

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,20 +1,15 @@
 name: Update Images
 
-# To run this workflow manually, use the following command:
-#  `gh workflow run "Update Images" -f commit=<40-char-sha>`
+# This workflow is only triggered by images-rb's "Notify dd-trace-rb" workflow
+# via repository_dispatch. If that link is broken, fall back to running
+# `rake images:pin[<commit-sha>]` locally and opening a PR by hand.
 
 on: # yamllint disable-line rule:truthy
   repository_dispatch:
     types: [images-updated]
-  workflow_dispatch:
-    inputs:
-      commit:
-        description: images-rb commit SHA to pin to (40-char hex)
-        required: true
-        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.commit || github.event.inputs.commit }}
+  group: ${{ github.workflow }}-${{ github.event.client_payload.commit }}
   cancel-in-progress: true
 
 # Default permissions for all jobs
@@ -43,7 +38,7 @@ jobs:
       - name: Determine trigger inputs
         id: inputs
         env:
-          RAW_COMMIT: ${{ github.event.client_payload.commit || github.event.inputs.commit }}
+          RAW_COMMIT: ${{ github.event.client_payload.commit }}
         run: |
           if ! [[ "$RAW_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::Invalid commit SHA: must be 40 lowercase hex characters"
@@ -92,12 +87,9 @@ jobs:
             _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/update-images.yml)_
             The PR pins images-rb images to commit [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
 
-            You can trigger this workflow manually from [here](https://github.com/DataDog/dd-trace-rb/actions/workflows/update-images.yml).
-
             **Trigger Information:**
-            - Event: ${{ github.event_name }}
-            - Triggered by: ${{ github.event.client_payload.triggered_by || 'Manual' }}
+            - Triggered by: ${{ github.event.client_payload.triggered_by }}
             - Source commit: [${{ steps.inputs.outputs.commit }}](https://github.com/DataDog/images-rb/commit/${{ steps.inputs.outputs.commit }})
-            - Source run: ${{ github.event.client_payload.source_run_url || 'N/A' }}
+            - Source run: ${{ github.event.client_payload.source_run_url }}
 
             Please review the changes and merge when ready.

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -3,7 +3,7 @@ name: Update Images
 # When a change merges into images-rb's `main`, its build publishes a new
 # commit-tagged image. Once that build succeeds, images-rb sends this repo a
 # `repository_dispatch` event carrying the merged commit's SHA, which starts
-# this workflow. images-rb's "Notify dd-trace-rb" workflow can also be
+# this workflow. images-rb's "Notify Consumers" workflow can also be
 # triggered manually from any branch, before merging into `main`, to send the
 # same dispatch ahead of time.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ tracing libraries.
   dd-trace-js, dd-trace-php, auto_inject, httpd-datadog, nginx-datadog,
   inject-browser-sdk (listed in `libdatadog-build/campaigner-config.yml`).
 
+## images-rb pin updates
+
+`.github/workflows/update-images.yml` receives a `repository_dispatch` from
+images-rb (after its `main` builds successfully) and opens a PR pinning this
+repo to the new images. Requires an external cross-repo dd-octo-sts grant
+(images-rb -> dd-trace-rb); no local trigger otherwise.
+
 # Guidelines
 
 ## ⚠️ Ask First


### PR DESCRIPTION
**What does this PR do?**
Adds a new `update-images.yml` workflow that listens for a `repository_dispatch` (`images-updated`) event from [images-rb](https://github.com/DataDog/images-rb). When triggered, it runs `rake images:pin[COMMIT]` to update this repo's pinned images-rb image references, then opens (or updates) a PR.

**Motivation:**
dd-trace-rb pins `ghcr.io/datadog/images-rb/engines/...` image references to a specific commit SHA. Today, updating that pin is entirely manual — nothing notifies dd-trace-rb when images-rb publishes new images, so pins go stale until someone remembers to bump them by hand. This automates the PR side of that: images-rb notifies this repo (via a companion workflow being added there), and this workflow opens a reviewable PR with the updated pin, validated by this repo's own CI running against the new pin.

**Change log entry**
None. This is internal CI/workflow tooling with no customer-visible behavior change.

**Additional Notes:**
This workflow is only reachable via `repository_dispatch` from images-rb's `notify-consumers.yml` (no local `workflow_dispatch` fallback — if the cross-repo link breaks, running `rake images:pin[<commit>]` locally and opening a PR by hand is the fallback, same as today's manual process). It's currently blocked on an external cross-repo dd-octo-sts grant (images-rb → dd-trace-rb) that hasn't been provisioned yet, so end-to-end verification is still pending.

**How to test the change?**
No automated tests added — this is a thin wrapper around the existing `rake images:pin` task (unchanged, already covered by its own tests) and standard GitHub Actions constructs. Verified by reading the workflow YAML and the `dd-octo-sts` policy against the `self.update-system-tests` precedent it's modeled on. End-to-end testing (triggering a real dispatch) is pending the cross-repo grant mentioned above.