### PR TITLE
Stop the signed-commit-pr action from closing the open pull request

### DIFF
--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -87,17 +87,23 @@ runs:
       shell: bash
       run: git diff --cached --stat
 
-    # The commit is built on a scratch branch rather than on `branch` itself,
-    # because createCommitOnBranch takes an expectedHeadOid that must equal the
-    # branch tip and ghcommit-action always derives it from local HEAD. Resetting
-    # `branch` to HEAD to satisfy that would leave it level with base for the
-    # duration of the commit, and GitHub closes an open pull request the moment
-    # its head holds nothing ahead of its base. `branch` is therefore only ever
-    # moved forward onto a finished commit, further down.
+    # The commit is built on a scratch branch rather than on `branch` itself
+    # because createCommitOnBranch can only append. Each run's commit is meant to
+    # replace the previous one, not stack on it, so `branch` has to be force-moved
+    # -- and the commit must already exist somewhere for that move to have a
+    # target. Committing in place instead would grow the branch by one full
+    # snapshot per run.
+    #
+    # Moving `branch` to HEAD first, then committing onto it, is the arrangement
+    # this replaces: it left the branch level with base for the duration of the
+    # commit, and GitHub closes an open pull request the moment its head holds
+    # nothing ahead of its base. `branch` is now only ever moved onto a finished
+    # commit, further down.
     #
     # Creates a remote ref only: resetting the local tree would discard what was
     # just staged, leaving nothing to commit and the run still green.
     - name: Create scratch branch
+      id: scratch
       if: steps.stage.outputs.changed == 'true'
       shell: bash
       env:
@@ -116,6 +122,7 @@ runs:
           gh api --silent -X PATCH "repos/$REPO/git/refs/heads/$SCRATCH" \
             -F "sha=$head_sha" -F force=true
         fi
+        echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
 
     - name: Create signed commit
       id: commit
@@ -130,6 +137,12 @@ runs:
         commit_message: ${{ inputs.commit-message }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+        # The expectedHeadOid the mutation is guarded by. ghcommit-action exposes
+        # no input for it, but the CLI reads GHCOMMIT_SHA and Docker actions
+        # inherit this block. Set explicitly so the guard is the SHA the scratch
+        # ref was just created at, rather than whatever the CLI's `git rev-parse
+        # HEAD` fallback resolves to.
+        GHCOMMIT_SHA: ${{ steps.scratch.outputs.head-sha }}
 
     # Single move onto a commit that already exists, so an open pull request on
     # `branch` never observes a head level with its base. Runs even when the

--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -16,7 +16,9 @@ inputs:
     description: 'Token with contents:write and pull_requests:write.'
     required: true
   branch:
-    description: 'Branch to commit to. Reset to the checked-out commit, so it must be one this workflow owns.'
+    description: >-
+      Branch to commit to. Force-moved onto the new commit, which replaces rather
+      than descends from whatever was there, so it must be one this workflow owns.
     required: true
   commit-message:
     description: 'Commit message.'
@@ -52,7 +54,7 @@ runs:
   using: "composite"
   steps:
     # Runs before any remote ref is touched, so a no-op run changes nothing
-    # remotely: no reset, no empty commit, no empty PR.
+    # remotely: no scratch branch, no empty commit, no empty PR.
     #
     # Both separators are flattened because either would silently commit a
     # subset and still exit green: git treats a comma as a literal pathspec
@@ -62,6 +64,7 @@ runs:
       shell: bash
       env:
         ADD_PATHS: ${{ inputs.add-paths }}
+        SCRATCH_PREFIX: signed-commit-pr/scratch
       run: |
         normalized="${ADD_PATHS//,/ }"
         normalized="${normalized//$'\n'/ }"
@@ -69,6 +72,8 @@ runs:
         git add -- "${paths[@]}"
         # Single line: ghcommit-action's file_pattern must not receive newlines.
         echo "paths=${paths[*]}" >> "$GITHUB_OUTPUT"
+        # Keyed to the run so concurrent runs cannot land on the same scratch ref.
+        echo "scratch=$SCRATCH_PREFIX/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
         if git diff --cached --quiet; then
           echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes to commit."
@@ -81,33 +86,34 @@ runs:
       shell: bash
       run: git diff --cached --stat
 
-    # Required because createCommitOnBranch takes an expectedHeadOid that must
-    # equal the branch tip, and ghcommit-action always derives it from local
-    # HEAD, so a branch left where a previous run put it makes the mutation fail.
-    # Pointing it at HEAD also keeps the branch at one commit on top of the
-    # checkout instead of accumulating one per run.
+    # The commit is built on a scratch branch rather than on `branch` itself,
+    # because createCommitOnBranch takes an expectedHeadOid that must equal the
+    # branch tip and ghcommit-action always derives it from local HEAD. Resetting
+    # `branch` to HEAD to satisfy that would leave it level with base for the
+    # duration of the commit, and GitHub closes an open pull request the moment
+    # its head holds nothing ahead of its base. `branch` is therefore only ever
+    # moved forward onto a finished commit, further down.
     #
-    # Moves the remote ref only: resetting the local tree would discard what was
+    # Creates a remote ref only: resetting the local tree would discard what was
     # just staged, leaving nothing to commit and the run still green.
-    - name: Reset branch
+    - name: Create scratch branch
       if: steps.stage.outputs.changed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
         REPO: ${{ github.repository }}
-        BRANCH: ${{ inputs.branch }}
+        SCRATCH: ${{ steps.stage.outputs.scratch }}
       run: |
         # Local HEAD, not `base`: the two diverge once base moves after checkout.
         head_sha="$(git rev-parse HEAD)"
-        echo "Pointing $BRANCH at $head_sha"
-        # PATCH failure falls through to create, as a missing ref is 404 or 422.
-        # The error stays visible so branch protection and token expiry are not
-        # hidden behind the POST's misleading "Reference already exists".
-        if ! gh api --silent -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" \
-              -F "sha=$head_sha" -F force=true; then
-          echo "Could not update the branch, attempting to create it."
-          gh api --silent -X POST "repos/$REPO/git/refs" \
-            -f "ref=refs/heads/$BRANCH" -f "sha=$head_sha"
+        echo "Pointing $SCRATCH at $head_sha"
+        # Force, so a scratch ref orphaned by an earlier cancelled run is reused
+        # rather than failing this one.
+        if ! gh api --silent -X POST "repos/$REPO/git/refs" \
+              -f "ref=refs/heads/$SCRATCH" -f "sha=$head_sha"; then
+          echo "Could not create the scratch branch, attempting to update it."
+          gh api --silent -X PATCH "repos/$REPO/git/refs/heads/$SCRATCH" \
+            -F "sha=$head_sha" -F force=true
         fi
 
     - name: Create signed commit
@@ -116,13 +122,44 @@ runs:
       uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
       with:
         repo: ${{ github.repository }}
-        branch: ${{ inputs.branch }}
+        branch: ${{ steps.stage.outputs.scratch }}
         # Normalized form, not raw add-paths: this is split with `read -r -a`,
         # which would keep only the first line and commit a subset.
         file_pattern: ${{ steps.stage.outputs.paths }}
         commit_message: ${{ inputs.commit-message }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+
+    # Single move onto a commit that already exists, so an open pull request on
+    # `branch` never observes a head level with its base. Runs even when the
+    # commit step failed, so the scratch ref is always cleaned up.
+    - name: Move branch onto the commit
+      if: always() && steps.stage.outputs.changed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+        BRANCH: ${{ inputs.branch }}
+        SCRATCH: ${{ steps.stage.outputs.scratch }}
+        COMMIT: ${{ steps.commit.outputs.commit-hash }}
+      run: |
+        # Always drop the scratch ref, whether or not the move below happens.
+        trap 'gh api --silent -X DELETE "repos/$REPO/git/refs/heads/$SCRATCH" || true' EXIT
+
+        if [ -z "$COMMIT" ]; then
+          echo "No commit was created, leaving $BRANCH untouched."
+          exit 1
+        fi
+
+        echo "Pointing $BRANCH at $COMMIT"
+        # Force, because the branch holds the previous run's commit, which the
+        # new one replaces rather than descends from.
+        if ! gh api --silent -X PATCH "repos/$REPO/git/refs/heads/$BRANCH" \
+              -F "sha=$COMMIT" -F force=true; then
+          echo "Could not update the branch, attempting to create it."
+          gh api --silent -X POST "repos/$REPO/git/refs" \
+            -f "ref=refs/heads/$BRANCH" -f "sha=$COMMIT"
+        fi
 
     # Reuses an open PR so reruns stay idempotent; `gh pr create` fails when one
     # already exists.

--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -73,6 +73,7 @@ runs:
         # Single line: ghcommit-action's file_pattern must not receive newlines.
         echo "paths=${paths[*]}" >> "$GITHUB_OUTPUT"
         # Keyed to the run so concurrent runs cannot land on the same scratch ref.
+        # Matrix jobs share a run id, so a matrix caller would need a further key.
         echo "scratch=$SCRATCH_PREFIX/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
         if git diff --cached --quiet; then
           echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**What does this PR do?**

Builds the signed commit on a per-run scratch branch, then moves the target branch onto the finished commit in a single step, instead of resetting the target branch to base beforehand.

**Motivation:**

Run 32110059423 closed PR #6194 instead of updating it. The action reset the PR's head branch to master so the branch tip would match the `expectedHeadOid` that `createCommitOnBranch` requires. That left the head with nothing ahead of its base, and GitHub closes an open pull request the moment that happens. The timeline confirms the ordering: the close landed at 07:15:13, the force-push at 07:15:14.

The close is permanent — the PR does not reopen when the commit arrives a second later. Worse, the run stayed green, because the action only ran `gh pr edit` and exited zero.

This is the reset-window concern raised on #6198, which I declined on the reasoning that it would self-heal. It does not.

**Change log entry**

None.

**Additional Notes:**

The scratch branch is needed because `createCommitOnBranch` can only append. Each run's commit is meant to replace the previous one rather than stack on it, so the target branch is force-moved — and a force-move needs the commit to already exist somewhere. Committing in place instead would grow the branch by one full snapshot per run.

The target branch is therefore now written exactly once per run, always onto a commit that already exists, so an open PR never observes a head level with its base.

The scratch ref is deleted on the way out, including when the commit step fails — that path now fails loudly with the branch untouched, rather than exiting green having shipped nothing.

Last commit is a robustness follow-up: `expectedHeadOid` is now passed explicitly via `GHCOMMIT_SHA` rather than left to the CLI's `git rev-parse HEAD` fallback. Both resolve to the same SHA today, since the scratch ref is created at local `HEAD`; the difference is that a future divergence fails the mutation instead of silently committing against an unexpected tip.

**How to test the change?**

PR #6194 was reopened and retains its correct commit (65559018fc).

Verified for the new remote writes: no `push`-triggered workflow can match `signed-commit-pr/scratch/*` (all eight pin explicit `master`/`release` allowlists, none use `branches-ignore` or wildcards), so the scratch ref spawns no CI. No active ruleset matches the prefix either — the only one carrying a `creation` rule targets `~DEFAULT_BRANCH` and `[0-9].*-stable`, and none of the target branches are covered by a `non_fast_forward` rule.

Confirmed the `EXIT` trap still runs on the failure path, and that ghcommit-action's own no-op check (`git status`, staged plus unstaged) is a superset of this action's gate (`git diff --cached`), so it cannot skip a commit the gate expected.

For `GHCOMMIT_SHA`: ghcommit-action exposes no input for it, but the underlying CLI declares `env:"GHCOMMIT_SHA"` and Docker container actions inherit the step's `env` block, which is already how `GITHUB_TOKEN` reaches it. Checked against the same `go-flags v1.6.1` the CLI pins that the env var populates the field and an explicit flag would override it; `entrypoint.sh` passes no `--sha` and never references the variable, so it passes through untouched.

`yamllint --strict` and `actionlint` clean on the action and all five callers.
