### PR TITLE
Harden OpenFeature flag evaluation aggregation [FFL-2963]

### DIFF
--- a/benchmarks/open_feature_flagevaluation.rb
+++ b/benchmarks/open_feature_flagevaluation.rb
@@ -56,6 +56,7 @@ class OpenFeatureFlagevaluationBenchmark
     @writer.instance_variable_set(:@aggregator, Datadog::OpenFeature::FlagEvaluation::Aggregator.new)
     @writer.instance_variable_set(:@queue, SizedQueue.new(Datadog::OpenFeature::FlagEvaluation::Writer::QUEUE_SIZE))
     @writer.instance_variable_set(:@stop_mutex, Mutex.new)
+    @writer.instance_variable_set(:@stop_cond, ConditionVariable.new)
     @writer.instance_variable_set(:@dropped_queue_overflow, 0)
     @writer.define_singleton_method(:start_background_thread) {}
 

--- a/lib/datadog/open_feature/flag_evaluation/aggregator.rb
+++ b/lib/datadog/open_feature/flag_evaluation/aggregator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Datadog
   module OpenFeature
     module FlagEvaluation
@@ -11,11 +13,33 @@ module Datadog
       # - Drop-and-count when degraded tier is full
       # - canonical_context_key: sorted type-tagged length-delimited encoding (no hash digest)
       # - Caps: global_cap=131_072 / per_flag_cap=10_000 / degraded_cap=32_768
-      # - Context pruning: 256 fields / 256 chars (matches flageval-worker backend limits)
+      #
+      # The writer applies `bounded_context_snapshot` on the evaluation thread before
+      # enqueue, so the queue only holds an already-bounded, flattened snapshot.
       class Aggregator
+        # Cross-SDK context caps (RFC: "Kept aligned with the cross-SDK RFC").
         MAX_CONTEXT_FIELDS = 256
-        MAX_FIELD_LENGTH = 256
-        MAX_CONTEXT_DEPTH = 32
+        MAX_VALUE_LENGTH = 256
+        MAX_KEY_LENGTH = 256
+        MAX_LIST_ELEMENTS = 256
+        MAX_STRUCTURE_PROPERTIES = 256
+        MAX_SNAPSHOT_DEPTH = 4
+
+        # The per-dimension caps match Go and Java. This additional total-node budget
+        # bounds leaf-free shared subtrees, which do not increase the retained field count.
+        # It still permits every retained field to sit at the maximum snapshot depth.
+        MAX_VISITED_NODES = MAX_CONTEXT_FIELDS * (MAX_SNAPSHOT_DEPTH + 1)
+
+        # Truncation reason labels, surfaced on the `flagevaluation.context.truncated`
+        # telemetry counter so operators can tell which cap was hit.
+        REASON_MAX_CONTEXT_FIELDS = "max_context_fields"
+        REASON_MAX_VALUE_LENGTH = "max_value_length"
+        REASON_MAX_KEY_LENGTH = "max_key_length"
+        REASON_MAX_LIST_ELEMENTS = "max_list_elements"
+        REASON_MAX_STRUCTURE_PROPERTIES = "max_structure_properties"
+        REASON_MAX_SNAPSHOT_DEPTH = "max_snapshot_depth"
+        REASON_MAX_VISITED_NODES = "max_visited_nodes"
+        REASON_CYCLE = "cycle"
 
         # Type tags so values of different Ruby types never collide in the canonical key.
         CTX_TAG_STRING = "s"
@@ -73,11 +97,8 @@ module Datadog
           error_message = error_message.to_s
           targeting_key = targeting_key.to_s
 
-          # Context pruning + canonical key (see prune_context and canonical_context_key).
-          # Runs in the background writer so caller eval threads do not pay the flatten/prune cost.
-          pruned_context = prune_context(attrs)
-          context_key = canonical_context_key(pruned_context)
-
+          context_key = canonical_context_key(attrs)
+          # @type var full_key: full_key
           full_key = [flag_key, variant, allocation_key, runtime_default, error_message, targeting_key, context_key]
           evaluation_time_ms = eval_time_ms.to_i
 
@@ -90,7 +111,9 @@ module Datadog
 
             per_flag_count = @per_flag_full[flag_key]
             if per_flag_count >= @per_flag_cap
-              add_to_degraded(flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms)
+              add_to_degraded(
+                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+              )
               return
             end
 
@@ -104,21 +127,22 @@ module Datadog
                 runtime_default: runtime_default,
                 error_message: error_message,
                 targeting_key: targeting_key,
-                context_attrs: pruned_context
+                context_attrs: attrs
               )
               @full[full_key] = entry
               @global_count += 1
             else
               # Route to degraded tier
-              add_to_degraded(flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms)
+              add_to_degraded(
+                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+              )
             end
           end
         end
 
         # Flush aggregation maps, reset state, return snapshot.
-        # Returns { full: Hash, degraded: Hash, dropped_degraded_overflow: Integer }.
-        # The overflow count is included in the snapshot so the caller can EMIT it before it is
-        # reset — the count is never reset-without-emit (backpressure stays observable).
+        # The overflow count is included in the snapshot so the caller can emit it before
+        # it is reset (never reset-without-emit).
         def flush_and_reset
           @mutex.synchronize do
             full_snapshot = @full
@@ -135,41 +159,180 @@ module Datadog
           end
         end
 
-        # Prune context: keep first MAX_CONTEXT_FIELDS fields (sorted), skip string values >256 chars.
-        # Keys are sorted before pruning to ensure deterministic subset selection.
-        def prune_context(attrs)
-          self.class.prune_context(attrs)
-        end
+        # Bound and flatten the caller's evaluation context on the evaluation thread,
+        # before enqueue, so the async queue only ever holds an already-bounded snapshot.
+        # Returns the flattened (dot-notation) context and the truncation reasons hit,
+        # which the writer surfaces on the `flagevaluation.context.truncated` counter.
+        #
+        # Work is bounded by the field and structure caps. Ruby Hash iteration is
+        # deterministic insertion order, so traversal stops at the limits instead of
+        # sorting or scanning the full input. This is the cross-SDK recommendation for
+        # languages with deterministic iteration (Ruby truncates; Go omits because its map
+        # iteration is randomized per call).
+        def self.bounded_context_snapshot(attrs)
+          return [{}, []] unless attrs.is_a?(Hash) && !attrs.empty?
 
-        def self.prune_context(attrs)
-          flattened_context = flatten_context(attrs)
-          return {} if flattened_context.empty?
-
-          pruned_context = {}
-          count = 0
-          flattened_context.keys.sort.each do |key|
-            break if count >= MAX_CONTEXT_FIELDS
-
-            value = flattened_context[key]
-            # Skip oversized string values (mirrors flageval-worker pruning behavior).
-            next if value.is_a?(String) && value.length > MAX_FIELD_LENGTH
-
-            pruned_context[key] = value
-            count += 1
-          end
-          pruned_context
-        end
-
-        def self.flatten_context(attrs)
-          return {} unless attrs.is_a?(Hash) && !attrs.empty?
-
-          flattened_context = {}
+          flattened = {}
+          reasons = Set.new
           seen = {attrs.object_id => true}
+          walked = 0
+          # Single-element array so the recursion shares one mutable counter.
+          budget = [MAX_VISITED_NODES]
           attrs.each do |key, value|
-            flatten_value(key.to_s, value, flattened_context, seen, 0)
+            key = context_key_string(key)
+            next unless key
+
+            if flattened.size >= MAX_CONTEXT_FIELDS
+              reasons << REASON_MAX_CONTEXT_FIELDS
+              reasons << REASON_MAX_STRUCTURE_PROPERTIES if walked >= MAX_STRUCTURE_PROPERTIES
+              break
+            end
+            if walked >= MAX_STRUCTURE_PROPERTIES
+              reasons << REASON_MAX_STRUCTURE_PROPERTIES
+              break
+            end
+            if budget[0] <= 0
+              reasons << REASON_MAX_VISITED_NODES
+              break
+            end
+            walked += 1
+            if key.length > MAX_KEY_LENGTH
+              reasons << REASON_MAX_KEY_LENGTH
+              next
+            end
+
+            key = key.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+            bounded_flatten(key, value, flattened, seen, 0, reasons, budget)
           end
-          flattened_context
+          [flattened, reasons.to_a]
+        rescue
+          # Caller-controlled container implementations must not interrupt flag evaluation.
+          [{}, []]
         end
+
+        def self.context_key_string(key)
+          case key
+          when String then String.new(key)
+          when Symbol then key.to_s
+          end
+        rescue
+          # Unsupported caller keys must not break flag evaluation.
+          nil
+        end
+        private_class_method :context_key_string
+
+        def self.bounded_flatten(prefix, value, output, seen, depth, reasons, budget)
+          # Charge every node first, before any early return. A node that exits early still
+          # cost a call, and the cheap exits (nil leaves especially) are exactly what an
+          # adversarial context is made of.
+          if budget[0] <= 0
+            reasons << REASON_MAX_VISITED_NODES
+            return
+          end
+          budget[0] -= 1
+
+          return if value.nil?
+          if output.size >= MAX_CONTEXT_FIELDS
+            reasons << REASON_MAX_CONTEXT_FIELDS
+            return
+          end
+          if depth >= MAX_SNAPSHOT_DEPTH
+            reasons << REASON_MAX_SNAPSHOT_DEPTH
+            return
+          end
+          if prefix.length > MAX_KEY_LENGTH
+            reasons << REASON_MAX_KEY_LENGTH
+            return
+          end
+
+          case value
+          when Hash
+            return if value.empty?
+
+            object_id = value.object_id
+            if seen[object_id]
+              reasons << REASON_CYCLE
+              return
+            end
+
+            seen[object_id] = true
+            reasons << REASON_MAX_STRUCTURE_PROPERTIES if value.size > MAX_STRUCTURE_PROPERTIES
+            walked = 0
+            value.each do |key, child_value|
+              if output.size >= MAX_CONTEXT_FIELDS
+                reasons << REASON_MAX_CONTEXT_FIELDS
+                break
+              end
+              break if walked >= MAX_STRUCTURE_PROPERTIES
+              if budget[0] <= 0
+                reasons << REASON_MAX_VISITED_NODES
+                break
+              end
+
+              walked += 1
+              child_key = context_key_string(key)
+              next unless child_key
+              if prefix.length + 1 + child_key.length > MAX_KEY_LENGTH
+                reasons << REASON_MAX_KEY_LENGTH
+                next
+              end
+
+              child_key = child_key.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+              bounded_flatten("#{prefix}.#{child_key}", child_value, output, seen, depth + 1, reasons, budget)
+            end
+            seen.delete(object_id)
+          when Array
+            return if value.empty?
+
+            object_id = value.object_id
+            if seen[object_id]
+              reasons << REASON_CYCLE
+              return
+            end
+
+            seen[object_id] = true
+            reasons << REASON_MAX_LIST_ELEMENTS if value.size > MAX_LIST_ELEMENTS
+            walked = 0
+            value.each_with_index do |child_value, index|
+              if output.size >= MAX_CONTEXT_FIELDS
+                reasons << REASON_MAX_CONTEXT_FIELDS
+                break
+              end
+              break if walked >= MAX_LIST_ELEMENTS
+              if budget[0] <= 0
+                reasons << REASON_MAX_VISITED_NODES
+                break
+              end
+
+              walked += 1
+              bounded_flatten("#{prefix}.#{index}", child_value, output, seen, depth + 1, reasons, budget)
+            end
+            seen.delete(object_id)
+          else
+            if value.is_a?(String)
+              begin
+                string_value = String.new(value)
+                if string_value.length > MAX_VALUE_LENGTH
+                  reasons << REASON_MAX_VALUE_LENGTH
+                  return
+                end
+
+                output[prefix] = string_value.encode(
+                  Encoding::UTF_8, invalid: :replace, undef: :replace
+                ).freeze
+              rescue
+                # Unsupported caller values must not break flag evaluation.
+              end
+              return
+            end
+
+            case value
+            when TrueClass, FalseClass, Integer, Float
+              output[prefix] = value
+            end
+          end
+        end
+        private_class_method :bounded_flatten
 
         # Canonical context key: sorted type-tagged length-delimited encoding.
         # Each field is: 8-byte big-endian key length + key bytes + type-tag byte +
@@ -187,34 +350,6 @@ module Datadog
           buffer
         end
 
-        def self.flatten_value(prefix, value, output, seen, depth)
-          return if depth > MAX_CONTEXT_DEPTH
-
-          case value
-          when Hash
-            object_id = value.object_id
-            return if seen[object_id]
-
-            seen[object_id] = true
-            value.each do |key, child_value|
-              flatten_value("#{prefix}.#{key}", child_value, output, seen, depth + 1)
-            end
-            seen.delete(object_id)
-          when Array
-            object_id = value.object_id
-            return if seen[object_id]
-
-            seen[object_id] = true
-            value.each_with_index do |child_value, index|
-              flatten_value("#{prefix}.#{index}", child_value, output, seen, depth + 1)
-            end
-            seen.delete(object_id)
-          else
-            output[prefix] = value unless value.nil?
-          end
-        end
-        private_class_method :flatten_value
-
         private
 
         def context_value_bytes(value)
@@ -230,7 +365,8 @@ module Datadog
 
         # 8-byte big-endian length prefix + raw bytes. Unambiguous field boundary.
         def length_delimited(string)
-          bytes = string.encode(Encoding::BINARY, invalid: :replace, undef: :replace)
+          utf8 = string.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+          bytes = utf8.dup.force_encoding(Encoding::BINARY)
           byte_length = bytes.bytesize
           # Build 8-byte big-endian length
           length_bytes = String.new("", encoding: Encoding::BINARY)
@@ -258,7 +394,10 @@ module Datadog
           entry[:last_evaluation] = evaluation_time_ms if evaluation_time_ms > entry[:last_evaluation]
         end
 
-        def add_to_degraded(flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms)
+        def add_to_degraded(
+          flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+        )
+          # @type var degraded_key: degraded_key
           degraded_key = [flag_key, variant, allocation_key, runtime_default, error_message]
 
           if (entry = @degraded[degraded_key])
@@ -273,7 +412,7 @@ module Datadog
             return
           end
 
-          # Degraded entry omits targeting_key + context_attrs (schema omitempty fields)
+          # Degraded entries omit targeting_key and context_attrs.
           @degraded[degraded_key] = new_entry(
             evaluation_time_ms,
             runtime_default: runtime_default,

--- a/lib/datadog/open_feature/flag_evaluation/aggregator.rb
+++ b/lib/datadog/open_feature/flag_evaluation/aggregator.rb
@@ -205,9 +205,6 @@ module Datadog
             bounded_flatten(key, value, flattened, seen, 0, reasons, budget)
           end
           [flattened, reasons.to_a]
-        rescue
-          # Caller-controlled container implementations must not interrupt flag evaluation.
-          [{}, []]
         end
 
         def self.context_key_string(key)

--- a/lib/datadog/open_feature/flag_evaluation/writer.rb
+++ b/lib/datadog/open_feature/flag_evaluation/writer.rb
@@ -100,6 +100,7 @@ module Datadog
             attrs: attrs,
           }
           @queue.push(bounded_event, true)
+          @stop_mutex.synchronize { @stop_cond.signal }
           start_background_thread unless running?
         rescue ThreadError
           # Queue full — drop and count (best-effort, same as Go: drop-and-count). The count is
@@ -200,7 +201,7 @@ module Datadog
 
         def wait_for_next_cycle
           @stop_mutex.synchronize do
-            return if @stopped
+            return if @stopped || !@queue.empty?
 
             @stop_cond.wait(@stop_mutex, DRAIN_INTERVAL_SECONDS)
           end

--- a/lib/datadog/open_feature/flag_evaluation/writer.rb
+++ b/lib/datadog/open_feature/flag_evaluation/writer.rb
@@ -33,11 +33,14 @@ module Datadog
         ROWS_DROPPED_METRIC = "flagevaluation.rows.dropped"
         ROWS_DEGRADED_METRIC = "flagevaluation.rows.degraded"
         PAYLOAD_SPLITS_METRIC = "flagevaluation.payload.splits"
+        CONTEXT_TRUNCATED_METRIC = "flagevaluation.context.truncated"
 
         REASON_QUEUE_OVERFLOW = "queue_overflow"
         REASON_DEGRADED_CAP = "degraded_cap"
         REASON_CARDINALITY_CAP = "cardinality_cap"
         REASON_PAYLOAD_LIMIT = "payload_limit"
+        REASON_PRE_QUEUE_OVERFLOW = "pre_queue_overflow"
+        REASON_SERIALIZATION_ERROR = "serialization_error"
 
         # Service context fields for the batch wrapper.
         attr_reader :service_context
@@ -56,6 +59,8 @@ module Datadog
           @stop_cond = ConditionVariable.new
           @stopped = false
           @dropped_queue_overflow = 0
+          @dropped_pre_queue_overflow = 0
+          @context_truncated_counts = Hash.new(0)
 
           self.fork_policy = Core::Workers::Async::Thread::FORK_POLICY_RESTART
 
@@ -64,20 +69,34 @@ module Datadog
         end
 
         # Non-blocking enqueue from the finally hook. Drops + counts on overflow.
-        # Context flattening/pruning runs in the background writer, not on the caller eval thread.
-        def enqueue(**event)
+        def enqueue(
+          flag_key:, eval_time_ms:, variant: nil, allocation_key: nil, error_message: nil,
+          runtime_default: nil, targeting_key: nil, attrs: nil, **_event
+        )
           start_background_thread if forked?
 
-          attrs = event[:attrs]
-          attrs = attrs.is_a?(Hash) ? snapshot_context_value(attrs, {}, 0) || {} : {}
+          # Avoid snapshot work when the queue is already full.
+          if @queue.size >= QUEUE_SIZE
+            @stop_mutex.synchronize { @dropped_pre_queue_overflow += 1 }
+            return
+          end
+
+          if attrs.is_a?(Hash)
+            attrs, reasons = Aggregator.bounded_context_snapshot(attrs)
+            unless reasons.empty?
+              @stop_mutex.synchronize { reasons.each { |reason| @context_truncated_counts[reason] += 1 } }
+            end
+          else
+            attrs = {}
+          end
           bounded_event = {
-            flag_key: event[:flag_key],
-            variant: event[:variant],
-            allocation_key: event[:allocation_key],
-            error_message: event[:error_message],
-            runtime_default: event[:runtime_default],
-            targeting_key: event[:targeting_key],
-            eval_time_ms: event[:eval_time_ms],
+            flag_key: snapshot_string(flag_key),
+            variant: snapshot_string(variant),
+            allocation_key: snapshot_string(allocation_key),
+            error_message: snapshot_string(error_message),
+            runtime_default: runtime_default,
+            targeting_key: snapshot_string(targeting_key),
+            eval_time_ms: snapshot_integer(eval_time_ms),
             attrs: attrs,
           }
           @queue.push(bounded_event, true)
@@ -111,45 +130,37 @@ module Datadog
           @stop_cond = ConditionVariable.new
           @stopped = false
           @dropped_queue_overflow = 0
+          @dropped_pre_queue_overflow = 0
+          @context_truncated_counts = Hash.new(0)
         end
 
         private
 
         def build_service_context
           config = Datadog.configuration
-          ctx = {"service" => config.service.to_s}
-          ctx["env"] = config.env if config.env && !config.env.empty?
-          ctx["version"] = config.version if config.version && !config.version.empty?
+          ctx = {"service" => snapshot_string(config.service) || ""}
+          env = snapshot_string(config.env)
+          version = snapshot_string(config.version)
+          ctx["env"] = env if env && !env.empty?
+          ctx["version"] = version if version && !version.empty?
           ctx
         end
 
-        def snapshot_context_value(value, seen, depth)
-          return if depth > Aggregator::MAX_CONTEXT_DEPTH
+        def snapshot_string(value)
+          return unless value
 
-          case value
-          when Hash
-            object_id = value.object_id
-            return if seen[object_id]
+          string = value.is_a?(String) ? value : value.to_s
+          String.new(string).encode(Encoding::UTF_8, invalid: :replace, undef: :replace).freeze
+        rescue
+          # Unsupported caller values must not break flag evaluation.
+          nil
+        end
 
-            seen[object_id] = true
-            value.each_with_object({}) do |(key, child_value), snapshot|
-              snapshot[key.is_a?(String) ? key.dup : key] = snapshot_context_value(child_value, seen, depth + 1)
-            end.tap { seen.delete(object_id) }
-          when Array
-            object_id = value.object_id
-            return if seen[object_id]
-
-            seen[object_id] = true
-            value.map { |child_value| snapshot_context_value(child_value, seen, depth + 1) }.tap { seen.delete(object_id) }
-          when String
-            value.dup
-          else
-            begin
-              value.dup
-            rescue TypeError
-              value
-            end
-          end
+        def snapshot_integer(value)
+          integer = value.to_i
+          integer.is_a?(Integer) ? integer : 0
+        rescue
+          0
         end
 
         def start_background_thread
@@ -230,12 +241,17 @@ module Datadog
         def flush_once
           snapshot = @aggregator.flush_and_reset
           dropped_overflow = snapshot[:dropped_degraded_overflow].to_i
-          dropped_queue = take_dropped_queue_overflow
+          dropped_queue = read_and_reset_dropped_queue_overflow
+          dropped_pre_queue = read_and_reset_dropped_pre_queue_overflow
+          context_truncated_counts = read_and_reset_context_truncated_counts
 
-          emit_drop_counts(dropped_queue, dropped_overflow)
+          emit_drop_counts(dropped_queue, dropped_overflow, dropped_pre_queue)
+          context_truncated_counts.each do |reason, count|
+            record_telemetry_count(CONTEXT_TRUNCATED_METRIC, count, reason: reason)
+          end
 
           events = build_events(snapshot)
-          emit_degraded_counts(snapshot[:degraded].values.sum { |entry| entry[:count].to_i })
+          record_telemetry_count(ROWS_DEGRADED_METRIC, snapshot[:degraded].values.sum { |entry| entry[:count].to_i }, reason: REASON_CARDINALITY_CAP)
           return if events.empty?
 
           send_payload_batches(events)
@@ -243,8 +259,7 @@ module Datadog
           @logger.debug { "OpenFeature EVP: flush error: #{e.class}: #{e.message}" }
         end
 
-        # Read-and-reset the queue-overflow drop counter under the stop mutex.
-        def take_dropped_queue_overflow
+        def read_and_reset_dropped_queue_overflow
           @stop_mutex.synchronize do
             count = @dropped_queue_overflow
             @dropped_queue_overflow = 0
@@ -252,26 +267,39 @@ module Datadog
           end
         end
 
+        def read_and_reset_dropped_pre_queue_overflow
+          @stop_mutex.synchronize do
+            count = @dropped_pre_queue_overflow
+            @dropped_pre_queue_overflow = 0
+            count
+          end
+        end
+
+        def read_and_reset_context_truncated_counts
+          @stop_mutex.synchronize do
+            counts = @context_truncated_counts
+            @context_truncated_counts = Hash.new(0)
+            counts
+          end
+        end
+
         # Emit (log) the observable drop counts so backpressure is never silently lost.
         # Σ(emitted tier counts + these drops) == evaluations processed.
-        def emit_drop_counts(dropped_queue, dropped_overflow)
-          return if dropped_queue.zero? && dropped_overflow.zero?
+        def emit_drop_counts(dropped_queue, dropped_overflow, dropped_pre_queue)
+          return if dropped_queue.zero? && dropped_overflow.zero? && dropped_pre_queue.zero?
 
+          record_telemetry_count(ROWS_DROPPED_METRIC, dropped_pre_queue, reason: REASON_PRE_QUEUE_OVERFLOW)
           record_telemetry_count(ROWS_DROPPED_METRIC, dropped_queue, reason: REASON_QUEUE_OVERFLOW)
           record_telemetry_count(ROWS_DROPPED_METRIC, dropped_overflow, reason: REASON_DEGRADED_CAP)
 
           @logger.debug do
             "OpenFeature EVP: dropped events " \
+              "pre_queue_overflow=#{dropped_pre_queue} " \
               "queue_overflow=#{dropped_queue} degraded_overflow=#{dropped_overflow}"
           end
         end
 
-        def emit_degraded_counts(degraded_count)
-          record_telemetry_count(ROWS_DEGRADED_METRIC, degraded_count, reason: REASON_CARDINALITY_CAP)
-        end
-
         # Build flagEvaluationEvent list from aggregation snapshot.
-        # Full-tier entries include all optional fields; degraded entries omit targeting_key + context.
         def build_events(snapshot)
           flush_time_ms = (Core::Utils::Time.now.to_f * 1000).to_i
           events = []
@@ -298,7 +326,7 @@ module Datadog
         end
 
         def build_event(flag_key:, variant:, allocation_key:, targeting_key:, entry:, flush_time_ms:, tier:)
-          # @type var event: ::Hash[::String, untyped]
+          # @type var event: ::Hash[::String, any]
           event = {
             "timestamp" => flush_time_ms,
             "flag" => {"key" => flag_key},
@@ -308,13 +336,17 @@ module Datadog
           }
 
           event["runtime_default_used"] = true if entry[:runtime_default]
-          event["error"] = {"message" => entry[:error_message]} if entry[:error_message] && !entry[:error_message].empty?
+
+          error_message = entry[:error_message]
+          if error_message && !error_message.empty?
+            event["error"] = {"message" => error_message}
+          end
 
           # variant + allocation are present in both tiers (omitempty per schema).
           event["variant"] = {"key" => variant} if variant && !variant.empty?
           event["allocation"] = {"key" => allocation_key} if allocation_key && !allocation_key.empty?
 
-          # Full-tier additionally carries targeting_key + the pruned evaluation context;
+          # Full-tier additionally carries targeting_key and the truncated evaluation context;
           # the degraded tier omits both.
           if tier == :full
             event["targeting_key"] = targeting_key if targeting_key && !targeting_key.empty?
@@ -336,11 +368,19 @@ module Datadog
           batch = []
           batch_size = base_payload_size
           dropped_oversized = 0
+          dropped_serialization = 0
           payload_limit_degraded = 0
           payload_splits = 0
 
           events.each do |event|
-            encoded_event = encoded_event_for_payload(event, base_payload_size)
+            begin
+              encoded_event = encoded_event_for_payload(event, base_payload_size)
+            rescue => e
+              # Keep one malformed event from discarding the complete flush snapshot.
+              dropped_serialization += event_count(event)
+              @logger.debug { "OpenFeature EVP: dropped event serialization_error=#{e.class}" }
+              next
+            end
             unless encoded_event
               dropped_oversized += event_count(event)
               next
@@ -365,8 +405,9 @@ module Datadog
           send_payload_batch(batch) unless batch.empty?
           record_telemetry_count(ROWS_DEGRADED_METRIC, payload_limit_degraded, reason: REASON_PAYLOAD_LIMIT)
           record_telemetry_count(ROWS_DROPPED_METRIC, dropped_oversized, reason: REASON_PAYLOAD_LIMIT)
+          record_telemetry_count(ROWS_DROPPED_METRIC, dropped_serialization, reason: REASON_SERIALIZATION_ERROR)
           record_telemetry_count(PAYLOAD_SPLITS_METRIC, payload_splits)
-          emit_payload_oversize_drops(dropped_oversized) if dropped_oversized.positive?
+          @logger.debug { "OpenFeature EVP: dropped events payload_oversize=#{dropped_oversized}" } if dropped_oversized.positive?
         end
 
         def send_payload_batch(events)
@@ -408,10 +449,6 @@ module Datadog
           degraded.delete("targeting_key")
           degraded.delete("context")
           degraded
-        end
-
-        def emit_payload_oversize_drops(dropped_oversized)
-          @logger.debug { "OpenFeature EVP: dropped events payload_oversize=#{dropped_oversized}" }
         end
 
         def event_count(event)

--- a/lib/datadog/open_feature/flag_evaluation/writer.rb
+++ b/lib/datadog/open_feature/flag_evaluation/writer.rb
@@ -41,6 +41,7 @@ module Datadog
         REASON_PAYLOAD_LIMIT = "payload_limit"
         REASON_PRE_QUEUE_OVERFLOW = "pre_queue_overflow"
         REASON_SERIALIZATION_ERROR = "serialization_error"
+        REASON_SNAPSHOT_ERROR = "snapshot_error"
 
         # Service context fields for the batch wrapper.
         attr_reader :service_context
@@ -61,6 +62,7 @@ module Datadog
           @dropped_queue_overflow = 0
           @dropped_pre_queue_overflow = 0
           @context_truncated_counts = Hash.new(0)
+          @context_snapshot_error_logged = false
 
           self.fork_policy = Core::Workers::Async::Thread::FORK_POLICY_RESTART
 
@@ -81,14 +83,7 @@ module Datadog
             return
           end
 
-          if attrs.is_a?(Hash)
-            attrs, reasons = Aggregator.bounded_context_snapshot(attrs)
-            unless reasons.empty?
-              @stop_mutex.synchronize { reasons.each { |reason| @context_truncated_counts[reason] += 1 } }
-            end
-          else
-            attrs = {}
-          end
+          attrs = snapshot_context(attrs)
           bounded_event = {
             flag_key: snapshot_string(flag_key),
             variant: snapshot_string(variant),
@@ -133,9 +128,32 @@ module Datadog
           @dropped_queue_overflow = 0
           @dropped_pre_queue_overflow = 0
           @context_truncated_counts = Hash.new(0)
+          @context_snapshot_error_logged = false
         end
 
         private
+
+        def snapshot_context(attrs)
+          return {} unless attrs.is_a?(Hash)
+
+          snapshot, reasons = Aggregator.bounded_context_snapshot(attrs)
+          unless reasons.empty?
+            @stop_mutex.synchronize { reasons.each { |reason| @context_truncated_counts[reason] += 1 } }
+          end
+          snapshot
+        rescue => e
+          # Context handling runs in the finally hook and must not interrupt flag evaluation.
+          should_log = false
+          @stop_mutex.synchronize do
+            @context_truncated_counts[REASON_SNAPSHOT_ERROR] += 1
+            unless @context_snapshot_error_logged
+              @context_snapshot_error_logged = true
+              should_log = true
+            end
+          end
+          @logger.debug { "OpenFeature EVP: context snapshot error: #{e.class}" } if should_log
+          {}
+        end
 
         def build_service_context
           config = Datadog.configuration

--- a/lib/datadog/open_feature/flag_evaluation/writer.rb
+++ b/lib/datadog/open_feature/flag_evaluation/writer.rb
@@ -95,7 +95,7 @@ module Datadog
             allocation_key: snapshot_string(allocation_key),
             error_message: snapshot_string(error_message),
             runtime_default: runtime_default,
-            targeting_key: snapshot_string(targeting_key),
+            targeting_key: snapshot_targeting_key(targeting_key),
             eval_time_ms: snapshot_integer(eval_time_ms),
             attrs: attrs,
           }
@@ -154,6 +154,18 @@ module Datadog
           String.new(string).encode(Encoding::UTF_8, invalid: :replace, undef: :replace).freeze
         rescue
           # Unsupported caller values must not break flag evaluation.
+          nil
+        end
+
+        def snapshot_targeting_key(value)
+          return unless value.is_a?(String)
+
+          string = String.new(value)
+          return unless string.valid_encoding?
+
+          string.encode!(Encoding::UTF_8)
+          string.freeze
+        rescue EncodingError
           nil
         end
 

--- a/sig/datadog/open_feature/flag_evaluation/aggregator.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/aggregator.rbs
@@ -2,11 +2,39 @@ module Datadog
   module OpenFeature
     module FlagEvaluation
       class Aggregator
+        type context_value = ::String | bool | ::Integer | ::Float
+        type context = ::Hash[::String, context_value]
+        type raw_context = ::Hash[any, any]
+        type full_key = [::String, ::String, ::String, bool, ::String, ::String, ::String]
+        type degraded_key = [::String, ::String, ::String, bool, ::String]
+        type entry = {
+          count: ::Integer,
+          first_evaluation: ::Integer,
+          last_evaluation: ::Integer,
+          runtime_default: bool,
+          error_message: ::String?,
+          targeting_key: ::String?,
+          context_attrs: context?
+        }
+        type snapshot = {
+          full: ::Hash[full_key, entry],
+          degraded: ::Hash[degraded_key, entry],
+          dropped_degraded_overflow: ::Integer
+        }
+
         MAX_CONTEXT_FIELDS: ::Integer
 
-        MAX_FIELD_LENGTH: ::Integer
+        MAX_VALUE_LENGTH: ::Integer
 
-        MAX_CONTEXT_DEPTH: ::Integer
+        MAX_KEY_LENGTH: ::Integer
+
+        MAX_LIST_ELEMENTS: ::Integer
+
+        MAX_STRUCTURE_PROPERTIES: ::Integer
+
+        MAX_SNAPSHOT_DEPTH: ::Integer
+
+        MAX_VISITED_NODES: ::Integer
 
         EVAL_SCALE_TARGET_FLAGS: ::Integer
 
@@ -40,6 +68,22 @@ module Datadog
 
         CTX_TAG_OTHER: ::String
 
+        REASON_MAX_CONTEXT_FIELDS: ::String
+
+        REASON_MAX_VALUE_LENGTH: ::String
+
+        REASON_MAX_KEY_LENGTH: ::String
+
+        REASON_MAX_LIST_ELEMENTS: ::String
+
+        REASON_MAX_STRUCTURE_PROPERTIES: ::String
+
+        REASON_MAX_SNAPSHOT_DEPTH: ::String
+
+        REASON_MAX_VISITED_NODES: ::String
+
+        REASON_CYCLE: ::String
+
         @global_cap: ::Integer
 
         @per_flag_cap: ::Integer
@@ -48,9 +92,9 @@ module Datadog
 
         @mutex: ::Thread::Mutex
 
-        @full: ::Hash[::Array[untyped], ::Hash[::Symbol, untyped]]
+        @full: ::Hash[full_key, entry]
 
-        @degraded: ::Hash[::Array[untyped], ::Hash[::Symbol, untyped]]
+        @degraded: ::Hash[degraded_key, entry]
 
         @per_flag_full: ::Hash[::String, ::Integer]
 
@@ -72,32 +116,32 @@ module Datadog
           allocation_key: ::String?,
           targeting_key: ::String?,
           eval_time_ms: ::Integer,
-          attrs: ::Hash[::String, untyped]?,
+          attrs: context?,
           ?error_message: ::String?,
           ?runtime_default: bool?
         ) -> void
 
-        def flush_and_reset: () -> ::Hash[::Symbol, untyped]
+        def flush_and_reset: () -> snapshot
 
-        def prune_context: (::Hash[::String, untyped]? attrs) -> ::Hash[::String, untyped]
+        def self.bounded_context_snapshot: (raw_context? attrs) -> [context, ::Array[::String]]
 
-        def self.prune_context: (::Hash[::String, untyped]? attrs) -> ::Hash[::String, untyped]
-
-        def self.flatten_context: (::Hash[::String, untyped]? attrs) -> ::Hash[::String, untyped]
-
-        def self.flatten_value: (
-          ::String prefix,
-          untyped value,
-          ::Hash[::String, untyped] output,
-          ::Hash[::Integer, bool] seen,
-          ::Integer depth
-        ) -> void
-
-        def canonical_context_key: (::Hash[::String, untyped]? attrs) -> ::String
+        def canonical_context_key: (context? attrs) -> ::String
 
         private
 
-        def context_value_bytes: (untyped value) -> ::String
+        def self.context_key_string: (any key) -> ::String?
+
+        def self.bounded_flatten: (
+          ::String prefix,
+          any value,
+          context output,
+          ::Hash[::Integer, bool] seen,
+          ::Integer depth,
+          ::Set[::String] reasons,
+          ::Array[::Integer] budget
+        ) -> void
+
+        def context_value_bytes: (context_value value) -> ::String
 
         def length_delimited: (::String string) -> ::String
 
@@ -106,10 +150,10 @@ module Datadog
           runtime_default: bool,
           ?error_message: ::String?,
           ?targeting_key: ::String?,
-          ?context_attrs: ::Hash[::String, untyped]?
-        ) -> ::Hash[::Symbol, untyped]
+          ?context_attrs: context?
+        ) -> entry
 
-        def observe: (::Hash[::Symbol, untyped] entry, ::Integer evaluation_time_ms) -> void
+        def observe: (entry entry, ::Integer evaluation_time_ms) -> void
 
         def add_to_degraded: (
           ::String flag_key,

--- a/sig/datadog/open_feature/flag_evaluation/writer.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/writer.rbs
@@ -40,6 +40,8 @@ module Datadog
 
         REASON_SERIALIZATION_ERROR: ::String
 
+        REASON_SNAPSHOT_ERROR: ::String
+
         @transport: Transport::HTTP
 
         @logger: Core::Logger
@@ -61,6 +63,8 @@ module Datadog
         @dropped_pre_queue_overflow: ::Integer
 
         @context_truncated_counts: ::Hash[::String, ::Integer]
+
+        @context_snapshot_error_logged: bool
 
         @service_context: ::Hash[::String, ::String]
 
@@ -91,6 +95,8 @@ module Datadog
         private
 
         def after_fork: () -> void
+
+        def snapshot_context: (Aggregator::raw_context? attrs) -> Aggregator::context
 
         def build_service_context: () -> ::Hash[::String, ::String]
 

--- a/sig/datadog/open_feature/flag_evaluation/writer.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/writer.rbs
@@ -4,6 +4,8 @@ module Datadog
       class Writer
         include Core::Workers::Async::Thread
 
+        type event = ::Hash[::String, any]
+
         FLUSH_INTERVAL_SECONDS: ::Integer
 
         DRAIN_INTERVAL_SECONDS: ::Float
@@ -24,6 +26,8 @@ module Datadog
 
         PAYLOAD_SPLITS_METRIC: ::String
 
+        CONTEXT_TRUNCATED_METRIC: ::String
+
         REASON_QUEUE_OVERFLOW: ::String
 
         REASON_DEGRADED_CAP: ::String
@@ -31,6 +35,10 @@ module Datadog
         REASON_CARDINALITY_CAP: ::String
 
         REASON_PAYLOAD_LIMIT: ::String
+
+        REASON_PRE_QUEUE_OVERFLOW: ::String
+
+        REASON_SERIALIZATION_ERROR: ::String
 
         @transport: Transport::HTTP
 
@@ -50,6 +58,10 @@ module Datadog
 
         @dropped_queue_overflow: ::Integer
 
+        @dropped_pre_queue_overflow: ::Integer
+
+        @context_truncated_counts: ::Hash[::String, ::Integer]
+
         @service_context: ::Hash[::String, ::String]
 
         attr_reader service_context: ::Hash[::String, ::String]
@@ -62,7 +74,17 @@ module Datadog
           ?telemetry: Core::Telemetry::Component?
         ) -> void
 
-        def enqueue: (**untyped event) -> void
+        def enqueue: (
+          flag_key: any,
+          eval_time_ms: any,
+          ?variant: any,
+          ?allocation_key: any,
+          ?error_message: any,
+          ?runtime_default: bool?,
+          ?targeting_key: any,
+          ?attrs: Aggregator::raw_context?,
+          **any event
+        ) -> void
 
         def stop: () -> bool
 
@@ -72,11 +94,8 @@ module Datadog
 
         def build_service_context: () -> ::Hash[::String, ::String]
 
-        def snapshot_context_value: (
-          untyped value,
-          ::Hash[::Integer, bool] seen,
-          ::Integer depth
-        ) -> untyped
+        def snapshot_string: (any value) -> ::String?
+        def snapshot_integer: (any value) -> ::Integer
 
         def start_background_thread: () -> void
 
@@ -94,44 +113,42 @@ module Datadog
 
         def flush_once: () -> void
 
-        def take_dropped_queue_overflow: () -> ::Integer
+        def read_and_reset_dropped_queue_overflow: () -> ::Integer
 
-        def emit_drop_counts: (::Integer dropped_queue, ::Integer dropped_overflow) -> void
+        def read_and_reset_dropped_pre_queue_overflow: () -> ::Integer
 
-        def emit_degraded_counts: (::Integer degraded_count) -> void
+        def read_and_reset_context_truncated_counts: () -> ::Hash[::String, ::Integer]
 
-        def build_events: (::Hash[::Symbol, untyped] snapshot) -> ::Array[::Hash[::String, untyped]]
+        def emit_drop_counts: (::Integer dropped_queue, ::Integer dropped_overflow, ::Integer dropped_pre_queue) -> void
+
+        def build_events: (Aggregator::snapshot snapshot) -> ::Array[event]
 
         def build_event: (
           flag_key: ::String,
           variant: ::String?,
           allocation_key: ::String?,
           targeting_key: ::String?,
-          entry: ::Hash[::Symbol, untyped],
+          entry: Aggregator::entry,
           flush_time_ms: ::Integer,
           tier: ::Symbol
-        ) -> ::Hash[::String, untyped]
+        ) -> event
 
-        def send_payload_batches: (::Array[::Hash[::String, untyped]] events) -> void
+        def send_payload_batches: (::Array[event] events) -> void
 
-        def send_payload_batch: (::Array[::Hash[::String, untyped]] events) -> untyped
+        def send_payload_batch: (::Array[event] events) -> any
 
         def encoded_event_for_payload: (
-          ::Hash[::String, untyped] event,
+          event event,
           ::Integer base_payload_size
-        ) -> [::Hash[::String, untyped], ::Integer, bool]?
+        ) -> [event, ::Integer, bool]?
 
-        def encoded_event: (::Hash[::String, untyped] event) -> [::Hash[::String, untyped], ::Integer]
+        def encoded_event: (event event) -> [event, ::Integer]
 
         def event_fits_payload?: (::Integer event_size, ::Integer base_payload_size) -> bool
 
-        def degrade_event_for_payload_limit: (
-          ::Hash[::String, untyped] event
-        ) -> ::Hash[::String, untyped]?
+        def degrade_event_for_payload_limit: (event event) -> event?
 
-        def emit_payload_oversize_drops: (::Integer dropped_oversized) -> void
-
-        def event_count: (::Hash[::String, untyped] event) -> ::Integer
+        def event_count: (event event) -> ::Integer
 
         def record_telemetry_count: (
           ::String metric_name,

--- a/sig/datadog/open_feature/flag_evaluation/writer.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/writer.rbs
@@ -95,6 +95,7 @@ module Datadog
         def build_service_context: () -> ::Hash[::String, ::String]
 
         def snapshot_string: (any value) -> ::String?
+        def snapshot_targeting_key: (any value) -> ::String?
         def snapshot_integer: (any value) -> ::Integer
 
         def start_background_thread: () -> void

--- a/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
         .to eq({})
     end
 
-    it "does not propagate errors from caller-controlled container subclasses" do
+    it "lets the writer boundary handle errors from caller-controlled container subclasses" do
       invalid_hash = Class.new(Hash) do
         def each
           raise "cannot iterate"
@@ -283,8 +283,17 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       end.new
       invalid_array << "value"
 
-      expect(described_class.bounded_context_snapshot(invalid_hash)).to eq([{}, []])
-      expect(described_class.bounded_context_snapshot("array" => invalid_array)).to eq([{}, []])
+      expect { described_class.bounded_context_snapshot(invalid_hash) }
+        .to raise_error(RuntimeError, "cannot iterate")
+      expect { described_class.bounded_context_snapshot("array" => invalid_array) }
+        .to raise_error(RuntimeError, "cannot inspect")
+    end
+
+    it "does not hide errors in the snapshot implementation" do
+      allow(described_class).to receive(:bounded_flatten).and_raise("snapshot bug")
+
+      expect { described_class.bounded_context_snapshot("key" => "value") }
+        .to raise_error(RuntimeError, "snapshot bug")
     end
 
     it "drops context branches beyond the maximum nesting depth" do

--- a/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
   def expected_context_key(*fields)
     fields.map do |key, tag, value|
       [key.bytesize].pack("Q>") + key + tag + [value.bytesize].pack("Q>") + value
-    end.join
+    end.join.force_encoding(Encoding::BINARY)
   end
 
   # canonical_context_key
@@ -66,30 +66,44 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       expect(aggregator.canonical_context_key("a" => "b=c"))
         .to eq(expected_context_key(["a", "s", "b=c"]))
     end
+
+    it "uses UTF-8 bytes for non-ASCII context values" do
+      tokyo = aggregator.canonical_context_key("city" => "東京")
+      osaka = aggregator.canonical_context_key("city" => "大阪")
+
+      expect(tokyo).to eq(expected_context_key(["city", "s", "東京"]))
+      expect(tokyo).not_to eq(osaka)
+    end
+
+    it "normalizes equivalent context values from different source encodings" do
+      utf8 = "café"
+      latin1 = utf8.encode(Encoding::ISO_8859_1)
+
+      expect(aggregator.canonical_context_key("name" => latin1))
+        .to eq(aggregator.canonical_context_key("name" => utf8))
+    end
   end
 
-  # context pruning
-
-  describe "#prune_context" do
+  describe ".bounded_context_snapshot" do
     it "skips string values exceeding 256 chars" do
       long_value = "x" * 257
       attrs = {"key" => long_value, "other" => "fine"}
-      pruned = aggregator.prune_context(attrs)
-      expect(pruned.keys).not_to include("key")
-      expect(pruned.keys).to include("other")
+      snapshot, = described_class.bounded_context_snapshot(attrs)
+      expect(snapshot.keys).not_to include("key")
+      expect(snapshot.keys).to include("other")
     end
 
     it "flattens nested hashes and arrays with dot-notation keys" do
       attrs = {"profile" => {"plan" => "pro"}, "groups" => ["beta", "staff"]}
-      pruned = aggregator.prune_context(attrs)
-      expect(pruned).to include("profile.plan" => "pro", "groups.0" => "beta", "groups.1" => "staff")
+      snapshot, = described_class.bounded_context_snapshot(attrs)
+      expect(snapshot).to include("profile.plan" => "pro", "groups.0" => "beta", "groups.1" => "staff")
     end
 
     it "omits nil values and keeps empty string values" do
       attrs = {"profile" => {"plan" => "pro", "" => 1, "what" => ""}, "groups" => ["beta", "staff", nil, ""]}
-      pruned = aggregator.prune_context(attrs)
+      snapshot, = described_class.bounded_context_snapshot(attrs)
 
-      expect(pruned).to include(
+      expect(snapshot).to include(
         "groups.0" => "beta",
         "groups.1" => "staff",
         "groups.3" => "",
@@ -97,33 +111,120 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
         "profile.plan" => "pro",
         "profile.what" => "",
       )
-      expect(pruned).not_to have_key("groups.2")
+      expect(snapshot).not_to have_key("groups.2")
     end
 
     it "keeps string values of exactly 256 chars" do
       exact_value = "x" * 256
       attrs = {"key" => exact_value}
-      pruned = aggregator.prune_context(attrs)
-      expect(pruned.keys).to include("key")
+      snapshot, = described_class.bounded_context_snapshot(attrs)
+      expect(snapshot.keys).to include("key")
+    end
+
+    it "keeps exactly 256 fields without reporting truncation" do
+      attrs = 256.times.each_with_object({}) { |i, h| h["k#{i}"] = "v" }
+      snapshot, reasons = described_class.bounded_context_snapshot(attrs)
+
+      expect(snapshot.size).to eq(256)
+      expect(reasons).not_to include("max_context_fields")
     end
 
     it "caps at 256 fields" do
       attrs = 257.times.each_with_object({}) { |i, h| h["k#{i}"] = "v" }
-      pruned = aggregator.prune_context(attrs)
-      expect(pruned.size).to eq(256)
+      snapshot, reasons = described_class.bounded_context_snapshot(attrs)
+
+      expect(snapshot.size).to eq(256)
+      expect(reasons).to include("max_context_fields")
     end
 
-    it "drops keys after the sorted 256-field cap" do
+    it "bounds inspected root properties even when values are discarded" do
+      attrs = 256.times.each_with_object({}) { |i, h| h["k#{i}"] = nil }
+      attrs["unvisited"] = "value"
+      snapshot, reasons = described_class.bounded_context_snapshot(attrs)
+
+      expect(snapshot).to eq({})
+      expect(reasons).to include("max_structure_properties")
+    end
+
+    it "keeps keys of exactly 256 chars without reporting truncation" do
+      key = "k" * 256
+      snapshot, reasons = described_class.bounded_context_snapshot({key => "value"})
+
+      expect(snapshot).to eq(key => "value")
+      expect(reasons).to be_empty
+    end
+
+    it "reports keys exceeding 256 chars" do
+      attrs = {"k" * 257 => "value"}
+      snapshot, reasons = described_class.bounded_context_snapshot(attrs)
+
+      expect(snapshot).to eq({})
+      expect(reasons).to include("max_key_length")
+    end
+
+    it "rejects oversized nested keys before constructing a flattened key" do
+      prefixes = []
+      original = described_class.method(:bounded_flatten)
+      allow(described_class).to receive(:bounded_flatten) do |prefix, *args|
+        prefixes << prefix
+        original.call(prefix, *args)
+      end
+
+      snapshot, reasons = described_class.bounded_context_snapshot(
+        "root" => {"k" * 10_000 => "value"}
+      )
+
+      expect(snapshot).to eq({})
+      expect(reasons).to include("max_key_length")
+      expect(prefixes).to contain_exactly("root")
+    end
+
+    it "keeps exactly 256 nested properties without reporting truncation" do
+      nested = 256.times.each_with_object({}) { |i, properties| properties["k#{i}"] = "v" }
+      snapshot, reasons = described_class.bounded_context_snapshot({"root" => nested})
+
+      expect(snapshot.size).to eq(256)
+      expect(reasons).to be_empty
+    end
+
+    it "bounds inspected nested properties even when values are discarded" do
+      nested = 256.times.each_with_object({}) { |i, properties| properties["k#{i}"] = nil }
+      nested["unvisited"] = "value"
+      snapshot, reasons = described_class.bounded_context_snapshot({"root" => nested})
+
+      expect(snapshot).to eq({})
+      expect(reasons).to include("max_structure_properties")
+    end
+
+    it "keeps exactly 256 list elements without reporting truncation" do
+      values = 256.times.map { |i| "v#{i}" }
+      snapshot, reasons = described_class.bounded_context_snapshot({"values" => values})
+
+      expect(snapshot.size).to eq(256)
+      expect(reasons).to be_empty
+    end
+
+    it "bounds inspected list elements even when values are discarded" do
+      values = Array.new(256)
+      values << "unvisited"
+      snapshot, reasons = described_class.bounded_context_snapshot({"values" => values})
+
+      expect(snapshot).to eq({})
+      expect(reasons).to include("max_list_elements")
+    end
+
+    it "keeps the first 256 fields in insertion order and drops the rest" do
       attrs = 257.times.each_with_object({}) { |i, h| h["k#{format("%03d", i)}"] = "v" }
-      pruned = aggregator.prune_context(attrs)
+      snapshot, = described_class.bounded_context_snapshot(attrs)
       expected_keys = 256.times.map { |i| "k#{format("%03d", i)}" }
 
-      expect(pruned.keys).to eq(expected_keys)
-      expect(pruned).not_to have_key("k256")
+      expect(snapshot.keys).to eq(expected_keys)
+      expect(snapshot).not_to have_key("k256")
     end
 
     it "returns empty hash for nil input" do
-      expect(aggregator.prune_context(nil)).to eq({})
+      snapshot, = described_class.bounded_context_snapshot(nil)
+      expect(snapshot).to eq({})
     end
 
     it "does not recurse forever on cyclic hashes and arrays" do
@@ -132,22 +233,99 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       attrs["array"] = []
       attrs["array"] << attrs["array"]
 
-      pruned = aggregator.prune_context(attrs)
+      snapshot, reasons = described_class.bounded_context_snapshot(attrs)
 
-      expect(pruned).to include("keep" => "ok")
-      expect(pruned.keys.grep(/self|array/)).to be_empty
+      expect(snapshot).to include("keep" => "ok")
+      expect(snapshot.keys.grep(/self|array/)).to be_empty
+      expect(reasons).to include("cycle")
+    end
+
+    it "copies String subclasses before calling String operations" do
+      custom_string = Class.new(String) do
+        def length
+          raise "unexpected custom length"
+        end
+
+        def encode(*)
+          raise "unexpected custom encoding"
+        end
+      end
+
+      snapshot, = described_class.bounded_context_snapshot(
+        custom_string.new("key") => custom_string.new("value")
+      )
+      expect(snapshot).to eq("key" => "value")
+    end
+
+    it "skips unsupported caller objects without converting them to strings" do
+      invalid = Class.new do
+        def to_s
+          raise "cannot convert"
+        end
+      end.new
+
+      expect(described_class.bounded_context_snapshot({invalid => "key", "value" => invalid}).first)
+        .to eq({})
+    end
+
+    it "does not propagate errors from caller-controlled container subclasses" do
+      invalid_hash = Class.new(Hash) do
+        def each
+          raise "cannot iterate"
+        end
+      end.new
+      invalid_hash["key"] = "value"
+
+      invalid_array = Class.new(Array) do
+        def empty?
+          raise "cannot inspect"
+        end
+      end.new
+      invalid_array << "value"
+
+      expect(described_class.bounded_context_snapshot(invalid_hash)).to eq([{}, []])
+      expect(described_class.bounded_context_snapshot("array" => invalid_array)).to eq([{}, []])
     end
 
     it "drops context branches beyond the maximum nesting depth" do
       attrs = {"root" => {}}
       cursor = attrs["root"]
-      (described_class::MAX_CONTEXT_DEPTH + 2).times do |i|
+      (described_class::MAX_SNAPSHOT_DEPTH + 2).times do |i|
         cursor["level#{i}"] = {}
         cursor = cursor["level#{i}"]
       end
       cursor["leaf"] = "too-deep"
 
-      expect(aggregator.prune_context(attrs)).to eq({})
+      snapshot, = described_class.bounded_context_snapshot(attrs)
+      expect(snapshot).to eq({})
+    end
+
+    # Exercises MAX_VISITED_NODES: this context yields no leaves, so the output-size
+    # caps never fire and only the visit budget stops the walk.
+    context "with a leaf-free tree of shared subtrees" do
+      let(:attrs) do
+        level = 256.times.map { |i| ["k#{i}", nil] }.to_h
+        3.times { level = 256.times.map { |i| ["k#{i}", level] }.to_h }
+        level
+      end
+
+      it "stops the walk within the derived visited-node budget" do
+        visited = 0
+        original = described_class.method(:bounded_flatten)
+        allow(described_class).to receive(:bounded_flatten) do |*args|
+          visited += 1
+          original.call(*args)
+        end
+
+        snapshot, reasons = described_class.bounded_context_snapshot(attrs)
+
+        expect(described_class::MAX_VISITED_NODES).to eq(
+          described_class::MAX_CONTEXT_FIELDS * (described_class::MAX_SNAPSHOT_DEPTH + 1)
+        )
+        expect(visited).to be <= described_class::MAX_VISITED_NODES
+        expect(snapshot).to eq({})
+        expect(reasons).to include("max_visited_nodes")
+      end
     end
   end
 
@@ -315,8 +493,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       expect(aggregator_small.dropped_degraded_overflow).to eq(0)
     end
 
-    # The snapshot must CARRY the degraded-overflow count so the writer can emit it before
-    # reset (not reset-without-emit). The count must equal what dropped at flush time.
+    # The snapshot must carry the degraded-overflow count so the writer can emit it before reset.
     it "returns the degraded-overflow count in the snapshot so it can be emitted before reset" do
       aggregator_small = described_class.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 1)
       aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 1, attrs: {"x" => 1})

--- a/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
@@ -139,6 +139,76 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP) }
     let(:logger) { instance_double(Logger, debug: nil) }
 
+    it "wakes an idle worker when an event is enqueued" do
+      stub_const("#{described_class}::DRAIN_INTERVAL_SECONDS", 10)
+      allow(transport).to receive(:send_flag_evaluations)
+      worker_waiting = Queue.new
+      allow_any_instance_of(ConditionVariable).to receive(:wait).and_wrap_original do |method, *args|
+        worker_waiting << true
+        method.call(*args)
+      end
+      drained = Queue.new
+      allow_any_instance_of(described_class).to receive(:drain_queue).and_wrap_original do |method, *args, **kwargs|
+        count = kwargs.empty? ? method.call(*args) : method.call(*args, **kwargs)
+        drained << count
+        count
+      end
+
+      writer = described_class.new(transport: transport, logger: logger)
+      try_wait_until(seconds: 1) { worker_waiting.pop(true) unless worker_waiting.empty? }
+      writer.enqueue(
+        flag_key: "wake-drain", variant: "on", allocation_key: "",
+        targeting_key: "user-1", eval_time_ms: realistic_eval_ms, attrs: {},
+      )
+
+      count = try_wait_until(seconds: 1) { drained.pop(true) unless drained.empty? }
+      expect(count).to eq(1)
+    ensure
+      writer&.stop
+    end
+
+    it "drains consecutive bounded batches without waiting while the queue remains nonempty" do
+      stub_const("#{described_class}::DRAIN_INTERVAL_SECONDS", 10)
+      stub_const("#{described_class}::MAX_DRAIN_EVENTS_PER_CYCLE", 2)
+      allow(transport).to receive(:send_flag_evaluations)
+      drain_started = Queue.new
+      release_drain = Queue.new
+      drained = Queue.new
+      block_first_drain = true
+      allow_any_instance_of(described_class).to receive(:drain_queue).and_wrap_original do |method, *args, **kwargs|
+        if block_first_drain
+          block_first_drain = false
+          drain_started << true
+          release_drain.pop
+        end
+        count = kwargs.empty? ? method.call(*args) : method.call(*args, **kwargs)
+        drained << count
+        count
+      end
+
+      writer = described_class.new(transport: transport, logger: logger)
+      writer.enqueue(
+        flag_key: "backlog-drain", variant: "on", allocation_key: "",
+        targeting_key: "user-0", eval_time_ms: realistic_eval_ms, attrs: {},
+      )
+      try_wait_until(seconds: 1) { drain_started.pop(true) unless drain_started.empty? }
+
+      4.times do |i|
+        writer.enqueue(
+          flag_key: "backlog-drain", variant: "on", allocation_key: "",
+          targeting_key: "user-#{i + 1}", eval_time_ms: realistic_eval_ms + i + 1, attrs: {},
+        )
+      end
+      release_drain << true
+
+      drained_count = try_wait_until(seconds: 1) { drained.size if drained.size >= 3 }
+      expect(drained_count).to be >= 3
+      expect(3.times.map { drained.pop(true) }).to eq([2, 2, 1])
+    ensure
+      release_drain << true if release_drain&.empty?
+      writer&.stop
+    end
+
     it "flushes a bounded drain cycle before the queue is empty" do
       stub_const("#{described_class}::MAX_DRAIN_EVENTS_PER_CYCLE", 2)
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)

--- a/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     expect(telemetry).to have_received(:inc).with("tracers", metric_name, value, tags: tags)
   end
 
+  def captured_payload
+    payload = nil
+    transport = instance_double(Datadog::OpenFeature::Transport::HTTP)
+    allow(transport).to receive(:send_flag_evaluations) { |value| payload = value }
+    allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
+    writer = described_class.new(transport: transport, logger: logger)
+    yield writer
+    writer.send(:drain_and_flush)
+    payload
+  end
+
   # Regression guard: rescue inside until...end (without begin) is a Ruby SyntaxError.
   # If writer.rb fails to parse, the EVP component silently falls back to nil and no
   # events are ever delivered to mock-intake.
@@ -263,12 +274,10 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
   end
 
-  # Backpressure must be OBSERVABLE. When the hand-off queue overflows, enqueue increments an
-  # observable counter that is emitted (logged) on the next flush — not silently dropped.
   describe "#enqueue queue-overflow backpressure" do
     let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil) }
     let(:logger) { instance_double(Logger, debug: nil) }
-    let(:telemetry) { spy("telemetry") }
+    let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
 
     it "increments dropped_queue_overflow and emits the count on flush" do
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
@@ -283,58 +292,43 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       capacity.times { writer.enqueue(**event) }
       expect(writer.dropped_queue_overflow).to eq(0)
 
-      # Three more pushes overflow the bounded queue and must be counted.
       3.times { writer.enqueue(**event) }
-      expect(writer.dropped_queue_overflow).to eq(3)
 
-      # On flush the count is emitted (logged) and reset to 0 (observable, not silently lost).
       logged = []
       allow(logger).to receive(:debug) { |&blk| logged << blk.call }
       writer.send(:flush_once)
 
-      expect(logged.join).to match(/queue_overflow=3/)
+      expect(logged.join).to match(/pre_queue_overflow=3/)
       expect_telemetry_count(
         telemetry,
         "flagevaluation.rows.dropped",
         3,
-        {reason: "queue_overflow"}
+        {reason: "pre_queue_overflow"}
       )
-      expect(writer.dropped_queue_overflow).to eq(0)
+      expect(writer.send(:read_and_reset_dropped_pre_queue_overflow)).to eq(0)
     end
 
-    it "does not flatten or prune context before buffering" do
+    it "bounds and flattens context before buffering" do
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
       writer = described_class.new(transport: transport, logger: logger)
       raw = {"profile" => {"plan" => "pro"}, "oversized" => "x" * 257}
       300.times { |i| raw["z#{format("%03d", i)}"] = "v" }
 
-      expect(Datadog::OpenFeature::FlagEvaluation::Aggregator).not_to receive(:prune_context)
       writer.enqueue(
         flag_key: "f", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: 1, attrs: raw,
       )
 
       queued = writer.instance_variable_get(:@queue).pop(true)
-      expect(queued[:attrs].size).to eq(302)
-      expect(queued[:attrs]).to have_key("profile")
-      expect(queued[:attrs]).to have_key("oversized")
-      expect(queued[:attrs]).not_to have_key("profile.plan")
+      expect(queued[:attrs].size).to be <= 256
+      expect(queued[:attrs]).to have_key("profile.plan")
+      expect(queued[:attrs]).not_to have_key("profile")
+      expect(queued[:attrs]).not_to have_key("oversized")
     end
   end
 
   describe "emitted payload shape" do
     let(:logger) { instance_double(Logger, debug: nil) }
-
-    def captured_payload
-      payload = nil
-      transport = instance_double(Datadog::OpenFeature::Transport::HTTP)
-      allow(transport).to receive(:send_flag_evaluations) { |p| payload = p }
-      allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
-      writer = described_class.new(transport: transport, logger: logger)
-      yield writer
-      writer.send(:drain_and_flush)
-      payload
-    end
 
     it "emits a full-tier row with variant, allocation, targeting_key, and context" do
       payload = captured_payload do |writer|
@@ -346,11 +340,50 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       end
 
       row = payload["flagEvaluations"].first
-      # Structural assertions: objects, not bare strings.
       expect(row["variant"]).to eq("key" => "on")
       expect(row["allocation"]).to eq("key" => "alloc-1")
       expect(row["targeting_key"]).to eq("user-42")
       expect(row["context"]).to eq("evaluation" => {"env" => "prod", "tier" => "gold"})
+    end
+
+    it "normalizes malformed strings before serialization" do
+      malformed = +"\xFF"
+      malformed.force_encoding(Encoding::UTF_8)
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "encoding-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: malformed, error_message: malformed,
+          eval_time_ms: realistic_eval_ms, attrs: {"value" => malformed},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["targeting_key"]).to eq("\uFFFD")
+      expect(row["error"]).to eq("message" => "\uFFFD")
+      expect(row["context"]).to eq("evaluation" => {"value" => "\uFFFD"})
+    end
+
+    it "copies String subclasses before transport serialization" do
+      custom_value = Class.new(String) do
+        def encode(*)
+          raise "unexpected custom encoding"
+        end
+
+        def to_json(*)
+          raise JSON::GeneratorError, "unexpected custom serialization"
+        end
+      end.new("custom-value")
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "custom-value-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: "user", eval_time_ms: realistic_eval_ms,
+          attrs: {"custom" => custom_value},
+        )
+      end
+
+      expect(payload["flagEvaluations"].first.dig("context", "evaluation", "custom"))
+        .to eq("custom-value")
+      expect { Datadog::Core::Encoding::JSONEncoder.encode(payload) }.not_to raise_error
     end
 
     it "uses flush time for timestamp and evaluation time for first/last bounds" do
@@ -376,7 +409,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
 
     it "does not emit flagevaluation telemetry counters for the normal path" do
-      telemetry = spy("telemetry")
+      telemetry = instance_spy(Datadog::Core::Telemetry::Component)
       transport = instance_double(Datadog::OpenFeature::Transport::HTTP)
       allow(transport).to receive(:send_flag_evaluations)
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
@@ -393,7 +426,6 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
 
     it "emits a degraded-tier row without targeting_key or context" do
       payload = captured_payload do |writer|
-        # Force overflow into the degraded tier with a tiny-capped aggregator.
         small = Datadog::OpenFeature::FlagEvaluation::Aggregator.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 10)
         writer.instance_variable_set(:@aggregator, small)
         writer.enqueue(
@@ -413,7 +445,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
 
     it "emits a degraded counter for rows routed to the degraded tier" do
-      telemetry = spy("telemetry")
+      telemetry = instance_spy(Datadog::Core::Telemetry::Component)
       transport = instance_double(Datadog::OpenFeature::Transport::HTTP)
       allow(transport).to receive(:send_flag_evaluations)
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
@@ -441,27 +473,6 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       )
     end
 
-    # The emitted context must hold the PRUNED attrs (oversized strings removed, <=256 fields),
-    # not the raw attrs. Proven by inspecting the emitted payload, not the aggregator internals.
-    it "emits PRUNED context attrs in the payload (oversized strings removed, capped at 256 fields)" do
-      raw = {"keep" => "ok", "toobig" => "x" * 257}
-      300.times { |i| raw["k#{format("%03d", i)}"] = "v" }
-
-      payload = captured_payload do |writer|
-        writer.enqueue(
-          flag_key: "prune-flag", variant: "on", allocation_key: "",
-          targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: raw,
-        )
-      end
-
-      emitted = payload["flagEvaluations"].first["context"]["evaluation"]
-      expect(emitted.size).to eq(256)              # capped
-      expect(emitted).not_to have_key("toobig")    # oversized string removed
-      # Deterministic subset = sorted-first 256 keys (so 'k000'..'k253' kept, 'keep'/'k254'+ cut).
-      expect(emitted).to have_key("k000")
-      expect(emitted).not_to have_key("k299")
-    end
-
     it "emits an enqueue-time snapshot of nested context attrs" do
       raw = {
         "profile" => {"plan" => "pro"},
@@ -486,6 +497,43 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         "groups.0" => "beta",
         "name" => "alice",
       )
+    end
+
+    it "emits an enqueue-time snapshot of mutable scalar strings" do
+      targeting_key = +"user-a"
+      flag_key = +"snapshot-flag"
+
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: flag_key, variant: "on", allocation_key: "alloc",
+          targeting_key: targeting_key, eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+
+        flag_key.replace("other-flag")
+        targeting_key.replace("user-b")
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["flag"]["key"]).to eq("snapshot-flag")
+      expect(row["targeting_key"]).to eq("user-a")
+    end
+
+    it "normalizes a non-Integer evaluation time before enqueue" do
+      invalid_time = Class.new do
+        def to_i
+          nil
+        end
+      end.new
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "invalid-time", variant: "on", allocation_key: "alloc",
+          targeting_key: "user", eval_time_ms: invalid_time, attrs: {},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["first_evaluation"]).to eq(0)
+      expect(row["last_evaluation"]).to eq(0)
     end
 
     it "emits non-cyclic context attrs when attrs contain cycles" do
@@ -562,7 +610,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     let(:logged) { [] }
     let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP) }
     let(:logger) { instance_double(Logger) }
-    let(:telemetry) { spy("telemetry") }
+    let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
 
     before do
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
@@ -633,6 +681,36 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         {reason: "payload_limit"}
       )
     end
+
+    it "drops an unserializable row without losing valid rows" do
+      allow(Datadog::Core::Encoding::JSONEncoder).to receive(:encode).and_wrap_original do |method, value|
+        if value.is_a?(Hash) && value.dig("flag", "key") == "invalid"
+          raise JSON::GeneratorError, "cannot serialize"
+        end
+
+        method.call(value)
+      end
+      writer.enqueue(
+        flag_key: "invalid", variant: "on", allocation_key: "alloc",
+        targeting_key: "user-invalid", eval_time_ms: realistic_eval_ms,
+        attrs: {"env" => "invalid"},
+      )
+      writer.enqueue(
+        flag_key: "valid", variant: "on", allocation_key: "alloc",
+        targeting_key: "user-valid", eval_time_ms: realistic_eval_ms,
+        attrs: {"env" => "prod"},
+      )
+      writer.send(:drain_and_flush)
+
+      rows = payloads.flat_map { |payload| payload["flagEvaluations"] }
+      expect(rows).to contain_exactly(include("flag" => {"key" => "valid"}))
+      expect_telemetry_count(
+        telemetry,
+        "flagevaluation.rows.dropped",
+        1,
+        {reason: "serialization_error"}
+      )
+    end
   end
 
   describe "#send_payload_batch" do
@@ -651,17 +729,15 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
   end
 
-  # The aggregator's degraded-overflow count must be EMITTED before reset (not reset-without-emit).
   describe "#flush_once emits degraded-overflow drops" do
     let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil) }
     let(:logger) { instance_double(Logger) }
-    let(:telemetry) { spy("telemetry") }
+    let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
 
     it "logs the degraded_overflow count returned in the aggregator snapshot" do
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
       writer = described_class.new(transport: transport, logger: logger, telemetry: telemetry)
 
-      # Inject an aggregator whose flush reports a degraded-overflow drop.
       fake_aggregator = instance_double(Datadog::OpenFeature::FlagEvaluation::Aggregator)
       allow(fake_aggregator).to receive(:flush_and_reset).and_return(
         {full: {}, degraded: {}, dropped_degraded_overflow: 7}
@@ -680,6 +756,66 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         7,
         {reason: "degraded_cap"}
       )
+    end
+  end
+
+  describe "context-truncation telemetry" do
+    let(:logger) { instance_double(Logger, debug: nil) }
+    let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
+
+    it "emits a context-truncated counter per reason when caps are hit" do
+      transport = instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil)
+      allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
+      writer = described_class.new(transport: transport, logger: logger, telemetry: telemetry)
+
+      # >256 fields hits the field-count cap.
+      wide_attrs = 257.times.each_with_object({}) { |i, h| h["k#{format("%03d", i)}"] = "v" }
+      writer.enqueue(
+        flag_key: "wide-flag", variant: "on", allocation_key: "",
+        targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: wide_attrs,
+      )
+      # An oversized string value hits the value-length cap.
+      writer.enqueue(
+        flag_key: "long-flag", variant: "on", allocation_key: "",
+        targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: {"toobig" => "x" * 257},
+      )
+      # An oversized key hits the key-length cap.
+      writer.enqueue(
+        flag_key: "long-key-flag", variant: "on", allocation_key: "",
+        targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: {"k" * 257 => "value"},
+      )
+      writer.send(:drain_and_flush)
+
+      expect(telemetry).to have_received(:inc).with(
+        "tracers", "flagevaluation.context.truncated", 1, tags: {reason: "max_context_fields"}
+      )
+      expect(telemetry).to have_received(:inc).with(
+        "tracers", "flagevaluation.context.truncated", 1, tags: {reason: "max_value_length"}
+      )
+      expect(telemetry).to have_received(:inc).with(
+        "tracers", "flagevaluation.context.truncated", 1, tags: {reason: "max_key_length"}
+      )
+    ensure
+      writer&.stop
+    end
+
+    it "does not emit truncation telemetry for exactly 256 fields" do
+      transport = instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil)
+      allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
+      writer = described_class.new(transport: transport, logger: logger, telemetry: telemetry)
+      attrs = 256.times.each_with_object({}) { |i, fields| fields["k#{i}"] = "v" }
+
+      writer.enqueue(
+        flag_key: "exact-flag", variant: "on", allocation_key: "",
+        targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: attrs,
+      )
+      writer.send(:drain_and_flush)
+
+      expect(telemetry).not_to have_received(:inc).with(
+        "tracers", "flagevaluation.context.truncated", 1, tags: {reason: "max_context_fields"}
+      )
+    ensure
+      writer&.stop
     end
   end
 end

--- a/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
@@ -416,7 +416,21 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       expect(row["context"]).to eq("evaluation" => {"env" => "prod", "tier" => "gold"})
     end
 
-    it "normalizes malformed strings before serialization" do
+    it "transcodes valid targeting keys to UTF-8 before serialization" do
+      targeting_key = "caf\u00E9".encode(Encoding::ISO_8859_1)
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "encoding-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: targeting_key, eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+      end
+
+      emitted_targeting_key = payload["flagEvaluations"].first["targeting_key"]
+      expect(emitted_targeting_key).to eq("caf\u00E9")
+      expect(emitted_targeting_key.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it "omits malformed targeting keys and normalizes other malformed strings" do
       malformed = +"\xFF"
       malformed.force_encoding(Encoding::UTF_8)
       payload = captured_payload do |writer|
@@ -428,9 +442,20 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       end
 
       row = payload["flagEvaluations"].first
-      expect(row["targeting_key"]).to eq("\uFFFD")
+      expect(row).not_to have_key("targeting_key")
       expect(row["error"]).to eq("message" => "\uFFFD")
       expect(row["context"]).to eq("evaluation" => {"value" => "\uFFFD"})
+    end
+
+    it "omits non-String targeting keys" do
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "encoding-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: 42, eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+      end
+
+      expect(payload["flagEvaluations"].first).not_to have_key("targeting_key")
     end
 
     it "copies String subclasses before transport serialization" do

--- a/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
@@ -894,6 +894,43 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       writer&.stop
     end
 
+    it "drops invalid contexts, counts each failure, and logs only the first failure" do
+      transport = instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil)
+      allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
+      logged = []
+      allow(logger).to receive(:debug) { |&block| logged << block.call }
+      writer = described_class.new(transport: transport, logger: logger, telemetry: telemetry)
+      invalid_attrs = Class.new(Hash) do
+        def each
+          raise "caller-controlled failure"
+        end
+      end.new
+      invalid_attrs["key"] = "value"
+
+      2.times do
+        writer.enqueue(
+          flag_key: "invalid-context", variant: "on", allocation_key: "",
+          targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: invalid_attrs,
+        )
+      end
+      writer.send(:drain_and_flush)
+
+      expect(logged).to eq(["OpenFeature EVP: context snapshot error: RuntimeError"])
+      expect_telemetry_count(
+        telemetry,
+        "flagevaluation.context.truncated",
+        2,
+        {reason: "snapshot_error"}
+      )
+      expect(transport).to have_received(:send_flag_evaluations) do |payload|
+        row = payload["flagEvaluations"].first
+        expect(row["evaluation_count"]).to eq(2)
+        expect(row).not_to have_key("context")
+      end
+    ensure
+      writer&.stop
+    end
+
     it "does not emit truncation telemetry for exactly 256 fields" do
       transport = instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil)
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)


### PR DESCRIPTION
## **What does this PR do?**

Bounds and snapshots OpenFeature flag-evaluation context on the evaluation thread before enqueue, including field, length, width, depth, cycle, and visited-node limits. It also normalizes caller values and evaluation time, fixes canonical UTF-8 key encoding, isolates per-row serialization failures, adds truncation/drop telemetry, and tightens the relevant RBS types.

This PR now also makes the flag-evaluation background writer event-driven under load: a successful enqueue wakes an idle worker, and a non-empty backlog is drained in consecutive bounded batches without another 100 ms wait. The 4,096-entry queue, non-blocking drop-and-count behavior, 1,024-event batch bound, flush-deadline checks, and shutdown final drain remain unchanged.

## **Motivation**

Caller-owned context can be mutable, cyclic, malformed, or adversarially large, and one serialization failure should not discard an entire flush. This establishes a safe aggregation pipeline before privacy policy behavior is layered on top in https://github.com/DataDog/dd-trace-rb/pull/6222 and aligns the truncation logic with other SDKs like `dd-trace-java` and `dd-trace-go`.

The Ruby worker previously waited 100 ms before every bounded drain, including while work remained queued. In a 12,000-evaluation burst this filled the hand-off queue before the aggregator reached its 10,000-bucket per-flag cap, so evaluations were dropped instead of entering the degraded tier. Waking on enqueue and skipping waits while backlogged aligns Ruby's scheduling more closely with the continuously consuming Go and Java workers without adding backpressure to evaluation threads.

## **Change log entry**

None. This hardens internal flag-evaluation aggregation and worker scheduling without changing the public OpenFeature evaluation API.

## **How to test the change?**

Run `docker compose run --rm --no-deps tracer-4.0 /bin/bash -lc 'bundle exec rake standard && bundle exec rake steep:check && bundle exec rake test:open_feature'`.

Local results:

- Latest and minimum OpenFeature gemfiles: **256 examples, 0 failures** each.
- Focused Ruby system-tests EVP suite: **9 passed, 2 expected PII-protection failures**. The degradation test accounted for all 12,000 evaluations as 10,000 full evaluations plus one degraded bucket containing the remaining 2,000, with no queue-overflow/drop telemetry.
- Focused Ruby parametric FFE suite: **24 passed, 22 xfailed, 25 xpassed, 0 failed**.
- Existing enqueue benchmark, compared with the previous PR head: no material regression (approximately -1.1% typical, -1.2% scale, and +0.5% stress; within run-to-run noise).
