### PR TITLE
Configure Ruby LSP to use Standard for formatting and linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "*.gemfile": "ruby",
     "Matrixfile": "ruby",
     "Dockerfile*": "dockerfile"
-  }
+  },
+  "rubyLsp.formatter": "standard",
+  "rubyLsp.linters": ["standard"]
 }


### PR DESCRIPTION
**What does this PR do?**
Points VS Code's Ruby LSP at Standard instead of raw RuboCop.

**Motivation:**
Ruby LSP defaults to RuboCop whenever it sees a direct `rubocop` dependency, which we have for our custom cops. That leaves in-editor formatting out of sync with `rake standard`, our actual linter.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
Reload the Ruby LSP server in VS Code and confirm autocorrect matches `standardrb` output.