### PR TITLE
Fix probe builder spec lint

### DIFF
--- a/spec/datadog/di/probe_builder_spec.rb
+++ b/spec/datadog/di/probe_builder_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Datadog::DI::ProbeBuilder do
          "type" => "LOG_PROBE",
          "where" => {"sourceFile" => "aaa.rb", "lines" => [4321]},
          "template" => "{password}",
-         "segments" => [{"dsl" => "password", "json" => {"ref" => "password"}}],}
+         "segments" => [{"dsl" => "password", "json" => {"ref" => "password"}}]}
       end
 
       it "records the referenced identifier on the segment for redaction" do


### PR DESCRIPTION
**What does this PR do?**

Removes an invalid trailing comma from a DI probe builder spec hash literal.

**Motivation:**

Restore the `standard/lint` check on `master`.

**Change log entry**

No.

**Additional Notes:**

None.

**How to test the change?**

- `bundle exec rubocop -D`
- `bundle exec rspec spec/datadog/di/probe_builder_spec.rb`