### PR TITLE
Track heap profiler liveness with ObjectSpace::WeakMap instead of _id2ref

### DIFF
--- a/benchmarks/profiling_allocation.rb
+++ b/benchmarks/profiling_allocation.rb
@@ -6,6 +6,14 @@ return unless __FILE__ == $PROGRAM_NAME || VALIDATE_BENCHMARK_MODE
 require_relative "benchmarks_helper"
 
 # This benchmark measures the performance of allocation profiling
+#
+# Set HEAP_SAMPLES=true to also enable heap profiling on top of it, which additionally exercises the heap recorder
+# from inside the allocation tracepoint. Heap live size follows HEAP_SAMPLES unless HEAP_SIZE=false is set.
+HEAP_SAMPLES = ENV["HEAP_SAMPLES"] == "true"
+HEAP_SIZE = ENV.fetch("HEAP_SIZE", HEAP_SAMPLES.to_s) == "true"
+# Only decorate the report name when heap profiling is on, so the default benchmark keeps reporting under the same
+# name as before (and thus stays comparable with previously recorded results).
+HEAP_CONFIG_SUFFIX = HEAP_SAMPLES ? " heap_samples=#{HEAP_SAMPLES} heap_size=#{HEAP_SIZE}" : ""
 
 class ExportToFile
   PPROF_PREFIX = ENV.fetch("DD_PROFILING_PPROF_PREFIX", "profiler-allocation")
@@ -34,6 +42,8 @@ class ProfilerAllocationBenchmark
       c.profiling.enabled = true
       c.profiling.allocation_enabled = true
       c.profiling.advanced.gc_enabled = false
+      c.profiling.advanced.experimental_heap_enabled = HEAP_SAMPLES
+      c.profiling.advanced.experimental_heap_size_enabled = HEAP_SIZE
       c.profiling.exporter.transport = ExportToFile.new unless VALIDATE_BENCHMARK_MODE
     end
     Datadog::Profiling.wait_until_running
@@ -46,7 +56,7 @@ class ProfilerAllocationBenchmark
         **benchmark_time,
       )
 
-      x.report("Allocations (#{ENV["CONFIG"]})", "BasicObject.new")
+      x.report("Allocations (#{ENV["CONFIG"]})#{HEAP_CONFIG_SUFFIX}", "BasicObject.new")
 
       x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
       x.compare!

--- a/benchmarks/profiling_memory_sample_serialize.rb
+++ b/benchmarks/profiling_memory_sample_serialize.rb
@@ -31,6 +31,9 @@ def sample_object(recorder, depth = 0)
       [],
       [],
     )
+    # Heap recordings are deferred and need to be committed after the sample is recorded; in the real profiler this
+    # is driven by a postponed job.
+    Datadog::Profiling::StackRecorder::Testing._native_commit_pending_heap_recordings(recorder)
     obj
   else
     sample_object(recorder, depth - 1)

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1301,6 +1301,9 @@ static VALUE _native_allocation_count(DDTRACE_UNUSED VALUE self) {
 // Implements memory-related profiling events. This function is called by Ruby via the `rb_add_event_hook2`
 // when the RUBY_INTERNAL_EVENT_NEWOBJ event is triggered.
 //
+// This function is called from the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
+// Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
+//
 // When allocation sampling is enabled, this function gets called for almost all* objects allocated by the Ruby VM.
 // (*In some weird cases the VM may skip this tracepoint.)
 //
@@ -1470,7 +1473,7 @@ static VALUE rescued_sample_allocation(VALUE arg) {
     #ifndef NO_POSTPONED_TRIGGER
       rb_postponed_job_trigger(after_allocation_from_postponed_job_handle);
     #else
-      // Not needed on legacy rubies
+      rb_postponed_job_register_one(0, after_allocation_from_postponed_job, NULL);
     #endif
   }
 
@@ -1670,11 +1673,9 @@ static VALUE rescued_after_allocation(VALUE self_instance) {
   return Qnil;
 }
 
-// This postponed job callback is used to finalize heap allocation recordings on Ruby 4+.
-// During on_newobj_event, calling rb_obj_id() is unsafe because it mutates the object.
-// So we defer getting the object_id until after the event completes.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function" // This is only used for some Rubies, but we want to build on all to make it easier to dev
+// This postponed job callback is used to commit heap allocation recordings.
+// During on_newobj_event, we can't take the weak reference the heap recorder needs to track the object, so we defer
+// that until after the event completes.
 static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
   cpu_and_wall_time_worker_state *state = active_sampler_instance_state;
 
@@ -1697,7 +1698,6 @@ static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
 
   during_sample_exit(state);
 }
-#pragma GCC diagnostic pop
 
 static inline void during_sample_enter(cpu_and_wall_time_worker_state* state) {
   // Tell the compiler it's not allowed to reorder the `during_sample` flag with anything that happens after.

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1665,8 +1665,8 @@ bool thread_context_collector_prepare_sample_inside_signal_handler(void) {
   return prepare_sample_thread(current_thread, &thread_context->sampling_buffer);
 }
 
-// This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should never allocate in the
-// Ruby heap.
+// This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
+// Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 //
 // Returns true if the after_allocation needs to be called (to do work that can't be done from inside the
 // tracepoint, such as allocate new objects), and false if it doesn't

--- a/ext/datadog_profiling_native_extension/datadog_ruby_common.h
+++ b/ext/datadog_profiling_native_extension/datadog_ruby_common.h
@@ -97,13 +97,3 @@ static inline VALUE get_error_details_and_drop(ddog_Error *error) {
 // Returns the amount of characters written to string (which are necessarily
 // bounded by capacity - 1 since the string will be null-terminated).
 size_t read_ddogerr_string_and_drop(ddog_Error *error, char *string, size_t capacity);
-
-#define IMEMO_MASK 0x0f
-
-// Returns the imemo type of an imemo object.
-// This mask is the same between Ruby 2.5 and 3.3-preview3. Furthermore, the intention of this method is to be used
-// to call `rb_imemo_name` which correctly handles invalid numbers so even if the mask changes in the future, at most
-// we'll get incorrect results (and never a VM crash)
-static inline int ddtrace_imemo_type(VALUE imemo) {
-  return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
-}

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -142,11 +142,6 @@ have_func "malloc_stats"
 # On older Rubies, there was no primitive mutex and condition variable implemented in `thread_sync.rb` (internal)
 $defs << "-DNO_PRIMITIVE_MUTEX_AND_CONDITION_VARIABLE" if RUBY_VERSION < "4"
 
-# On Ruby 4.0, we've seen crashes when computing the memsize of a class/module/iclass:
-# rb_obj_memsize_of walks the per-namespace class extensions (classext_memsize), which seem to sometimes be in an inconsistent state
-# (see https://github.com/DataDog/dd-trace-rb/issues/5936)
-$defs << "-DNO_SAFE_CLASS_MEMSIZE" unless RUBY_VERSION < "4"
-
 # This symbol is exclusively visible on certain Ruby versions: 2.6 to 3.2, as well as 3.4 (but not 4.0+)
 # It's only used to get extra information about an object when a failure happens, so it's a "very nice to have" but not
 # actually required for correct behavior of the profiler.

--- a/ext/datadog_profiling_native_extension/extconf.rb
+++ b/ext/datadog_profiling_native_extension/extconf.rb
@@ -142,14 +142,6 @@ have_func "malloc_stats"
 # On older Rubies, there was no primitive mutex and condition variable implemented in `thread_sync.rb` (internal)
 $defs << "-DNO_PRIMITIVE_MUTEX_AND_CONDITION_VARIABLE" if RUBY_VERSION < "4"
 
-# On Ruby 4, we can't ask the object_id from IMEMOs (https://github.com/ruby/ruby/pull/13347)
-$defs << "-DNO_IMEMO_OBJECT_ID" unless RUBY_VERSION < "4"
-
-# On Ruby 4, we need to defer calling rb_obj_id during heap allocation recording
-# because it's not safe to mutate objects during the newobj tracepoint
-# (see https://bugs.ruby-lang.org/issues/21710)
-$defs << "-DUSE_DEFERRED_HEAP_ALLOCATION_RECORDING" unless RUBY_VERSION < "4"
-
 # On Ruby 4.0, we've seen crashes when computing the memsize of a class/module/iclass:
 # rb_obj_memsize_of walks the per-namespace class extensions (classext_memsize), which seem to sometimes be in an inconsistent state
 # (see https://github.com/DataDog/dd-trace-rb/issues/5936)

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -69,16 +69,6 @@ static int heap_record_cmp_st(st_data_t, st_data_t);
 static st_index_t heap_record_hash_st(st_data_t);
 static const struct st_hash_type st_hash_type_heap_record = { .compare = heap_record_cmp_st, .hash = heap_record_hash_st };
 
-// An object record is used for storing data about currently tracked live objects
-typedef struct {
-  long record_id;
-  heap_record *heap_record;
-  live_object_data object_data;
-} object_record;
-static object_record* object_record_new(long, heap_record*, live_object_data);
-static void object_record_free(heap_recorder*, object_record*, bool should_unintern);
-static VALUE object_record_inspect(heap_recorder*, object_record*);
-
 // A pending recording is used to defer adding the object to the `weak_objects` map: doing so is a Ruby method
 // call that allocates, and neither of those is safe to do during on_newobj_event
 typedef struct {
@@ -87,6 +77,16 @@ typedef struct {
   heap_record *heap_record;
   live_object_data object_data;
 } pending_recording;
+
+// An object record is used for storing data about currently tracked live objects
+typedef struct {
+  long record_id;
+  heap_record *heap_record;
+  live_object_data object_data;
+} object_record;
+static object_record* object_record_new(pending_recording *pending);
+static void object_record_free(heap_recorder*, object_record*, bool should_unintern);
+static VALUE object_record_inspect(heap_recorder*, object_record*);
 
 #define MAX_PENDING_RECORDINGS 256
 
@@ -537,7 +537,7 @@ void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder) {
     // Nil it out as we don't need it anymore, and we should not keep it alive longer than necessary
     pending->object_ref = Qnil;
 
-    object_record *record = object_record_new(pending->record_id, pending->heap_record, pending->object_data);
+    object_record *record = object_record_new(pending);
 
     commit_recording(heap_recorder, pending->heap_record, record);
   }
@@ -969,11 +969,11 @@ static void on_committed_object_record_cleanup(heap_recorder *heap_recorder, obj
 // =================
 // Object Record API
 // =================
-object_record* object_record_new(long record_id, heap_record *heap_record, live_object_data object_data) {
+object_record* object_record_new(pending_recording *pending) {
   object_record *record = calloc(1, sizeof(object_record)); // See "note on calloc vs ruby_xcalloc use" above
-  record->record_id = record_id;
-  record->heap_record = heap_record;
-  record->object_data = object_data;
+  record->record_id = pending->record_id;
+  record->heap_record = pending->heap_record;
+  record->object_data = pending->object_data;
   return record;
 }
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -3,6 +3,7 @@
 #include "ruby_helpers.h"
 #include "collectors_stack.h"
 #include "libdatadog_helpers.h"
+#include "private_vm_api_access.h"
 #include "time_helpers.h"
 
 // note on calloc vs ruby_xcalloc use:
@@ -397,6 +398,19 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
       // See notes on `heap_recorder_update` for details.
       || heap_recorder->updating
     ) {
+    heap_recorder->recording_skipped = true;
+    return false;
+  }
+
+  // Do not sample internal objects in the heap profiler because
+  // they are added to a ObjectSpace::WeakMap, which would not be safe.
+  // This means we ignore internal objects samples for the heap profiler,
+  // which is a trade-off discussed in https://github.com/DataDog/dd-trace-rb/pull/6176#discussion_r3819776251
+  //
+  // Note this is checked after the sample rate above, as the sample rate is in number of allocation profiler samples,
+  // not in number of non-internal samples. Like the skips above, num_recordings_skipped is not reset here, so the
+  // next allocation sample still gets a chance to be tracked.
+  if (ddtrace_is_internal_object_p(new_obj)) {
     heap_recorder->recording_skipped = true;
     return false;
   }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -220,6 +220,52 @@ static void unintern_or_raise(heap_recorder *, ddog_prof_ManagedStringId);
 static void unintern_all_or_raise(heap_recorder *recorder, ddog_prof_Slice_ManagedStringId ids);
 static VALUE get_ruby_string_or_raise(heap_recorder*, ddog_prof_ManagedStringId);
 
+// The following global variables are initialized at startup to save expensive lookups later.
+// They are not expected to be mutated outside of init.
+static VALUE class_weak_map = Qnil;
+static ID aref_id = Qnil;
+static ID aset_id = Qnil;
+
+void collectors_heap_recorder_init(void) {
+  rb_global_variable(&class_weak_map);
+
+  VALUE module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
+  class_weak_map = rb_const_get(module_object_space, rb_intern("WeakMap"));
+  aref_id = rb_intern("[]");
+  aset_id = rb_intern("[]=");
+}
+
+// Native wrapper to create a new `ObjectSpace::WeakMap`.
+//
+// Because an `ObjectSpace::WeakMap` entry is dropped as soon as *either* its key or its value is garbage
+// collected, pairing a key that can never be collected (such as a fixnum) with the object of interest as the
+// value gives us a weak reference: reading the key back returns the object while it's alive, and nothing once
+// it's been collected.
+static VALUE ruby_weak_map_new(void) {
+  return rb_class_new_instance(0, NULL, class_weak_map);
+}
+
+// Native wrapper to get an object from an `ObjectSpace::WeakMap`.
+// Returns the object on success and nil if the entry is gone, meaning
+// the object has been garbage collected.
+// We never store nil as a value, see ruby_weak_map_set(), so nil unambiguously means "the value was garbage collected".
+//
+// Note: GVL can be released and other threads may get to run before this method returns
+static VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
+  return rb_funcall(weak_map, aref_id, 1, key);
+}
+
+// Native wrapper to add an entry to an `ObjectSpace::WeakMap`.
+// Raises RuntimeError if passed nil as a value.
+//
+// Note: GVL can be released and other threads may get to run before this method returns
+static void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value) {
+  if (value == Qnil) {
+    raise_error(rb_eRuntimeError, "Can't use nil as the value in the WeakMap, otherwise #[] can't differentiate alive vs nil value");
+  }
+  rb_funcall(weak_map, aset_id, 2, key, value);
+}
+
 // ==========================
 // Heap Recorder External API
 //

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -70,19 +70,19 @@ static const struct st_hash_type st_hash_type_heap_record = { .compare = heap_re
 
 // An object record is used for storing data about currently tracked live objects
 typedef struct {
-  long obj_id;
+  long record_id;
   heap_record *heap_record;
   live_object_data object_data;
 } object_record;
 static object_record* object_record_new(long, heap_record*, live_object_data);
 static void object_record_free(heap_recorder*, object_record*, bool should_unintern);
 static VALUE object_record_inspect(heap_recorder*, object_record*);
-static object_record SKIPPED_RECORD = {0};
 
-// A pending recording is used to defer the object_id call on Ruby 4+
-// where calling rb_obj_id during on_newobj_event is unsafe.
+// A pending recording is used to defer adding the object to the `weak_objects` map: doing so is a Ruby method
+// call that allocates, and neither of those is safe to do during on_newobj_event
 typedef struct {
   VALUE object_ref;
+  long record_id; // Always in Fixnum range
   heap_record *heap_record;
   live_object_data object_data;
 } pending_recording;
@@ -106,7 +106,7 @@ struct heap_recorder {
   // entire stacks for us, then we wouldn't need to do it on the Ruby side.
   st_table *heap_records;
 
-  // Map[obj_id: long, record: object_record*]
+  // Map[record_id: long, record: object_record*]
   // NOTE: This table is currently only protected by the GVL since we never interact with it
   // outside the GVL.
   // NOTE: This table has ownership of its object_records. The keys are longs and so are
@@ -114,11 +114,10 @@ struct heap_recorder {
   //
   // TODO: @ivoanjo We've evolved to actually never need to look up on object_records (we only insert and iterate),
   // so right now this seems to be just a really really fancy self-resizing list/set.
-  // If we replace this with a list, we could record the latest id and compare it when inserting to make sure our
-  // assumption of ids never reused + always increasing always holds. (This as an alternative to checking for duplicates)
+  // Tests do use it for lookup currently though.
   st_table *object_records;
 
-  // Map[obj_id: long, record: object_record*]
+  // Map[record_id: long, record: object_record*]
   // NOTE: This is a snapshot of object_records built ahead of a iteration. Outside of an
   // iteration context, this table will be NULL. During an iteration, there will be no
   // mutation of the data so iteration can occur without acquiring a lock.
@@ -137,12 +136,23 @@ struct heap_recorder {
   // When did we do the last update of heap recorder?
   long last_update_ns;
 
-  // Data for a heap recording that was started but not yet ended
-  object_record *active_recording;
+  // ObjectSpace::WeakMap[record_id: Integer (Fixnum) => object]
+  // Weak references to every object we're tracking.
+  // Looking a record_id up returns the object while it's alive, and nil once it's been garbage collected, which
+  // is how we determine liveness. See `ruby_weak_map_new` for details on why this gives us a weak reference.
+  VALUE weak_objects;
+  // Source for the ids used as keys in `object_records` and `weak_objects`. Ids are never reused.
+  long next_record_id;
 
-  // Pending recordings that need to be finalized after on_newobj_event completes.
-  // On Ruby 4+, we can't call rb_obj_id during the newobj event, so we store the
-  // VALUE reference here and finalize it via a postponed job.
+  // Is there a heap recording that was started but not yet ended?
+  bool recording_in_progress;
+  // Was the recording in progress one we decided not to keep (e.g. due to the sample rate)? If so, the matching
+  // end call has nothing to do.
+  bool recording_skipped;
+
+  // Recordings that are waiting to be committed after on_newobj_event completes.
+  // We can't add the object to `weak_objects` during the newobj event, so we store the
+  // VALUE reference here and commit it via a postponed job.
   pending_recording pending_recordings[MAX_PENDING_RECORDINGS];
   // Temporary storage for the recording in progress, used between start and end
   VALUE active_deferred_object;
@@ -184,7 +194,7 @@ struct heap_recorder {
     double ewma_objects_skipped;
 
     unsigned long deferred_recordings_skipped_buffer_full;
-    unsigned long deferred_recordings_finalized;
+    unsigned long deferred_recordings_committed;
   } stats_lifetime;
 };
 
@@ -201,16 +211,14 @@ static int st_object_record_entry_free_no_unintern(st_data_t, st_data_t, st_data
 static int st_object_record_update(st_data_t, st_data_t, st_data_t);
 static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
 static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t extra);
-static int update_object_record_entry(st_data_t*, st_data_t*, st_data_t, int);
 static void inc_tracked_objects_or_fail(heap_record *heap_record);
-static void commit_recording(heap_recorder *, heap_record *, object_record *active_recording);
+static void commit_recording(heap_recorder *, heap_record *, object_record *new_record);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
 static inline double ewma_stat(double previous, double current);
 static void unintern_or_raise(heap_recorder *, ddog_prof_ManagedStringId);
 static void unintern_all_or_raise(heap_recorder *recorder, ddog_prof_Slice_ManagedStringId ids);
 static VALUE get_ruby_string_or_raise(heap_recorder*, ddog_prof_ManagedStringId);
-static long obj_id_or_fail(VALUE obj);
 
 // ==========================
 // Heap Recorder External API
@@ -230,11 +238,13 @@ heap_recorder* heap_recorder_new(ddog_prof_ManagedStringStorage string_storage) 
   recorder->reusable_locations = ruby_xcalloc(REUSABLE_LOCATIONS_SIZE, sizeof(ddog_prof_Location));
   recorder->reusable_ids = ruby_xcalloc(REUSABLE_FRAME_DETAILS_SIZE, sizeof(ddog_prof_ManagedStringId));
   recorder->reusable_char_slices = ruby_xcalloc(REUSABLE_FRAME_DETAILS_SIZE, sizeof(ddog_CharSlice));
-  recorder->active_recording = NULL;
   recorder->size_enabled = true;
   recorder->sample_rate = 1; // By default do no sampling on top of what allocation profiling already does
   recorder->string_storage = string_storage;
   recorder->active_deferred_object = Qnil;
+  // Note: This allocates, and thus can trigger a GC. That's fine: our caller only publishes the heap recorder on the
+  // stack recorder state after we return, so `heap_recorder_mark` will not observe a half-initialized recorder.
+  recorder->weak_objects = ruby_weak_map_new();
 
   return recorder;
 }
@@ -264,11 +274,6 @@ void heap_recorder_free(heap_recorder *heap_recorder) {
   // Clean-up all heap records (this includes those only referred to by queued_samples)
   st_foreach(heap_recorder->heap_records, st_heap_record_entry_free_no_unintern, (st_data_t) heap_recorder);
   st_free_table(heap_recorder->heap_records);
-
-  if (heap_recorder->active_recording != NULL && heap_recorder->active_recording != &SKIPPED_RECORD) {
-    // If there's a partial object record, clean it up as well
-    object_record_free(heap_recorder, heap_recorder->active_recording, false);
-  }
 
   ruby_xfree(heap_recorder->reusable_locations);
   ruby_xfree(heap_recorder->reusable_ids);
@@ -326,69 +331,57 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
   heap_recorder->stats_lifetime = (struct stats_lifetime) {0};
 }
 
+// This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
+// Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class) {
   if (heap_recorder == NULL) {
     return false;
   }
 
-  if (heap_recorder->active_recording != NULL) {
+  if (heap_recorder->recording_in_progress) {
     raise_error(rb_eRuntimeError, "Detected consecutive heap allocation recording starts without end.");
   }
 
-  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate ||
-      #ifdef NO_IMEMO_OBJECT_ID
-        // On Ruby 4, we can't ask the object_id from IMEMOs (https://github.com/ruby/ruby/pull/13347)
-        RB_BUILTIN_TYPE(new_obj) == RUBY_T_IMEMO
-      #else
-        false
-      #endif
+  heap_recorder->recording_in_progress = true;
+  heap_recorder->recording_skipped = false;
+
+  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate
       // If we got really unlucky and an allocation showed up during an update (because it triggered an allocation
       // directly OR because the GVL got released in the middle of an update), let's skip this sample as well.
       // See notes on `heap_recorder_update` for details.
       || heap_recorder->updating
     ) {
-    heap_recorder->active_recording = &SKIPPED_RECORD;
+    heap_recorder->recording_skipped = true;
     return false;
   }
 
-  bool needs_after_allocation = false;
-
-  #ifdef USE_DEFERRED_HEAP_ALLOCATION_RECORDING
-  // Skip if we've hit the pending recordings limit or if there's already a deferred object being recorded
+  // Skip if we've hit the pending recordings limit
   if (heap_recorder->pending_recordings_count >= MAX_PENDING_RECORDINGS) {
     heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full++;
-    heap_recorder->active_recording = &SKIPPED_RECORD;
+    heap_recorder->recording_skipped = true;
     return true; // If the buffer is full, we keep asking for a callback (see `needs_after_allocation` below)
-  } else {
-    // The intuition here is: We start by asking for an `after_allocation` callback when the buffer is about to go
-    // from empty -> non-empty, because this is going to be mapped onto a postponed job, so after it gets queued once
-    // it doesn't seem worth it to keep spamming requests.
-    //
-    // Yet, if for some reason the postponed job doesn't flush the pending list (or if e.g. it ran with `during_sample == true` and thus
-    // was skipped) we need to have some mechanism to recover -- and so if the buffer starts accumulating too much we
-    // start always requesting the callback to happen so that we eventually flush the buffer.
-    needs_after_allocation =
-      heap_recorder->pending_recordings_count == 0 || heap_recorder->pending_recordings_count >= (MAX_PENDING_RECORDINGS / 2);
   }
-  #endif
+
+  // The intuition here is: We start by asking for an `after_allocation` callback when the buffer is about to go
+  // from empty -> non-empty, because this is going to be mapped onto a postponed job, so after it gets queued once
+  // it doesn't seem worth it to keep spamming requests.
+  //
+  // Yet, if for some reason the postponed job doesn't commit the pending list (or if e.g. it ran with `during_sample == true` and thus
+  // was skipped) we need to have some mechanism to recover -- and so if the buffer starts accumulating too much we
+  // start always requesting the callback to happen so that we eventually empty the buffer.
+  bool needs_after_allocation =
+    heap_recorder->pending_recordings_count == 0 || heap_recorder->pending_recordings_count >= (MAX_PENDING_RECORDINGS / 2);
 
   heap_recorder->num_recordings_skipped = 0;
 
-  live_object_data object_data = (live_object_data) {
+  // We can't add the object to `weak_objects` during on_newobj_event, so we store the VALUE reference and will do
+  // it later via a postponed job.
+  heap_recorder->active_deferred_object = new_obj;
+  heap_recorder->active_deferred_object_data = (live_object_data) {
     .weight = weight * heap_recorder->sample_rate,
     .class = intern_or_raise(heap_recorder->string_storage, alloc_class),
     .alloc_gen = rb_gc_count(),
   };
-
-  #ifdef USE_DEFERRED_HEAP_ALLOCATION_RECORDING
-    // On Ruby 4+, we can't call rb_obj_id during on_newobj_event as it mutates the object.
-    // Instead, we store the VALUE reference and will get the object_id later via a postponed job.
-    // active_deferred_object != Qnil indicates we're in deferred mode.
-    heap_recorder->active_deferred_object = new_obj;
-    heap_recorder->active_deferred_object_data = object_data;
-  #else
-    heap_recorder->active_recording = object_record_new(obj_id_or_fail(new_obj), NULL, object_data);
-  #endif
 
   return needs_after_allocation;
 }
@@ -401,9 +394,10 @@ int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, 
   if (heap_recorder == NULL) {
     return 0;
   }
-  if (heap_recorder->active_recording == &SKIPPED_RECORD) {
+  if (heap_recorder->recording_skipped) {
     // Short circuit, in this case there's nothing to be done
-    heap_recorder->active_recording = NULL;
+    heap_recorder->recording_skipped = false;
+    heap_recorder->recording_in_progress = false;
     return 0;
   }
 
@@ -422,48 +416,34 @@ static VALUE end_heap_allocation_recording(VALUE protect_args) {
   heap_recorder *heap_recorder = args->heap_recorder;
   ddog_prof_Slice_Location locations = args->locations;
 
-  #ifdef USE_DEFERRED_HEAP_ALLOCATION_RECORDING
-    if (heap_recorder->active_deferred_object == Qnil) {
-      // Recording ended without having been started?
-      raise_error(rb_eRuntimeError, "Ended a heap recording that was not started");
-    }
-  #else
-    object_record *active_recording = heap_recorder->active_recording;
+  if (!heap_recorder->recording_in_progress) {
+    // Recording ended without having been started?
+    raise_error(rb_eRuntimeError, "Ended a heap recording that was not started");
+  }
+  // From now on, mark the recording as no longer in progress so we can short-circuit at any point
+  // and not end up with a still active recording.
+  heap_recorder->recording_in_progress = false;
 
-    if (active_recording == NULL) {
-      // Recording ended without having been started?
-      raise_error(rb_eRuntimeError, "Ended a heap recording that was not started");
-    }
-    // From now on, mark the global active recording as invalid so we can short-circuit at any point
-    // and not end up with a still active recording. the local active_recording still holds the
-    // data required for committing though.
-    heap_recorder->active_recording = NULL;
-
-    if (active_recording == &SKIPPED_RECORD) {
-      raise_error(
-        rb_eRuntimeError,
-        "BUG: end_heap_allocation_recording should never observe SKIPPED_RECORDING because " \
-        "end_heap_allocation_recording_with_rb_protect is supposed to test for it directly"
-      );
-    }
-  #endif
+  long record_id = ++heap_recorder->next_record_id;
+  if (record_id > RUBY_FIXNUM_MAX) {
+    // We rely on record_id always fitting in a FIXNUM to avoid extra overhead and
+    // allocation here. If we exhaust the record_id, we stop profiling.
+    // We don't expect this to happen in practice, as we don't heap sample every object, and RUBY_FIXNUM_MAX is (2**62 - 1)
+    raise_error(rb_eRuntimeError, "Heap profiling: Exhausted usable record_ids");
+  }
 
   heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
   inc_tracked_objects_or_fail(heap_record);
 
-  #ifdef USE_DEFERRED_HEAP_ALLOCATION_RECORDING
-    // Commit is delayed, so we need to record all we'll need for it
-    pending_recording *pending = &heap_recorder->pending_recordings[heap_recorder->pending_recordings_count++];
-    pending->object_ref = heap_recorder->active_deferred_object;
-    pending->heap_record = heap_record;
-    pending->object_data = heap_recorder->active_deferred_object_data;
+  // Commit is delayed, so we need to record all we'll need for it
+  pending_recording *pending = &heap_recorder->pending_recordings[heap_recorder->pending_recordings_count++];
+  pending->object_ref = heap_recorder->active_deferred_object;
+  pending->record_id = record_id;
+  pending->heap_record = heap_record;
+  pending->object_data = heap_recorder->active_deferred_object_data;
 
-    heap_recorder->active_deferred_object = Qnil;
-    heap_recorder->active_deferred_object_data = (live_object_data) {0};
-  #else
-    // And then commit the new allocation
-    commit_recording(heap_recorder, heap_record, active_recording);
-  #endif
+  heap_recorder->active_deferred_object = Qnil;
+  heap_recorder->active_deferred_object_data = (live_object_data) {0};
 
   return Qnil;
 }
@@ -476,46 +456,51 @@ void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
   heap_recorder_update(heap_recorder, /* full_update: */ false);
 }
 
-void heap_recorder_finalize_pending_recordings(heap_recorder *heap_recorder) {
+void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
     return; // Nothing to do
   }
 
-  uint count = heap_recorder->pending_recordings_count;
-  if (count == 0) {
-    return; // Nothing to do
-  }
+  heap_recorder->stats_lifetime.deferred_recordings_committed += heap_recorder->pending_recordings_count;
 
-  heap_recorder->stats_lifetime.deferred_recordings_finalized += count;
-
-  for (uint i = 0; i < count; i++) {
-    pending_recording *pending = &heap_recorder->pending_recordings[i];
+  // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
+  // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark
+  // already-processed pending_recordings (slower and would extend the lifetime of these recordings if not cleared) and
+  // (c) if one of the steps below raises we don't reprocess the entries we already committed, i.e., we're idempotent.
+  while (heap_recorder->pending_recordings_count > 0) {
+    pending_recording *pending = &heap_recorder->pending_recordings[--heap_recorder->pending_recordings_count];
 
     // This is the step we couldn't do during the original sample call -- we're now expected to be called in a context
     // where it's finally safe to call this
-    long obj_id = obj_id_or_fail(pending->object_ref);
+    ruby_weak_map_set(heap_recorder->weak_objects, LONG2FIX(pending->record_id), pending->object_ref);
 
-    // Create the object record now that we have the object_id
-    object_record *record = object_record_new(obj_id, pending->heap_record, pending->object_data);
+    // Nil it out as we don't need it anymore, and we should not keep it alive longer than necessary
+    pending->object_ref = Qnil;
+
+    object_record *record = object_record_new(pending->record_id, pending->heap_record, pending->object_data);
 
     commit_recording(heap_recorder, pending->heap_record, record);
   }
-
-  heap_recorder->pending_recordings_count = 0;
 }
 
-// Mark pending recordings to prevent GC from collecting the objects
-// while they're waiting to be finalized
-void heap_recorder_mark_pending_recordings(heap_recorder *heap_recorder) {
+// Mark the Ruby objects the heap recorder holds on to.
+//
+// Note that the objects we track are deliberately **not** marked here: `weak_objects` holds only weak references
+// to them, which is exactly what lets us detect that they've been garbage collected.
+void heap_recorder_mark(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
     return;
   }
 
+  // Mark pending recordings while they're waiting to be committed, otherwise it won't be safe to read them later.
+  // We would not mind if they are GC'd, but we would need to know that reliably and we can't.
   for (uint i = 0; i < heap_recorder->pending_recordings_count; i++) {
     rb_gc_mark(heap_recorder->pending_recordings[i].object_ref);
   }
 
   rb_gc_mark(heap_recorder->active_deferred_object);
+
+  rb_gc_mark(heap_recorder->weak_objects);
 }
 
 // NOTE: This function needs and assumes it gets called with the GVL being held.
@@ -690,7 +675,7 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder) {
     ID2SYM(rb_intern("lifetime_ewma_objects_skipped")), /* => */ DBL2NUM(heap_recorder->stats_lifetime.ewma_objects_skipped),
 
     ID2SYM(rb_intern("lifetime_deferred_recordings_skipped_buffer_full")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full),
-    ID2SYM(rb_intern("lifetime_deferred_recordings_finalized")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_finalized),
+    ID2SYM(rb_intern("lifetime_deferred_recordings_committed")), /* => */ ULONG2NUM(heap_recorder->stats_lifetime.deferred_recordings_committed),
   };
   VALUE hash = rb_hash_new();
   for (long unsigned int i = 0; i < VALUE_COUNT(arguments); i += 2) rb_hash_aset(hash, arguments[i], arguments[i+1]);
@@ -737,11 +722,9 @@ static int st_object_record_entry_free_no_unintern(DDTRACE_UNUSED st_data_t key,
 
 // NOTE: Some operations inside this function can cause the GVL to be released! Plan accordingly.
 static int st_object_record_update(st_data_t key, st_data_t value, st_data_t extra_arg) {
-  long obj_id = (long) key;
+  long record_id = (long) key;
   object_record *record = (object_record*) value;
   heap_recorder *recorder = (heap_recorder*) extra_arg;
-
-  VALUE ref;
 
   size_t update_gen = recorder->update_gen;
   size_t alloc_gen = record->object_data.alloc_gen;
@@ -761,8 +744,10 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
     return ST_CONTINUE;
   }
 
-  if (!ruby_ref_from_id(LONG2NUM(obj_id), &ref)) { // Note: This function call can cause the GVL to be released
-    // Id no longer associated with a valid ref. Need to delete this object record!
+  // Note: This function call can cause the GVL to be released
+  VALUE ref = ruby_weak_map_get(recorder->weak_objects, LONG2FIX(record_id));
+  if (ref == Qnil) {
+    // The weak reference is gone, meaning the object was garbage collected. Need to delete this object record!
     on_committed_object_record_cleanup(recorder, record);
     recorder->stats_last_update.objects_dead++;
     return ST_DELETE;
@@ -845,15 +830,6 @@ static int st_object_records_debug(DDTRACE_UNUSED st_data_t key, st_data_t value
   return ST_CONTINUE;
 }
 
-static int update_object_record_entry(DDTRACE_UNUSED st_data_t *key, st_data_t *value, st_data_t new_object_record, int existing) {
-  if (!existing) {
-    (*value) = (st_data_t) new_object_record; // Expected to be a `object_record *`
-  } else {
-    // If key already existed, we don't touch the existing value, so it can be used for diagnostics
-  }
-  return ST_CONTINUE;
-}
-
 static void inc_tracked_objects_or_fail(heap_record *heap_record) {
   if (heap_record->num_tracked_objects == UINT32_MAX) {
     raise_error(rb_eRuntimeError, "Reached maximum number of tracked objects for heap record");
@@ -861,21 +837,14 @@ static void inc_tracked_objects_or_fail(heap_record *heap_record) {
   heap_record->num_tracked_objects++;
 }
 
-static void commit_recording(heap_recorder *heap_recorder, heap_record *heap_record, object_record *active_recording) {
+static void commit_recording(heap_recorder *heap_recorder, heap_record *heap_record, object_record *new_record) {
   // Link the object record with the corresponding heap record. This was the last remaining thing we
   // needed to fully build the object_record.
-  active_recording->heap_record = heap_record;
+  new_record->heap_record = heap_record;
 
-  int existing_error = st_update(heap_recorder->object_records, active_recording->obj_id, update_object_record_entry, (st_data_t) active_recording);
-  if (existing_error) {
-    object_record *existing_record = NULL;
-    st_lookup(heap_recorder->object_records, active_recording->obj_id, (st_data_t *) &existing_record);
-    if (existing_record == NULL) raise_error(rb_eRuntimeError, "Unexpected NULL when reading existing record");
-
-    VALUE existing_inspect = object_record_inspect(heap_recorder, existing_record);
-    VALUE new_inspect = object_record_inspect(heap_recorder, active_recording);
-    raise_error(rb_eRuntimeError, "Object ids are supposed to be unique. We got 2 allocation recordings with "
-      "the same id. previous={%"PRIsVALUE"} new={%"PRIsVALUE"}", existing_inspect, new_inspect);
+  int existing = st_insert(heap_recorder->object_records, new_record->record_id, (st_data_t) new_record);
+  if (existing) {
+    raise_error(rb_eRuntimeError, "Unexpected record with the same record_id in heap_recorder->object_records");
   }
 }
 
@@ -895,7 +864,7 @@ static heap_record* get_or_create_heap_record(heap_recorder *heap_recorder, ddog
   heap_record *stack = heap_record_new(heap_recorder, locations);
 
   heap_record *new_or_existing_record = NULL; // Will be set inside update_heap_record_entry_with_new_allocation
-  bool existing = st_update(heap_recorder->heap_records, (st_data_t) stack, update_heap_record_entry_with_new_allocation, (st_data_t) &new_or_existing_record);
+  int existing = st_update(heap_recorder->heap_records, (st_data_t) stack, update_heap_record_entry_with_new_allocation, (st_data_t) &new_or_existing_record);
   if (existing) {
     heap_record_free(heap_recorder, stack, true);
   }
@@ -940,9 +909,9 @@ static void on_committed_object_record_cleanup(heap_recorder *heap_recorder, obj
 // =================
 // Object Record API
 // =================
-object_record* object_record_new(long obj_id, heap_record *heap_record, live_object_data object_data) {
+object_record* object_record_new(long record_id, heap_record *heap_record, live_object_data object_data) {
   object_record *record = calloc(1, sizeof(object_record)); // See "note on calloc vs ruby_xcalloc use" above
-  record->obj_id = obj_id;
+  record->record_id = record_id;
   record->heap_record = heap_record;
   record->object_data = object_data;
   return record;
@@ -962,8 +931,8 @@ VALUE object_record_inspect(heap_recorder *recorder, object_record *record) {
   VALUE filename = get_ruby_string_or_raise(recorder, top_frame.filename);
   live_object_data object_data = record->object_data;
 
-  VALUE inspect = rb_sprintf("obj_id=%ld weight=%d size=%zu location=%"PRIsVALUE":%d alloc_gen=%zu gen_age=%zu frozen=%d ",
-      record->obj_id, object_data.weight, object_data.size, filename,
+  VALUE inspect = rb_sprintf("record_id=%ld weight=%d size=%zu location=%"PRIsVALUE":%d alloc_gen=%zu gen_age=%zu frozen=%d ",
+      record->record_id, object_data.weight, object_data.size, filename,
       (int) top_frame.line, object_data.alloc_gen, object_data.gen_age, object_data.is_frozen);
 
   if (record->object_data.class.value > 0) {
@@ -971,9 +940,9 @@ VALUE object_record_inspect(heap_recorder *recorder, object_record *record) {
 
     rb_str_catf(inspect, "class=%"PRIsVALUE" ", class);
   }
-  VALUE ref;
 
-  if (!ruby_ref_from_id(LONG2NUM(record->obj_id), &ref)) {
+  VALUE ref = ruby_weak_map_get(recorder->weak_objects, LONG2FIX(record->record_id));
+  if (ref == Qnil) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {
     rb_str_catf(inspect, "value=%p ", (void *) ref);
@@ -1093,29 +1062,47 @@ static VALUE get_ruby_string_or_raise(heap_recorder *recorder, ddog_prof_Managed
   return ruby_string;
 }
 
-static long obj_id_or_fail(VALUE obj) {
-  VALUE ruby_obj_id = rb_obj_id(obj);
-  if (!FIXNUM_P(ruby_obj_id)) {
-    // Bignum object ids indicate the fixnum range is exhausted - all future IDs will also be bignums.
-    // Heap profiling cannot continue.
-    raise_error(rb_eRuntimeError, "Heap profiling: bignum object id detected. Heap profiling cannot continue.");
-  }
-
-  return FIX2LONG(ruby_obj_id);
-}
-
 static inline double ewma_stat(double previous, double current) {
   double alpha = 0.3;
   return (1 - alpha) * previous + alpha * current;
 }
 
-VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, VALUE obj_id) {
+VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, long record_id) {
   if (heap_recorder == NULL) {
     raise_error(rb_eArgError, "heap_recorder is NULL");
   }
 
-  // Check if object records contains an object with this object_id
-  return st_is_member(heap_recorder->object_records, FIX2LONG(obj_id)) ? Qtrue : Qfalse;
+  // Check if object records contains an object with this record_id
+  return st_is_member(heap_recorder->object_records, record_id) ? Qtrue : Qfalse;
+}
+
+typedef struct {
+  heap_recorder *recorder;
+  VALUE target;
+  VALUE result;
+} record_id_for_context;
+
+static int st_object_record_id_for(st_data_t key, DDTRACE_UNUSED st_data_t value, st_data_t extra) {
+  record_id_for_context *context = (record_id_for_context*) extra;
+  long record_id = (long) key;
+
+  VALUE ref = ruby_weak_map_get(context->recorder->weak_objects, LONG2FIX(record_id));
+  if (ref != Qnil && ref == context->target) {
+    context->result = LONG2FIX(record_id);
+    return ST_STOP;
+  }
+
+  return ST_CONTINUE;
+}
+
+VALUE heap_recorder_testonly_record_id_for(heap_recorder *heap_recorder, VALUE obj) {
+  // Heap profiling is disabled, so nothing is being tracked
+  if (heap_recorder == NULL) return Qnil;
+
+  record_id_for_context context = (record_id_for_context) {.recorder = heap_recorder, .target = obj, .result = Qnil};
+  st_foreach(heap_recorder->object_records, st_object_record_id_for, (st_data_t) &context);
+
+  return context.result;
 }
 
 void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -99,6 +99,9 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder);
 // This heap allocation recording needs to be ended via ::end_heap_allocation_recording
 // before it will become fully committed and able to be iterated on.
 //
+// Some objects are never tracked (e.g. internal objects, or because of the sample rate); this is handled internally
+// by skipping the recording, so callers always need to pair this with ::end_heap_allocation_recording anyway.
+//
 // @param new_obj
 //   The newly allocated Ruby object/value.
 // @param weight

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -125,14 +125,13 @@ int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, 
 // these objects quicker) and hopefully reduces tail latency (because there's less objects at serialization time to check).
 void heap_recorder_update_young_objects(heap_recorder *heap_recorder);
 
-// Finalize any pending heap allocation recordings by getting their object IDs.
+// Commit any pending heap allocation recordings by taking a weak reference to their objects.
 // This should be called via a postponed job, after the on_newobj_event has completed.
-// Raises an exception if a fatal error occurs (e.g., bignum object ID detected).
-void heap_recorder_finalize_pending_recordings(heap_recorder *heap_recorder);
+void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder);
 
-// Mark pending recordings to prevent GC from collecting the objects
-// while they're waiting for the recordings to be finalized.
-void heap_recorder_mark_pending_recordings(heap_recorder *heap_recorder);
+// Mark the Ruby objects the heap recorder holds on to: the objects of any pending recordings (so that GC does not
+// collect them while they're waiting to be committed) and the weak map itself.
+void heap_recorder_mark(heap_recorder *heap_recorder);
 
 // Update the heap recorder to reflect the latest state of the VM and prepare internal structures
 // for efficient iteration.
@@ -179,8 +178,14 @@ VALUE heap_recorder_state_snapshot(heap_recorder *heap_recorder);
 // troubleshoot issues such as unexpected test failures.
 VALUE heap_recorder_testonly_debug(heap_recorder *heap_recorder);
 
-// Check if a given object_id is being tracked or not
-VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, VALUE obj_id);
+// Check if a given record_id is being tracked or not
+VALUE heap_recorder_testonly_is_object_recorded(heap_recorder *heap_recorder, long record_id);
+
+// Returns the record id being used to track the given (still alive) object, or nil if it's not being tracked (which
+// includes the case where heap profiling is disabled). This lets tests hold on to a record id and keep asking about
+// it after the object itself is gone.
+// NOTE: This is a linear scan over the tracked objects; fine for the small numbers tests track.
+VALUE heap_recorder_testonly_record_id_for(heap_recorder *heap_recorder, VALUE obj);
 
 // Used to ensure that a GC actually triggers an update of the objects
 void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder);

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.c
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.c
@@ -1096,7 +1096,7 @@ const char *ddtrace_cme_original_method_name(const rb_callable_method_entry_t *c
 // This function is not present in the VM headers, but is a public symbol that can be invoked.
 int rb_objspace_internal_object_p(VALUE obj);
 
-int ddtrace_is_internal_object_p(VALUE obj) {
+bool ddtrace_is_internal_object_p(VALUE obj) {
   if (RB_SPECIAL_CONST_P(obj)) {
     // Ruby special constants are not internal, except Qundef.
     // See enum ruby_special_consts in CRuby.

--- a/ext/datadog_profiling_native_extension/private_vm_api_access.h
+++ b/ext/datadog_profiling_native_extension/private_vm_api_access.h
@@ -101,4 +101,5 @@ VALUE ddtrace_location_base_label(const rb_callable_method_entry_t *cme, const r
 void* ddtrace_cme_cfunc_func(const rb_callable_method_entry_t *cme);
 const char *ddtrace_cme_original_method_name(const rb_callable_method_entry_t *cme);
 
-int ddtrace_is_internal_object_p(VALUE obj);
+// Returns true for internal objects (like T_IMEMO/T_ICLASS/etc) and "hidden" objects (rb_class_of(obj) == 0)
+bool ddtrace_is_internal_object_p(VALUE obj);

--- a/ext/datadog_profiling_native_extension/profiling.c
+++ b/ext/datadog_profiling_native_extension/profiling.c
@@ -21,6 +21,7 @@ void collectors_dynamic_sampling_rate_init(VALUE profiling_module);
 void collectors_idle_sampling_helper_init(VALUE profiling_module);
 void collectors_stack_init(VALUE profiling_module);
 void collectors_thread_context_init(VALUE profiling_module);
+void collectors_heap_recorder_init(void);
 void encoded_profile_init(VALUE profiling_module);
 void http_transport_init(VALUE profiling_module);
 void stack_recorder_init(VALUE profiling_module);
@@ -73,6 +74,7 @@ void DDTRACE_EXPORT Init_datadog_profiling_native_extension(void) {
   collectors_idle_sampling_helper_init(profiling_module);
   collectors_stack_init(profiling_module);
   collectors_thread_context_init(profiling_module);
+  collectors_heap_recorder_init();
   encoded_profile_init(profiling_module);
   http_transport_init(profiling_module);
   stack_recorder_init(profiling_module);

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -7,19 +7,10 @@
 
 // The following global variables are initialized at startup to save expensive lookups later.
 // They are not expected to be mutated outside of init.
-static VALUE class_weak_map = Qnil;
-static ID aref_id = Qnil;
-static ID aset_id = Qnil;
 static ID inspect_id = Qnil;
 static ID to_s_id = Qnil;
 
 void ruby_helpers_init(void) {
-  rb_global_variable(&class_weak_map);
-
-  VALUE module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
-  class_weak_map = rb_const_get(module_object_space, rb_intern("WeakMap"));
-  aref_id = rb_intern("[]");
-  aset_id = rb_intern("[]=");
   inspect_id = rb_intern("inspect");
   to_s_id = rb_intern("to_s");
 }
@@ -114,24 +105,6 @@ void private_raise_enforce_syserr(
   } else {
     private_grab_gvl_and_raise(Qnil, syserr_errno, format, expression, file, line, function_name);
   }
-}
-
-// See notes on header for important details
-VALUE ruby_weak_map_new(void) {
-  return rb_class_new_instance(0, NULL, class_weak_map);
-}
-
-// See notes on header for important details
-void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value) {
-  if (value == Qnil) {
-    raise_error(rb_eRuntimeError, "Can't use nil as the value in the WeakMap, otherwise #[] can't differentiate alive vs nil value");
-  }
-  rb_funcall(weak_map, aset_id, 2, key, value);
-}
-
-// See notes on header for important details
-VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
-  return rb_funcall(weak_map, aref_id, 1, key);
 }
 
 // Not part of public headers but is externed from Ruby

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -149,16 +149,9 @@ size_t rb_obj_memsize_of(VALUE obj);
 size_t ruby_obj_memsize_of(VALUE obj) {
   switch (rb_type(obj)) {
     case T_OBJECT:
-    // On Ruby 4.0, computing the size of a class/module/iclass seems to not be safe: `rb_obj_memsize_of` walks the
-    // per-namespace class extensions (`rb_class_classext_foreach` -> `classext_memsize` -> `rb_id_table_memsize`)
-    // and can crash the VM when called on objects tracked by heap profiling.
-    // See https://github.com/DataDog/dd-trace-rb/issues/5936. Class objects contribute negligibly to heap size,
-    // so we skip them (fall through to the `default` branch, returning 0) rather than risk a SIGSEGV.
-    #ifndef NO_SAFE_CLASS_MEMSIZE
     case T_MODULE:
     case T_CLASS:
     case T_ICLASS:
-    #endif
     case T_STRING:
     case T_ARRAY:
     case T_HASH:

--- a/ext/datadog_profiling_native_extension/ruby_helpers.c
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.c
@@ -7,16 +7,19 @@
 
 // The following global variables are initialized at startup to save expensive lookups later.
 // They are not expected to be mutated outside of init.
-static VALUE module_object_space = Qnil;
-static ID _id2ref_id = Qnil;
+static VALUE class_weak_map = Qnil;
+static ID aref_id = Qnil;
+static ID aset_id = Qnil;
 static ID inspect_id = Qnil;
 static ID to_s_id = Qnil;
 
 void ruby_helpers_init(void) {
-  rb_global_variable(&module_object_space);
+  rb_global_variable(&class_weak_map);
 
-  module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
-  _id2ref_id = rb_intern("_id2ref");
+  VALUE module_object_space = rb_const_get(rb_cObject, rb_intern("ObjectSpace"));
+  class_weak_map = rb_const_get(module_object_space, rb_intern("WeakMap"));
+  aref_id = rb_intern("[]");
+  aset_id = rb_intern("[]=");
   inspect_id = rb_intern("inspect");
   to_s_id = rb_intern("to_s");
 }
@@ -113,38 +116,22 @@ void private_raise_enforce_syserr(
   }
 }
 
-static VALUE _id2ref(VALUE obj_id) {
-  // Call ::ObjectSpace._id2ref natively. It will raise if the id is no longer valid
-  return rb_funcall(module_object_space, _id2ref_id, 1, obj_id);
-}
-
-static VALUE _id2ref_failure(DDTRACE_UNUSED VALUE _unused1, DDTRACE_UNUSED VALUE _unused2) {
-  return Qfalse;
+// See notes on header for important details
+VALUE ruby_weak_map_new(void) {
+  return rb_class_new_instance(0, NULL, class_weak_map);
 }
 
 // See notes on header for important details
-bool ruby_ref_from_id(VALUE obj_id, VALUE *value) {
-  // Call ::ObjectSpace._id2ref natively. It will raise if the id is no longer valid
-  // so we need to call it via rb_rescue2
-  // TODO: Benchmark rb_rescue2 vs rb_protect here
-  VALUE result = rb_rescue2(
-    _id2ref,
-    obj_id,
-    _id2ref_failure,
-    Qnil,
-    rb_eRangeError, // rb_eRangeError is the error used to flag invalid ids
-    0 // Required by API to be the last argument
-  );
-
-  if (result == Qfalse) {
-    return false;
+void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value) {
+  if (value == Qnil) {
+    raise_error(rb_eRuntimeError, "Can't use nil as the value in the WeakMap, otherwise #[] can't differentiate alive vs nil value");
   }
+  rb_funcall(weak_map, aset_id, 2, key, value);
+}
 
-  if (value != NULL) {
-    (*value) = result;
-  }
-
-  return true;
+// See notes on header for important details
+VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
+  return rb_funcall(weak_map, aref_id, 1, key);
 }
 
 // Not part of public headers but is externed from Ruby

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -79,28 +79,6 @@ NORETURN(void private_raise_enforce_syserr(
   const char *function_name
 ));
 
-// Native wrapper to create a new `ObjectSpace::WeakMap`.
-//
-// Because an `ObjectSpace::WeakMap` entry is dropped as soon as *either* its key or its value is garbage
-// collected, pairing a key that can never be collected (such as a fixnum) with the object of interest as the
-// value gives us a weak reference: reading the key back returns the object while it's alive, and nothing once
-// it's been collected.
-VALUE ruby_weak_map_new(void);
-
-// Native wrapper to add an entry to an `ObjectSpace::WeakMap`.
-// Raises RuntimeError if passed nil as a value.
-//
-// Note: GVL can be released and other threads may get to run before this method returns
-void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value);
-
-// Native wrapper to get an object from an `ObjectSpace::WeakMap`.
-// Returns the object on success and nil if the entry is gone, meaning
-// the object has been garbage collected.
-// We never store nil as a value, see ruby_weak_map_set(), so nil unambiguously means "the value was garbage collected".
-//
-// Note: GVL can be released and other threads may get to run before this method returns
-VALUE ruby_weak_map_get(VALUE weak_map, VALUE key);
-
 // Native wrapper to get the approximate/estimated current size of the passed
 // object.
 size_t ruby_obj_memsize_of(VALUE obj);

--- a/ext/datadog_profiling_native_extension/ruby_helpers.h
+++ b/ext/datadog_profiling_native_extension/ruby_helpers.h
@@ -79,12 +79,27 @@ NORETURN(void private_raise_enforce_syserr(
   const char *function_name
 ));
 
-// Native wrapper to get an object ref from an id. Returns true on success and
-// writes the ref to the value pointer parameter if !NULL. False if id doesn't
-// reference a valid object (in which case value is not changed).
+// Native wrapper to create a new `ObjectSpace::WeakMap`.
+//
+// Because an `ObjectSpace::WeakMap` entry is dropped as soon as *either* its key or its value is garbage
+// collected, pairing a key that can never be collected (such as a fixnum) with the object of interest as the
+// value gives us a weak reference: reading the key back returns the object while it's alive, and nothing once
+// it's been collected.
+VALUE ruby_weak_map_new(void);
+
+// Native wrapper to add an entry to an `ObjectSpace::WeakMap`.
+// Raises RuntimeError if passed nil as a value.
 //
 // Note: GVL can be released and other threads may get to run before this method returns
-bool ruby_ref_from_id(VALUE obj_id, VALUE *value);
+void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value);
+
+// Native wrapper to get an object from an `ObjectSpace::WeakMap`.
+// Returns the object on success and nil if the entry is gone, meaning
+// the object has been garbage collected.
+// We never store nil as a value, see ruby_weak_map_set(), so nil unambiguously means "the value was garbage collected".
+//
+// Note: GVL can be released and other threads may get to run before this method returns
+VALUE ruby_weak_map_get(VALUE weak_map, VALUE key);
 
 // Native wrapper to get the approximate/estimated current size of the passed
 // object.

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -258,12 +258,13 @@ static VALUE _native_end_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self
 static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_stats(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns, long heap_iteration_prep_time_ns, long heap_profile_build_time_ns);
-static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE object_id);
+static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE record_id);
+static VALUE _native_record_id_for(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE obj);
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_benchmark_intern(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE string, VALUE times, VALUE use_all);
 static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE_UNUSED VALUE _self);
-static VALUE _native_finalize_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_commit_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 
 void stack_recorder_init(VALUE profiling_module) {
   VALUE stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
@@ -296,11 +297,12 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_debug_heap_recorder",
       _native_debug_heap_recorder, 1);
   rb_define_singleton_method(testing_module, "_native_is_object_recorded?", _native_is_object_recorded, 2);
+  rb_define_singleton_method(testing_module, "_native_record_id_for", _native_record_id_for, 2);
   rb_define_singleton_method(testing_module, "_native_heap_recorder_reset_last_update", _native_heap_recorder_reset_last_update, 1);
   rb_define_singleton_method(testing_module, "_native_recorder_after_gc_step", _native_recorder_after_gc_step, 1);
   rb_define_singleton_method(testing_module, "_native_benchmark_intern", _native_benchmark_intern, 4);
   rb_define_singleton_method(testing_module, "_native_test_managed_string_storage_produces_valid_profiles", _native_test_managed_string_storage_produces_valid_profiles, 0);
-  rb_define_singleton_method(testing_module, "_native_finalize_pending_heap_recordings", _native_finalize_pending_heap_recordings, 1);
+  rb_define_singleton_method(testing_module, "_native_commit_pending_heap_recordings", _native_commit_pending_heap_recordings, 1);
 
   ok_symbol = ID2SYM(rb_intern_const("ok"));
   error_symbol = ID2SYM(rb_intern_const("error"));
@@ -398,7 +400,7 @@ static void stack_recorder_typed_data_mark(void *state_ptr) {
   stack_recorder_state *state = (stack_recorder_state *) state_ptr;
 
   rb_gc_mark(state->thread_context_collector_instance);
-  heap_recorder_mark_pending_recordings(state->heap_recorder);
+  heap_recorder_mark(state->heap_recorder);
 }
 
 static void stack_recorder_typed_data_free(void *state_ptr) {
@@ -657,6 +659,9 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   }
 }
 
+// This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
+// Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
+//
 // Returns needs_after_allocation: true whenever an after_sample callback is required
 bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class) {
   stack_recorder_state *state;
@@ -693,7 +698,7 @@ void recorder_after_sample(VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_finalize_pending_recordings(state->heap_recorder);
+  heap_recorder_commit_pending_recordings(state->heap_recorder);
 }
 
 #define MAX_LEN_HEAP_ITERATION_ERROR_MSG 256
@@ -1024,13 +1029,20 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
   return stats_as_hash;
 }
 
-static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE obj_id) {
-  ENFORCE_TYPE(obj_id, T_FIXNUM);
+static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE record_id) {
+  ENFORCE_TYPE(record_id, T_FIXNUM);
 
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  return heap_recorder_testonly_is_object_recorded(state->heap_recorder, obj_id);
+  return heap_recorder_testonly_is_object_recorded(state->heap_recorder, FIX2LONG(record_id));
+}
+
+static VALUE _native_record_id_for(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE obj) {
+  stack_recorder_state *state;
+  TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
+
+  return heap_recorder_testonly_record_id_for(state->heap_recorder, obj);
 }
 
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
@@ -1153,11 +1165,11 @@ static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE
   return rb_ary_new_from_args(2, encoded_pprof_1, encoded_pprof_2);
 }
 
-static VALUE _native_finalize_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+static VALUE _native_commit_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_finalize_pending_recordings(state->heap_recorder);
+  heap_recorder_commit_pending_recordings(state->heap_recorder);
 
   return Qtrue;
 }

--- a/ext/libdatadog_api/datadog_ruby_common.h
+++ b/ext/libdatadog_api/datadog_ruby_common.h
@@ -97,13 +97,3 @@ static inline VALUE get_error_details_and_drop(ddog_Error *error) {
 // Returns the amount of characters written to string (which are necessarily
 // bounded by capacity - 1 since the string will be null-terminated).
 size_t read_ddogerr_string_and_drop(ddog_Error *error, char *string, size_t capacity);
-
-#define IMEMO_MASK 0x0f
-
-// Returns the imemo type of an imemo object.
-// This mask is the same between Ruby 2.5 and 3.3-preview3. Furthermore, the intention of this method is to be used
-// to call `rb_imemo_name` which correctly handles invalid numbers so even if the mask changes in the future, at most
-// we'll get incorrect results (and never a VM crash)
-static inline int ddtrace_imemo_type(VALUE imemo) {
-  return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
-}

--- a/ext/libdatadog_api/di.c
+++ b/ext/libdatadog_api/di.c
@@ -14,6 +14,10 @@ void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),
     void *data);
 
+// The mask is unchanged between Ruby 2.5 and 4.1-dev, but the `enum imemo_type` values do get
+// renumbered from time to time (e.g. Ruby 4.0 moved imemo_callinfo from 11 to 10), and 4.1-dev already uses all
+// 16 values the mask allows. Thus IMEMO_TYPE_ISEQ must be re-checked when adding support for a new Ruby.
+#define IMEMO_MASK 0x0f
 #define IMEMO_TYPE_ISEQ 7
 
 // The ID value of the string "mesg" which is used in Ruby source as
@@ -26,6 +30,12 @@ static ID id_mesg;
 // directly via rb_thread_local_aref / rb_thread_local_aset so that user-installed
 // method probes on Thread#[] / Thread#[]= cannot intercept guard reads/writes.
 static ID id_datadog_di_in_probe;
+
+// Returns the imemo type of an imemo object, that is `imemo_type()` from CRuby's internal/imemo.h.
+// The caller must have already checked the object is a T_IMEMO, otherwise the result is meaningless.
+static inline int ddtrace_imemo_type(VALUE imemo) {
+  return (RBASIC(imemo)->flags >> FL_USHIFT) & IMEMO_MASK;
+}
 
 // Returns whether the argument is an IMEMO of type ISEQ.
 static bool ddtrace_imemo_iseq_p(VALUE v) {

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -254,17 +254,7 @@ module Datadog
       private_class_method def self.enable_heap_size_profiling?(settings, heap_profiling_enabled, logger)
         heap_size_profiling_enabled = settings.profiling.advanced.experimental_heap_size_enabled
 
-        return false unless heap_profiling_enabled && heap_size_profiling_enabled
-
-        if RubyVersion.is?(">= 4")
-          logger.info(
-            "Heap live size profiling is currently incompatible with Ruby 4 and has been disabled. " \
-            "Heap live objects is not affected and remains enabled."
-          )
-          return false
-        end
-
-        true
+        heap_profiling_enabled && heap_size_profiling_enabled
       end
 
       private_class_method def self.no_signals_workaround_enabled?(settings, logger) # rubocop:disable Metrics/MethodLength

--- a/lib/datadog/profiling/component.rb
+++ b/lib/datadog/profiling/component.rb
@@ -227,11 +227,13 @@ module Datadog
           return false
         end
 
-        # Heap profiling relies on `ObjectSpace._id2ref`, which was removed on Ruby 4.1
-        # (https://bugs.ruby-lang.org/issues/22135).
-        if RubyVersion.is?(">= 4.1")
+        # Heap profiling tracks live objects using an `ObjectSpace::WeakMap`, which could corrupt its internal
+        # state during compaction before these versions (https://bugs.ruby-lang.org/issues/19529).
+        if RubyVersion.is?("< 3.1.4") || RubyVersion.is?(">= 3.2", "< 3.2.3")
           logger.warn(
-            "Heap profiling is currently incompatible with Ruby 4.1+ and has been disabled."
+            "Current Ruby version (#{RUBY_VERSION}) cannot support heap profiling due to a VM bug. " \
+            "Please upgrade to Ruby >= 3.1.4 or >= 3.2.3 in order to use this feature. " \
+            "Heap profiling has been disabled."
           )
           return false
         end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -9,13 +9,11 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
   let(:gc_profiling_enabled) { true }
   let(:allocation_profiling_enabled) { false }
   let(:heap_profiling_enabled) { false }
-  let(:heap_size_profiling_available) { RubyVersion.is?("< 4") } # Currently incompatible with Ruby 4
-  let(:heap_size_profiling_enabled) { heap_profiling_enabled && heap_size_profiling_available }
   let(:recorder) do
     Datadog::Profiling::StackRecorder.for_testing(
       alloc_samples_enabled: true,
       heap_samples_enabled: heap_profiling_enabled,
-      heap_size_enabled: heap_size_profiling_enabled,
+      heap_size_enabled: heap_profiling_enabled,
       **stack_recorder_options,
     )
   end
@@ -976,9 +974,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
         expected_size_of_object = 40 # 40 is the size of a basic object and we have test_num_allocated_object of them
 
-        if heap_size_profiling_available
-          expect(total_size).to eq test_num_allocated_object * expected_size_of_object
-        end
+        expect(total_size).to eq test_num_allocated_object * expected_size_of_object
       end
 
       describe "heap cleanup after GC" do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -922,8 +922,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         allow(Datadog.logger).to receive(:warn)
         expect(Datadog.logger).to receive(:warn).with(/dynamic sampling rate disabled/)
 
-        skip "Heap profiling is only supported on Ruby >= 2.7" unless RubyVersion.is?(">= 2.7")
-        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
+        skip "Heap profiling is only supported on Ruby >= 3.1" unless RubyVersion.is?(">= 3.1")
       end
 
       after do |example|
@@ -985,7 +984,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       describe "heap cleanup after GC" do
         let(:options) { {dynamic_sampling_rate_enabled: false} }
 
-        let(:cleared_object_id) do
+        let(:cleared_record_id) do
           stub_const("CpuAndWallTimeWorkerSpec::TestStruct", Struct.new(:foo))
 
           start
@@ -994,11 +993,10 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           GC.start
 
           test_object = CpuAndWallTimeWorkerSpec::TestStruct.new
-          test_object_id = test_object.object_id
+          # The allocation went through the real tracepoint, so we need to ask the recorder which id it handed out
+          test_record_id = Datadog::Profiling::StackRecorder::Testing._native_record_id_for(recorder, test_object)
 
-          expect(
-            Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, test_object_id)
-          ).to be true
+          expect(test_record_id).to_not be_nil
 
           # Let's replace the test_object reference with another object, so that the original one can be GC'd
           test_object = Object.new # rubocop:disable Lint/UselessAssignment
@@ -1008,7 +1006,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
           GC.start
 
-          test_object_id
+          test_record_id
         end
 
         context "when gc_profiling_enabled is enabled" do
@@ -1019,7 +1017,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
             it "removes live heap objects after GCs" do
               expect(
-                Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_object_id)
+                Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_record_id)
               ).to be false
             end
           end
@@ -1029,7 +1027,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
 
             it "does not remove live heap objects after GCs" do
               expect(
-                Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_object_id)
+                Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_record_id)
               ).to be true
             end
           end
@@ -1041,14 +1039,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           it "does not remove live heap objects after minor GCs" do
             # The object is still being tracked!
             expect(
-              Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_object_id)
+              Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_record_id)
             ).to be true
 
             # Sanity checking: It stops being tracked after a serialization, proving it was indeed dead, we just hadn't
             # updated our state yet
             recorder.serialize!
             expect(
-              Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_object_id)
+              Datadog::Profiling::StackRecorder::Testing._native_is_object_recorded?(recorder, cleared_record_id)
             ).to be false
           end
         end

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -977,6 +977,37 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         expect(total_size).to eq test_num_allocated_object * expected_size_of_object
       end
 
+      context "internal VM objects" do
+        let(:something_that_triggers_creation_of_imemo_objects) do
+          eval("proc { def self.foo; rand; end; foo }.call", binding, __FILE__, __LINE__)
+        end
+
+        # Internal objects are skipped by the heap profiler (see `start_heap_allocation_recording()`) because tracking
+        # them would mean adding them to a `ObjectSpace::WeakMap`, which is not safe. They are still allocation
+        # sampled, as that is safe and useful.
+        it "records them as allocation samples but never as heap samples" do
+          start
+
+          something_that_triggers_creation_of_imemo_objects
+
+          # Force a GC so that any tracked object would be old enough to show up in the heap profile
+          GC.start
+
+          cpu_and_wall_time_worker.stop
+
+          internal_samples = samples_from_pprof(recorder.serialize!).select do |sample|
+            sample.labels.fetch(:"allocation class", "").start_with?("(VM Internal")
+          end
+
+          # Guard against this passing just because no internal object was sampled at all
+          expect(internal_samples).to_not be_empty
+          expect(internal_samples.map { |sample| sample.values[:"alloc-samples"] || 0 }.sum).to be > 0
+
+          expect(internal_samples.map { |sample| sample.values[:"heap-live-samples"] || 0 }.sum).to eq 0
+          expect(internal_samples.map { |sample| sample.values[:"heap-live-size"] || 0 }.sum).to eq 0
+        end
+      end
+
       describe "heap cleanup after GC" do
         let(:options) { {dynamic_sampling_rate_enabled: false} }
 

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -368,17 +368,20 @@ RSpec.describe Datadog::Profiling::Component do
             end
           end
 
-          context "on Ruby 4.1 or newer" do
-            let(:testing_version) { "4.1.0" }
+          # See https://bugs.ruby-lang.org/issues/19529 -- ObjectSpace::WeakMap could corrupt itself during compaction
+          ["3.1.0", "3.1.3", "3.2.0", "3.2.2"].each do |version_with_weak_map_bug|
+            context "on Ruby #{version_with_weak_map_bug}" do
+              let(:testing_version) { version_with_weak_map_bug }
 
-            it "initializes StackRecorder without heap sampling support and warns" do
-              expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
-                .and_call_original
+              it "initializes StackRecorder without heap sampling support and warns" do
+                expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                  .with(hash_including(heap_samples_enabled: false, heap_size_enabled: false))
+                  .and_call_original
 
-              expect(logger).to receive(:warn).with(/Heap profiling is currently incompatible with Ruby 4.1/)
+                expect(logger).to receive(:warn).with(/upgrade to Ruby >= 3.1.4 or >= 3.2.3/)
 
-              build_profiler_component
+                build_profiler_component
+              end
             end
           end
 
@@ -413,6 +416,23 @@ RSpec.describe Datadog::Profiling::Component do
               expect(logger).to receive(:debug).with(/Enabled heap profiling/)
 
               build_profiler_component
+            end
+
+            # See https://bugs.ruby-lang.org/issues/19529 -- these are the first versions with the WeakMap fix
+            ["3.1.4", "3.2.3"].each do |version_with_weak_map_fix|
+              context "on Ruby #{version_with_weak_map_fix}" do
+                let(:testing_version) { version_with_weak_map_fix }
+
+                before { allow(logger).to receive(:debug) }
+
+                it "initializes StackRecorder with heap sampling support" do
+                  expect(Datadog::Profiling::StackRecorder).to receive(:new)
+                    .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
+                    .and_call_original
+
+                  build_profiler_component
+                end
+              end
             end
 
             context "on Ruby 4.0 or newer" do

--- a/spec/datadog/profiling/component_spec.rb
+++ b/spec/datadog/profiling/component_spec.rb
@@ -345,7 +345,6 @@ RSpec.describe Datadog::Profiling::Component do
         context "when heap profiling is enabled", ruby: ">= 2.7" do
           # Universally supported ruby version for allocation profiling by default
           let(:testing_version) { "3.3.0" }
-          let(:heap_size_profiling_available) { RubyVersion.is?("< 4") } # Currently incompatible with Ruby 4
 
           before do
             settings.profiling.advanced.experimental_heap_enabled = true
@@ -408,7 +407,7 @@ RSpec.describe Datadog::Profiling::Component do
 
             it "initializes StackRecorder with heap sampling support and warns" do
               expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: heap_size_profiling_available))
+                .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
                 .and_call_original
 
               expect(logger).to receive(:debug).with(/Ractors.+stopping/)
@@ -440,12 +439,10 @@ RSpec.describe Datadog::Profiling::Component do
 
               before { allow(logger).to receive(:debug) }
 
-              it "initializes StackRecorder with heap sampling but without heap size profiling support and logs" do
+              it "initializes StackRecorder with heap sampling support" do
                 expect(Datadog::Profiling::StackRecorder).to receive(:new)
-                  .with(hash_including(heap_samples_enabled: true, heap_size_enabled: false))
+                  .with(hash_including(heap_samples_enabled: true, heap_size_enabled: true))
                   .and_call_original
-
-                expect(logger).to receive(:info).with(/Heap live size profiling is currently incompatible with Ruby 4/)
 
                 build_profiler_component
               end

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     described_class::Testing._native_slot_two_mutex_locked?(stack_recorder)
   end
 
-  def is_object_recorded?(obj_id)
-    described_class::Testing._native_is_object_recorded?(stack_recorder, obj_id)
+  def is_object_recorded?(record_id)
+    described_class::Testing._native_is_object_recorded?(stack_recorder, record_id)
   end
 
   def recorder_after_gc_step
@@ -382,13 +382,15 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       let(:samples) { samples_from_pprof(encoded_pprof) }
 
+      # Returns the record id the heap recorder is using to track `obj`, or nil if the allocation wasn't sampled
       def sample_allocation(obj)
         # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
         described_class::Testing._native_track_object(stack_recorder, obj, sample_rate, obj.class.name)
         Datadog::Profiling::Collectors::Stack::Testing
           ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
-        # On Ruby 4+, heap recordings are deferred and need to be finalized after the sample is recorded
-        described_class::Testing._native_finalize_pending_heap_recordings(stack_recorder)
+        # Heap recordings are deferred and need to be committed after the sample is recorded
+        described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
+        described_class::Testing._native_record_id_for(stack_recorder, obj)
       end
 
       def introduce_distinct_stacktraces(i, obj)
@@ -400,7 +402,11 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
 
       before do
-        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
+        # NOTE: This needs to be checked before the allocations below, since those already go through the heap
+        # recorder. (See `Profiling::Component.enable_heap_profiling?` for the versions we actually support.)
+        if (heap_samples_enabled || heap_size_enabled) && RubyVersion.is?("< 3.1")
+          skip "Heap profiling is only supported on Ruby >= 3.1"
+        end
 
         allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash,
           {"z" => -1, "y" => "-2", "x" => false}, Object.new]
@@ -459,10 +465,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         let(:non_heap_samples) do
           samples.reject { |s| s.value?(:"heap-live-samples") }
-        end
-
-        before do
-          skip "Heap profiling is only supported on Ruby >= 2.7" unless RubyVersion.is?(">= 2.7")
         end
 
         it "include the stack and sample counts for the objects still left alive" do
@@ -712,25 +714,25 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           end
         end
 
-        describe "pending heap recordings cleanup", ruby: ">= 4" do
+        describe "pending heap recordings cleanup" do
           def has_pending_recordings?
             described_class::Testing._native_debug_heap_recorder(stack_recorder).to_h.dig(:state, :pending_recordings_count) > 0
           end
 
-          def track_object_without_finalize(obj)
+          def track_object_without_commit(obj)
             described_class::Testing._native_track_object(stack_recorder, obj, sample_rate, obj.class.name)
             Datadog::Profiling::Collectors::Stack::Testing
               ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
           end
 
-          it "clears pending recordings after finalization" do
+          it "clears pending recordings after committing" do
             test_object = Object.new
 
-            track_object_without_finalize(test_object)
+            track_object_without_commit(test_object)
 
             expect(has_pending_recordings?).to be true
 
-            described_class::Testing._native_finalize_pending_heap_recordings(stack_recorder)
+            described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
 
             expect(has_pending_recordings?).to be false
           end
@@ -738,12 +740,12 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           it "clears all pending recordings after multiple allocations" do
             3.times do
               test_object = Object.new
-              track_object_without_finalize(test_object)
+              track_object_without_commit(test_object)
             end
 
             expect(has_pending_recordings?).to be true
 
-            described_class::Testing._native_finalize_pending_heap_recordings(stack_recorder)
+            described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
 
             expect(has_pending_recordings?).to be false
           end
@@ -751,19 +753,23 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
         describe "#recorder_after_gc_step" do
           def sample_and_clear
-            test_object = Object.new
-            test_object_id = test_object.object_id
-            sample_allocation(test_object)
-            # Let's replace the test_object reference with another object, so that the original one can be GC'd
-            test_object = Object.new # rubocop:disable Lint/UselessAssignment
+            # The object is allocated and sampled on a separate thread which we immediately join. Once that thread
+            # is gone, so are its machine stack and registers, so there is nowhere left for a stale reference to
+            # the object to hide from Ruby's conservative garbage collector -- only the record id (an Integer)
+            # crosses back to us.
+            #
+            # Doing this on the main thread instead made these examples flaky on CI: the object would survive the
+            # GC below and the recorder would (correctly!) keep reporting it. That's the same class of problem the
+            # enclosing `before` documents, see https://bugs.ruby-lang.org/issues/19460.
+            record_id = Thread.new { sample_allocation(Object.new) }.value
             GC.start
-            test_object_id
+            record_id
           end
 
           before do
             GC.disable
 
-            @object_ids = Array.new(4) { sample_and_clear }
+            @record_ids = Array.new(4) { sample_and_clear }
           end
 
           after { GC.enable }
@@ -773,25 +779,20 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             it "clears young dead objects with age 1 and 2, but not older objects" do
               # Every object is still being tracked at this point
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
 
               recorder_after_gc_step
 
               # Young objects should no longer be tracked, but older objects are still kept
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, false, false]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, false, false]
 
               stack_recorder.serialize
 
               GC.enable
               GC.start
 
-              # Sanity check: All the objects should've been garbage collected
-              @object_ids.map do |object_id|
-                expect { ObjectSpace._id2ref(object_id) }.to raise_error(RangeError)
-              end
-
               # Older objects are only cleared at serialization time
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [false, false, false, false]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [false, false, false, false]
             end
 
             context "when there's a heap serialization ongoing" do
@@ -800,12 +801,12 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
                 described_class::Testing._native_start_fake_slow_heap_serialization(stack_recorder)
 
-                test_object_id = sample_and_clear
+                test_record_id = sample_and_clear
 
                 expect do
                   described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
                   recorder_after_gc_step
-                end.to_not change { is_object_recorded?(test_object_id) }.from(true)
+                end.to_not change { is_object_recorded?(test_record_id) }.from(true)
 
                 described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
 
@@ -813,34 +814,34 @@ RSpec.describe Datadog::Profiling::StackRecorder do
                 expect do
                   described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
                   recorder_after_gc_step
-                end.to change { is_object_recorded?(test_object_id) }.from(true).to(false)
+                end.to change { is_object_recorded?(test_record_id) }.from(true).to(false)
               end
             end
 
             it "enforces a minimum time between heap updates" do
               skip_asan_flaky
 
-              test_object_id_1 = sample_and_clear
+              test_record_id_1 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_object_id_1) }.from(true).to(false)
+              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
 
-              test_object_id_2 = sample_and_clear
+              test_record_id_2 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_object_id_2) }.from(true)
+              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
             end
 
             it "does not apply the minimum time between heap updates when serializing" do
               skip_asan_flaky
 
-              test_object_id_1 = sample_and_clear
+              test_record_id_1 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_object_id_1) }.from(true).to(false)
+              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
 
-              test_object_id_2 = sample_and_clear
+              test_record_id_2 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_object_id_2) }.from(true)
+              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
 
-              expect { serialize }.to change { is_object_recorded?(test_object_id_2) }.from(true).to(false)
+              expect { serialize }.to change { is_object_recorded?(test_record_id_2) }.from(true).to(false)
             end
           end
 
@@ -851,17 +852,17 @@ RSpec.describe Datadog::Profiling::StackRecorder do
               skip_asan_flaky
 
               # Every object is still being tracked at this point
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
 
               recorder_after_gc_step
 
               # No change -- all objects are still being tracked
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
 
               stack_recorder.serialize
 
               # All objects are finally cleared
-              expect(@object_ids.map { |it| is_object_recorded?(it) }).to eq [false, false, false, false]
+              expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [false, false, false, false]
             end
           end
         end
@@ -1050,8 +1051,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       let(:heap_size_enabled) { true }
 
       before do
-        skip "Heap profiling is only supported on Ruby >= 2.7" unless RubyVersion.is?(">= 2.7")
-        skip "Heap profiling relies on ObjectSpace._id2ref, removed in Ruby 4.1" if RubyVersion.is?(">= 4.1")
+        skip "Heap profiling is only supported on Ruby >= 3.1" unless RubyVersion.is?(">= 3.1")
       end
 
       def sample_allocation(obj)
@@ -1060,8 +1060,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         Datadog::Profiling::Collectors::Stack::Testing._native_sample(
           Thread.current, stack_recorder, {"alloc-samples" => 1, "heap_sample" => true}, [], [],
         )
-        # On Ruby 4+, heap recordings are deferred and need to be finalized after the sample is recorded
-        described_class::Testing._native_finalize_pending_heap_recordings(stack_recorder)
+        # Heap recordings are deferred and need to be committed after the sample is recorded
+        described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
       end
 
       it "includes heap recorder snapshot" do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -490,8 +490,9 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           expect(hash_sample.values[:"heap-live-size"]).to eq(ObjectSpace.memsize_of(a_hash) * sample_rate)
         end
 
-        # Regression test for https://github.com/DataDog/dd-trace-rb/issues/5936,
-        # see comments on `ruby_obj_memsize_of` for details
+        # Regression test for https://github.com/DataDog/dd-trace-rb/issues/5936: on Ruby 4, sizing a class walks the
+        # per-namespace class extensions, which used to crash the VM when we handed it an object resurrected via
+        # `ObjectSpace._id2ref`. We no longer use `_id2ref`, so this is expected to report a real size everywhere.
         context "for class objects" do
           let(:a_class) { Class.new }
 
@@ -500,17 +501,13 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             GC.start # Age the class past the current GC gen so it is reported as a live heap object (gen_age > 0)
           end
 
-          it "tracks the class without crashing and reports a size that is safe for the current Ruby" do
+          it "tracks the class without crashing and reports its size" do
             skip_asan_flaky
 
             class_sample = heap_samples.find { |s| s.labels[:"allocation class"] == "Class" }
             expect(class_sample).to_not be_nil
 
-            if RubyVersion.is?(">= 4")
-              expect(class_sample.values[:"heap-live-size"]).to eq(0)
-            else
-              expect(class_sample.values[:"heap-live-size"]).to eq(ObjectSpace.memsize_of(a_class) * sample_rate)
-            end
+            expect(class_sample.values[:"heap-live-size"]).to eq(ObjectSpace.memsize_of(a_class) * sample_rate)
           end
         end
 


### PR DESCRIPTION
`ObjectSpace._id2ref` is a dead end for the heap profiler: it was removed in Ruby 4.1 ([[Feature #22135]](https://bugs.ruby-lang.org/issues/22135)), is deprecated in 4.0 ([[Feature #15408]](https://bugs.ruby-lang.org/issues/15408)), and has a history of crashes such as returning unrelated live objects under lazy sweeping ([[Bug #22200]](https://bugs.ruby-lang.org/issues/22200)).

Each heap recorder now owns an `ObjectSpace::WeakMap` mapping `record_id -> object`. A WeakMap entry is dropped as soon as either side is collected, so pairing an immortal fixnum key with the tracked object as the (weak) value gives us exactly the weak reference we need: reading the key back returns the object while it's alive, and nil once it's gone. This also replaces a `rb_rescue2` + raise-per-dead-object with a plain lookup.

While here, drop `rb_obj_id` from the heap path in favour of a per-recorder monotonic counter. Asking for an object_id mutates the profiled application's objects -- a shape/fields transition on Ruby 4, and two st_table entries plus FL_SEEN_OBJ_ID on Ruby 3 -- so not needing it makes heap profiling less intrusive. It also lets us drop NO_IMEMO_OBJECT_ID (Ruby 4 was silently dropping IMEMO heap samples), the bignum-exhaustion failure mode, and the duplicate-id check, since ids are now unique by construction.

Deferred recording becomes unconditional. `WeakMap#[]=` is a Ruby method call that allocates, and neither is safe inside the newobj tracepoint on Ruby < 4.0: `ruby_xmalloc` can trigger a GC there, as Ruby only added `rb_gc_local_disable_no_rest()` around the hook in 4.0. So the object reference is always buffered and the weak map entry is added later from the after_allocation postponed job. This removes the USE_DEFERRED_HEAP_ALLOCATION_RECORDING split rather than widening it, and needs a `rb_postponed_job_register_one` fallback for Ruby < 3.3. It also restores the "consecutive recording starts without end" guard, which was a no-op in deferred mode. Note that buffer-full drops (`deferred_recordings_skipped_buffer_full`) now become possible on Ruby < 4, which previously committed inline.

Heap profiling is force-disabled on Ruby 3.1.0-3.1.3 and 3.2.0-3.2.2, where `ObjectSpace::WeakMap` can corrupt its internal state during compaction ([[Bug #19529]](https://bugs.ruby-lang.org/issues/19529), fixed in 3.1.4 and 3.2.3). The Ruby 4.1 guard is removed.

Note that enabling heap profiling on Ruby 4.1 end to end additionally needs a `datadog-ruby_core_source` release with 4.1 headers, which the profiler extension does not build without today.

Verified: full profiling suite on 3.1.7 (docker), 3.2.11, 3.3.11, 3.4.9 and 4.0.6, covering both WeakMap implementations (finalizer-based on 3.1/3.2, weak-reference-based on 3.3+).

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Make heap profiling work reliably.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Profiling: Improved stability of heap profiling by using `ObjectSpace::WeakMap` instead of `_id2ref`. Profiling: Re-enabled heap live size profiling for Ruby 4+. Profiling: VM-internal objects are no longer sampled for heap profiling.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
