### PR TITLE
Speed up signed-commit PR workflows

### DIFF
--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -1,0 +1,62 @@
+name: 'Signed commit pull request'
+
+description: 'Commits the working tree as a GitHub-signed commit and opens or updates a pull request'
+
+inputs:
+  token:
+    description: 'Token used to push, create the signed commit and open the PR (needs contents and pull-requests write)'
+    required: true
+  branch:
+    description: 'Head branch to create or force-update'
+    required: true
+  title:
+    description: 'Pull request title'
+    required: true
+  commit-message:
+    description: 'Commit message'
+    required: true
+  body:
+    description: 'Pull request body'
+    required: true
+  base:
+    description: 'Base branch the pull request targets'
+    default: 'master'
+  labels:
+    description: 'Labels to apply, comma- or newline-separated'
+    default: ''
+  paths:
+    description: 'Git pathspecs to commit, comma- or newline-separated. Defaults to the whole working tree'
+    default: '.'
+  fail-if-empty:
+    description: 'Fail instead of no-op when there is nothing to commit'
+    default: 'false'
+
+outputs:
+  pull-request-url:
+    description: 'URL of the created or updated pull request, empty when there was nothing to commit'
+    value: ${{ steps.signed-commit-pr.outputs.pull-request-url }}
+  commit-sha:
+    description: 'SHA of the signed commit, empty when there was nothing to commit'
+    value: ${{ steps.signed-commit-pr.outputs.commit-sha }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Commit, push and open the pull request
+      id: signed-commit-pr
+      shell: bash
+      # Inputs go through `env` rather than being interpolated into the script:
+      # titles and bodies embed `github.event.client_payload.*`, which is
+      # attacker-controlled for `repository_dispatch` triggers.
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ inputs.branch }}
+        BASE: ${{ inputs.base }}
+        TITLE: ${{ inputs.title }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        BODY: ${{ inputs.body }}
+        LABELS: ${{ inputs.labels }}
+        PATHS: ${{ inputs.paths }}
+        FAIL_IF_EMPTY: ${{ inputs.fail-if-empty }}
+      run: ${{ github.action_path }}/signed_commit_pr.sh

--- a/.github/actions/signed-commit-pr/signed_commit_pr.sh
+++ b/.github/actions/signed-commit-pr/signed_commit_pr.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Commits the working tree and opens (or updates) a pull request whose commit is
+# signed. Invoked by `.github/actions/signed-commit-pr/action.yml`.
+#
+# We have no signing key on the runner, but GitHub signs any commit created through
+# its own API, which is how `peter-evans/create-pull-request` implements
+# `sign-commits: true`. It does so by uploading every changed file as an individual
+# blob API call, taking over 10 minutes for the ~640 lockfiles a release touches.
+#
+# Uploading blobs is only a way to get the tree onto the server, and `git push` does
+# that in a single packfile. So: commit and push with plain `git`, then re-create the
+# identical tree as a commit through the API so GitHub signs it, and repoint the
+# branch at that signed commit. Three API calls instead of one per changed file.
+#
+# Like `create-pull-request`, the branch ends up with a single commit on top of base
+# and is force-pushed, so re-runs update an open PR in place.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?}" "${REPO:?}" "${BRANCH:?}" "${BASE:?}" "${TITLE:?}" "${COMMIT_MESSAGE:?}" "${BODY:?}"
+
+# Splits a comma- or newline-separated input into the `entries` array, trimming
+# whitespace and dropping blanks. Entries are never word-split or globbed by the
+# shell, so pathspecs such as `tools/*.lock` reach git verbatim.
+entries=()
+split_list() {
+  entries=()
+  local item
+  while IFS= read -r item; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
+    if [ -n "$item" ]; then
+      entries+=("$item")
+    fi
+  done < <(printf '%s\n' "$1" | tr ',' '\n')
+}
+
+# `${PATHS-.}` rather than `${PATHS:-.}`: an unset value means the whole working tree,
+# but a blank one is a caller mistake and must not silently widen to everything.
+split_list "${PATHS-.}"
+pathspecs=(${entries[@]+"${entries[@]}"})
+if [ "${#pathspecs[@]}" -eq 0 ]; then
+  echo "::error::The 'paths' input is blank; pass pathspecs to commit, or omit it to commit the whole tree" >&2
+  exit 1
+fi
+
+split_list "${LABELS:-}"
+create_label_args=()
+edit_label_args=()
+for label in ${entries[@]+"${entries[@]}"}; do
+  create_label_args+=(--label "$label")
+  edit_label_args+=(--add-label "$label")
+done
+
+base_sha=$(git rev-parse HEAD)
+git checkout -B "$BRANCH"
+git add -A -- "${pathspecs[@]}"
+
+if git diff --cached --quiet; then
+  if [ "${FAIL_IF_EMPTY:-false}" = "true" ]; then
+    echo "::error::Nothing to commit under ${pathspecs[*]}" >&2
+    exit 1
+  fi
+  echo "Nothing to commit under ${pathspecs[*]}; skipping the pull request"
+  exit 0
+fi
+
+# This identity is discarded along with the local commit: GitHub attributes the signed
+# commit below to the token's own identity, and commits it as `GitHub <noreply@…>`.
+git -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+    commit --quiet -m "$COMMIT_MESSAGE"
+
+# Pushed first so the blobs and trees exist on GitHub. This commit is unsigned and is
+# replaced right below; nothing observes it in the meantime, as no workflow triggers on
+# pushes to these branches and the PR head is only read once the PR is opened.
+#
+# Pushing with our own credential, rather than relying on the checkout having persisted
+# one, keeps this working for the callers that use `persist-credentials: false`. The
+# helper reads the token from the environment, so it reaches neither argv nor
+# .git/config; the leading `credential.helper=` clears any inherited helpers.
+git -c credential.helper= \
+    -c 'credential.helper=!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "$GH_TOKEN"; }; f' \
+    push --force "${GITHUB_SERVER_URL:-https://github.com}/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
+
+commit=$(gh api "repos/${REPO}/git/commits" \
+  -f "message=${COMMIT_MESSAGE}" \
+  -f "tree=$(git rev-parse 'HEAD^{tree}')" \
+  -f "parents[]=${base_sha}")
+
+sha=$(printf '%s' "$commit" | jq -r '.sha')
+verified=$(printf '%s' "$commit" | jq -r '.verification.verified')
+reason=$(printf '%s' "$commit" | jq -r '.verification.reason')
+
+if [ "$verified" != "true" ]; then
+  echo "::error::Commit ${sha} is not signed (reason: ${reason}); refusing to open the pull request" >&2
+  exit 1
+fi
+
+echo "Created signed commit ${sha} (verification: ${reason})"
+gh api --silent --method PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" -f "sha=${sha}" -F force=true
+
+# The force-push above already moved an open PR's head, so only the title, body and
+# labels need refreshing; `gh pr create` fails outright when one is already open.
+url=$(gh pr list --repo "$REPO" --head "$BRANCH" --base "$BASE" --state open --json url --jq '.[0].url // empty')
+if [ -n "$url" ]; then
+  gh pr edit "$url" --title "$TITLE" --body "$BODY" ${edit_label_args[@]+"${edit_label_args[@]}"}
+  echo "Updated pull request ${url}"
+else
+  url=$(gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" \
+    --title "$TITLE" --body "$BODY" ${create_label_args[@]+"${create_label_args[@]}"})
+  echo "Created pull request ${url}"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  { echo "pull-request-url=${url}"; echo "commit-sha=${sha}"; } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/bump-gem-version.yml
+++ b/.github/workflows/bump-gem-version.yml
@@ -67,7 +67,7 @@ jobs:
         run: cp .github/forced-tests-list.cfg.template .github/forced-tests-list.cfg
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: auto-generate/bump-datadog-gem-version
@@ -75,9 +75,7 @@ jobs:
           base: master
           labels: dev/internal
           commit-message: "[🤖] Update datadog gem version to ${{ inputs.version }}"
-          delete-branch: true
-          sign-commits: true
-          add-paths: gemfiles,tools/*.lock,lib/datadog/version.rb,.github/forced-tests-list.cfg
+          paths: gemfiles,tools/*.lock,lib/datadog/version.rb,.github/forced-tests-list.cfg
           body: |
             _This is an auto-generated PR from [here](${{github.server_url}}/${{ github.repository }}/blob/master/.github/workflows/bump-datadog-gem-version.yml)_
             The PR updates the version of datadog gem to ${{ inputs.version }}

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: auto-generate/update-supported-versions
@@ -49,8 +49,6 @@ jobs:
           base: master
           labels: dev/internal, integrations
           commit-message: "Test creating supported versions"
-          delete-branch: true
-          sign-commits: true
           body: |
             This is a PR to update the table for supported integration versions.
             The supported versions markdown is generated from the minimum and maximum tested versions of each integration,

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -44,8 +44,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: true # required for `git` operations in later steps
-          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false # the signed-commit-pr action pushes with its own credential
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -65,7 +64,7 @@ jobs:
         run: bundle exec ruby .github/scripts/update_supported_versions.rb
 
       - name: Create release Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: bump_to_version_${{ inputs.version }}
@@ -73,9 +72,9 @@ jobs:
           title: "Bump to version ${{ inputs.version }}"
           commit-message: "Bump to version ${{ inputs.version }}"
           labels: release
-          delete-branch: true
-          sign-commits: true
-          add-paths: |
+          # A release that changes nothing means an earlier step failed to do its job.
+          fail-if-empty: true
+          paths: |
             CHANGELOG.md
             docs/integration_versions.md
             docs/integration_versions.json

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: auto-generate/update-images
@@ -72,9 +72,7 @@ jobs:
           base: master
           labels: dev/internal
           commit-message: "[🤖] Update images-rb pin: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          delete-branch: true
-          sign-commits: true
-          add-paths: |
+          paths: |
             .github/
             .gitlab/
             docker-compose.yml

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: auto-generate/update-latest-dependencies
@@ -105,8 +105,6 @@ jobs:
           base: master
           labels: dev/internal, integrations
           commit-message: "[🤖] Update Latest Dependency: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          delete-branch: true
-          sign-commits: true
           body: |
             _This is an auto-generated PR from [here](https://github.com/DataDog/dd-trace-rb/blob/master/.github/workflows/update-latest-dependency.yml), which creates a pull request that will be continually updated with new changes until it is merged or closed)_
 

--- a/.github/workflows/update-system-tests.yml
+++ b/.github/workflows/update-system-tests.yml
@@ -87,7 +87,7 @@ jobs:
         # Skip PR creation if dry-run is true (from either trigger type)
         if: ${{ github.event.inputs.dry-run != 'true' && github.event.client_payload.dry-run != 'true' }}
         id: cpr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: auto-generate/update-system-tests
@@ -95,9 +95,7 @@ jobs:
           base: master
           labels: dev/internal
           commit-message: "[🤖] Update System Tests: ${{github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          delete-branch: true
-          sign-commits: true
-          add-paths: |
+          paths: |
             .github/
             .gitlab-ci.yml
           body: |


### PR DESCRIPTION
Fixes https://github.com/DataDog/ruby-guild/issues/317

`peter-evans/create-pull-request` with `sign-commits: true` builds the commit through the GitHub API, uploading every changed file as an individual blob call at roughly one per second. For a release that rewrites ~640 lockfiles this took 10m37s of the release-prep run's 11m54s.

Uploading blobs is only a way to get the tree onto the server, and `git push` does that in one packfile. GitHub signs any commit created through its own API, so we can commit and push with plain `git`, re-create the identical tree as a commit via `POST /git/commits`, and repoint the branch at that signed commit. Three API calls instead of one per changed file, with the same `verified: true` result and the same author and committer as before.

Extracted as the `signed-commit-pr` composite action and used by all six workflows that opened signed PRs. It pushes with its own credential, read from the environment by a git credential helper so it reaches neither argv nor .git/config, which keeps working for the four callers that check out with `persist-credentials: false`. As before, the branch holds a single commit on top of base and is force-pushed, so a re-run updates an open PR in place.

Two behaviour notes: `paths` now also accepts a blank value as an error rather than silently committing the whole working tree, and release-prep opts into `fail-if-empty` because a release that changes nothing means an earlier step failed.
`delete-branch` has no equivalent, but we already have `Automatically delete head branches` in settings so it's redundant anyway.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Faster releases and automated PRs/commits touching lockfiles.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Needs to be verified in practice, e.g. via `workflow_dispatch`.

<!-- Unsure? Have a question? Request a review! -->
