### PR TITLE
Add dd-octo-sts trust policy for images-rb cross-repo dispatch

### DIFF
--- a/.github/chainguard/images-rb.notify-consumers.sts.yaml
+++ b/.github/chainguard/images-rb.notify-consumers.sts.yaml
@@ -2,12 +2,15 @@ issuer: https://token.actions.githubusercontent.com
 
 # The caller is images-rb's notify-consumers.yml, not dd-trace-rb itself --
 # this policy grants images-rb permission to dispatch into this repo.
-subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/main"
+# notify-consumers.yml's workflow_dispatch trigger can be run manually from
+# any branch (to send an early pin-update dispatch before merging to main),
+# so the ref is not restricted to main.
+subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/.+"
 
 claim_pattern:
   event_name: workflow_run|workflow_dispatch
   repository: DataDog/images-rb
-  job_workflow_ref: DataDog/images-rb/\.github/workflows/notify-consumers\.yml@refs/heads/main
+  job_workflow_ref: DataDog/images-rb/\.github/workflows/notify-consumers\.yml@refs/heads/.+
 
 permissions:
   contents: write

--- a/.github/chainguard/images-rb.notify-consumers.sts.yaml
+++ b/.github/chainguard/images-rb.notify-consumers.sts.yaml
@@ -1,10 +1,7 @@
 issuer: https://token.actions.githubusercontent.com
 
-# The caller is images-rb's notify-consumers.yml, not dd-trace-rb itself --
-# this policy grants images-rb permission to dispatch into this repo.
-# notify-consumers.yml's workflow_dispatch trigger can be run manually from
-# any branch (to send an early pin-update dispatch before merging to main),
-# so the ref is not restricted to main.
+# Caller: images-rb's notify-consumers.yml. Any branch, since it can be
+# manually dispatched pre-merge to send an early pin-update.
 subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/.+"
 
 claim_pattern:

--- a/.github/chainguard/images-rb.notify-consumers.sts.yaml
+++ b/.github/chainguard/images-rb.notify-consumers.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+# The caller is images-rb's notify-consumers.yml, not dd-trace-rb itself --
+# this policy grants images-rb permission to dispatch into this repo.
+subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/main"
+
+claim_pattern:
+  event_name: workflow_run|workflow_dispatch
+  repository: DataDog/images-rb
+  job_workflow_ref: DataDog/images-rb/\.github/workflows/notify-consumers\.yml@refs/heads/main
+
+permissions:
+  contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,10 @@ tracing libraries.
 
 `.github/workflows/update-images.yml` receives a `repository_dispatch` from
 images-rb (after its `main` builds successfully) and opens a PR pinning this
-repo to the new images. Requires an external cross-repo dd-octo-sts grant
-(images-rb -> dd-trace-rb); no local trigger otherwise.
+repo to the new images. images-rb authenticates via the
+`images-rb.notify-consumers` dd-octo-sts trust policy
+(`.github/chainguard/images-rb.notify-consumers.sts.yaml`), an in-repo file --
+no external grant needed. No local trigger otherwise.
 
 # Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ tracing libraries.
 images-rb (after its `main` builds successfully) and opens a PR pinning this
 repo to the new images. images-rb authenticates via the
 `images-rb.notify-consumers` dd-octo-sts trust policy
-(`.github/chainguard/images-rb.notify-consumers.sts.yaml`), an in-repo file --
+(`.github/chainguard/images-rb.notify-consumers.sts.yaml`), an in-repo file –
 no external grant needed. No local trigger otherwise.
 
 # Guidelines


### PR DESCRIPTION
## Summary
- Adds the missing dd-octo-sts trust policy for images-rb's cross-repo dispatch, fixing a 404 during token exchange.
- Companion: DataDog/images-rb#111

**Change log entry**

None.