### PR TITLE
profiling: add a null check when traversing EP

### DIFF
--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -647,7 +647,9 @@ check_method_entry(VALUE obj, int can_be_svar) {
 // While older Rubies may have this function, the symbol is not exported which leads to dynamic loader issues, e.g.
 // `dyld: lazy symbol binding failed: Symbol not found: _rb_vm_frame_method_entry`.
 //
-// Modifications: None
+// Modifications:
+// * Added NULL check on ep after VM_ENV_PREV_EP to guard against corrupted EP chains
+//   when called from a signal handler during vm_make_env_each
 MJIT_STATIC const rb_callable_method_entry_t *
 rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
 {
@@ -659,6 +661,10 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
             return me;
         }
         ep = VM_ENV_PREV_EP(ep);
+        // Safety: VM_ENV_PREV_EP can return NULL when the profiler's signal handler interrupts
+        // vm_make_env_each (vm.c), which non-atomically converts stack EPs to heap EPs during
+        // Thread.new. The SPECVAL link in the new heap EP may not yet be initialized.
+        if (ep == NULL) return NULL;
     }
 
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -642,6 +642,10 @@ check_method_entry(VALUE obj, int can_be_svar) {
 }
 #endif // RUBY_MJIT_HEADER
 
+// Identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c) except for a FIXNUM_P guard
+// after VM_ENV_PREV_EP to detect torn EPs. The profiler's signal handler can interrupt
+// vm_make_env_each (vm.c) mid-escape, at which point a child frame's SPECVAL still points to
+// the parent's old stack EP whose flags slot has been overwritten with (VALUE)env for GC marking
 static const rb_callable_method_entry_t *
 safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
 {
@@ -653,9 +657,8 @@ safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
             return me;
         }
         ep = VM_ENV_PREV_EP(ep);
-        // This is identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c)
-        // except for this one extra guard below
-        if (ep == NULL) return NULL;
+        // This function is idential to upstream rb_vm_frame_method_entry except for the one extra guard below
+        if (ep == NULL || !FIXNUM_P(ep[VM_ENV_DATA_INDEX_FLAGS])) return NULL;
     }
 
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -640,33 +640,6 @@ check_method_entry(VALUE obj, int can_be_svar) {
 
   return NULL;
 }
-
-// Taken from upstream vm_insnhelper.c at commit 5f10bd634fb6ae8f74a4ea730176233b0ca96954 (March 2022, Ruby 3.2 trunk)
-// Copyright (C) 2007 Koichi Sasada
-// to support our custom rb_profile_frames (see above)
-//
-// While older Rubies may have this function, the symbol is not exported which leads to dynamic loader issues, e.g.
-// `dyld: lazy symbol binding failed: Symbol not found: _rb_vm_frame_method_entry`.
-//
-// Modifications: None
-// Note: This function is not called directly by our code; safe_vm_frame_method_entry (below)
-// is used instead. This definition is kept because it is needed to satisfy the linker on
-// non-MJIT Ruby builds where the symbol is not exported.
-MJIT_STATIC const rb_callable_method_entry_t *
-rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
-{
-    const VALUE *ep = cfp->ep;
-    rb_callable_method_entry_t *me;
-
-    while (!VM_ENV_LOCAL_P(ep)) {
-        if ((me = check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], FALSE)) != NULL) {
-            return me;
-        }
-        ep = VM_ENV_PREV_EP(ep);
-    }
-
-    return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
-}
 #endif // RUBY_MJIT_HEADER
 
 static const rb_callable_method_entry_t *

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -642,24 +642,31 @@ check_method_entry(VALUE obj, int can_be_svar) {
 }
 #endif // RUBY_MJIT_HEADER
 
-// Identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c) except for a FIXNUM_P guard
-// after VM_ENV_PREV_EP to detect torn EPs. The profiler's signal handler can interrupt
-// vm_make_env_each (vm.c) mid-escape, at which point a child frame's SPECVAL still points to
-// the parent's old stack EP whose flags slot has been overwritten with (VALUE)env for GC marking
+// Identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c) with two additions:
+// 1. FIXNUM_P check on ep[FLAGS] before each iteration to detect torn EPs
+// 2. NULL check on ep after VM_ENV_PREV_EP
+//
+// When the profiler's signal handler interrupts vm_make_env_each (vm.c) mid-escape,
+// a child frame's SPECVAL can still point to the parent's old stack EP whose flags
+// slot has been overwritten with (VALUE)env for GC marking.
 static const rb_callable_method_entry_t *
 safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
 {
     const VALUE *ep = cfp->ep;
     rb_callable_method_entry_t *me;
 
-    while (!VM_ENV_LOCAL_P(ep)) {
+    // Torn-EP check before VM_ENV_LOCAL_P, check_method_entry, and VM_ENV_PREV_EP
+    // dereference ep
+    while (FIXNUM_P(ep[VM_ENV_DATA_INDEX_FLAGS]) && !VM_ENV_LOCAL_P(ep)) {
         if ((me = check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], FALSE)) != NULL) {
             return me;
         }
         ep = VM_ENV_PREV_EP(ep);
-        // This function is idential to upstream rb_vm_frame_method_entry except for the one extra guard below
-        if (ep == NULL || !FIXNUM_P(ep[VM_ENV_DATA_INDEX_FLAGS])) return NULL;
+        if (ep == NULL) return NULL;
     }
+
+    // If we exited because of a torn EP (failed FIXNUM_P), bail out
+    if (!FIXNUM_P(ep[VM_ENV_DATA_INDEX_FLAGS])) return NULL;
 
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
 }

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -669,13 +669,10 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
 }
 #endif // RUBY_MJIT_HEADER
 
-// Signal-safe replacement for rb_vm_frame_method_entry.
+// Signal-safe replacement for rb_vm_frame_method_entry that adds a NULL check after
+// VM_ENV_PREV_EP.
 //
-// On MJIT-header builds (Ruby 2.6–3.2), rb_vm_frame_method_entry comes from the MJIT header
-// and has no NULL guard on the EP chain. On non-MJIT builds (Ruby 3.3+), our fallback above
-// includes the guard but we use this wrapper uniformly so there is a single call site to maintain.
-//
-// The guard is needed because the profiler's signal handler can interrupt vm_make_env_each,
+// The guard is needed because the profiler's signal handler can interrupt vm_make_env_each (vm.c),
 // which non-atomically converts stack-allocated EPs to heap-allocated EPs during Thread.new.
 // During the transition, VM_ENV_PREV_EP may return NULL because the SPECVAL link in the new
 // heap EP has not yet been initialized.

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -669,10 +669,10 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
 }
 #endif // RUBY_MJIT_HEADER
 
-// Signal-safe replacement for rb_vm_frame_method_entry that adds a NULL check after
-// VM_ENV_PREV_EP.
+// Identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c) except for one added guard:
+// a NULL check on ep after VM_ENV_PREV_EP.
 //
-// The guard is needed because the profiler's signal handler can interrupt vm_make_env_each (vm.c),
+// This is needed because the profiler's signal handler can interrupt vm_make_env_each (vm.c),
 // which non-atomically converts stack-allocated EPs to heap-allocated EPs during Thread.new.
 // During the transition, VM_ENV_PREV_EP may return NULL because the SPECVAL link in the new
 // heap EP has not yet been initialized.

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -669,13 +669,6 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
 }
 #endif // RUBY_MJIT_HEADER
 
-// Identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c) except for one added guard:
-// a NULL check on ep after VM_ENV_PREV_EP.
-//
-// This is needed because the profiler's signal handler can interrupt vm_make_env_each (vm.c),
-// which non-atomically converts stack-allocated EPs to heap-allocated EPs during Thread.new.
-// During the transition, VM_ENV_PREV_EP may return NULL because the SPECVAL link in the new
-// heap EP has not yet been initialized.
 static const rb_callable_method_entry_t *
 safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
 {
@@ -687,6 +680,8 @@ safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
             return me;
         }
         ep = VM_ENV_PREV_EP(ep);
+        // This is identical to upstream rb_vm_frame_method_entry (vm_insnhelper.c)
+        // except for this one extra guard below
         if (ep == NULL) return NULL;
     }
 

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -59,6 +59,7 @@
 #include "private_vm_api_access.h"
 
 static inline const rb_callable_method_entry_t* get_cfunc_method_entry(const rb_control_frame_t *cfp);
+static const rb_callable_method_entry_t* safe_vm_frame_method_entry(const rb_control_frame_t *cfp);
 
 // MRI has a similar rb_thread_ptr() function which we can't call it directly
 // because Ruby does not expose the thread_data_type publicly.
@@ -525,7 +526,7 @@ int ddtrace_rb_profile_frames(VALUE thread, int start, int limit, frame_info *st
                 continue;
             }
 
-            cme = rb_vm_frame_method_entry(cfp);
+            cme = safe_vm_frame_method_entry(cfp);
 
             // Upstream (Ruby 4.0) does:
             // if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ) {
@@ -647,9 +648,10 @@ check_method_entry(VALUE obj, int can_be_svar) {
 // While older Rubies may have this function, the symbol is not exported which leads to dynamic loader issues, e.g.
 // `dyld: lazy symbol binding failed: Symbol not found: _rb_vm_frame_method_entry`.
 //
-// Modifications:
-// * Added NULL check on ep after VM_ENV_PREV_EP to guard against corrupted EP chains
-//   when called from a signal handler during vm_make_env_each
+// Modifications: None
+// Note: This function is not called directly by our code; safe_vm_frame_method_entry (below)
+// is used instead. This definition is kept because it is needed to satisfy the linker on
+// non-MJIT Ruby builds where the symbol is not exported.
 MJIT_STATIC const rb_callable_method_entry_t *
 rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
 {
@@ -661,15 +663,38 @@ rb_vm_frame_method_entry(const rb_control_frame_t *cfp)
             return me;
         }
         ep = VM_ENV_PREV_EP(ep);
-        // Safety: VM_ENV_PREV_EP can return NULL when the profiler's signal handler interrupts
-        // vm_make_env_each (vm.c), which non-atomically converts stack EPs to heap EPs during
-        // Thread.new. The SPECVAL link in the new heap EP may not yet be initialized.
-        if (ep == NULL) return NULL;
     }
 
     return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
 }
 #endif // RUBY_MJIT_HEADER
+
+// Signal-safe replacement for rb_vm_frame_method_entry.
+//
+// On MJIT-header builds (Ruby 2.6–3.2), rb_vm_frame_method_entry comes from the MJIT header
+// and has no NULL guard on the EP chain. On non-MJIT builds (Ruby 3.3+), our fallback above
+// includes the guard but we use this wrapper uniformly so there is a single call site to maintain.
+//
+// The guard is needed because the profiler's signal handler can interrupt vm_make_env_each,
+// which non-atomically converts stack-allocated EPs to heap-allocated EPs during Thread.new.
+// During the transition, VM_ENV_PREV_EP may return NULL because the SPECVAL link in the new
+// heap EP has not yet been initialized.
+static const rb_callable_method_entry_t *
+safe_vm_frame_method_entry(const rb_control_frame_t *cfp)
+{
+    const VALUE *ep = cfp->ep;
+    rb_callable_method_entry_t *me;
+
+    while (!VM_ENV_LOCAL_P(ep)) {
+        if ((me = check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], FALSE)) != NULL) {
+            return me;
+        }
+        ep = VM_ENV_PREV_EP(ep);
+        if (ep == NULL) return NULL;
+    }
+
+    return check_method_entry(ep[VM_ENV_DATA_INDEX_ME_CREF], TRUE);
+}
 
 // Optimized version of rb_vm_frame_method_entry() for cfunc frames.
 // Cfunc frames always have VM_ENV_FLAG_LOCAL set, so ep[-2] is the cme directly


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
An attempt to fix [a NULL pointer dereference crash](https://app.datadoghq.com/error-tracking/issue/2ddc4794-94f1-11f1-ba33-da7ad0900002?query=source%3Aruby+service%3Ainstrumentation-telemetry-data%2A+%40tags.crash_datadog%3Atrue&from_ts=1786303561000&to_ts=1786389961000&live=false&monitor_id=278486761&monitor_sub_type=.new%28%29&link_source=monitor_notif) in the profiler when the `SIGPROF` handler interrupts `vm_make_env_each` during `Thread.new`. 

The profiler's signal handler can interrupt `vm_make_env_each `mid-escape, at which point a child frame's SPECVAL still points to the parent's old stack EP whose flags slot has been overwritten with (VALUE)env for GC marking


note: Returning NULL here just means a frame wont have a method name field


**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
Yes. Fix a rare crash (SIGSEGV) in the profiler that could occur when sampling a thread during Thread.new.
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
Its hard to reproduce this
<!-- Unsure? Have a question? Request a review! -->
