### PR TITLE
Send the split serial id on exposure events

### DIFF
--- a/lib/datadog/open_feature/exposures/event.rb
+++ b/lib/datadog/open_feature/exposures/event.rb
@@ -15,12 +15,14 @@ module Datadog
             "#{flag_key}:#{context.targeting_key}"
           end
 
+          # NOTE: The serial id is part of the value because it can appear or change on a
+          #       configuration refresh while the allocation and the variant stay the same.
           def cache_value(result, flag_key:, context:)
-            "#{result.allocation_key}:#{result.variant}"
+            "#{result.allocation_key}:#{result.variant}:#{result.serial_id}"
           end
 
           def build(result, flag_key:, context:)
-            {
+            event = {
               timestamp: current_timestamp_ms,
               allocation: {
                 key: result.allocation_key,
@@ -35,7 +37,12 @@ module Datadog
                 id: context.targeting_key,
                 attributes: extract_attributes(context),
               },
-            }.freeze
+            }
+
+            serial_id = result.serial_id
+            event[:serial_id] = serial_id unless serial_id.nil?
+
+            event.freeze
           end
 
           private

--- a/spec/datadog/open_feature/exposures/event_spec.rb
+++ b/spec/datadog/open_feature/exposures/event_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
 
   let(:now) { Time.utc(2025, 1, 1, 0, 0, 0) }
   let(:event) { described_class.build(result, flag_key: "feature_flag", context: context) }
+  let(:serial_id) { nil }
+  let(:context) do
+    instance_double(
+      "OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
+    )
+  end
   let(:result) do
     Datadog::OpenFeature::ResolutionDetails.new(
       value: 4,
       allocation_key: "4-for-john-doe",
       variant: "4",
+      serial_id: serial_id,
       flag_metadata: {
         "allocationKey" => "4-for-john-doe",
         "variationType" => "number",
@@ -76,6 +83,38 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
 
       it { expect(event).to eq(expected) }
     end
+
+    context "when result has a serial id" do
+      let(:serial_id) { 7 }
+      let(:expected) do
+        {
+          timestamp: 1_735_689_600_000,
+          allocation: {key: "4-for-john-doe"},
+          flag: {key: "feature_flag"},
+          variant: {key: "4"},
+          subject: {id: "john-doe", attributes: {}},
+          serial_id: 7,
+        }
+      end
+
+      it { expect(event).to eq(expected) }
+    end
+
+    context "when result has a serial id of zero" do
+      let(:serial_id) { 0 }
+      let(:expected) do
+        {
+          timestamp: 1_735_689_600_000,
+          allocation: {key: "4-for-john-doe"},
+          flag: {key: "feature_flag"},
+          variant: {key: "4"},
+          subject: {id: "john-doe", attributes: {}},
+          serial_id: 0,
+        }
+      end
+
+      it { expect(event).to eq(expected) }
+    end
   end
 
   describe ".cache_key" do
@@ -92,7 +131,25 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
 
     it "returns cache value based on allocation and variant" do
       expect(described_class.cache_value(result, flag_key: "feature_flag", context: context))
-        .to eq("4-for-john-doe:4")
+        .to eq("4-for-john-doe:4:")
+    end
+
+    context "when result has a serial id" do
+      let(:serial_id) { 7 }
+
+      it "returns cache value based on allocation, variant and serial id" do
+        expect(described_class.cache_value(result, flag_key: "feature_flag", context: context))
+          .to eq("4-for-john-doe:4:7")
+      end
+    end
+
+    context "when result has a serial id of zero" do
+      let(:serial_id) { 0 }
+
+      it "returns a value that differs from the value without a serial id" do
+        expect(described_class.cache_value(result, flag_key: "feature_flag", context: context))
+          .to eq("4-for-john-doe:4:0")
+      end
     end
   end
 end

--- a/spec/datadog/open_feature/exposures/event_spec.rb
+++ b/spec/datadog/open_feature/exposures/event_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "open_feature/sdk"
 require "datadog/open_feature/exposures/event"
 
 RSpec.describe Datadog::OpenFeature::Exposures::Event do
@@ -11,7 +12,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
   let(:serial_id) { nil }
   let(:context) do
     instance_double(
-      "OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
+      OpenFeature::SDK::EvaluationContext, targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
     )
   end
   let(:result) do
@@ -34,7 +35,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
     context "when context contains nested fields" do
       let(:context) do
         instance_double(
-          "OpenFeature::SDK::EvaluationContext",
+          OpenFeature::SDK::EvaluationContext,
           targeting_key: "john-doe",
           fields: {
             "targeting_key" => "john-doe",
@@ -68,7 +69,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
     context "when context does not contain extra fields" do
       let(:context) do
         instance_double(
-          "OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
+          OpenFeature::SDK::EvaluationContext, targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
         )
       end
       let(:expected) do
@@ -118,7 +119,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
   end
 
   describe ".cache_key" do
-    let(:context) { instance_double("OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe") }
+    let(:context) { instance_double(OpenFeature::SDK::EvaluationContext, targeting_key: "john-doe") }
 
     it "returns cache key based on flag and targeting key" do
       expect(described_class.cache_key(result, flag_key: "feature_flag", context: context))
@@ -127,7 +128,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Event do
   end
 
   describe ".cache_value" do
-    let(:context) { instance_double("OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe") }
+    let(:context) { instance_double(OpenFeature::SDK::EvaluationContext, targeting_key: "john-doe") }
 
     it "returns cache value based on allocation and variant" do
       expect(described_class.cache_value(result, flag_key: "feature_flag", context: context))

--- a/spec/datadog/open_feature/exposures/reporter_spec.rb
+++ b/spec/datadog/open_feature/exposures/reporter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "open_feature/sdk"
 require "datadog/open_feature/exposures/reporter"
 
 RSpec.describe Datadog::OpenFeature::Exposures::Reporter do
@@ -17,7 +18,7 @@ RSpec.describe Datadog::OpenFeature::Exposures::Reporter do
   let(:deduplicator) { instance_double(Datadog::OpenFeature::Exposures::Deduplicator) }
   let(:context) do
     instance_double(
-      "OpenFeature::SDK::EvaluationContext", targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
+      OpenFeature::SDK::EvaluationContext, targeting_key: "john-doe", fields: {"targeting_key" => "john-doe"}
     )
   end
   let(:result) do

--- a/spec/datadog/open_feature/exposures/reporter_spec.rb
+++ b/spec/datadog/open_feature/exposures/reporter_spec.rb
@@ -88,6 +88,40 @@ RSpec.describe Datadog::OpenFeature::Exposures::Reporter do
       end
     end
 
+    context "when a serial id appears on a later evaluation of the same allocation" do
+      before { allow(Datadog::OpenFeature::Exposures::Deduplicator).to receive(:new).and_call_original }
+
+      let(:result_with_serial_id) do
+        Datadog::OpenFeature::ResolutionDetails.new(
+          value: 4,
+          allocation_key: "4-for-john-doe",
+          variant: "4",
+          serial_id: 0,
+          flag_metadata: {
+            "allocationKey" => "4-for-john-doe",
+            "variationType" => "number",
+            "doLog" => true,
+          },
+          log?: true,
+          error?: false
+        )
+      end
+
+      it "enqueues a second event" do
+        expect(worker).to receive(:enqueue).twice.and_return(true)
+
+        expect(reporter.report(result, flag_key: "feature_flag", context: context)).to be(true)
+        expect(reporter.report(result_with_serial_id, flag_key: "feature_flag", context: context)).to be(true)
+      end
+
+      it "does not enqueue the same serial id twice" do
+        expect(worker).to receive(:enqueue).once.and_return(true)
+
+        expect(reporter.report(result_with_serial_id, flag_key: "feature_flag", context: context)).to be(true)
+        expect(reporter.report(result_with_serial_id, flag_key: "feature_flag", context: context)).to be(false)
+      end
+    end
+
     context "when evaluation context is nil" do
       it "skips enqueueing exposure" do
         expect(deduplicator).not_to receive(:duplicate?)


### PR DESCRIPTION
**What does this PR do?**

Adds a top-level `serial_id` field to the exposure events that the OpenFeature provider sends, taken from the resolution details. The field is omitted when the evaluation gives no serial id. The exposure deduplication cache value now includes the serial id.

**Motivation:**

The exposures intake uses the serial id to find the holdout that an allocation comes from. A holdout becomes a usual allocation before an SDK receives the flag configuration, so the serial id is the only link back to it. Without the serial id in the cache value, a serial id that appears on a later configuration refresh, while the allocation and the variant stay the same, sends no new exposure.

**Change log entry**

Yes. The OpenFeature provider sends the serial ID of the assigned split on exposure events.

**Additional Notes:**

The value goes through unchanged. The flag configuration layer owns validation. Serial IDs start at zero for each organization, so absence and zero are different states: the event omits the key when the serial ID is absent, and the cache value keeps them distinct.

No RBS signature changes: `serial_id` is already declared on both resolution details classes, and the exposure event type is `::Hash[::Symbol, untyped]`.

**How to test the change?**

`bundle exec rspec spec/datadog/open_feature` with `BUNDLE_GEMFILE=gemfiles/ruby_3.2_openfeature_latest.gemfile`. New specs cover a present serial ID, a serial ID of zero, an absent serial ID, and a second exposure when a serial ID appears on a later evaluation of the same allocation.

*Written with the help of Claude.*
