### PR TITLE
Enable testing the profiler in development by default on macOS

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -37,7 +37,6 @@ jobs:
       DD_INSTRUMENTATION_TELEMETRY_ENABLED: false
       DD_REMOTE_CONFIGURATION_ENABLED: false
       DATADOG_GEM_CI: true
-      DD_PROFILING_MACOS_TESTING: true
       BUNDLE_GEMFILE: gemfiles/ruby-${{ matrix.ruby.version }}.gemfile
       BUNDLE_FROZEN: "true"
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,6 @@ no external grant needed. No local trigger otherwise.
 
 - Always pipe stdout and stderr of `rspec` and `rake test:*` to `2>&1 | tee /tmp/full_rspec.log | grep -E 'Pending:|Failures:|Finished' -A 99` to get concise but complete test outputs.
 - Transport noise (`Internal error during Datadog::Tracing::Transport::HTTP::Client request`) is expected unless you are debugging transport logic.
-- Profiling specs fail on MacOS without additinal setup; ask user if they actually want to run them.
 - Thread leaks: use `rspec --seed <N>` and inspect `docs/DevelopmentGuide.md#ensuring-tests-dont-leak-resources`.
 - `docker compose run` failures: run `docker compose pull` before retrying.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,6 @@ bundle exec rspec spec/path/file_spec.rb:123  # Run specific test (only works fo
 
 - Pipe rspec output: `2>&1 | tee /tmp/rspec.log | grep -E 'Pending:|Failures:|Finished' -A 99`
 - Transport noise (`Internal error during Datadog::Tracing::Transport::HTTP::Client request`) is expected
-- Running profiling specs on macOS requires building with `DD_PROFILING_MACOS_TESTING=true bundle exec rake compile`
 - `ProbeNotifierWorker#flush` blocks until queues are empty - never add `sleep` after it
 
 # Style

--- a/Rakefile
+++ b/Rakefile
@@ -55,6 +55,9 @@ DSM_ENABLED_LIBRARIES = [
   :karafka,
 ].freeze
 
+# The Rakefile is only for development, enable testing the profiler on macOS
+ENV["DD_PROFILING_MACOS_TESTING"] = "true"
+
 # rubocop:disable Metrics/BlockLength
 namespace :test do
   desc "Run all tests"
@@ -514,8 +517,8 @@ namespace :spec do
     task all: [:main, :ractors]
 
     task :compile_native_extensions do
-      # "bundle exec rake compile" currently only works on MRI Ruby on Linux
-      if RUBY_ENGINE == "ruby" && OS.linux? && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
+      # "bundle exec rake compile" currently only works on CRuby
+      if RUBY_ENGINE == "ruby"
         Rake::Task[:clean].invoke
         Rake::Task[:compile].invoke
       end

--- a/docs/LibdatadogDevelopment.md
+++ b/docs/LibdatadogDevelopment.md
@@ -40,8 +40,3 @@ with:
 2. From inside of the libdatadog repo, follow the [instructions to build libdatadog](https://github.com/datadog/libdatadog?tab=readme-ov-file#builder-crate)
    and build libdatadog into the build folder you picked: `cargo run --bin release (...see libdatadog readme for details...) -- --out my-libdatadog-build/$DD_RUBY_PLATFORM`
 3. Jump to step 4 of "Using libdatadog builds from CI or GitHub"
-
-## Native development on macOS
-
-For profiling in particular, you'll need to set `export DD_PROFILING_MACOS_TESTING=true` and re-run `bundle exec rake clean compile`
-as we don't build/enable profiling on macOS by default.

--- a/spec/datadog/profiling/spec_helper.rb
+++ b/spec/datadog/profiling/spec_helper.rb
@@ -21,15 +21,6 @@ module ProfileHelpers
   def skip_if_profiling_not_supported
     skip_if_libdatadog_not_supported
 
-    # Profiling is not officially supported on macOS
-    # but it's still useful to allow it to be enabled for development.
-    if PlatformHelpers.mac? && ENV["DD_PROFILING_MACOS_TESTING"] != "true"
-      testcase.skip(
-        "Profiling is not supported on macOS. If you still want to run these specs, you can use " \
-        "DD_PROFILING_MACOS_TESTING=true to override this check."
-      )
-    end
-
     return if Datadog::Profiling.supported?
 
     # Ensure profiling was loaded correctly


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Simplicity, not needing extra setup for no real reason, etc.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

I checked before this PR it fails on `bundle exec rake clean compile`, and that after that succeeds + running the spec works. Also fails as expected to run the specs before the change there to remove the guard.
(I made sure to remove my local env var before testing)

<!-- Unsure? Have a question? Request a review! -->
