### PR TITLE
[NO-TICKET] Typing stats: Use the base sha instead of the base ref

### DIFF
--- a/.github/workflows/typing-stats.yml
+++ b/.github/workflows/typing-stats.yml
@@ -5,7 +5,6 @@ on: # yamllint disable-line rule:truthy
 
 # TODO:
 # Upload the report somewhere not limited by the 64k char limit (maybe FPD ?) to be able to include links to the files
-# Compare the result with master to see if there are any progress/regression
 # Create a Datadog dashboard to track the progress on a larger timescale
 jobs:
   compute-stats:
@@ -66,13 +65,13 @@ jobs:
           mkdir -p "${{ github.workspace }}/tmp"
           ruby ${{ runner.temp }}/typing_stats_compute.rb >> "${{ runner.temp }}/typing-stats-current.json"
 
-      - name: Checkout base branch
+      - name: Checkout base commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: Run typing stats on base branch
+      - name: Run typing stats on base commit
         id: typing-stats-base
         env:
           STEEPFILE_PATH: ${{ github.workspace }}/Steepfile


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Use the base sha instead of the base ref for typing stats

**Motivation:**
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/dd-trace-rb/pull/6163
This PR contains a lot of typing changes but the diff shows it has none of that (it only change a yml file)

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
