### PR TITLE
[PROF-15692] Profiling: Disable heap profiling on Ruby 4 due to incompatibility

### DIFF
--- a/lib/datadog/core/configuration/settings.rb
+++ b/lib/datadog/core/configuration/settings.rb
@@ -340,7 +340,8 @@ module Datadog
 
             # Can be used to enable/disable the collection of heap profiles.
             #
-            # This feature is in preview and disabled by default. Requires Ruby 3.1+.
+            # This feature is in preview and disabled by default. Requires Ruby 3.1+, and is currently
+            # unavailable on Ruby 4+.
             #
             # @warn To enable heap profiling you are required to also enable allocation profiling.
             #

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -227,11 +227,12 @@ module Datadog
           return false
         end
 
-        # Heap profiling relies on `ObjectSpace._id2ref`, which was removed on Ruby 4.1
+        # Heap profiling relies on `ObjectSpace._id2ref`, which can return an unrelated object on Ruby 4.0
+        # (https://bugs.ruby-lang.org/issues/22200), and which was removed on Ruby 4.1
         # (https://bugs.ruby-lang.org/issues/22135).
-        if RubyVersion.is?(">= 4.1")
+        if RubyVersion.is?(">= 4")
           logger.warn(
-            "Heap profiling is currently incompatible with Ruby 4.1+ and has been disabled."
+            "Heap profiling is currently incompatible with Ruby 4+ and has been disabled."
           )
           return false
         end
@@ -252,15 +253,9 @@ module Datadog
       private_class_method def self.enable_heap_size_profiling?(settings, heap_profiling_enabled, logger)
         heap_size_profiling_enabled = settings.profiling.advanced.experimental_heap_size_enabled
 
+        # NOTE: No need to check for Ruby 4+ here: heap size profiling requires heap profiling, which is already
+        # disabled on Ruby 4+ (see `enable_heap_profiling?`).
         return false unless heap_profiling_enabled && heap_size_profiling_enabled
-
-        if RubyVersion.is?(">= 4")
-          logger.info(
-            "Heap live size profiling is currently incompatible with Ruby 4 and has been disabled. " \
-            "Heap live objects is not affected and remains enabled."
-          )
-          return false
-        end
 
         true
       end

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -345,7 +345,6 @@ RSpec.describe Datadog::Profiling::Component do
         context "when heap profiling is enabled", ruby: ">= 2.7" do
           # Universally supported ruby version for allocation profiling by default
           let(:testing_version) { "3.3.0" }
-          let(:heap_size_profiling_available) { RubyVersion.is?("< 4") } # Currently incompatible with Ruby 4
 
           before do
             settings.profiling.advanced.experimental_heap_enabled = true
@@ -368,15 +367,15 @@ RSpec.describe Datadog::Profiling::Component do
             end
           end
 
-          context "on Ruby 4.1 or newer" do
-            let(:testing_version) { "4.1.0" }
+          context "on Ruby 4 or newer" do
+            let(:testing_version) { "4.0.0" }
 
             it "initializes StackRecorder without heap sampling support and warns" do
               expect(Datadog::Profiling::StackRecorder).to receive(:new)
                 .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
                 .and_call_original
 
-              expect(logger).to receive(:warn).with(/Heap profiling is currently incompatible with Ruby 4.1/)
+              expect(logger).to receive(:warn).with(/Heap profiling is currently incompatible with Ruby 4/)
 
               build_profiler_component
             end
@@ -405,7 +404,7 @@ RSpec.describe Datadog::Profiling::Component do
 
             it "initializes StackRecorder with heap sampling support and warns" do
               expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: heap_size_profiling_available))
+                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
                 .and_call_original
 
               expect(logger).to receive(:debug).with(/Ractors.+stopping/)
@@ -413,22 +412,6 @@ RSpec.describe Datadog::Profiling::Component do
               expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 
               build_profiler_component
-            end
-
-            context "on Ruby 4.0 or newer" do
-              let(:testing_version) { "4.0.0" }
-
-              before { allow(logger).to receive(:debug) }
-
-              it "initializes StackRecorder with heap sampling but without heap size profiling support and logs" do
-                expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                  .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
-                  .and_call_original
-
-                expect(logger).to receive(:info).with(/Heap live size profiling is currently incompatible with Ruby 4/)
-
-                build_profiler_component
-              end
             end
 
             context "but heap size profiling is disabled" do


### PR DESCRIPTION
**What does this PR do?**

Disables heap profiling entirely on Ruby 4+, by widening the existing Ruby 4.1+ check in `enable_heap_profiling?` to cover Ruby 4.0.

**Motivation:**

Heap profiling relies on `ObjectSpace._id2ref`, and on Ruby 4.0 that method can return a different, unrelated live object instead of raising `RangeError`, once the object that owned the id has been collected and its heap slot reused (https://bugs.ruby-lang.org/issues/22200).

Ruby <= 3.4 is not affected, and the method was removed outright on Ruby 4.1 (https://bugs.ruby-lang.org/issues/22135), which is what the previous gate covered.

This supersedes https://github.com/DataDog/dd-trace-rb/pull/6022, which disabled only heap live size on Ruby 4: that check is now unreachable and has been removed, along with its no-longer-accurate "Heap live objects is not affected and remains enabled" message.

**Change log entry**

Yes. Profiling: Disable heap profiling on Ruby 4 due to incompatibility

**Additional Notes:**

The low-level specs (`stack_recorder_spec.rb`, `cpu_and_wall_time_worker_spec.rb`) still skip only at `>= 4.1`, so the native heap recorder keeps its Ruby 4.0 coverage. In particular `describe "pending heap recordings cleanup", ruby: ">= 4"` would otherwise become dead code, leaving the deferred-recording path untested for when we re-enable the feature.

This is how the message looks in practice:

```
W, [2026-08-10T16:45:12.183472 #3184672]  WARN -- datadog: [datadog] Heap
profiling is currently incompatible with Ruby 4+ and has been disabled.
```

**How to test the change?**

`component_spec.rb` covers the new check. Verified on Ruby 4.0.6 and 2.6.10 (134 examples, 0 failures on each), and the new example fails if the `component.rb` change is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
