### PR TITLE
[APMS-20299] Fix peer tags on ActiveRecord query spans

### DIFF
--- a/lib/datadog/tracing/contrib/active_record/events/sql.rb
+++ b/lib/datadog/tracing/contrib/active_record/events/sql.rb
@@ -46,6 +46,7 @@ module Datadog
               span.resource = payload.fetch(:sql)
               span.type = Tracing::Metadata::Ext::SQL::TYPE
 
+              span.set_tag(Tracing::Metadata::Ext::TAG_KIND, Tracing::Metadata::Ext::SpanKind::TAG_CLIENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_COMPONENT, Ext::TAG_COMPONENT)
               span.set_tag(Tracing::Metadata::Ext::TAG_OPERATION, Ext::TAG_OPERATION_SQL)
 

--- a/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
+++ b/spec/datadog/tracing/contrib/active_record/tracer_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "ActiveRecord instrumentation" do
       expect(span.service).to eq("mysql2")
       expect(span.name).to eq("mysql2.query")
       expect(span.type).to eq("sql")
+      expect(span.get_tag("span.kind")).to eq("client")
       expect(span.resource.strip).to eq("SELECT COUNT(*) FROM `articles`")
       expect(span.get_tag("active_record.db.vendor")).to eq("mysql2")
       expect(span.get_tag("db.instance")).to eq("mysql")


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Add `span.kind` tag to active record spans

**Motivation:**
<!-- What inspired you to submit this pull request? -->
ActiveRecord spans don't have `peer.db.name` tag on Datadog UI. This is because the agent requires the `span.kind` tag to be set to `client`, `producer` or `consumer`, and ActiveRecord did not set it. This PR sets it to `client`

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
Yes. Fixed missing peer tags for database queries traced through ActiveRecord.

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Unit test in CI

<!-- Unsure? Have a question? Request a review! -->
