### PR TITLE
fix(crashtracking): ignore signal exception for unhandled exception reporting

### DIFF
--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -47,7 +47,8 @@ module Datadog
           return unless exception &&
             !exception.is_a?(SystemExit) &&
             !exception.is_a?(SignalException) &&
-            !exception.is_a?(NoMemoryError)
+            !exception.is_a?(NoMemoryError) &&
+            !exception.is_a?(SystemStackError)
 
           begin
             crashtracker = Datadog.send(:components, allow_initialization: false)&.crashtracker

--- a/lib/datadog/core/crashtracking/component.rb
+++ b/lib/datadog/core/crashtracking/component.rb
@@ -44,7 +44,10 @@ module Datadog
         # Reports unhandled exceptions to the crash tracker if available and appropriate.
         # This is called from the at_exit hook to report unhandled exceptions.
         def self.report_unhandled_exception(exception)
-          return unless exception && !exception.is_a?(SystemExit) && !exception.is_a?(NoMemoryError)
+          return unless exception &&
+            !exception.is_a?(SystemExit) &&
+            !exception.is_a?(SignalException) &&
+            !exception.is_a?(NoMemoryError)
 
           begin
             crashtracker = Datadog.send(:components, allow_initialization: false)&.crashtracker

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -101,6 +101,45 @@ RSpec.describe Datadog::Core::Crashtracking::Component do
     end
   end
 
+  describe ".report_unhandled_exception" do
+    let(:crashtracker) { instance_double(described_class) }
+
+    before do
+      allow(Datadog).to receive(:components).and_return(double(crashtracker: crashtracker))
+    end
+
+    it "reports a StandardError exception" do
+      exception = StandardError.new("test")
+      expect(crashtracker).to receive(:report_unhandled_exception).with(exception)
+      described_class.report_unhandled_exception(exception)
+    end
+
+    it "does not report SystemExit" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(SystemExit.new)
+    end
+
+    it "does not report NoMemoryError" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(NoMemoryError.new)
+    end
+
+    it "does not report SignalException" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(SignalException.new("TERM"))
+    end
+
+    it "does not report Interrupt (subclass of SignalException)" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(Interrupt.new)
+    end
+
+    it "does not report when exception is nil" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(nil)
+    end
+  end
+
   context "instance methods" do
     shared_context "HTTP server" do
       http_server do |http_server|

--- a/spec/datadog/core/crashtracking/component_spec.rb
+++ b/spec/datadog/core/crashtracking/component_spec.rb
@@ -124,6 +124,11 @@ RSpec.describe Datadog::Core::Crashtracking::Component do
       described_class.report_unhandled_exception(NoMemoryError.new)
     end
 
+    it "does not report SystemStackError" do
+      expect(crashtracker).to_not receive(:report_unhandled_exception)
+      described_class.report_unhandled_exception(SystemStackError.new)
+    end
+
     it "does not report SignalException" do
       expect(crashtracker).to_not receive(:report_unhandled_exception)
       described_class.report_unhandled_exception(SignalException.new("TERM"))


### PR DESCRIPTION
<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
Exclude SignalException from being reported as an unhandled exception crash by the crashtracker.                                                

**Motivation:**
Reported by customer here: https://github.com/DataDog/dd-trace-rb/issues/6202

`SignalException`s are reported to Error Tracking as `is_crash: true` with `kind UnhandledException`. SIGTERM is the    standard way to stop containerized processes, so every rolling deploy, scale-in, or pod eviction produces a false crash report. The guard already excludes `SystemExit` and `NoMemoryError` but not `SignalException`. This aligns the filter with `lib/datadog/di/fatal_exceptions.rb` which lists all three. VM level signal crashes (SIGSEGV, SIGBUS, SIGABRT, etc) are caught by libdatadog's native signal handler and application level exceptions are not filtered out. 

**Change log entry**

Yes. `SignalException`s are ignored by crashtracker as unhandled exception errors.
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->


[PROF-15800](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15800)

[PROF-15800]: https://datadoghq.atlassian.net/browse/PROF-15800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ