### PR TITLE
test(openfeature): cover isolated malformed flags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
       - dependency-name: "DataDog/system-tests/.github/workflows/system-tests.yml"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -157,6 +157,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Restore bundle cache
         uses: ./.github/actions/bundle-restore
         with:
@@ -242,6 +243,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Restore bundle cache
         uses: ./.github/actions/bundle-restore
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/datadog/open_feature/ffe-system-test-data"]
+	path = spec/datadog/open_feature/ffe-system-test-data
+	url = https://github.com/DataDog/ffe-system-test-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/datadog/open_feature/ffe-system-test-data"]
+  path = spec/datadog/open_feature/ffe-system-test-data
+  url = https://github.com/DataDog/ffe-system-test-data.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec/datadog/open_feature/ffe-system-test-data"]
-	path = spec/datadog/open_feature/ffe-system-test-data
-	url = https://github.com/DataDog/ffe-system-test-data.git
+  path = spec/datadog/open_feature/ffe-system-test-data
+  url = https://github.com/DataDog/ffe-system-test-data.git

--- a/lib/datadog/open_feature/native_evaluator.rb
+++ b/lib/datadog/open_feature/native_evaluator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../core/feature_flags"
+require_relative "ext"
 
 module Datadog
   module OpenFeature

--- a/lib/datadog/open_feature/native_evaluator.rb
+++ b/lib/datadog/open_feature/native_evaluator.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "../core/feature_flags"
-require_relative "ext"
-require_relative "resolution_details"
 
 module Datadog
   module OpenFeature
     # This class is an interface of evaluation logic using native extension
     class NativeEvaluator
-      INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE = "flag configuration is invalid or unsupported"
-
       # NOTE: In a currect implementation configuration is expected to be a raw
       #       JSON string containing feature flags (straight from the remote config)
       #       in the format expected by `libdatadog` without any modifications
@@ -31,29 +27,11 @@ module Datadog
       def get_assignment(flag_key, default_value:, expected_type:, context:)
         result = @configuration.get_assignment(flag_key, expected_type, context)
 
-        return invalid_flag_configuration_error(default_value) if invalid_flag_configuration?(result)
-
         # NOTE: This is a special case when we need to fallback to the default
         #       value, even tho the evaluation itself doesn't produce an error
         #       resolution details
         result.value = default_value if result.variant.nil?
         result
-      end
-
-      private
-
-      def invalid_flag_configuration?(result)
-        result.reason == Ext::DEFAULT &&
-          result.error_code.nil? &&
-          result.error_message == INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE
-      end
-
-      def invalid_flag_configuration_error(default_value)
-        ResolutionDetails.build_error(
-          value: default_value,
-          error_code: Ext::PARSE_ERROR,
-          error_message: INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE
-        )
       end
     end
   end

--- a/sig/datadog/open_feature/native_evaluator.rbs
+++ b/sig/datadog/open_feature/native_evaluator.rbs
@@ -1,8 +1,6 @@
 module Datadog
   module OpenFeature
     class NativeEvaluator
-      INVALID_FLAG_CONFIGURATION_ERROR_MESSAGE: ::String
-
       @configuration: Core::FeatureFlags::Configuration
 
       def initialize: (::String configuration) -> void
@@ -12,13 +10,7 @@ module Datadog
         default_value: untyped,
         context: ::OpenFeature::SDK::EvaluationContext::fields_t,
         expected_type: ::Symbol
-      ) -> (Core::FeatureFlags::ResolutionDetails | ResolutionDetails)
-
-      private
-
-      def invalid_flag_configuration?: (Core::FeatureFlags::ResolutionDetails result) -> bool
-
-      def invalid_flag_configuration_error: (untyped default_value) -> ResolutionDetails
+      ) -> Core::FeatureFlags::ResolutionDetails
     end
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "spec_helper"
 require "datadog/open_feature/native_evaluator"
 
@@ -53,19 +54,20 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       evaluator.get_assignment(flag_key, default_value: false, expected_type: expected_type, context: context)
     end
 
-    context "when libdatadog reports an invalid per-flag configuration as caller default" do
-      let(:reason) { "DEFAULT" }
+    context "when libdatadog reports an invalid per-flag configuration" do
+      let(:reason) { "ERROR" }
+      let(:error_code) { "PARSE_ERROR" }
       let(:error_message) { "flag configuration is invalid or unsupported" }
       let(:variant) { nil }
 
-      it "returns an OpenFeature parse error using the caller default" do
-        expect(assignment).not_to receive(:value=)
+      it "keeps the parse error and applies the caller default value" do
+        expect(assignment).to receive(:value=).with(false).and_call_original
 
+        expect(result).to be(assignment)
         expect(result.value).to be(false)
         expect(result.reason).to eq("ERROR")
         expect(result.error_code).to eq("PARSE_ERROR")
-        expect(result.error_message).to eq("flag configuration is invalid or unsupported")
-        expect(result.error?).to be(true)
+        expect(result.error_message).to eq(error_message)
       end
     end
 
@@ -80,5 +82,59 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
         expect(result).to be(assignment)
       end
     end
+  end
+end
+
+RSpec.describe Datadog::OpenFeature::NativeEvaluator do
+  fixture_root = File.expand_path("ffe-system-test-data", __dir__)
+  fixture_files = Dir[File.join(fixture_root, "evaluation-cases", "*.json")].sort
+
+  raise "FFE fixture submodule is missing or empty" if fixture_files.empty?
+
+  subject(:evaluator) { described_class.new(configuration) }
+
+  let(:configuration) { File.read(File.join(fixture_root, "ufc-config.json")) }
+
+  describe "canonical FFE fixtures" do
+    fixture_files.each do |fixture_file|
+      JSON.parse(File.read(fixture_file)).each_with_index do |test_case, index|
+        it "evaluates #{File.basename(fixture_file)}[#{index}]" do
+          result = evaluator.get_assignment(
+            test_case.fetch("flag"),
+            default_value: test_case.fetch("defaultValue"),
+            expected_type: expected_type(test_case.fetch("variationType")),
+            context: evaluation_context(test_case)
+          )
+
+          expected = test_case.fetch("result")
+
+          expect(result.value).to eq(expected.fetch("value"))
+          expect(result.reason).to eq(expected.fetch("reason"))
+          expect(result.variant).to eq(expected["variant"]) if expected.key?("variant")
+          expect(result.error_code).to eq(expected["errorCode"]) if expected.key?("errorCode")
+        end
+      end
+    end
+  end
+
+  def expected_type(variation_type)
+    case variation_type
+    when "BOOLEAN"
+      :boolean
+    when "STRING"
+      :string
+    when "INTEGER"
+      :integer
+    when "NUMERIC"
+      :number
+    when "JSON"
+      :object
+    else
+      raise "Unsupported variation type: #{variation_type}"
+    end
+  end
+
+  def evaluation_context(test_case)
+    {"targeting_key" => test_case["targetingKey"]}.merge(test_case.fetch("attributes") || {})
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "spec_helper"
 require "datadog/open_feature/native_evaluator"
 
@@ -58,14 +59,10 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       let(:error_message) { "flag configuration is invalid or unsupported" }
       let(:variant) { nil }
 
-      it "returns an OpenFeature parse error using the caller default" do
-        expect(assignment).not_to receive(:value=)
+      it "keeps the default result and applies the caller default value" do
+        expect(assignment).to receive(:value=).with(false)
 
-        expect(result.value).to be(false)
-        expect(result.reason).to eq("ERROR")
-        expect(result.error_code).to eq("PARSE_ERROR")
-        expect(result.error_message).to eq("flag configuration is invalid or unsupported")
-        expect(result.error?).to be(true)
+        expect(result).to be(assignment)
       end
     end
 
@@ -80,5 +77,59 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
         expect(result).to be(assignment)
       end
     end
+  end
+end
+
+RSpec.describe Datadog::OpenFeature::NativeEvaluator do
+  fixture_root = File.expand_path("ffe-system-test-data", __dir__)
+  fixture_files = Dir[File.join(fixture_root, "evaluation-cases", "*.json")].sort
+
+  raise "FFE fixture submodule is missing or empty" if fixture_files.empty?
+
+  subject(:evaluator) { described_class.new(configuration) }
+
+  let(:configuration) { File.read(File.join(fixture_root, "ufc-config.json")) }
+
+  describe "canonical FFE fixtures" do
+    fixture_files.each do |fixture_file|
+      JSON.parse(File.read(fixture_file)).each_with_index do |test_case, index|
+        it "evaluates #{File.basename(fixture_file)}[#{index}]" do
+          result = evaluator.get_assignment(
+            test_case.fetch("flag"),
+            default_value: test_case.fetch("defaultValue"),
+            expected_type: expected_type(test_case.fetch("variationType")),
+            context: evaluation_context(test_case)
+          )
+
+          expected = test_case.fetch("result")
+
+          expect(result.value).to eq(expected.fetch("value"))
+          expect(result.reason).to eq(expected.fetch("reason"))
+          expect(result.variant).to eq(expected["variant"]) if expected.key?("variant")
+          expect(result.error_code).to eq(expected["errorCode"]) if expected.key?("errorCode")
+        end
+      end
+    end
+  end
+
+  def expected_type(variation_type)
+    case variation_type
+    when "BOOLEAN"
+      :boolean
+    when "STRING"
+      :string
+    when "INTEGER"
+      :integer
+    when "NUMERIC"
+      :number
+    when "JSON"
+      :object
+    else
+      raise "Unsupported variation type: #{variation_type}"
+    end
+  end
+
+  def evaluation_context(test_case)
+    {"targeting_key" => test_case["targetingKey"]}.merge(test_case.fetch("attributes") || {})
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "spec_helper"
 require "datadog/open_feature/native_evaluator"
 
@@ -80,5 +81,59 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
         expect(result).to be(assignment)
       end
     end
+  end
+end
+
+RSpec.describe Datadog::OpenFeature::NativeEvaluator do
+  fixture_root = File.expand_path("ffe-system-test-data", __dir__)
+  fixture_files = Dir[File.join(fixture_root, "evaluation-cases", "*.json")].sort
+
+  raise "FFE fixture submodule is missing or empty" if fixture_files.empty?
+
+  subject(:evaluator) { described_class.new(configuration) }
+
+  let(:configuration) { File.read(File.join(fixture_root, "ufc-config.json")) }
+
+  describe "canonical FFE fixtures" do
+    fixture_files.each do |fixture_file|
+      JSON.parse(File.read(fixture_file)).each_with_index do |test_case, index|
+        it "evaluates #{File.basename(fixture_file)}[#{index}]" do
+          result = evaluator.get_assignment(
+            test_case.fetch("flag"),
+            default_value: test_case.fetch("defaultValue"),
+            expected_type: expected_type(test_case.fetch("variationType")),
+            context: evaluation_context(test_case)
+          )
+
+          expected = test_case.fetch("result")
+
+          expect(result.value).to eq(expected.fetch("value"))
+          expect(result.reason).to eq(expected.fetch("reason"))
+          expect(result.variant).to eq(expected["variant"])
+          expect(result.error_code).to eq(expected["error"])
+        end
+      end
+    end
+  end
+
+  def expected_type(variation_type)
+    case variation_type
+    when "BOOLEAN"
+      :boolean
+    when "STRING"
+      :string
+    when "INTEGER"
+      :integer
+    when "NUMERIC"
+      :number
+    when "JSON"
+      :object
+    else
+      raise "Unsupported variation type: #{variation_type}"
+    end
+  end
+
+  def evaluation_context(test_case)
+    {"targeting_key" => test_case["targetingKey"]}.merge(test_case.fetch("attributes") || {})
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -59,14 +59,10 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       let(:error_message) { "flag configuration is invalid or unsupported" }
       let(:variant) { nil }
 
-      it "returns an OpenFeature parse error using the caller default" do
-        expect(assignment).not_to receive(:value=)
+      it "keeps the default result and applies the caller default value" do
+        expect(assignment).to receive(:value=).with(false)
 
-        expect(result.value).to be(false)
-        expect(result.reason).to eq("ERROR")
-        expect(result.error_code).to eq("PARSE_ERROR")
-        expect(result.error_message).to eq("flag configuration is invalid or unsupported")
-        expect(result.error?).to be(true)
+        expect(result).to be(assignment)
       end
     end
 
@@ -109,8 +105,8 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
 
           expect(result.value).to eq(expected.fetch("value"))
           expect(result.reason).to eq(expected.fetch("reason"))
-          expect(result.variant).to eq(expected["variant"])
-          expect(result.error_code).to eq(expected["errorCode"])
+          expect(result.variant).to eq(expected["variant"]) if expected.key?("variant")
+          expect(result.error_code).to eq(expected["errorCode"]) if expected.key?("errorCode")
         end
       end
     end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
           expect(result.value).to eq(expected.fetch("value"))
           expect(result.reason).to eq(expected.fetch("reason"))
           expect(result.variant).to eq(expected["variant"])
-          expect(result.error_code).to eq(expected["errorCode"]) if expected.key?("errorCode")
+          expect(result.error_code).to eq(expected["errorCode"])
         end
       end
     end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
           expect(result.value).to eq(expected.fetch("value"))
           expect(result.reason).to eq(expected.fetch("reason"))
           expect(result.variant).to eq(expected["variant"])
-          expect(result.error_code).to eq(expected["error"])
+          expect(result.error_code).to eq(expected["errorCode"]) if expected.key?("errorCode")
         end
       end
     end

--- a/spec/datadog/release_gem_spec.rb
+++ b/spec/datadog/release_gem_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "gem release process" do
            |\.git-blame-ignore-revs
            |\.gitattributes
            |\.gitignore
+           |\.gitmodules
            |\.gitlab-ci.yml
            |\.pryrc
            |\.rspec


### PR DESCRIPTION
## Motivation

The updated canonical FFE corpus verifies malformed-flag isolation and exposes shared libdatadog behavior that Ruby should consume without duplicating evaluator logic.

## Changes

- integrate the canonical fixture submodule and pin it to `ea8b5cc5ce335109f11f3efbc5fd608f98a3ca54`
- preserve native `ERROR/PARSE_ERROR` details while applying the caller default value
- remove the Ruby-side malformed-configuration workaround
- assert canonical reasons, variants, and error codes

## Decisions

- keep malformed-flag isolation and SemVer precedence in DataDog/libdatadog#2339
- do not source-pin libdatadog: dd-trace-rb consumes packaged platform artifacts from libdatadog-rb
- bump `datadog.gemspec` and `ext/libdatadog_extconf_helpers.rb` together only after the fixed binary gem is published
- keep the separate regex-fixture proposal in ffe-system-test-data#21 out of scope

## Validation

- Ruby 3.2 native extension compilation
- contract spec passed on latest and minimum OpenFeature appraisals
- StandardRB, targeted Steep, and `git diff --check`
- full OpenFeature suite: 499 examples; 13 dependency-gated failures on released libdatadog 40.0.0.1.0 (12 malformed-flag results and one SemVer build-metadata result)

Depends on DataDog/libdatadog#2339 and its follow-up binary gem publication.