### PR TITLE
Fix DDCI benchmark gate dependency

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -378,7 +378,9 @@ microbenchmarks-pr-comment:
 # If bypassing is necessary, see https://datadoghq.atlassian.net/wiki/x/8YFzMwE for more details.
 microbenchmarks-check-big-regressions:
   stage: microbenchmarks
-  needs: ["microbenchmarks"]
+  needs:
+    - job: microbenchmarks
+      optional: true
   tags: ["arch:amd64"]
   image: $BASE_CI_IMAGE
   timeout: 30m


### PR DESCRIPTION
**What does this PR do?**

Marks the `microbenchmarks-check-big-regressions` dependency on the parallel `microbenchmarks` job as optional. The gate retains the same rules, while GitLab can compile pipelines in which the matrix jobs are filtered out.

**Motivation:**

DDCI rejects non-benchmark pipelines during creation because the gate has a hard dependency on matrix jobs that do not exist. The error currently breaks `master` DDCI for changes outside the benchmark rule paths.

Recent reproductions:

- https://mosaic.us1.ddbuild.io/change-request/11197477637100458558
- https://mosaic.us1.ddbuild.io/change-request/12148255796376065994

**Change log entry**

No.

**Additional Notes:**

- Latent bug introduced by `5cd7833356` / PR #5571 on 14 April: added `microbenchmarks-check-big-regressions` with a hard `needs`.
- PR #5727 (`efc2e59e76`, 11 May) attempted to fix the exact error by sharing rules, but retained the hard dependency.
- First observed `master` DDCI failure: `ed1e47e0a5` on 28 July. Its changes were only under `.github/`.
- Subsequent pattern is consistent:
  - Non-benchmark changes: DDCI fails.
  - `lib`, `ext`, `datadog.gemspec`, `benchmarks`, or `.gitlab` changes: DDCI succeeds.
- The One Pipeline 1.2.0 merge `fb83d01f52` succeeded because it changed `.gitlab/one-pipeline.locked.yml`, activating the microbenchmark jobs. It did not fix the defect.
- `90f5bb606d` and `95f09c4338` then failed because their changes did not match the microbenchmark paths.

No earlier `master` DDCI statuses appeared in the preceding history examined. This suggests DDCI started surfacing the latent bug around 28 July, likely due to an external DDCI rollout rather than a repository merge at that time.

The appropriate fix remains making the gate matrix dependency optional; updating One Pipeline would only temporarily mask the problem.

This is local `dd-trace-rb` benchmark configuration. The One Pipeline template does not define these jobs. AI assistance was used; the analysis and change were reviewed.

**How to test the change?**

- `nix run nixpkgs#yamllint -- --strict .gitlab/benchmarks.yml`
- Parse `.gitlab/benchmarks.yml` with Ruby YAML aliases enabled.
- Run `git diff --check`.
- Confirm DDCI can create a pipeline for a subsequent change outside `lib`, `ext`, `datadog.gemspec`, `benchmarks`, and `.gitlab`. The PR itself changes `.gitlab`, so its matrix jobs are expected to exist.