### PR TITLE
Run CI for stacked pull requests

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -2,8 +2,6 @@ name: Check Pull Request CI Status
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -12,8 +12,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,8 +4,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches: [master, release]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}

--- a/.github/workflows/lock-dependency.yml
+++ b/.github/workflows/lock-dependency.yml
@@ -2,8 +2,6 @@ name: Lock Dependencies
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
   workflow_dispatch: {}
   schedule:
     - cron: "00 04 * * 0-6"

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/test-memory-leaks.yaml
+++ b/.github/workflows/test-memory-leaks.yaml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/test-yjit.yaml
+++ b/.github/workflows/test-yjit.yaml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ on: # yamllint disable-line rule:truthy
     branches:
       - master
   pull_request:
-    branches:
-      - master
+  workflow_dispatch: {}
   schedule:
     - cron: 0 */4 * * 1-5
     - cron: 0 3 * * 0,6

--- a/.github/workflows/typing-stats.yml
+++ b/.github/workflows/typing-stats.yml
@@ -2,8 +2,6 @@ name: Comment typing stats on PR
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    branches:
-      - master
 
 # TODO:
 # Upload the report somewhere not limited by the 64k char limit (maybe FPD ?) to be able to include links to the files


### PR DESCRIPTION
**What does this PR do?**

Runs the full pull request CI suite for PRs targeting any branch, including stacked PRs. It also adds `workflow_dispatch` to the unit test workflow for ad-hoc runs. Push workflows remain restricted to their existing branches.

**Motivation:**

The CI workflows currently filter `pull_request` events to `master`. Stacked PRs therefore receive only the few unfiltered checks until they are retargeted, leaving changes untested and required checks absent. [#6132](https://github.com/DataDog/dd-trace-rb/pull/6132) is a recent example.

**Change log entry**

None.

**Additional Notes:**

AI-generated code disclosure: this CI-only change was implemented with AI assistance and manually reviewed and validated.

**How to test the change?**

- `yamllint --strict .`
- `actionlint` passes with the existing `if: false` warning in `check.yml` suppressed.
- Confirmed no workflow retains a `pull_request.branches` filter.