### PR TITLE
Add `DataDog/@ruby-guild` as owner for Datadog::Core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ lib/datadog/profiling/ @DataDog/profiling-rb @DataDog/ruby-guild
 lib/datadog/profiling.rb @DataDog/profiling-rb @DataDog/ruby-guild
 lib/datadog/data_streams/ @DataDog/data-streams-monitoring @DataDog/ruby-guild
 lib/datadog/data_streams.rb @DataDog/data-streams-monitoring @DataDog/ruby-guild
+lib/datadog/core/ @DataDog/ruby-guild
 lib/datadog/core/feature_flags.rb @DataDog/feature-flagging-and-experimentation-sdk @DataDog/ruby-guild
 lib/datadog/open_feature/ @DataDog/feature-flagging-and-experimentation-sdk
 lib/datadog/open_feature.rb @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
**What does this PR do?**
This PR sets `DataDog/@ruby-guild` as the owner for `lib/datadog/core/`.

**Motivation:**
The only CODEOWNER entry for `lib/datadog/core` is for `lib/datadog/core/feature_flags.rb` - and Github tags every PR that changes core files with a necessary review from FFE team.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
Create a PR with changes to `lib/datadog/core` and see who is tagged for review.