### PR TITLE
Normalize CRLF line endings in GitHub release bodies during release prep

### DIFF
--- a/spec/tasks/release_notes_spec.rb
+++ b/spec/tasks/release_notes_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "rake"
+require_relative "../../tasks/release_notes"
 
-Rake.application ||= Rake::Application.new
-load File.expand_path("../../tasks/release_prep.rake", __dir__) unless defined?(ReleasePrep)
-
-RSpec.describe ReleasePrep, webmock: true do
+RSpec.describe ReleaseNotes, webmock: true do
   describe ".draft_changelog" do
     let(:version) { "2.36.0" }
     let(:releases_url) { "https://api.github.com/repos/DataDog/dd-trace-rb/releases?per_page=100" }

--- a/spec/tasks/release_prep_spec.rb
+++ b/spec/tasks/release_prep_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rake"
+
+Rake.application ||= Rake::Application.new
+load File.expand_path("../../tasks/release_prep.rake", __dir__) unless defined?(ReleasePrep)
+
+RSpec.describe ReleasePrep, webmock: true do
+  describe ".draft_changelog" do
+    let(:version) { "2.36.0" }
+    let(:releases_url) { "https://api.github.com/repos/DataDog/dd-trace-rb/releases?per_page=100" }
+
+    def stub_releases(body:)
+      stub_request(:get, releases_url).to_return(
+        status: 200,
+        body: [
+          {"tag_name" => "v2.36.0", "draft" => true, "body" => body},
+        ].to_json,
+      )
+    end
+
+    it "normalizes CRLF line endings from the GitHub API response to LF" do
+      stub_releases(body: "* Fix a bug\r\n* Fix another bug\r\n")
+
+      expect(described_class.draft_changelog(version)).to eq("* Fix a bug\n* Fix another bug")
+    end
+
+    it "normalizes lone CR line endings to LF" do
+      stub_releases(body: "* Fix a bug\r* Fix another bug\r")
+
+      expect(described_class.draft_changelog(version)).to eq("* Fix a bug\n* Fix another bug")
+    end
+
+    it "leaves LF-only bodies unchanged" do
+      stub_releases(body: "* Fix a bug\n* Fix another bug\n")
+
+      expect(described_class.draft_changelog(version)).to eq("* Fix a bug\n* Fix another bug")
+    end
+
+    it "keeps only the content after the changelog marker" do
+      stub_releases(body: "Highlights\r\n<!-- changelog -->\r\n* Fix a bug\r\n")
+
+      expect(described_class.draft_changelog(version)).to eq("* Fix a bug")
+    end
+  end
+end

--- a/tasks/release_notes.rb
+++ b/tasks/release_notes.rb
@@ -30,7 +30,7 @@ module ReleaseNotes
   def draft_changelog(version)
     uri = URI("#{API_URL}/repos/#{REPO}/releases?per_page=100")
     request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "Bearer #{Datadog::DATADOG_ENV["GITHUB_TOKEN"]}"
+    request["Authorization"] = "Bearer #{ENV["GITHUB_TOKEN"]}"
     request["Accept"] = "application/vnd.github+json"
     request["X-GitHub-Api-Version"] = "2022-11-28"
     request["User-Agent"] = "dd-trace-rb-release-prep"

--- a/tasks/release_notes.rb
+++ b/tasks/release_notes.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "date"
+require "json"
+require "net/http"
+
+module ReleaseNotes
+  REPO = "DataDog/dd-trace-rb"
+  REPO_URL = "https://github.com/#{REPO}"
+  API_URL = "https://api.github.com"
+  CHANGELOG_FILE = "CHANGELOG.md"
+
+  # Separates release "highlights" (release-page only) from the changelog body in
+  # the draft release. When the marker is absent we fall back to the whole body.
+  CHANGELOG_MARKER = "<!-- changelog -->"
+
+  PREVIOUS_VERSION_PATTERN = %r{\[Unreleased\]: #{Regexp.escape(REPO_URL)}/compare/v(.+?)\.\.\.master}
+  UNRELEASED_FOOTER_PATTERN = %r{\[Unreleased\]: #{Regexp.escape(REPO_URL)}/compare/.*?\.\.\.master}
+
+  module_function
+
+  def previous_version
+    content = File.read(CHANGELOG_FILE)
+    match = content.match(PREVIOUS_VERSION_PATTERN)
+    fail!("Could not find the [Unreleased] compare link in #{CHANGELOG_FILE}") unless match
+
+    match[1]
+  end
+
+  def draft_changelog(version)
+    uri = URI("#{API_URL}/repos/#{REPO}/releases?per_page=100")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{ENV["GITHUB_TOKEN"]}"
+    request["Accept"] = "application/vnd.github+json"
+    request["X-GitHub-Api-Version"] = "2022-11-28"
+    request["User-Agent"] = "dd-trace-rb-release-prep"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+    fail!("GitHub API request failed: #{response.code} #{response.body}") unless response.is_a?(Net::HTTPSuccess)
+
+    tag = "v#{version}"
+    draft = JSON.parse(response.body).find { |release| release["tag_name"] == tag && release["draft"] == true }
+    fail!("No draft release found with tag #{tag}. Please create and approve a draft release first.") unless draft
+
+    # GitHub's API intermittently returns release bodies with CRLF line endings.
+    # Normalize to LF so we don't pollute CHANGELOG.md with mixed line endings.
+    body = draft["body"].to_s.gsub(/\r\n?/, "\n")
+
+    # Highlights (release-page only) precede the marker; the changelog follows
+    # it. Fall back to the whole body when the marker is absent.
+    changelog = body.include?(CHANGELOG_MARKER) ? body.split(CHANGELOG_MARKER, 2).last : body
+    changelog.strip
+  end
+
+  def insert_changelog(version, changelog)
+    content = File.read(CHANGELOG_FILE)
+    match = content.match(/\[Unreleased\]/)
+    fail!("Could not find [Unreleased] marker in #{CHANGELOG_FILE}") unless match
+
+    section = "\n## [#{version}] - #{Date.today}\n\n#{changelog}".rstrip
+    File.write(CHANGELOG_FILE, content.insert(match.end(0), "\n#{section}"))
+  end
+
+  def rewrite_footer(version, previous)
+    pattern = UNRELEASED_FOOTER_PATTERN
+    replacement =
+      "[Unreleased]: #{REPO_URL}/compare/v#{version}...master\n" \
+      "[#{version}]: #{REPO_URL}/compare/v#{previous}...v#{version}"
+
+    content = File.read(CHANGELOG_FILE)
+    fail!("Could not find [Unreleased] compare link in #{CHANGELOG_FILE}") unless content.match?(pattern)
+
+    File.write(CHANGELOG_FILE, content.sub(pattern, replacement))
+  end
+
+  def fail!(message)
+    abort "::error::#{message}"
+  end
+end

--- a/tasks/release_notes.rb
+++ b/tasks/release_notes.rb
@@ -30,7 +30,7 @@ module ReleaseNotes
   def draft_changelog(version)
     uri = URI("#{API_URL}/repos/#{REPO}/releases?per_page=100")
     request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "Bearer #{ENV["GITHUB_TOKEN"]}"
+    request["Authorization"] = "Bearer #{Datadog::DATADOG_ENV["GITHUB_TOKEN"]}"
     request["Accept"] = "application/vnd.github+json"
     request["X-GitHub-Api-Version"] = "2022-11-28"
     request["User-Agent"] = "dd-trace-rb-release-prep"
@@ -42,8 +42,7 @@ module ReleaseNotes
     draft = JSON.parse(response.body).find { |release| release["tag_name"] == tag && release["draft"] == true }
     fail!("No draft release found with tag #{tag}. Please create and approve a draft release first.") unless draft
 
-    # GitHub's API intermittently returns release bodies with CRLF line endings.
-    # Normalize to LF so we don't pollute CHANGELOG.md with mixed line endings.
+    # Normalize to LF because GitHub's API could return bodies with CRLF line endings.
     body = draft["body"].to_s.gsub(/\r\n?/, "\n")
 
     # Highlights (release-page only) precede the marker; the changelog follows

--- a/tasks/release_prep.rake
+++ b/tasks/release_prep.rake
@@ -1,82 +1,6 @@
 # frozen_string_literal: true
 
-require "date"
-require "json"
-require "net/http"
-
-module ReleasePrep
-  REPO = "DataDog/dd-trace-rb"
-  REPO_URL = "https://github.com/#{REPO}"
-  API_URL = "https://api.github.com"
-  CHANGELOG_FILE = "CHANGELOG.md"
-
-  # Separates release "highlights" (release-page only) from the changelog body in
-  # the draft release. When the marker is absent we fall back to the whole body.
-  CHANGELOG_MARKER = "<!-- changelog -->"
-
-  PREVIOUS_VERSION_PATTERN = %r{\[Unreleased\]: #{Regexp.escape(REPO_URL)}/compare/v(.+?)\.\.\.master}
-  UNRELEASED_FOOTER_PATTERN = %r{\[Unreleased\]: #{Regexp.escape(REPO_URL)}/compare/.*?\.\.\.master}
-
-  module_function
-
-  def previous_version
-    content = File.read(CHANGELOG_FILE)
-    match = content.match(PREVIOUS_VERSION_PATTERN)
-    fail!("Could not find the [Unreleased] compare link in #{CHANGELOG_FILE}") unless match
-
-    match[1]
-  end
-
-  def draft_changelog(version)
-    uri = URI("#{API_URL}/repos/#{REPO}/releases?per_page=100")
-    request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "Bearer #{ENV["GITHUB_TOKEN"]}"
-    request["Accept"] = "application/vnd.github+json"
-    request["X-GitHub-Api-Version"] = "2022-11-28"
-    request["User-Agent"] = "dd-trace-rb-release-prep"
-
-    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
-    fail!("GitHub API request failed: #{response.code} #{response.body}") unless response.is_a?(Net::HTTPSuccess)
-
-    tag = "v#{version}"
-    draft = JSON.parse(response.body).find { |release| release["tag_name"] == tag && release["draft"] == true }
-    fail!("No draft release found with tag #{tag}. Please create and approve a draft release first.") unless draft
-
-    # GitHub's API intermittently returns release bodies with CRLF line endings.
-    # Normalize to LF so we don't pollute CHANGELOG.md with mixed line endings.
-    body = draft["body"].to_s.gsub(/\r\n?/, "\n")
-
-    # Highlights (release-page only) precede the marker; the changelog follows
-    # it. Fall back to the whole body when the marker is absent.
-    changelog = body.include?(CHANGELOG_MARKER) ? body.split(CHANGELOG_MARKER, 2).last : body
-    changelog.strip
-  end
-
-  def insert_changelog(version, changelog)
-    content = File.read(CHANGELOG_FILE)
-    match = content.match(/\[Unreleased\]/)
-    fail!("Could not find [Unreleased] marker in #{CHANGELOG_FILE}") unless match
-
-    section = "\n## [#{version}] - #{Date.today}\n\n#{changelog}".rstrip
-    File.write(CHANGELOG_FILE, content.insert(match.end(0), "\n#{section}"))
-  end
-
-  def rewrite_footer(version, previous)
-    pattern = UNRELEASED_FOOTER_PATTERN
-    replacement =
-      "[Unreleased]: #{REPO_URL}/compare/v#{version}...master\n" \
-      "[#{version}]: #{REPO_URL}/compare/v#{previous}...v#{version}"
-
-    content = File.read(CHANGELOG_FILE)
-    fail!("Could not find [Unreleased] compare link in #{CHANGELOG_FILE}") unless content.match?(pattern)
-
-    File.write(CHANGELOG_FILE, content.sub(pattern, replacement))
-  end
-
-  def fail!(message)
-    abort "::error::#{message}"
-  end
-end
+require_relative "release_notes"
 
 # Release-prep logic for the `release_prep:prepare` task, invoked by
 # `.github/workflows/release-prep.yml`.
@@ -93,15 +17,15 @@ namespace :release_prep do
     version = args[:version] || raise(ArgumentError, 'Please provide a version, e.g. rake "release_prep:prepare[2.36.0]"')
 
     invalid_version = "Invalid version '#{version}' (expected an official release, e.g. 2.36.0)"
-    ReleasePrep.fail!(invalid_version) unless Gem::Version.correct?(version)
-    Gem::Version.new(version).tap { |v| ReleasePrep.fail!(invalid_version) if v.prerelease? || v.segments.length != 3 }
+    ReleaseNotes.fail!(invalid_version) unless Gem::Version.correct?(version)
+    Gem::Version.new(version).tap { |v| ReleaseNotes.fail!(invalid_version) if v.prerelease? || v.segments.length != 3 }
 
-    previous = ReleasePrep.previous_version
-    changelog = ReleasePrep.draft_changelog(version)
+    previous = ReleaseNotes.previous_version
+    changelog = ReleaseNotes.draft_changelog(version)
 
-    ReleasePrep.insert_changelog(version, changelog)
+    ReleaseNotes.insert_changelog(version, changelog)
     Rake::Task["changelog:format"].invoke
-    ReleasePrep.rewrite_footer(version, previous)
+    ReleaseNotes.rewrite_footer(version, previous)
 
     # `version:bump` also asserts the resulting gemspec matches the version.
     Rake::Task["version:bump"].invoke(version)

--- a/tasks/release_prep.rake
+++ b/tasks/release_prep.rake
@@ -42,7 +42,9 @@ module ReleasePrep
     draft = JSON.parse(response.body).find { |release| release["tag_name"] == tag && release["draft"] == true }
     fail!("No draft release found with tag #{tag}. Please create and approve a draft release first.") unless draft
 
-    body = draft["body"].to_s
+    # GitHub's API intermittently returns release bodies with CRLF line endings.
+    # Normalize to LF so we don't pollute CHANGELOG.md with mixed line endings.
+    body = draft["body"].to_s.gsub(/\r\n?/, "\n")
 
     # Highlights (release-page only) precede the marker; the changelog follows
     # it. Fall back to the whole body when the marker is absent.


### PR DESCRIPTION
**What does this PR do?**
Normalizes CRLF line endings from GitHub release bodies before they're written into `CHANGELOG.md`.

**Motivation:**
GitHub's Releases API intermittently returns release bodies with CRLF line endings, which have been polluting `CHANGELOG.md` with mixed line endings since 2.36.0.

**Change log entry**
None.

**Additional Notes:**
Fixes this going forward; doesn't retroactively clean up existing CRLF already in `CHANGELOG.md`.

**How to test the change?**
Added `spec/tasks/release_prep_spec.rb` covering CRLF/CR normalization and existing marker-split behavior.