### PR TITLE
Fix unused variable warning in DI spec_helper leak detector

### DIFF
--- a/spec/datadog/di/spec_helper.rb
+++ b/spec/datadog/di/spec_helper.rb
@@ -248,7 +248,7 @@ module ProbeNotifierWorkerLeakDetector
   end
 
   def stop(*args)
-    ProbeNotifierWorkerLeakDetector.workers.delete_if do |(worker, example)|
+    ProbeNotifierWorkerLeakDetector.workers.delete_if do |(worker, _example)|
       worker == self
     end
     super


### PR DESCRIPTION
**What does this PR do?**

Silences a Ruby verbose warning emitted while loading `spec/datadog/di/spec_helper.rb`:

```
spec/datadog/di/spec_helper.rb:251: warning: assigned but unused variable - example
```

**Motivation:**

Keep spec output free of Ruby warnings.

**Change log entry**

None.

**Additional Notes:**

Test-only change.

**How to test the change?**

Existing CI