### PR TITLE
 Redact sensitive data in DI log-probe messages

### DIFF
--- a/lib/datadog/di/el/compiler.rb
+++ b/lib/datadog/di/el/compiler.rb
@@ -31,6 +31,29 @@ module Datadog
           [code, regexps]
         end
 
+        # Returns the identifier that +ast+ directly references at its top
+        # level, so the message path can redact direct references the same
+        # way snapshots redact by name.
+        #
+        # @param ast [untyped] top-level expression AST from a probe definition.
+        # @return [String, nil] the variable name for a `ref`/`iref`, the field
+        #   name for a `getmember`, or the string key for an `index`; nil when
+        #   the top-level expression is not a direct reference.
+        def redaction_identifier(ast)
+          return nil unless Hash === ast && ast.length == 1
+
+          entry = ast.first
+          return nil if entry.nil?
+
+          op, target = entry
+          case op
+          when "ref"
+            target if String === target
+          when "getmember", "index"
+            target[1] if Array === target && target.length == 2 && String === target[1]
+          end
+        end
+
         private
 
         # Steep: https://github.com/soutaro/steep/issues/363

--- a/lib/datadog/di/el/expression.rb
+++ b/lib/datadog/di/el/expression.rb
@@ -12,12 +12,17 @@ module Datadog
         # @param regexps [Array<Regexp>] precompiled `matches` regexps (see
         #   Compiler#precompile_regexp), the second element returned by
         #   Compiler#compile.
-        def initialize(dsl_expr, compiled_expr, regexps = [])
+        # @param redaction_identifier [String, nil] the identifier this
+        #   expression directly references at its top level (see
+        #   Compiler#redaction_identifier); nil when it is not a direct
+        #   reference.
+        def initialize(dsl_expr, compiled_expr, regexps = [], redaction_identifier: nil)
           unless String === compiled_expr
             raise ArgumentError, "compiled_expr must be a string"
           end
 
           @dsl_expr = dsl_expr
+          @redaction_identifier = redaction_identifier
 
           cls = Class.new(Evaluator)
           cls.class_exec do
@@ -36,6 +41,7 @@ module Datadog
 
         attr_reader :dsl_expr
         attr_reader :evaluator
+        attr_reader :redaction_identifier
 
         def evaluate(context)
           @evaluator.evaluate(context)

--- a/lib/datadog/di/el/expression.rb
+++ b/lib/datadog/di/el/expression.rb
@@ -16,7 +16,7 @@ module Datadog
         #   expression directly references at its top level (see
         #   Compiler#redaction_identifier); nil when it is not a direct
         #   reference.
-        def initialize(dsl_expr, compiled_expr, regexps = [], redaction_identifier: nil)
+        def initialize(dsl_expr, compiled_expr, regexps: [], redaction_identifier: nil)
           unless String === compiled_expr
             raise ArgumentError, "compiled_expr must be a string"
           end

--- a/lib/datadog/di/probe_builder.rb
+++ b/lib/datadog/di/probe_builder.rb
@@ -152,8 +152,9 @@ module Datadog
               unless dsl = segment["dsl"]
                 raise ArgumentError, "Missing dsl for json in segment: #{segment}"
               end
-              compiled, regexps = EL::Compiler.new.compile(ast)
-              EL::Expression.new(dsl, compiled, regexps)
+              compiler = EL::Compiler.new
+              compiled, regexps = compiler.compile(ast)
+              EL::Expression.new(dsl, compiled, regexps, redaction_identifier: compiler.redaction_identifier(ast))
             else
               # TODO report to telemetry?
             end

--- a/lib/datadog/di/probe_builder.rb
+++ b/lib/datadog/di/probe_builder.rb
@@ -46,7 +46,7 @@ module Datadog
             raise ArgumentError, "Malformed condition specification for probe: #{config}"
           end
           compiled, regexps = EL::Compiler.new.compile(cond_spec["json"])
-          EL::Expression.new(cond_spec["dsl"], compiled, regexps)
+          EL::Expression.new(cond_spec["dsl"], compiled, regexps: regexps)
         end
         capture_expressions = build_capture_expressions(config["captureExpressions"])
         capture_expressions = dedup_capture_expressions(capture_expressions, config["id"], logger)
@@ -101,7 +101,7 @@ module Datadog
             raise ArgumentError, "captureExpressions entry #{name}: missing or malformed expr"
           end
           compiled, regexps = EL::Compiler.new.compile(expr_spec["json"])
-          expr = EL::Expression.new(expr_spec["dsl"], compiled, regexps)
+          expr = EL::Expression.new(expr_spec["dsl"], compiled, regexps: regexps)
           limits = build_capture_limits(entry["capture"])
           CaptureExpression.new(name: name, expr: expr, limits: limits)
         end
@@ -154,7 +154,7 @@ module Datadog
               end
               compiler = EL::Compiler.new
               compiled, regexps = compiler.compile(ast)
-              EL::Expression.new(dsl, compiled, regexps, redaction_identifier: compiler.redaction_identifier(ast))
+              EL::Expression.new(dsl, compiled, regexps: regexps, redaction_identifier: compiler.redaction_identifier(ast))
             else
               # TODO report to telemetry?
             end

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -405,7 +405,7 @@ module Datadog
           when String
             segment
           when EL::Expression
-            serializer.serialize_value_for_message(segment.evaluate(context))
+            serializer.serialize_value_for_message(segment.evaluate(context), name: segment.redaction_identifier)
           else
             raise ArgumentError, "Invalid template segment type: #{segment}"
           end

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -382,11 +382,16 @@ module Datadog
       #
       # We also use the Ruby-like syntax for symbols, which don't exist
       # in other languages.
-      def serialize_value_for_message(value, depth = 1)
+      #
+      # +name+, when given, is the identifier the template expression
+      # references at its top level; a redacted identifier yields the
+      # redaction placeholder, mirroring #serialize_value on the snapshot path.
+      def serialize_value_for_message(value, depth = 1, name: nil)
         # This method is more verbose than "normal" Ruby code to avoid
         # array allocations.
 
         return REDACTED_VALUE_FOR_MESSAGE if redactor.redact_type?(value)
+        return REDACTED_VALUE_FOR_MESSAGE if name && redactor.redact_identifier?(name)
 
         case value
         when NilClass

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -428,7 +428,7 @@ module Datadog
             truncated = true
           end
           serialized = keys.map do |key|
-            serialized_value = if redactor.redact_identifier?(key)
+            serialized_value = if (String === key || Symbol === key) && redactor.redact_identifier?(key)
               REDACTED_VALUE_FOR_MESSAGE
             else
               serialize_value_for_message(value[key], depth - 1)

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -50,6 +50,13 @@ module Datadog
       # return a safe stub rather than tear the process down.
       SERIALIZABLE_FATAL_EXCEPTION_CLASSES = [SystemExit, SignalException].freeze
 
+      # Placeholder emitted by #serialize_value_for_message in place of a value
+      # whose identifier or type matches the redaction configuration. This
+      # mirrors, for the human-readable log-probe message path, the
+      # notCapturedReason: "redactedIdent"/"redactedType" gating that
+      # #serialize_value applies on the snapshot path.
+      REDACTED_VALUE_FOR_MESSAGE = "[redacted]"
+
       # Third-party library integration / custom serializers.
       #
       # Dynamic instrumentation has limited payload sizes, and for efficiency
@@ -378,6 +385,11 @@ module Datadog
       def serialize_value_for_message(value, depth = 1)
         # This method is more verbose than "normal" Ruby code to avoid
         # array allocations.
+
+        # Redact by type before interpolating any of the value's contents,
+        # matching the redact_type? gating in #serialize_value.
+        return REDACTED_VALUE_FOR_MESSAGE if redactor.redact_type?(value)
+
         case value
         when NilClass
           "nil"
@@ -413,7 +425,15 @@ module Datadog
             truncated = true
           end
           serialized = keys.map do |key|
-            "#{serialize_value_for_message(key, depth - 1)} => #{serialize_value_for_message(value[key], depth - 1)}"
+            # Redact the value (not the key) when the key matches a redacted
+            # identifier, matching the redact_identifier? gating that
+            # #serialize_value applies to hash entries via the name argument.
+            serialized_value = if redactor.redact_identifier?(key)
+              REDACTED_VALUE_FOR_MESSAGE
+            else
+              serialize_value_for_message(value[key], depth - 1)
+            end
+            "#{serialize_value_for_message(key, depth - 1)} => #{serialized_value}"
           end
           if truncated
             serialized[serialized.length] = serialized[serialized.length - 1]
@@ -435,7 +455,17 @@ module Datadog
           serialized = vars.map do |var|
             # +var+ here is always the instance variable name which is a
             # symbol, we do not need to run it through our serializer.
-            "#{var}=#{serialize_value_for_message(value.send(:instance_variable_get, var), depth - 1)}"
+            #
+            # Redact the value when the instance variable name matches a
+            # redacted identifier, matching the redact_identifier? gating that
+            # #serialize_value applies to instance variables via the name
+            # argument.
+            serialized_value = if redactor.redact_identifier?(var)
+              REDACTED_VALUE_FOR_MESSAGE
+            else
+              serialize_value_for_message(value.send(:instance_variable_get, var), depth - 1)
+            end
+            "#{var}=#{serialized_value}"
           end
           if truncated
             serialized << serialized.last

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -386,8 +386,6 @@ module Datadog
         # This method is more verbose than "normal" Ruby code to avoid
         # array allocations.
 
-        # Redact by type before interpolating any of the value's contents,
-        # matching the redact_type? gating in #serialize_value.
         return REDACTED_VALUE_FOR_MESSAGE if redactor.redact_type?(value)
 
         case value
@@ -425,9 +423,6 @@ module Datadog
             truncated = true
           end
           serialized = keys.map do |key|
-            # Redact the value when the key matches a redacted
-            # identifier, matching the redact_identifier? gating that
-            # #serialize_value applies to hash entries via the name argument.
             serialized_value = if redactor.redact_identifier?(key)
               REDACTED_VALUE_FOR_MESSAGE
             else
@@ -455,11 +450,6 @@ module Datadog
           serialized = vars.map do |var|
             # +var+ here is always the instance variable name which is a
             # symbol, we do not need to run it through our serializer.
-            #
-            # Redact the value when the instance variable name matches a
-            # redacted identifier, matching the redact_identifier? gating that
-            # #serialize_value applies to instance variables via the name
-            # argument.
             serialized_value = if redactor.redact_identifier?(var)
               REDACTED_VALUE_FOR_MESSAGE
             else

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -425,7 +425,7 @@ module Datadog
             truncated = true
           end
           serialized = keys.map do |key|
-            # Redact the value (not the key) when the key matches a redacted
+            # Redact the value when the key matches a redacted
             # identifier, matching the redact_identifier? gating that
             # #serialize_value applies to hash entries via the name argument.
             serialized_value = if redactor.redact_identifier?(key)

--- a/lib/datadog/di/serializer.rb
+++ b/lib/datadog/di/serializer.rb
@@ -386,7 +386,7 @@ module Datadog
       # +name+, when given, is the identifier the template expression
       # references at its top level; a redacted identifier yields the
       # redaction placeholder, mirroring #serialize_value on the snapshot path.
-      def serialize_value_for_message(value, depth = 1, name: nil)
+      def serialize_value_for_message(value, depth: 1, name: nil)
         # This method is more verbose than "normal" Ruby code to avoid
         # array allocations.
 
@@ -413,7 +413,7 @@ module Datadog
             value = value_
           end
           "[" + value.map do |item|
-            serialize_value_for_message(item, depth - 1)
+            serialize_value_for_message(item, depth: depth - 1)
           end.join(", ") + "]"
         when Hash
           return "..." if depth <= 0
@@ -431,9 +431,9 @@ module Datadog
             serialized_value = if (String === key || Symbol === key) && redactor.redact_identifier?(key)
               REDACTED_VALUE_FOR_MESSAGE
             else
-              serialize_value_for_message(value[key], depth - 1)
+              serialize_value_for_message(value[key], depth: depth - 1)
             end
-            "#{serialize_value_for_message(key, depth - 1)} => #{serialized_value}"
+            "#{serialize_value_for_message(key, depth: depth - 1)} => #{serialized_value}"
           end
           if truncated
             serialized[serialized.length] = serialized[serialized.length - 1]
@@ -458,7 +458,7 @@ module Datadog
             serialized_value = if redactor.redact_identifier?(var)
               REDACTED_VALUE_FOR_MESSAGE
             else
-              serialize_value_for_message(value.send(:instance_variable_get, var), depth - 1)
+              serialize_value_for_message(value.send(:instance_variable_get, var), depth: depth - 1)
             end
             "#{var}=#{serialized_value}"
           end

--- a/sig/datadog/di/el/compiler.rbs
+++ b/sig/datadog/di/el/compiler.rbs
@@ -4,6 +4,8 @@ module Datadog
       class Compiler
         def compile: (ast ast) -> [ ::String, ::Array[::Regexp] ]
 
+        def redaction_identifier: (ast ast) -> ::String?
+
         private
 
         OPERATORS: { "eq" => "==", "ne" => "!=", "ge" => ">=", "gt" => ">", "le" => "<=", "lt" => "<" }

--- a/sig/datadog/di/el/expression.rbs
+++ b/sig/datadog/di/el/expression.rbs
@@ -6,11 +6,15 @@ module Datadog
 
         @evaluator: Evaluator
 
-        def initialize: (::String dsl_expr, ::String compiled_expr, ?::Array[::Regexp] regexps) -> void
+        @redaction_identifier: ::String?
+
+        def initialize: (::String dsl_expr, ::String compiled_expr, ?::Array[::Regexp] regexps, ?redaction_identifier: ::String?) -> void
 
         attr_reader dsl_expr: String
 
         attr_reader evaluator: Evaluator
+
+        attr_reader redaction_identifier: ::String?
 
         def evaluate: (Context context) -> any
 

--- a/sig/datadog/di/el/expression.rbs
+++ b/sig/datadog/di/el/expression.rbs
@@ -8,7 +8,7 @@ module Datadog
 
         @redaction_identifier: ::String?
 
-        def initialize: (::String dsl_expr, ::String compiled_expr, ?::Array[::Regexp] regexps, ?redaction_identifier: ::String?) -> void
+        def initialize: (::String dsl_expr, ::String compiled_expr, ?regexps: ::Array[::Regexp], ?redaction_identifier: ::String?) -> void
 
         attr_reader dsl_expr: String
 

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -4,6 +4,7 @@ module Datadog
       MAX_MESSAGE_COLLECTION_SIZE: Integer
       MAX_MESSAGE_ATTRIBUTE_COUNT: Integer
       SERIALIZABLE_FATAL_EXCEPTION_CLASSES: ::Array[singleton(::Exception)]
+      REDACTED_VALUE_FOR_MESSAGE: ::String
 
       @@flat_registry: ::Array[{condition: ::Proc?, proc: ^(Serializer serializer, any value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped}]
 

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -26,7 +26,7 @@ module Datadog
       def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
-      def serialize_value_for_message: (any value, ?::Integer depth) -> String?
+      def serialize_value_for_message: (any value, ?::Integer depth, ?name: (::Symbol | ::String)?) -> String?
 
       def self.register: (?condition: Proc?) {
         (Serializer serializer, any value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped } -> void

--- a/sig/datadog/di/serializer.rbs
+++ b/sig/datadog/di/serializer.rbs
@@ -26,7 +26,7 @@ module Datadog
       def serialize_args: (Array[untyped] args, Hash[Symbol, untyped] kwargs, untyped instance_vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_vars: (Hash[Symbol, untyped] vars, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?) -> Hash[Symbol, untyped]
       def serialize_value: (any value, ?name: (Symbol | String)?, ?depth: Integer, ?attribute_count: Integer?, ?length: Integer?, ?collection_size: Integer?, ?type: Class?) -> Hash[Symbol, untyped]
-      def serialize_value_for_message: (any value, ?::Integer depth, ?name: (::Symbol | ::String)?) -> String?
+      def serialize_value_for_message: (any value, ?depth: ::Integer, ?name: (::Symbol | ::String)?) -> String?
 
       def self.register: (?condition: Proc?) {
         (Serializer serializer, any value, name: ::Symbol?, depth: ::Integer, ?attribute_count: ::Integer?) -> untyped } -> void

--- a/spec/datadog/di/capture_expression_evaluator_spec.rb
+++ b/spec/datadog/di/capture_expression_evaluator_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Datadog::DI::CaptureExpressionEvaluator do
   end
 
   def compile_expression(dsl_string, json)
-    Datadog::DI::EL::Expression.new(dsl_string, *Datadog::DI::EL::Compiler.new.compile(json))
+    compiled, regexps = Datadog::DI::EL::Compiler.new.compile(json)
+    Datadog::DI::EL::Expression.new(dsl_string, compiled, regexps: regexps)
   end
 
   let(:context) do

--- a/spec/datadog/di/el/compiler_spec.rb
+++ b/spec/datadog/di/el/compiler_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require_relative "../spec_helper"
+require "datadog/di/el"
+
+RSpec.describe Datadog::DI::EL::Compiler do
+  di_test
+
+  let(:compiler) { described_class.new }
+
+  describe "#redaction_identifier" do
+    [
+      ["local reference", {"ref" => "password"}, "password"],
+      ["instance variable reference", {"ref" => "@password"}, "@password"],
+      ["member access", {"getmember" => [{"ref" => "obj"}, "password"]}, "password"],
+      ["string index", {"index" => [{"ref" => "h"}, "password"]}, "password"],
+      ["numeric index", {"index" => [{"ref" => "arr"}, 0]}, nil],
+      ["non-reference operation", {"len" => {"ref" => "password"}}, nil],
+      ["non-hash ast", "password", nil],
+      ["empty hash", {}, nil],
+    ].each do |desc, ast, expected|
+      context desc do
+        it "returns #{expected.inspect}" do
+          expect(compiler.redaction_identifier(ast)).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/di/el/duration_spec.rb
+++ b/spec/datadog/di/el/duration_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "DI EL @duration" do
   end
 
   def evaluate(ast)
-    Datadog::DI::EL::Expression.new("(expression)", *compiler.compile(ast)).evaluate(context)
+    compiled, regexps = compiler.compile(ast)
+    Datadog::DI::EL::Expression.new("(expression)", compiled, regexps: regexps).evaluate(context)
   end
 
   context "at entry time, when duration is nil" do

--- a/spec/datadog/di/el/integration_spec.rb
+++ b/spec/datadog/di/el/integration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Datadog::DI::EL do
 
           let(:compile_result) { compiler.compile(ast) }
           let(:compiled) { compile_result.first }
-          let(:expr) { Datadog::DI::EL::Expression.new("(expression)", *compile_result) }
+          let(:expr) { Datadog::DI::EL::Expression.new("(expression)", compiled, regexps: compile_result.last) }
 
           let(:evaluated) do
             expr.evaluate(context)

--- a/spec/datadog/di/probe_builder_spec.rb
+++ b/spec/datadog/di/probe_builder_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe Datadog::DI::ProbeBuilder do
       end
     end
 
+    context "template with expression segment referencing a redacted identifier" do
+      let(:rc_probe_spec) do
+        {"id" => "3ecfd456-2d7c-4359-a51f-d4cc44141ffe",
+         "type" => "LOG_PROBE",
+         "where" => {"sourceFile" => "aaa.rb", "lines" => [4321]},
+         "template" => "{password}",
+         "segments" => [{"dsl" => "password", "json" => {"ref" => "password"}}],}
+      end
+
+      it "records the referenced identifier on the segment for redaction" do
+        segment = probe.template_segments.first
+        expect(segment).to be_a(Datadog::DI::EL::Expression)
+        expect(segment.redaction_identifier).to eq("password")
+      end
+    end
+
     context "minimum set of fields" do
       # This is a made up payload to test attribute defaulting.
       # In practice payloads like this should not be seen.

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -707,6 +707,37 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
         expect(builder.send(:evaluate_template, template_segments, context)).to eq([expected, []])
       end
     end
+
+    context "when a segment references a redacted identifier" do
+      let(:template_segments) do
+        compiler = Datadog::DI::EL::Compiler.new
+        password_ast = {"ref" => "password"}
+        user_ast = {"ref" => "user"}
+        [
+          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile(password_ast),
+            redaction_identifier: compiler.redaction_identifier(password_ast)),
+          " ",
+          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile(user_ast),
+            redaction_identifier: compiler.redaction_identifier(user_ast)),
+        ]
+      end
+
+      let(:vars) do
+        {password: "hunter2", user: "alice"}
+      end
+
+      let(:context) do
+        Datadog::DI::Context.new(
+          settings: settings, serializer: serializer,
+          locals: vars,
+          probe: probe
+        )
+      end
+
+      it "redacts the referenced value in the rendered message" do
+        expect(builder.send(:evaluate_template, template_segments, context)).to eq(["[redacted] alice", []])
+      end
+    end
   end
 
   describe "#build_snapshot with capture_expressions" do

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -678,10 +678,12 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       let(:compiler) { Datadog::DI::EL::Compiler.new }
 
       let(:template_segments) do
+        hello_compiled, hello_regexps = compiler.compile("ref" => "hello")
+        world_compiled, world_regexps = compiler.compile("ref" => "world")
         [
-          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile("ref" => "hello")),
+          Datadog::DI::EL::Expression.new("(expression)", hello_compiled, regexps: hello_regexps),
           " ",
-          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile("ref" => "world")),
+          Datadog::DI::EL::Expression.new("(expression)", world_compiled, regexps: world_regexps),
         ]
       end
 
@@ -713,11 +715,13 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
         compiler = Datadog::DI::EL::Compiler.new
         password_ast = {"ref" => "password"}
         user_ast = {"ref" => "user"}
+        password_compiled, password_regexps = compiler.compile(password_ast)
+        user_compiled, user_regexps = compiler.compile(user_ast)
         [
-          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile(password_ast),
+          Datadog::DI::EL::Expression.new("(expression)", password_compiled, regexps: password_regexps,
             redaction_identifier: compiler.redaction_identifier(password_ast)),
           " ",
-          Datadog::DI::EL::Expression.new("(expression)", *compiler.compile(user_ast),
+          Datadog::DI::EL::Expression.new("(expression)", user_compiled, regexps: user_regexps,
             redaction_identifier: compiler.redaction_identifier(user_ast)),
         ]
       end
@@ -742,7 +746,8 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
 
   describe "#build_snapshot with capture_expressions" do
     let(:compiled_expr) do
-      Datadog::DI::EL::Expression.new("x", *Datadog::DI::EL::Compiler.new.compile({"ref" => "x"}))
+      compiled, regexps = Datadog::DI::EL::Compiler.new.compile({"ref" => "x"})
+      Datadog::DI::EL::Expression.new("x", compiled, regexps: regexps)
     end
 
     let(:capture_expression) do
@@ -909,7 +914,8 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
 
     context "evaluation error in a capture expression" do
       let(:failing_expr) do
-        Datadog::DI::EL::Expression.new("len(badvar)", *Datadog::DI::EL::Compiler.new.compile({"len" => {"ref" => "badvar"}}))
+        compiled, regexps = Datadog::DI::EL::Compiler.new.compile({"len" => {"ref" => "badvar"}})
+        Datadog::DI::EL::Expression.new("len(badvar)", compiled, regexps: regexps)
       end
 
       let(:probe) do

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -533,8 +533,7 @@ RSpec.describe Datadog::DI::Serializer do
       ["object with array field", DISerializerSpecFields.new(a: 1, b: [2]), "#<DISerializerSpecFields @a=1 @b=...>"],
       ["object with hash field", DISerializerSpecFields.new(a: 1, b: {x: 2}), "#<DISerializerSpecFields @a=1 @b=...>"],
       ["when serialization fails", DISerializerSpecBrokenHash.new, "#<DISerializerSpecBrokenHash: serialization error>"],
-      # Redaction — mirrors the redact_type?/redact_identifier? gating that
-      # #serialize_value applies on the snapshot path (INV-R7-001).
+      # Redaction
       ["hash with redacted symbol key", {password: "hunter2"}, "{:password => [redacted]}"],
       ["hash with redacted string key", {"session-key" => 42}, "{session-key => [redacted]}"],
       ["hash with non-redacted key", {name: "alice"}, "{:name => alice}"],

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -533,6 +533,17 @@ RSpec.describe Datadog::DI::Serializer do
       ["object with array field", DISerializerSpecFields.new(a: 1, b: [2]), "#<DISerializerSpecFields @a=1 @b=...>"],
       ["object with hash field", DISerializerSpecFields.new(a: 1, b: {x: 2}), "#<DISerializerSpecFields @a=1 @b=...>"],
       ["when serialization fails", DISerializerSpecBrokenHash.new, "#<DISerializerSpecBrokenHash: serialization error>"],
+      # Redaction — mirrors the redact_type?/redact_identifier? gating that
+      # #serialize_value applies on the snapshot path (INV-R7-001).
+      ["hash with redacted symbol key", {password: "hunter2"}, "{:password => [redacted]}"],
+      ["hash with redacted string key", {"session-key" => 42}, "{session-key => [redacted]}"],
+      ["hash with non-redacted key", {name: "alice"}, "{:name => alice}"],
+      ["hash value of redacted type", {value: DISerializerSpecSensitiveType.new}, "{:value => [redacted]}"],
+      ["object with redacted and non-redacted fields", DISerializerSpecFields.new(name: "alice", password: "hunter2"), "#<DISerializerSpecFields @name=alice @password=[redacted]>"],
+      ["object with redacted instance variable", DISerializerSpecRedactedInstanceVariable.new(42), "#<DISerializerSpecRedactedInstanceVariable @session=[redacted]>"],
+      ["value of redacted type", DISerializerSpecSensitiveType.new, "[redacted]"],
+      ["value of redacted wildcard type", DISerializerSpecWildCardClass.new, "[redacted]"],
+      ["array with element of redacted type", [1, DISerializerSpecSensitiveType.new], "[1, [redacted]]"],
     ].each do |desc, input, expected_output|
       context desc do
         let(:actual) do

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -63,6 +63,12 @@ class DISerializerSpecBrokenHash < Hash
   end
 end
 
+class DISerializerSpecRaisingToSKey
+  def to_s
+    raise "#to_s must not be called on a non-String/Symbol hash key"
+  end
+end
+
 class DISerializerSpecFields
   def initialize(**fields)
     fields.each do |k, v|
@@ -537,6 +543,7 @@ RSpec.describe Datadog::DI::Serializer do
       ["hash with redacted symbol key", {password: "hunter2"}, "{:password => [redacted]}"],
       ["hash with redacted string key", {"session-key" => 42}, "{session-key => [redacted]}"],
       ["hash with non-redacted key", {name: "alice"}, "{:name => alice}"],
+      ["hash with non-string/symbol key does not invoke key#to_s", {DISerializerSpecRaisingToSKey.new => "value"}, "{... => value}"],
       ["hash value of redacted type", {value: DISerializerSpecSensitiveType.new}, "{:value => [redacted]}"],
       ["object with redacted and non-redacted fields", DISerializerSpecFields.new(name: "alice", password: "hunter2"), "#<DISerializerSpecFields @name=alice @password=[redacted]>"],
       ["object with redacted instance variable", DISerializerSpecRedactedInstanceVariable.new(42), "#<DISerializerSpecRedactedInstanceVariable @session=[redacted]>"],

--- a/spec/datadog/di/serializer_spec.rb
+++ b/spec/datadog/di/serializer_spec.rb
@@ -556,6 +556,25 @@ RSpec.describe Datadog::DI::Serializer do
     end
   end
 
+  describe "#serialize_value_for_message with a name" do
+    [
+      ["redacted identifier", "hunter2", "password", "[redacted]"],
+      ["redacted instance variable identifier", "hunter2", "@password", "[redacted]"],
+      ["non-redacted identifier", "alice", "name", "alice"],
+      ["nil name", "alice", nil, "alice"],
+    ].each do |desc, input, name, expected_output|
+      context desc do
+        let(:actual) do
+          serializer.serialize_value_for_message(input, name: name)
+        end
+
+        it "produces expected output" do
+          expect(actual).to eq(expected_output)
+        end
+      end
+    end
+  end
+
   describe ".register" do
     with_di_registry_change
 


### PR DESCRIPTION
**What does this PR do?**

Redacts DI log probe messages the same way that the values are redacted in snapshots.

**Motivation:**

Currently it is possible to bypass value redaction by explicitly referencing values in the message template.

The behavior of most tracers is to redact in messages also. This PR makes Ruby aligned with the majority of tracers.

**Change log entry**

Yes. Dynamic Instrumentation now redacts sensitive identifiers and types in log probe messages, matching the redaction already applied to captured snapshots.

**How to test the change?**

Unit tests added.