### PR TITLE
Fix WaterDrop propagation with frozen headers

### DIFF
--- a/lib/datadog/tracing/contrib/waterdrop/middleware.rb
+++ b/lib/datadog/tracing/contrib/waterdrop/middleware.rb
@@ -11,21 +11,26 @@ module Datadog
           class << self
             def call(message)
               trace_op = Datadog::Tracing.active_trace
-
-              if trace_op && Datadog::Tracing::Distributed::PropagationPolicy.enabled?(
+              trace_propagation_enabled = trace_op && Datadog::Tracing::Distributed::PropagationPolicy.enabled?(
                 global_config: configuration,
                 trace: trace_op
               )
-                WaterDrop.inject(trace_op.to_digest, message[:headers] ||= {})
+              data_streams_enabled = Datadog::DataStreams.enabled?
+
+              if trace_propagation_enabled || data_streams_enabled
+                message[:headers] = (message[:headers] || {}).dup
               end
 
-              if Datadog::DataStreams.enabled?
+              if trace_propagation_enabled
+                WaterDrop.inject(trace_op.to_digest, message[:headers])
+              end
+
+              if data_streams_enabled
                 Datadog::DataStreams.set_produce_checkpoint(
                   type: "kafka",
                   destination: message[:topic],
                   auto_instrumentation: true
                 ) do |key, value|
-                  message[:headers] ||= {}
                   message[:headers][key] = value
                 end
               end

--- a/lib/datadog/tracing/contrib/waterdrop/middleware.rb
+++ b/lib/datadog/tracing/contrib/waterdrop/middleware.rb
@@ -18,7 +18,7 @@ module Datadog
               data_streams_enabled = Datadog::DataStreams.enabled?
 
               if trace_propagation_enabled || data_streams_enabled
-                message[:headers] = (message[:headers] || {}).dup
+                message[:headers] = message[:headers]&.dup || {}
               end
 
               if trace_propagation_enabled

--- a/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe "WaterDrop middleware" do
           "x-datadog-parent-id" => span.id.to_s
         )
       end
+
+      it "copies frozen headers before propagating trace context" do
+        source_headers = {"existing" => "header"}.freeze
+        message = {topic: "topic_name", payload: "foo", headers: source_headers}
+
+        Datadog::Tracing.trace("test.span") do
+          middleware.call(message)
+        end
+
+        expect(message[:headers]).not_to equal(source_headers)
+      end
+
+      it "keeps the copied headers mutable for trace propagation" do
+        message = {topic: "topic_name", payload: "foo", headers: {"existing" => "header"}.freeze}
+
+        Datadog::Tracing.trace("test.span") do
+          middleware.call(message)
+        end
+
+        expect(message[:headers]).not_to be_frozen
+      end
     end
 
     context "when DataStreams is enabled" do

--- a/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
@@ -100,6 +100,53 @@ RSpec.describe "WaterDrop middleware" do
           "existing" => "header"
         )
       end
+
+      it "does not raise for frozen existing headers" do
+        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
+        message = {topic: "some_topic", payload: "hello", headers: source_headers}
+
+        expect { middleware.call(message) }.not_to raise_error
+      end
+
+      it "leaves the frozen source headers unchanged" do
+        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
+        message = {topic: "some_topic", payload: "hello", headers: source_headers}
+
+        middleware.call(message)
+
+        expect(source_headers).to eq("existing" => "header", "binary" => "\x00\xFF".b)
+      end
+
+      it "keeps the source headers frozen" do
+        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
+        message = {topic: "some_topic", payload: "hello", headers: source_headers}
+
+        middleware.call(message)
+
+        expect(source_headers).to be_frozen
+      end
+
+      it "copies the source headers before injecting the pathway context" do
+        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
+        message = {topic: "some_topic", payload: "hello", headers: source_headers}
+
+        middleware.call(message)
+
+        expect(message[:headers]).not_to equal(source_headers)
+      end
+
+      it "preserves existing and binary headers while injecting the pathway context" do
+        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
+        message = {topic: "some_topic", payload: "hello", headers: source_headers}
+
+        middleware.call(message)
+
+        expect(message[:headers]).to eq(
+          "existing" => "header",
+          "binary" => "\x00\xFF".b,
+          "data_streams_key" => "data_streams_value"
+        )
+      end
     end
 
     context "when DataStreams is disabled" do

--- a/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
+++ b/spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
@@ -122,51 +122,23 @@ RSpec.describe "WaterDrop middleware" do
         )
       end
 
-      it "does not raise for frozen existing headers" do
-        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
-        message = {topic: "some_topic", payload: "hello", headers: source_headers}
-
-        expect { middleware.call(message) }.not_to raise_error
-      end
-
-      it "leaves the frozen source headers unchanged" do
+      it "copies frozen headers before injecting the pathway context" do
         source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
         message = {topic: "some_topic", payload: "hello", headers: source_headers}
 
         middleware.call(message)
 
-        expect(source_headers).to eq("existing" => "header", "binary" => "\x00\xFF".b)
-      end
-
-      it "keeps the source headers frozen" do
-        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
-        message = {topic: "some_topic", payload: "hello", headers: source_headers}
-
-        middleware.call(message)
-
-        expect(source_headers).to be_frozen
-      end
-
-      it "copies the source headers before injecting the pathway context" do
-        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
-        message = {topic: "some_topic", payload: "hello", headers: source_headers}
-
-        middleware.call(message)
-
-        expect(message[:headers]).not_to equal(source_headers)
-      end
-
-      it "preserves existing and binary headers while injecting the pathway context" do
-        source_headers = {"existing" => "header", "binary" => "\x00\xFF".b}.freeze
-        message = {topic: "some_topic", payload: "hello", headers: source_headers}
-
-        middleware.call(message)
-
-        expect(message[:headers]).to eq(
-          "existing" => "header",
-          "binary" => "\x00\xFF".b,
-          "data_streams_key" => "data_streams_value"
-        )
+        aggregate_failures do
+          expect(source_headers).to eq("existing" => "header", "binary" => "\x00\xFF".b)
+          expect(source_headers).to be_frozen
+          expect(message[:headers]).not_to equal(source_headers)
+          expect(message[:headers]).not_to be_frozen
+          expect(message[:headers]).to eq(
+            "existing" => "header",
+            "binary" => "\x00\xFF".b,
+            "data_streams_key" => "data_streams_value"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

WaterDrop can receive frozen header hashes from rdkafka consumer messages. The WaterDrop integration currently mutates that hash when distributed tracing or DSM propagation is enabled, which raises FrozenError.

Copy the headers once before either propagation path runs. This preserves the caller-owned hash and keeps the outbound hash mutable.

## Testing

- BUNDLE_GEMFILE=gemfiles/ruby_3.3_waterdrop_latest.gemfile rbenv exec bundle exec rspec spec/datadog/tracing/contrib/waterdrop/middleware_spec.rb
- 13 examples, 0 failures

This patch was prepared with coding-agent assistance. I reviewed the implementation and tests and verified the reproduction.