### PR TITLE
Migrate release prep to the signed-commit-pr action

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -65,7 +65,7 @@ jobs:
         run: bundle exec ruby .github/scripts/update_supported_versions.rb
 
       - name: Create release Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: bump_to_version_${{ inputs.version }}
@@ -73,8 +73,6 @@ jobs:
           title: "Bump to version ${{ inputs.version }}"
           commit-message: "Bump to version ${{ inputs.version }}"
           labels: release
-          delete-branch: true
-          sign-commits: true
           add-paths: |
             CHANGELOG.md
             docs/integration_versions.md


### PR DESCRIPTION
**What does this PR do?**

Switches the release PR step in `release-prep.yml` from `peter-evans/create-pull-request` to the `signed-commit-pr` action added in #6198.

**Motivation:**

Follow-up to #6198, where @eregon asked for the release workflows to use it too, since [ruby-guild#317](https://github.com/DataDog/ruby-guild/issues/317) is about these slow release updates.

`sign-commits: true` rebuilds the commit over REST, one blob and tree object per file. A release touches 638 files, and the release manager waits through that twice per release. The dev-version bump was already migrated in #6198; this closes the other half.

**Change log entry**

None.

**Additional Notes:**

Blocked on #6204. The composite as merged reset the target branch to base before committing, which closes an already-open PR on that branch; a re-dispatch of the same release version would have closed the release PR. #6204 fixes that, and this should not merge before it.

Separately, `delete-branch: true` has no equivalent in the composite. The repository sets `delete_branch_on_merge`, so merged branches are still cleaned up; only an abandoned release PR leaves its branch behind (one exists in the repo's entire history).

**How to test the change?**

The action was validated against the live API in #6198, so verification here covered the inputs crossing that boundary: the staged file set is unchanged (the composite's newline-to-space normalization matches the raw path list file-for-file, `tools/*.lock` included), all six required inputs are supplied, the existing trust policy already grants the needed permissions, and the `workflow_dispatch`-only trigger keeps the workspace-relative `uses:` out of reach of PR code. `yamllint --strict` and `actionlint` clean.

One thing for reviewers: a release sends 638 files as a ~9.5 MB GraphQL request, above the ~400 exercised in #6198. Well under GitHub's documented 40 MB endpoint limit, but not yet sent live — the first real release run confirms it.
