### PR TITLE
Protect OpenFeature flag evaluation data [FFL-2963]

### DIFF
--- a/benchmarks/open_feature_flagevaluation.rb
+++ b/benchmarks/open_feature_flagevaluation.rb
@@ -65,6 +65,7 @@ class OpenFeatureFlagevaluationBenchmark
     @details = HookDetails.new("variant-on", "TARGETING_MATCH", nil, {
       "__dd_allocation_key" => "allocation-7",
       "dd.eval.timestamp_ms" => 1_760_000_000_000,
+      Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true,
     })
 
     @attrs_by_profile = BENCHMARK_PROFILES.each_with_object({}) do |profile, attrs_by_profile|
@@ -145,6 +146,7 @@ class OpenFeatureFlagevaluationBenchmark
             targeting_key: targeting_keys[counter % targeting_keys.length],
             eval_time_ms: 1_760_000_000_000 + counter,
             attrs: attrs,
+            observe_full_evaluation_data: true,
           )
           counter += 1
         end
@@ -185,6 +187,7 @@ class OpenFeatureFlagevaluationBenchmark
               targeting_key: targeting_keys[counter % targeting_keys.length],
               eval_time_ms: 1_760_000_000_000 + counter,
               attrs: attrs,
+              observe_full_evaluation_data: true,
             )
             counter += worker_count
           end

--- a/lib/datadog/open_feature/evaluation_engine.rb
+++ b/lib/datadog/open_feature/evaluation_engine.rb
@@ -23,17 +23,29 @@ module Datadog
       end
 
       def fetch_value(flag_key, default_value:, expected_type:, evaluation_context: nil)
+        # Pre-bound to the safe default so the rescue below can still read it if the
+        # evaluator read itself raises.
+        observe_full_evaluation_data = false
+        # Snapshot the evaluator once: a concurrent reconfigure! must not retroactively
+        # apply a different environment's full-evaluation-data policy to this evaluation.
+        evaluator = @evaluator
+        observe_full_evaluation_data = evaluator.observe_full_evaluation_data == true
+
         unless ALLOWED_TYPES.include?(expected_type)
           message = "unknown type #{expected_type.inspect}, allowed types #{ALLOWED_TYPES.join(", ")}"
-          return ResolutionDetails.build_error(
+          result = ResolutionDetails.build_error(
             value: default_value, error_code: Ext::UNKNOWN_TYPE, error_message: message
           )
+
+          return with_observe_full_evaluation_data(result, observe_full_evaluation_data)
         end
 
         context = evaluation_context&.fields.to_h
-        result = @evaluator.get_assignment(
+        result = evaluator.get_assignment(
           flag_key, default_value: default_value, context: context, expected_type: expected_type
         )
+
+        result = with_observe_full_evaluation_data(result, observe_full_evaluation_data)
 
         @reporter.report(result, flag_key: flag_key, context: evaluation_context)
 
@@ -41,9 +53,12 @@ module Datadog
       rescue => e
         @telemetry.report(e, description: "OpenFeature: Failed to fetch flag value")
 
-        ResolutionDetails.build_error(
+        result = ResolutionDetails.build_error(
           value: default_value, error_code: Ext::GENERAL, error_message: "#{e.class}: #{e.message}"
         )
+        # `== true` is load-bearing: Steep types this local as `(nil | bool)` in a rescue
+        # body, and coercing at the use site is what narrows it to `bool`.
+        with_observe_full_evaluation_data(result, observe_full_evaluation_data == true)
       end
 
       # NOTE: In a currect implementation configuration is expected to be a raw
@@ -64,6 +79,17 @@ module Datadog
         @telemetry.report(e, description: "#{message} (#{e.class})")
 
         raise ReconfigurationError, "#{e.class}: #{e.message}"
+      end
+
+      private
+
+      # Stamps observe_full_evaluation_data onto the result metadata so the hook
+      # reads it from the event, not live config.
+      def with_observe_full_evaluation_data(result, observe_full_evaluation_data)
+        result = result.dup if result.frozen?
+        metadata = result.flag_metadata ||= {}
+        metadata[Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA] = observe_full_evaluation_data
+        result
       end
     end
   end

--- a/lib/datadog/open_feature/ext.rb
+++ b/lib/datadog/open_feature/ext.rb
@@ -11,11 +11,30 @@ module Datadog
       GENERAL = "GENERAL"
       PROVIDER_FATAL = "PROVIDER_FATAL"
       PROVIDER_NOT_READY = "PROVIDER_NOT_READY"
+      FLAG_NOT_FOUND = "FLAG_NOT_FOUND"
+      TYPE_MISMATCH = "TYPE_MISMATCH"
+      TARGETING_KEY_MISSING = "TARGETING_KEY_MISSING"
+      INVALID_CONTEXT = "INVALID_CONTEXT"
+
+      STANDARD_ERROR_CODES = [
+        PROVIDER_NOT_READY,
+        FLAG_NOT_FOUND,
+        PARSE_ERROR,
+        TYPE_MISMATCH,
+        TARGETING_KEY_MISSING,
+        INVALID_CONTEXT,
+        PROVIDER_FATAL,
+        GENERAL,
+      ].freeze
 
       # Flag-metadata key under which the provider threads the assignment's
       # allocation key to the flag-evaluation hooks. The wire string is the
       # value so the writer (provider) and readers (EVP/metrics hooks) can't drift.
       METADATA_ALLOCATION_KEY = "__dd_allocation_key"
+
+      # Stamped from the UFC the evaluation ran against; the hook reads only this
+      # key, never live config.
+      METADATA_OBSERVE_FULL_EVALUATION_DATA = "__dd_observe_full_evaluation_data"
     end
   end
 end

--- a/lib/datadog/open_feature/flag_evaluation/aggregator.rb
+++ b/lib/datadog/open_feature/flag_evaluation/aggregator.rb
@@ -8,16 +8,18 @@ module Datadog
       # Two-tier aggregation for EVP flagevaluation events.
       #
       # Two-tier design:
-      # - full-tier  key: (flag_key, variant, allocation_key, runtime_default, error_message, targeting_key, canonical_context_key)
+      # - full-tier key: (flag_key, variant, allocation_key, runtime_default, error_message,
+      #   targeting_key, canonical_context_key, observe_full_evaluation_data)
       # - degraded-tier key: (flag_key, variant, allocation_key, runtime_default, error_message)
       # - Drop-and-count when degraded tier is full
       # - canonical_context_key: sorted type-tagged length-delimited encoding (no hash digest)
       # - Caps: global_cap=131_072 / per_flag_cap=10_000 / degraded_cap=32_768
       #
-      # The writer applies `bounded_context_snapshot` on the evaluation thread before
-      # enqueue, so the queue only holds an already-bounded, flattened snapshot.
+      # Context bounding: the writer applies `bounded_context_snapshot` on the evaluation
+      # thread before enqueue, so the queue only ever holds an already-bounded, flattened
+      # snapshot. `record` receives that snapshot and keys on it directly.
       class Aggregator
-        # Cross-SDK context caps (RFC: "Kept aligned with the cross-SDK RFC").
+        # Cross-SDK context caps. The per-dimension caps match Go and Java.
         MAX_CONTEXT_FIELDS = 256
         MAX_VALUE_LENGTH = 256
         MAX_KEY_LENGTH = 256
@@ -25,9 +27,9 @@ module Datadog
         MAX_STRUCTURE_PROPERTIES = 256
         MAX_SNAPSHOT_DEPTH = 4
 
-        # The per-dimension caps match Go and Java. This additional total-node budget
-        # bounds leaf-free shared subtrees, which do not increase the retained field count.
-        # It still permits every retained field to sit at the maximum snapshot depth.
+        # Total-node budget bounding leaf-free shared subtrees, which do not increase the
+        # retained field count. It still permits every retained field to sit at the
+        # maximum snapshot depth.
         MAX_VISITED_NODES = MAX_CONTEXT_FIELDS * (MAX_SNAPSHOT_DEPTH + 1)
 
         # Truncation reason labels, surfaced on the `flagevaluation.context.truncated`
@@ -86,33 +88,43 @@ module Datadog
         # Record one evaluation event. Thread-safe. Called from the background writer.
         def record(
           flag_key:, variant:, allocation_key:, targeting_key:, eval_time_ms:, attrs:, error_message: nil,
-          runtime_default: nil
+          runtime_default: nil, observe_full_evaluation_data: false
         )
           runtime_default = variant.nil? if runtime_default.nil?
           runtime_default = !!runtime_default
+          # Runtime defaults have no resolved variant or allocation in the EVP schema.
+          if runtime_default
+            variant = nil
+            allocation_key = nil
+          end
+          observe_full_evaluation_data = !!observe_full_evaluation_data
 
-          # Normalize nil/empty strings
+          # Preserve targeting-key presence; other dimensions use empty strings.
           variant = variant.to_s
           allocation_key = allocation_key.to_s
           error_message = error_message.to_s
-          targeting_key = targeting_key.to_s
+          targeting_key = targeting_key.to_s unless targeting_key.nil?
 
-          context_key = canonical_context_key(attrs)
+          context_key = observe_full_evaluation_data ? canonical_context_key(attrs) : nil
           # @type var full_key: full_key
-          full_key = [flag_key, variant, allocation_key, runtime_default, error_message, targeting_key, context_key]
+          full_key = [
+            flag_key, variant, allocation_key, runtime_default, error_message,
+            targeting_key, context_key, observe_full_evaluation_data,
+          ]
           evaluation_time_ms = eval_time_ms.to_i
 
           @mutex.synchronize do
             # --- Full tier ---
             if (entry = @full[full_key])
-              observe(entry, evaluation_time_ms)
+              observe(entry, evaluation_time_ms, observe_full_evaluation_data)
               return
             end
 
             per_flag_count = @per_flag_full[flag_key]
             if per_flag_count >= @per_flag_cap
               add_to_degraded(
-                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms,
+                observe_full_evaluation_data
               )
               return
             end
@@ -127,14 +139,16 @@ module Datadog
                 runtime_default: runtime_default,
                 error_message: error_message,
                 targeting_key: targeting_key,
-                context_attrs: attrs
+                context_attrs: observe_full_evaluation_data ? attrs : nil,
+                observe_full_evaluation_data: observe_full_evaluation_data
               )
               @full[full_key] = entry
               @global_count += 1
             else
               # Route to degraded tier
               add_to_degraded(
-                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+                flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms,
+                observe_full_evaluation_data
               )
             end
           end
@@ -164,12 +178,10 @@ module Datadog
         # Returns the flattened (dot-notation) context and the truncation reasons hit,
         # which the writer surfaces on the `flagevaluation.context.truncated` counter.
         #
-        # Work is bounded by the field and structure caps. Ruby Hash iteration is
-        # deterministic insertion order, so traversal stops at the limits instead of
-        # sorting or scanning the full input. This is the cross-SDK recommendation for
-        # languages with deterministic iteration (Ruby truncates; Go omits because its map
-        # iteration is randomized per call).
-        def self.bounded_context_snapshot(attrs)
+        # Ruby Hash insertion order lets traversal stop at the caps without sorting
+        # or scanning the complete input. Ruby therefore truncates where Go omits,
+        # whose map iteration is randomized per call.
+        def self.bounded_context_snapshot(attrs, excluded_key: nil)
           return [{}, []] unless attrs.is_a?(Hash) && !attrs.empty?
 
           flattened = {}
@@ -181,6 +193,7 @@ module Datadog
           attrs.each do |key, value|
             key = context_key_string(key)
             next unless key
+            next if key == excluded_key
 
             if flattened.size >= MAX_CONTEXT_FIELDS
               reasons << REASON_MAX_CONTEXT_FIELDS
@@ -373,7 +386,10 @@ module Datadog
           length_bytes + bytes
         end
 
-        def new_entry(evaluation_time_ms, runtime_default:, error_message: nil, targeting_key: nil, context_attrs: nil)
+        def new_entry(
+          evaluation_time_ms, runtime_default:, observe_full_evaluation_data:, error_message: nil,
+          targeting_key: nil, context_attrs: nil
+        )
           {
             count: 1,
             first_evaluation: evaluation_time_ms,
@@ -382,23 +398,26 @@ module Datadog
             error_message: error_message,
             targeting_key: targeting_key,
             context_attrs: context_attrs,
+            observe_full_evaluation_data: observe_full_evaluation_data,
           }
         end
 
-        def observe(entry, evaluation_time_ms)
+        def observe(entry, evaluation_time_ms, observe_full_evaluation_data)
           entry[:count] += 1
           entry[:first_evaluation] = evaluation_time_ms if evaluation_time_ms < entry[:first_evaluation]
           entry[:last_evaluation] = evaluation_time_ms if evaluation_time_ms > entry[:last_evaluation]
+          entry[:observe_full_evaluation_data] &&= observe_full_evaluation_data
         end
 
         def add_to_degraded(
-          flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms
+          flag_key, variant, allocation_key, runtime_default, error_message, evaluation_time_ms,
+          observe_full_evaluation_data
         )
           # @type var degraded_key: degraded_key
           degraded_key = [flag_key, variant, allocation_key, runtime_default, error_message]
 
           if (entry = @degraded[degraded_key])
-            observe(entry, evaluation_time_ms)
+            observe(entry, evaluation_time_ms, observe_full_evaluation_data)
             return
           end
 
@@ -413,7 +432,8 @@ module Datadog
           @degraded[degraded_key] = new_entry(
             evaluation_time_ms,
             runtime_default: runtime_default,
-            error_message: error_message
+            error_message: error_message,
+            observe_full_evaluation_data: observe_full_evaluation_data
           )
         end
       end

--- a/lib/datadog/open_feature/flag_evaluation/writer.rb
+++ b/lib/datadog/open_feature/flag_evaluation/writer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "digest"
+
 require_relative "aggregator"
+require_relative "../ext"
 require_relative "../../core/encoding"
 require_relative "../../core/evp"
 require_relative "../../core/utils/time"
@@ -43,6 +46,14 @@ module Datadog
         REASON_SERIALIZATION_ERROR = "serialization_error"
         REASON_SNAPSHOT_ERROR = "snapshot_error"
 
+        # Must equal OpenFeature::SDK::EvaluationContext::TARGETING_KEY. Duplicated as a
+        # literal rather than referenced because the SDK is an optional dependency and
+        # this file loads without it. If the two drift, the targeting key stops being
+        # excluded from the context snapshot and lands in context.evaluation as raw PII,
+        # so a spec asserts the equality.
+        TARGETING_KEY_FIELD = "targeting_key"
+        TARGETING_KEY_HASH_PREFIX = "sha256_"
+
         # Service context fields for the batch wrapper.
         attr_reader :service_context
 
@@ -73,7 +84,8 @@ module Datadog
         # Non-blocking enqueue from the finally hook. Drops + counts on overflow.
         def enqueue(
           flag_key:, eval_time_ms:, variant: nil, allocation_key: nil, error_message: nil,
-          runtime_default: nil, targeting_key: nil, attrs: nil, **_event
+          runtime_default: nil, targeting_key: nil, attrs: nil, observe_full_evaluation_data: false,
+          **_event
         )
           start_background_thread if forked?
 
@@ -83,23 +95,24 @@ module Datadog
             return
           end
 
-          attrs = snapshot_context(attrs)
+          observe_full_evaluation_data = observe_full_evaluation_data == true
+          attrs = observe_full_evaluation_data ? snapshot_context(attrs) : nil
           bounded_event = {
             flag_key: snapshot_string(flag_key),
             variant: snapshot_string(variant),
             allocation_key: snapshot_string(allocation_key),
-            error_message: snapshot_string(error_message),
+            error_message: normalized_error_code(error_message),
             runtime_default: runtime_default,
             targeting_key: snapshot_targeting_key(targeting_key),
             eval_time_ms: snapshot_integer(eval_time_ms),
             attrs: attrs,
+            observe_full_evaluation_data: observe_full_evaluation_data,
           }
           @queue.push(bounded_event, true)
           @stop_mutex.synchronize { @stop_cond.signal }
           start_background_thread unless running?
         rescue ThreadError
-          # Queue full — drop and count (best-effort, same as Go: drop-and-count). The count is
-          # emitted on the next flush so backpressure is observable, not silently lost.
+          # Report queue backpressure on the next flush.
           @stop_mutex.synchronize { @dropped_queue_overflow += 1 }
         end
 
@@ -136,7 +149,7 @@ module Datadog
         def snapshot_context(attrs)
           return {} unless attrs.is_a?(Hash)
 
-          snapshot, reasons = Aggregator.bounded_context_snapshot(attrs)
+          snapshot, reasons = Aggregator.bounded_context_snapshot(attrs, excluded_key: TARGETING_KEY_FIELD)
           unless reasons.empty?
             @stop_mutex.synchronize { reasons.each { |reason| @context_truncated_counts[reason] += 1 } }
           end
@@ -192,6 +205,15 @@ module Datadog
           integer.is_a?(Integer) ? integer : 0
         rescue
           0
+        end
+
+        def normalized_error_code(value)
+          error_code = snapshot_string(value)
+          # Preserve absence so evaluations without errors omit the error field.
+          return error_code if !error_code || error_code.empty?
+          return error_code if Ext::STANDARD_ERROR_CODES.include?(error_code)
+
+          Ext::GENERAL
         end
 
         def start_background_thread
@@ -257,9 +279,10 @@ module Datadog
                 allocation_key: event[:allocation_key],
                 targeting_key: event[:targeting_key],
                 eval_time_ms: event[:eval_time_ms].to_i,
-                attrs: event[:attrs].is_a?(Hash) ? event[:attrs] : {},
+                attrs: event[:attrs],
                 error_message: event[:error_message],
                 runtime_default: event[:runtime_default],
+                observe_full_evaluation_data: event[:observe_full_evaluation_data],
               )
               drained += 1
             rescue ThreadError
@@ -336,7 +359,7 @@ module Datadog
           events = []
 
           snapshot[:full].each do |key, entry|
-            flag_key, variant, allocation_key, _runtime_default, _error_message, targeting_key, _ctx_key = key
+            flag_key, variant, allocation_key, _runtime_default, _error_message, targeting_key, _ctx_key, _observe_full_evaluation_data = key
             event = build_event(
               flag_key: flag_key, variant: variant, allocation_key: allocation_key,
               targeting_key: targeting_key, entry: entry, flush_time_ms: flush_time_ms, tier: :full,
@@ -344,8 +367,9 @@ module Datadog
             events << event
           end
 
+          # Degraded rows omit targeting_key and context, so the policy is not a key dimension.
           snapshot[:degraded].each do |key, entry|
-            flag_key, variant, allocation_key, _runtime_default, _error_message = key
+            flag_key, variant, allocation_key, _runtime_default, _error_dimension = key
             event = build_event(
               flag_key: flag_key, variant: variant, allocation_key: allocation_key,
               targeting_key: nil, entry: entry, flush_time_ms: flush_time_ms, tier: :degraded,
@@ -356,7 +380,10 @@ module Datadog
           events
         end
 
-        def build_event(flag_key:, variant:, allocation_key:, targeting_key:, entry:, flush_time_ms:, tier:)
+        def build_event(
+          flag_key:, variant:, allocation_key:, targeting_key:, entry:, flush_time_ms:, tier:
+        )
+          observe_full_evaluation_data = entry[:observe_full_evaluation_data]
           # @type var event: ::Hash[::String, any]
           event = {
             "timestamp" => flush_time_ms,
@@ -368,6 +395,7 @@ module Datadog
 
           event["runtime_default_used"] = true if entry[:runtime_default]
 
+          # EVP uses the normalized code as error.message and an aggregation dimension.
           error_message = entry[:error_message]
           if error_message && !error_message.empty?
             event["error"] = {"message" => error_message}
@@ -380,14 +408,29 @@ module Datadog
           # Full-tier additionally carries targeting_key and the truncated evaluation context;
           # the degraded tier omits both.
           if tier == :full
-            event["targeting_key"] = targeting_key if targeting_key && !targeting_key.empty?
+            unless targeting_key.nil?
+              event["targeting_key"] =
+                if targeting_key.empty? || observe_full_evaluation_data
+                  targeting_key
+                else
+                  prefixed_targeting_key_digest(targeting_key)
+                end
+            end
 
-            if entry[:context_attrs] && !entry[:context_attrs].empty?
+            if observe_full_evaluation_data && entry[:context_attrs] && !entry[:context_attrs].empty?
               event["context"] = {"evaluation" => entry[:context_attrs]}
             end
           end
 
           event
+        end
+
+        # Encode to UTF-8 first so Ruby encodings do not change the digest.
+        # Distinct from SpanEnrichmentHook::Codec.hash_targeting_key, which emits a
+        # bare digest for a different wire format on the span track.
+        def prefixed_targeting_key_digest(targeting_key)
+          utf8 = targeting_key.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+          TARGETING_KEY_HASH_PREFIX + Digest::SHA256.hexdigest(utf8)
         end
 
         def send_payload_batches(events)

--- a/lib/datadog/open_feature/hooks/flag_eval_evp_hook.rb
+++ b/lib/datadog/open_feature/hooks/flag_eval_evp_hook.rb
@@ -15,8 +15,6 @@ module Datadog
       # stay on the OTel path. This hook is registered as a provider hook so it receives
       # the SDK-final EvaluationDetails after hook failures and type validation.
       class FlagEvalEVPHook
-        TYPE_MISMATCH_ERROR_CODE = "TYPE_MISMATCH"
-
         # Include the Hook module if available (SDK >= 0.5.0) for interface documentation
         # and default implementations of other hook methods (before, after, error)
         include ::OpenFeature::SDK::Hooks::Hook if defined?(::OpenFeature::SDK::Hooks::Hook)
@@ -42,15 +40,31 @@ module Datadog
           eval_time_ms = metadata.is_a?(Hash) ? metadata["dd.eval.timestamp_ms"] : nil
           eval_time_ms ||= (Core::Utils::Time.now.to_f * 1000).to_i
 
+          # observe_full_evaluation_data travels on the event metadata (stamped from
+          # the UFC the evaluation ran against), never read from live config.
+          observe_full_evaluation_data = metadata.is_a?(Hash) ? metadata[Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA] : nil
+          observe_full_evaluation_data = false unless observe_full_evaluation_data == true
+
+          attrs = if observe_full_evaluation_data
+            extract_attributes(hook_context.evaluation_context)
+          end
+
+          # Raw messages may contain high-cardinality data, so only error codes enter EVP.
+          reason = evaluation_details.reason.to_s
+          runtime_default = runtime_default_reason?(reason)
+          error_code = evaluation_details.error_code
+          error_code = Ext::GENERAL if reason == Ext::ERROR && error_code.to_s.empty?
+
           writer.enqueue(
             flag_key: hook_context.flag_key,
-            variant: evaluation_details.variant,
-            allocation_key: extract_allocation_key(evaluation_details),
-            error_message: extract_error_message(evaluation_details),
-            runtime_default: runtime_default?(evaluation_details),
+            variant: runtime_default ? nil : evaluation_details.variant,
+            allocation_key: runtime_default ? nil : extract_allocation_key(evaluation_details),
+            error_message: error_code,
+            runtime_default: runtime_default,
             targeting_key: extract_targeting_key(hook_context.evaluation_context),
             eval_time_ms: eval_time_ms,
-            attrs: extract_attributes(hook_context.evaluation_context),
+            attrs: attrs,
+            observe_full_evaluation_data: observe_full_evaluation_data,
           )
         end
 
@@ -72,9 +86,7 @@ module Datadog
           return {} unless evaluation_context.respond_to?(:fields)
 
           fields = evaluation_context.fields
-          return {} unless fields.is_a?(Hash)
-
-          fields.reject { |k, _| k.to_s == ::OpenFeature::SDK::EvaluationContext::TARGETING_KEY }
+          fields.is_a?(Hash) ? fields : {}
         end
 
         def extract_allocation_key(evaluation_details)
@@ -84,17 +96,8 @@ module Datadog
           metadata[Ext::METADATA_ALLOCATION_KEY]
         end
 
-        def extract_error_message(evaluation_details)
-          return unless evaluation_details.respond_to?(:error_message)
-
-          evaluation_details.error_message
-        end
-
-        def runtime_default?(evaluation_details)
-          return true if evaluation_details.variant.nil?
-          return false unless evaluation_details.respond_to?(:error_code)
-
-          evaluation_details.error_code.to_s == TYPE_MISMATCH_ERROR_CODE
+        def runtime_default_reason?(reason)
+          reason == Ext::DEFAULT || reason == Ext::ERROR
         end
       end
     end

--- a/lib/datadog/open_feature/native_evaluator.rb
+++ b/lib/datadog/open_feature/native_evaluator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require_relative "../core/feature_flags"
 require_relative "ext"
 require_relative "resolution_details"
@@ -15,7 +16,10 @@ module Datadog
       #       in the format expected by `libdatadog` without any modifications
       def initialize(configuration)
         @configuration = Core::FeatureFlags::Configuration.new(configuration)
+        @observe_full_evaluation_data = parse_observe_full_evaluation_data(configuration)
       end
+
+      attr_reader :observe_full_evaluation_data
 
       # Returns the assignment for a given flag key based on the feature flags
       # configuration
@@ -27,20 +31,43 @@ module Datadog
       # @param context [Hash] The context of the evaluation, containing targeting key
       #                       and other attributes
       #
-      # @return [Core::FeatureFlags::ResolutionDetails] The assignment for the flag
+      # @return [ResolutionDetails] The assignment for the flag
       def get_assignment(flag_key, default_value:, expected_type:, context:)
         result = @configuration.get_assignment(flag_key, expected_type, context)
 
         return invalid_flag_configuration_error(default_value) if invalid_flag_configuration?(result)
 
-        # NOTE: This is a special case when we need to fallback to the default
-        #       value, even tho the evaluation itself doesn't produce an error
-        #       resolution details
-        result.value = default_value if result.variant.nil?
-        result
+        build_resolution_details(result, default_value)
       end
 
       private
+
+      # Parse observe_full_evaluation_data from the top level of the UFC JSON (a sibling
+      # of `environment`). Absent, null, or wrong-typed values return false.
+      def parse_observe_full_evaluation_data(configuration)
+        return false unless configuration.is_a?(String) && !configuration.empty?
+
+        parsed = JSON.parse(configuration)
+        parsed.is_a?(Hash) && parsed["observeFullEvaluationData"] == true
+      rescue
+        # This secondary policy parse must not reject configuration accepted by the native evaluator.
+        false
+      end
+
+      def build_resolution_details(result, default_value)
+        ResolutionDetails.new(
+          value: result.variant.nil? ? default_value : result.value,
+          reason: result.reason,
+          variant: result.variant,
+          error_code: result.error_code,
+          error_message: result.error_message,
+          flag_metadata: result.flag_metadata,
+          allocation_key: result.allocation_key,
+          serial_id: result.serial_id,
+          log?: result.log?,
+          error?: result.error?,
+        )
+      end
 
       def invalid_flag_configuration?(result)
         result.reason == Ext::DEFAULT &&

--- a/lib/datadog/open_feature/noop_evaluator.rb
+++ b/lib/datadog/open_feature/noop_evaluator.rb
@@ -7,6 +7,11 @@ module Datadog
   module OpenFeature
     # This class is a noop interface of evaluation logic
     class NoopEvaluator
+      # Privacy-preserving default before configuration is present.
+      def observe_full_evaluation_data
+        false
+      end
+
       def initialize(_configuration)
         # no-op
       end

--- a/lib/datadog/open_feature/provider.rb
+++ b/lib/datadog/open_feature/provider.rb
@@ -112,6 +112,7 @@ module Datadog
         # Stamp evaluation entry time once, here on the eval thread. The EVP path uses this for
         # accurate first/last_evaluation bounds instead of a later hook-fire clock read.
         eval_time_ms = (Core::Utils::Time.now.to_f * 1000).to_i
+        flag_meta = nil
 
         engine = OpenFeature.engine
         return component_not_configured_default(default_value, eval_time_ms) if engine.nil?
@@ -138,7 +139,10 @@ module Datadog
           error_code: Ext::GENERAL,
           error_message: error_message
         )
-        error_flag_meta = build_flag_metadata(error_result, eval_time_ms || (Core::Utils::Time.now.to_f * 1000).to_i)
+        error_flag_meta = flag_meta
+        error_flag_meta ||= build_flag_metadata(
+          error_result, eval_time_ms || (Core::Utils::Time.now.to_f * 1000).to_i
+        )
 
         sdk_error_details(default_value, Ext::GENERAL, error_message, Ext::ERROR, error_flag_meta)
       end
@@ -173,6 +177,8 @@ module Datadog
 
       def build_flag_metadata(result, eval_time_ms)
         metadata = result.flag_metadata&.dup || {}
+        metadata[Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA] =
+          metadata[Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA] == true
         allocation_key = result.allocation_key
         metadata[Ext::METADATA_ALLOCATION_KEY] = allocation_key if allocation_key && !allocation_key.empty?
 
@@ -218,7 +224,10 @@ module Datadog
           error_code: Ext::PROVIDER_FATAL,
           error_message: "Datadog's OpenFeature component must be configured",
           reason: Ext::ERROR,
-          flag_metadata: {"dd.eval.timestamp_ms" => eval_time_ms}
+          flag_metadata: {
+            "dd.eval.timestamp_ms" => eval_time_ms,
+            Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => false,
+          }
         )
       end
     end

--- a/sig/datadog/open_feature/evaluation_engine.rbs
+++ b/sig/datadog/open_feature/evaluation_engine.rbs
@@ -22,9 +22,16 @@ module Datadog
         default_value: untyped,
         expected_type: ::Symbol,
         ?evaluation_context: ::OpenFeature::SDK::EvaluationContext?
-      ) -> (ResolutionDetails | Core::FeatureFlags::ResolutionDetails)
+      ) -> ResolutionDetails
 
       def reconfigure!: (::String? configuration) -> void
+
+      private
+
+      def with_observe_full_evaluation_data: (
+        ResolutionDetails result,
+        bool observe_full_evaluation_data
+      ) -> ResolutionDetails
     end
   end
 end

--- a/sig/datadog/open_feature/exposures/event.rbs
+++ b/sig/datadog/open_feature/exposures/event.rbs
@@ -9,19 +9,19 @@ module Datadog
         TARGETING_KEY_FIELD: ::String
 
         def self.cache_key: (
-          ResolutionDetails | Core::FeatureFlags::ResolutionDetails result,
+          ResolutionDetails result,
           flag_key: ::String,
           context: ::OpenFeature::SDK::EvaluationContext
         ) -> ::String
 
         def self.cache_value: (
-          ResolutionDetails | Core::FeatureFlags::ResolutionDetails result,
+          ResolutionDetails result,
           flag_key: ::String,
           context: ::OpenFeature::SDK::EvaluationContext
         ) -> ::String
 
         def self.build: (
-          ResolutionDetails | Core::FeatureFlags::ResolutionDetails result,
+          ResolutionDetails result,
           flag_key: ::String,
           context: ::OpenFeature::SDK::EvaluationContext
         ) -> t

--- a/sig/datadog/open_feature/exposures/reporter.rbs
+++ b/sig/datadog/open_feature/exposures/reporter.rbs
@@ -13,7 +13,7 @@ module Datadog
         def initialize: (Worker worker, telemetry: Core::Telemetry::Component, logger: Core::Logger) -> void
 
         def report: (
-          ResolutionDetails | Core::FeatureFlags::ResolutionDetails result,
+          ResolutionDetails result,
           flag_key: ::String,
           context: ::OpenFeature::SDK::EvaluationContext?
         ) -> bool

--- a/sig/datadog/open_feature/ext.rbs
+++ b/sig/datadog/open_feature/ext.rbs
@@ -17,7 +17,19 @@ module Datadog
 
       PROVIDER_NOT_READY: ::String
 
+      FLAG_NOT_FOUND: ::String
+
+      TYPE_MISMATCH: ::String
+
+      TARGETING_KEY_MISSING: ::String
+
+      INVALID_CONTEXT: ::String
+
+      STANDARD_ERROR_CODES: ::Array[::String]
+
       METADATA_ALLOCATION_KEY: ::String
+
+      METADATA_OBSERVE_FULL_EVALUATION_DATA: ::String
     end
   end
 end

--- a/sig/datadog/open_feature/flag_evaluation/aggregator.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/aggregator.rbs
@@ -5,7 +5,7 @@ module Datadog
         type context_value = ::String | bool | ::Integer | ::Float
         type context = ::Hash[::String, context_value]
         type raw_context = ::Hash[any, any]
-        type full_key = [::String, ::String, ::String, bool, ::String, ::String, ::String]
+        type full_key = [::String, ::String, ::String, bool, ::String, ::String?, ::String?, bool]
         type degraded_key = [::String, ::String, ::String, bool, ::String]
         type entry = {
           count: ::Integer,
@@ -14,7 +14,8 @@ module Datadog
           runtime_default: bool,
           error_message: ::String?,
           targeting_key: ::String?,
-          context_attrs: context?
+          context_attrs: context?,
+          observe_full_evaluation_data: bool
         }
         type snapshot = {
           full: ::Hash[full_key, entry],
@@ -118,12 +119,16 @@ module Datadog
           eval_time_ms: ::Integer,
           attrs: context?,
           ?error_message: ::String?,
-          ?runtime_default: bool?
+          ?runtime_default: bool?,
+          ?observe_full_evaluation_data: bool
         ) -> void
 
         def flush_and_reset: () -> snapshot
 
-        def self.bounded_context_snapshot: (raw_context? attrs) -> [context, ::Array[::String]]
+        def self.bounded_context_snapshot: (
+          raw_context? attrs,
+          ?excluded_key: ::String?
+        ) -> [context, ::Array[::String]]
 
         def canonical_context_key: (context? attrs) -> ::String
 
@@ -148,12 +153,13 @@ module Datadog
         def new_entry: (
           ::Integer evaluation_time_ms,
           runtime_default: bool,
+          observe_full_evaluation_data: bool,
           ?error_message: ::String?,
           ?targeting_key: ::String?,
           ?context_attrs: context?
         ) -> entry
 
-        def observe: (entry entry, ::Integer evaluation_time_ms) -> void
+        def observe: (entry entry, ::Integer evaluation_time_ms, bool observe_full_evaluation_data) -> void
 
         def add_to_degraded: (
           ::String flag_key,
@@ -161,7 +167,8 @@ module Datadog
           ::String allocation_key,
           bool runtime_default,
           ::String error_message,
-          ::Integer evaluation_time_ms
+          ::Integer evaluation_time_ms,
+          bool observe_full_evaluation_data
         ) -> void
       end
     end

--- a/sig/datadog/open_feature/flag_evaluation/writer.rbs
+++ b/sig/datadog/open_feature/flag_evaluation/writer.rbs
@@ -42,6 +42,10 @@ module Datadog
 
         REASON_SNAPSHOT_ERROR: ::String
 
+        TARGETING_KEY_FIELD: ::String
+
+        TARGETING_KEY_HASH_PREFIX: ::String
+
         @transport: Transport::HTTP
 
         @logger: Core::Logger
@@ -87,6 +91,7 @@ module Datadog
           ?runtime_default: bool?,
           ?targeting_key: any,
           ?attrs: Aggregator::raw_context?,
+          ?observe_full_evaluation_data: bool,
           **any event
         ) -> void
 
@@ -103,6 +108,7 @@ module Datadog
         def snapshot_string: (any value) -> ::String?
         def snapshot_targeting_key: (any value) -> ::String?
         def snapshot_integer: (any value) -> ::Integer
+        def normalized_error_code: (any value) -> ::String?
 
         def start_background_thread: () -> void
 
@@ -139,6 +145,8 @@ module Datadog
           flush_time_ms: ::Integer,
           tier: ::Symbol
         ) -> event
+
+        def prefixed_targeting_key_digest: (::String targeting_key) -> ::String
 
         def send_payload_batches: (::Array[event] events) -> void
 

--- a/sig/datadog/open_feature/hooks/flag_eval_evp_hook.rbs
+++ b/sig/datadog/open_feature/hooks/flag_eval_evp_hook.rbs
@@ -4,8 +4,6 @@ module Datadog
       class FlagEvalEVPHook
         include ::OpenFeature::SDK::Hooks::Hook
 
-        TYPE_MISMATCH_ERROR_CODE: ::String
-
         @writer: FlagEvaluation::Writer?
 
         def self.available?: () -> bool
@@ -13,22 +11,20 @@ module Datadog
         def initialize: (FlagEvaluation::Writer? writer) -> void
 
         def finally: (
-          hook_context: untyped,
-          evaluation_details: untyped,
-          **untyped _opts
+          hook_context: ::OpenFeature::SDK::Hooks::HookContext,
+          evaluation_details: ::OpenFeature::SDK::EvaluationDetails,
+          **any _opts
         ) -> void
 
         private
 
-        def extract_targeting_key: (untyped evaluation_context) -> ::String?
+        def extract_targeting_key: (::OpenFeature::SDK::EvaluationContext? evaluation_context) -> ::String?
 
-        def extract_attributes: (untyped evaluation_context) -> ::Hash[::String, untyped]
+        def extract_attributes: (::OpenFeature::SDK::EvaluationContext? evaluation_context) -> ::Hash[::String, any]
 
-        def extract_allocation_key: (untyped evaluation_details) -> ::String?
+        def extract_allocation_key: (::OpenFeature::SDK::EvaluationDetails evaluation_details) -> ::String?
 
-        def extract_error_message: (untyped evaluation_details) -> ::String?
-
-        def runtime_default?: (untyped evaluation_details) -> bool
+        def runtime_default_reason?: (::String reason) -> bool
       end
     end
   end

--- a/sig/datadog/open_feature/native_evaluator.rbs
+++ b/sig/datadog/open_feature/native_evaluator.rbs
@@ -5,6 +5,10 @@ module Datadog
 
       @configuration: Core::FeatureFlags::Configuration
 
+      @observe_full_evaluation_data: bool
+
+      attr_reader observe_full_evaluation_data: bool
+
       def initialize: (::String configuration) -> void
 
       def get_assignment: (
@@ -12,9 +16,16 @@ module Datadog
         default_value: untyped,
         context: ::OpenFeature::SDK::EvaluationContext::fields_t,
         expected_type: ::Symbol
-      ) -> (Core::FeatureFlags::ResolutionDetails | ResolutionDetails)
+      ) -> ResolutionDetails
 
       private
+
+      def parse_observe_full_evaluation_data: (::String? configuration) -> bool
+
+      def build_resolution_details: (
+        Core::FeatureFlags::ResolutionDetails result,
+        untyped default_value
+      ) -> ResolutionDetails
 
       def invalid_flag_configuration?: (Core::FeatureFlags::ResolutionDetails result) -> bool
 

--- a/sig/datadog/open_feature/noop_evaluator.rbs
+++ b/sig/datadog/open_feature/noop_evaluator.rbs
@@ -9,6 +9,8 @@ module Datadog
         context: ::OpenFeature::SDK::EvaluationContext::fields_t,
         expected_type: ::Symbol
       ) -> ResolutionDetails
+
+      def observe_full_evaluation_data: () -> false
     end
   end
 end

--- a/sig/datadog/open_feature/provider.rbs
+++ b/sig/datadog/open_feature/provider.rbs
@@ -69,10 +69,10 @@ module Datadog
         ::OpenFeature::SDK::Provider::ResolutionDetails::value_t default_value,
         ::Symbol expected_type,
         ::OpenFeature::SDK::EvaluationContext? evaluation_context
-      ) -> (ResolutionDetails | Core::FeatureFlags::ResolutionDetails)
+      ) -> ResolutionDetails
 
       def sdk_success_details: (
-        (ResolutionDetails | Core::FeatureFlags::ResolutionDetails) result,
+        ResolutionDetails result,
         ::Hash[::String, untyped] flag_meta
       ) -> ::OpenFeature::SDK::Provider::ResolutionDetails
 
@@ -85,13 +85,13 @@ module Datadog
       ) -> ::OpenFeature::SDK::Provider::ResolutionDetails
 
       def build_flag_metadata: (
-        (ResolutionDetails | Core::FeatureFlags::ResolutionDetails) result,
+        ResolutionDetails result,
         ::Integer eval_time_ms
       ) -> ::Hash[::String, untyped]
 
       def enrich_span: (
         ::String flag_key,
-        (ResolutionDetails | Core::FeatureFlags::ResolutionDetails) result,
+        ResolutionDetails result,
         ::OpenFeature::SDK::EvaluationContext? evaluation_context
       ) -> void
 

--- a/spec/datadog/open_feature/evaluation_engine_spec.rb
+++ b/spec/datadog/open_feature/evaluation_engine_spec.rb
@@ -4,13 +4,19 @@ require "spec_helper"
 require "datadog/open_feature/evaluation_engine"
 
 RSpec.describe Datadog::OpenFeature::EvaluationEngine do
-  before { allow(Datadog::OpenFeature::NativeEvaluator).to receive(:new).and_return(evaluator) }
+  before do
+    allow(Datadog::OpenFeature::NativeEvaluator).to receive(:new).and_return(evaluator)
+    allow(evaluator).to receive(:observe_full_evaluation_data).and_return(false)
+  end
 
   let(:engine) { described_class.new(reporter, telemetry: telemetry, logger: logger) }
   let(:reporter) { instance_double(Datadog::OpenFeature::Exposures::Reporter) }
   let(:telemetry) { instance_double(Datadog::Core::Telemetry::Component) }
   let(:logger) { instance_double(Datadog::Core::Logger) }
   let(:evaluator) { instance_double(Datadog::OpenFeature::NativeEvaluator) }
+  let(:observe_full_evaluation_data_key) do
+    Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA
+  end
   let(:configuration) do
     <<~JSON
       {
@@ -50,6 +56,7 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
         expect(result.error_code).to eq("PROVIDER_NOT_READY")
         expect(result.error_message).to eq("Waiting for flags configuration")
         expect(result.reason).to eq("ERROR")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
       end
     end
 
@@ -79,6 +86,32 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
         expect(result.error_code).to eq("PROVIDER_FATAL")
         expect(result.error_message).to eq("Ooops")
         expect(result.reason).to eq("ERROR")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
+      end
+    end
+
+    context "when binding evaluator returns a frozen error" do
+      before do
+        allow(evaluator).to receive(:get_assignment).and_return(error)
+        engine.reconfigure!(configuration)
+      end
+
+      let(:error) do
+        Datadog::OpenFeature::ResolutionDetails.build_error(
+          value: "fallback",
+          error_code: Datadog::OpenFeature::Ext::PARSE_ERROR,
+          error_message: "invalid configuration"
+        )
+      end
+
+      it "preserves the error and stamps the evaluation metadata" do
+        expect(reporter).to receive(:report).with(
+          kind_of(Datadog::OpenFeature::ResolutionDetails), flag_key: "test", context: nil
+        )
+
+        expect(result.error_code).to eq("PARSE_ERROR")
+        expect(result.error_message).to eq("invalid configuration")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
       end
     end
 
@@ -99,6 +132,58 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
         expect(result.error_code).to eq("GENERAL")
         expect(result.error_message).to eq("RuntimeError: Crash")
         expect(result.reason).to eq("ERROR")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
+      end
+    end
+
+    context "when the evaluator changes while an error is returned" do
+      before do
+        allow(telemetry).to receive(:report)
+        allow(replacement_evaluator).to receive(:observe_full_evaluation_data).and_return(true)
+        allow(Datadog::OpenFeature::NativeEvaluator).to receive(:new).and_return(evaluator, replacement_evaluator)
+        allow(evaluator).to receive(:get_assignment) do
+          engine.reconfigure!(configuration)
+          raise error
+        end
+        engine.reconfigure!(configuration)
+      end
+
+      let(:replacement_evaluator) { instance_double(Datadog::OpenFeature::NativeEvaluator) }
+      let(:error) { RuntimeError.new("Crash") }
+
+      it "uses the policy snapshot from the evaluator that performed the evaluation" do
+        expect(evaluator).to receive(:observe_full_evaluation_data).once.and_return(false)
+        expect(replacement_evaluator).not_to receive(:observe_full_evaluation_data)
+        expect(reporter).not_to receive(:report)
+
+        expect(result.error_code).to eq("GENERAL")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
+      end
+    end
+
+    # The in-flight evaluation keeps the policy from the evaluator that performed it;
+    # reconfiguration must not replace that snapshot retroactively.
+    context "when full evaluation data is disabled while an evaluation is in flight" do
+      before do
+        allow(telemetry).to receive(:report)
+        allow(replacement_evaluator).to receive(:observe_full_evaluation_data).and_return(false)
+        allow(Datadog::OpenFeature::NativeEvaluator).to receive(:new).and_return(evaluator, replacement_evaluator)
+        allow(evaluator).to receive(:get_assignment) do
+          engine.reconfigure!(configuration)
+          raise error
+        end
+        engine.reconfigure!(configuration)
+      end
+
+      let(:replacement_evaluator) { instance_double(Datadog::OpenFeature::NativeEvaluator) }
+      let(:error) { RuntimeError.new("Crash") }
+
+      it "keeps the enabled policy from the evaluator that performed the evaluation" do
+        expect(evaluator).to receive(:observe_full_evaluation_data).once.and_return(true)
+        expect(replacement_evaluator).not_to receive(:observe_full_evaluation_data)
+
+        expect(result.error_code).to eq("GENERAL")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => true)
       end
     end
 
@@ -114,6 +199,7 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
         expect(result.error_code).to eq("UNKNOWN_TYPE")
         expect(result.error_message).to start_with("unknown type :whatever, allowed types")
         expect(result.reason).to eq("ERROR")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
       end
     end
 
@@ -149,6 +235,14 @@ RSpec.describe Datadog::OpenFeature::EvaluationEngine do
           .with(kind_of(Datadog::OpenFeature::ResolutionDetails), flag_key: "test", context: evaluation_context)
 
         expect(result.value).to eq("hello")
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => false)
+      end
+
+      it "stamps an enabled policy from the evaluator" do
+        allow(evaluator).to receive(:observe_full_evaluation_data).and_return(true)
+        expect(reporter).to receive(:report)
+
+        expect(result.flag_metadata).to include(observe_full_evaluation_data_key => true)
       end
     end
   end

--- a/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/aggregator_spec.rb
@@ -146,6 +146,13 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       expect(reasons).to include("max_structure_properties")
     end
 
+    it "omits an excluded root key during bounded traversal" do
+      attrs = {"targeting_key" => "user-1", "env" => "prod"}
+      snapshot, = described_class.bounded_context_snapshot(attrs, excluded_key: "targeting_key")
+
+      expect(snapshot).to eq("env" => "prod")
+    end
+
     it "keeps keys of exactly 256 chars without reporting truncation" do
       key = "k" * 256
       snapshot, reasons = described_class.bounded_context_snapshot({key => "value"})
@@ -171,7 +178,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       end
 
       snapshot, reasons = described_class.bounded_context_snapshot(
-        "root" => {"k" * 10_000 => "value"}
+        {"root" => {"k" * 10_000 => "value"}}
       )
 
       expect(snapshot).to eq({})
@@ -252,7 +259,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       end
 
       snapshot, = described_class.bounded_context_snapshot(
-        custom_string.new("key") => custom_string.new("value")
+        {custom_string.new("key") => custom_string.new("value")}
       )
       expect(snapshot).to eq("key" => "value")
     end
@@ -285,14 +292,14 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
 
       expect { described_class.bounded_context_snapshot(invalid_hash) }
         .to raise_error(RuntimeError, "cannot iterate")
-      expect { described_class.bounded_context_snapshot("array" => invalid_array) }
+      expect { described_class.bounded_context_snapshot({"array" => invalid_array}) }
         .to raise_error(RuntimeError, "cannot inspect")
     end
 
     it "does not hide errors in the snapshot implementation" do
       allow(described_class).to receive(:bounded_flatten).and_raise("snapshot bug")
 
-      expect { described_class.bounded_context_snapshot("key" => "value") }
+      expect { described_class.bounded_context_snapshot({"key" => "value"}) }
         .to raise_error(RuntimeError, "snapshot bug")
     end
 
@@ -368,11 +375,21 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
 
     context 'two evaluations differing only by context value type (int 1 vs string "1")' do
       it "creates two distinct full-tier buckets (type-tagged canonical key)" do
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
-        aggregator.record(**base_event.merge(attrs: {"x" => "1"}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(attrs: {"x" => "1"}, observe_full_evaluation_data: true))
 
         snapshot = aggregator.flush_and_reset
         expect(snapshot[:full].size).to eq(2)
+      end
+    end
+
+    context "targeting key presence" do
+      it "keeps nil and empty targeting keys in separate buckets" do
+        aggregator.record(**base_event.merge(targeting_key: nil))
+        aggregator.record(**base_event.merge(targeting_key: ""))
+
+        targeting_keys = aggregator.flush_and_reset[:full].keys.map { |key| key[5] }
+        expect(targeting_keys).to contain_exactly(nil, "")
       end
     end
 
@@ -393,11 +410,20 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
         expect(entry[:runtime_default]).to be(false)
       end
 
-      it "uses an explicit runtime_default signal when the SDK returns a typed default" do
-        aggregator.record(**base_event.merge(runtime_default: true))
+      it "coalesces runtime defaults with different variants and allocations" do
+        aggregator.record(
+          **base_event.merge(variant: "a", allocation_key: "alloc-a", runtime_default: true)
+        )
+        aggregator.record(
+          **base_event.merge(
+            variant: "b", allocation_key: "alloc-b", runtime_default: true, eval_time_ms: 2000
+          )
+        )
 
         snapshot = aggregator.flush_and_reset
         entry = snapshot[:full].values.first
+        expect(snapshot[:full].size).to eq(1)
+        expect(entry[:count]).to eq(2)
         expect(entry[:runtime_default]).to be(true)
       end
     end
@@ -408,10 +434,10 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
 
       it "routes to degraded when global_cap is reached with a new bucket" do
         # First two fill the full tier
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
-        aggregator.record(**base_event.merge(attrs: {"x" => 2}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(attrs: {"x" => 2}, observe_full_evaluation_data: true))
         # Third has different context — full tier full — routes to degraded
-        aggregator.record(**base_event.merge(attrs: {"x" => 3}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 3}, observe_full_evaluation_data: true))
 
         snapshot = aggregator.flush_and_reset
         expect(snapshot[:full].size).to eq(2)
@@ -419,9 +445,9 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       end
 
       it "counts full-tier attempts before global cap routing" do
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
-        aggregator.record(**base_event.merge(attrs: {"x" => 2}))
-        aggregator.record(**base_event.merge(attrs: {"x" => 3}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(attrs: {"x" => 2}, observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(attrs: {"x" => 3}, observe_full_evaluation_data: true))
 
         per_flag_full = aggregator.instance_variable_get(:@per_flag_full)
         expect(per_flag_full["my-flag"]).to eq(3)
@@ -433,10 +459,10 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       let(:per_flag_cap) { 2 }
 
       it "routes to degraded when per_flag_cap is reached for a flag" do
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
-        aggregator.record(**base_event.merge(attrs: {"x" => 2}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(attrs: {"x" => 2}, observe_full_evaluation_data: true))
         # Third bucket for same flag: per_flag_cap exceeded
-        aggregator.record(**base_event.merge(attrs: {"x" => 3}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 3}, observe_full_evaluation_data: true))
 
         snapshot = aggregator.flush_and_reset
         expect(snapshot[:full].size).to eq(2)
@@ -451,12 +477,12 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
 
       it "increments dropped counter beyond degraded_cap" do
         # First event: goes to full tier (cap=1, one slot)
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
         # Second event: different context, full tier full → goes to degraded.
         # creates the one allowed degraded bucket
-        aggregator.record(**base_event.merge(attrs: {"x" => 2}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 2}, observe_full_evaluation_data: true))
         # Third event: different schema-visible error.message → degraded full → DROPPED
-        aggregator.record(**base_event.merge(attrs: {"x" => 3}, error_message: "boom"))
+        aggregator.record(**base_event.merge(attrs: {"x" => 3}, error_message: "boom", observe_full_evaluation_data: true))
 
         expect(aggregator.dropped_degraded_overflow).to eq(1)
       end
@@ -467,14 +493,68 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
       let(:per_flag_cap) { 1 }
 
       it "degraded entry has no targeting_key or context_attrs" do
-        aggregator.record(**base_event.merge(attrs: {"x" => 1}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 1}, observe_full_evaluation_data: true))
         # Force overflow to degraded
-        aggregator.record(**base_event.merge(attrs: {"x" => 2}))
+        aggregator.record(**base_event.merge(attrs: {"x" => 2}, observe_full_evaluation_data: true))
 
         snapshot = aggregator.flush_and_reset
         degraded_entry = snapshot[:degraded].values.first
         expect(degraded_entry[:targeting_key]).to be_nil
         expect(degraded_entry[:context_attrs]).to be_nil
+      end
+    end
+
+    context "observe_full_evaluation_data in the bucket key" do
+      it "separates policy states and retains context only when enabled" do
+        aggregator.record(**base_event.merge(attrs: {"env" => "prod"}, observe_full_evaluation_data: false))
+        aggregator.record(**base_event.merge(attrs: {"env" => "prod"}, observe_full_evaluation_data: true))
+
+        entries = aggregator.flush_and_reset[:full]
+        disabled_entry = entries.find { |key, _entry| key.last == false }.last
+        enabled_entry = entries.find { |key, _entry| key.last == true }.last
+
+        expect(entries.size).to eq(2)
+        expect(disabled_entry[:context_attrs]).to be_nil
+        expect(disabled_entry[:observe_full_evaluation_data]).to be(false)
+        expect(enabled_entry[:context_attrs]).to eq("env" => "prod")
+        expect(enabled_entry[:observe_full_evaluation_data]).to be(true)
+      end
+
+      it "AND-folds mixed consent in a degraded bucket" do
+        degraded_aggregator = described_class.new(global_cap: 0, per_flag_cap: 10, degraded_cap: 10)
+        degraded_aggregator.record(
+          **base_event.merge(observe_full_evaluation_data: true)
+        )
+        degraded_aggregator.record(
+          **base_event.merge(
+            targeting_key: "user-456", eval_time_ms: 1_700_000_000_001,
+            observe_full_evaluation_data: false
+          )
+        )
+
+        entries = degraded_aggregator.flush_and_reset[:degraded]
+        entry = entries.values.first
+        expect(entries.size).to eq(1)
+        expect(entry[:count]).to eq(2)
+        expect(entry[:observe_full_evaluation_data]).to be(false)
+      end
+
+      it "does not key on context when observe_full_evaluation_data is false (high-cardinality context does not split buckets)" do
+        # Prevents the per-flag bucket cap from burning on privacy-protected traffic.
+        aggregator.record(**base_event.merge(attrs: {"request_id" => "a"}, observe_full_evaluation_data: false))
+        aggregator.record(**base_event.merge(attrs: {"request_id" => "b"}, observe_full_evaluation_data: false))
+
+        snapshot = aggregator.flush_and_reset
+        expect(snapshot[:full].size).to eq(1)
+        expect(snapshot[:full].values.first[:count]).to eq(2)
+      end
+
+      it "keys buckets on the normalized error code" do
+        aggregator.record(**base_event.merge(error_message: "FLAG_NOT_FOUND", observe_full_evaluation_data: true))
+        aggregator.record(**base_event.merge(error_message: "TYPE_MISMATCH", observe_full_evaluation_data: true))
+
+        snapshot = aggregator.flush_and_reset
+        expect(snapshot[:full].size).to eq(2)
       end
     end
   end
@@ -495,9 +575,9 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
 
     it "resets dropped_degraded_overflow counter after flush" do
       aggregator_small = described_class.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 1)
-      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 1, attrs: {"x" => 1})
-      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 2, attrs: {"x" => 2})
-      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 3, attrs: {"x" => 3})
+      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 1, attrs: {"x" => 1}, observe_full_evaluation_data: true)
+      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 2, attrs: {"x" => 2}, observe_full_evaluation_data: true)
+      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 3, attrs: {"x" => 3}, observe_full_evaluation_data: true)
       aggregator_small.flush_and_reset
       expect(aggregator_small.dropped_degraded_overflow).to eq(0)
     end
@@ -505,11 +585,11 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Aggregator do
     # The snapshot must carry the degraded-overflow count so the writer can emit it before reset.
     it "returns the degraded-overflow count in the snapshot so it can be emitted before reset" do
       aggregator_small = described_class.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 1)
-      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 1, attrs: {"x" => 1})
-      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 2, attrs: {"x" => 2})
+      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 1, attrs: {"x" => 1}, observe_full_evaluation_data: true)
+      aggregator_small.record(flag_key: "f", variant: "v", allocation_key: "", targeting_key: "", eval_time_ms: 2, attrs: {"x" => 2}, observe_full_evaluation_data: true)
       aggregator_small.record(
         flag_key: "f", variant: "v", allocation_key: "", error_message: "boom",
-        targeting_key: "", eval_time_ms: 3, attrs: {"x" => 3}
+        targeting_key: "", eval_time_ms: 3, attrs: {"x" => 3}, observe_full_evaluation_data: true
       )
 
       snapshot = aggregator_small.flush_and_reset

--- a/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
+++ b/spec/datadog/open_feature/flag_evaluation/writer_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: "prefork-flag", variant: "on", allocation_key: "alloc",
           targeting_key: "prefork-user", eval_time_ms: realistic_eval_ms, attrs: {"worker" => "child"},
+          observe_full_evaluation_data: true,
         )
         writer.stop
 
@@ -344,25 +345,47 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
   end
 
+  describe "#enqueue context capture" do
+    subject(:writer) { described_class.new(transport: transport, logger: logger) }
+
+    let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP) }
+    let(:logger) { instance_double(Logger, debug: nil) }
+    let(:aggregator) { instance_double(Datadog::OpenFeature::FlagEvaluation::Aggregator, record: nil) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
+      allow(Datadog::OpenFeature::FlagEvaluation::Aggregator).to receive(:new).and_return(aggregator)
+    end
+
+    it "passes nil context attributes to the aggregator when full evaluation data is disabled" do
+      expect(aggregator).to receive(:record).with(hash_including(attrs: nil))
+
+      writer.enqueue(
+        flag_key: "f", variant: "on", allocation_key: "",
+        targeting_key: "t", eval_time_ms: 1, attrs: {"ignored" => "value"},
+      )
+      writer.send(:drain_queue)
+    end
+  end
+
   describe "#enqueue queue-overflow backpressure" do
     let(:transport) { instance_double(Datadog::OpenFeature::Transport::HTTP, send_flag_evaluations: nil) }
     let(:logger) { instance_double(Logger, debug: nil) }
     let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
 
-    it "increments dropped_queue_overflow and emits the count on flush" do
+    it "drops immediately and emits the pre-queue overflow count" do
+      stub_const("#{described_class}::QUEUE_SIZE", 1)
       allow_any_instance_of(described_class).to receive(:start_background_thread).and_return(nil)
       writer = described_class.new(transport: transport, logger: logger, telemetry: telemetry)
-
-      # Fill the queue to capacity, then overflow it.
-      capacity = described_class::QUEUE_SIZE
       event = {
         flag_key: "f", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: 1, attrs: {},
       }
-      capacity.times { writer.enqueue(**event) }
-      expect(writer.dropped_queue_overflow).to eq(0)
+      writer.enqueue(**event)
 
+      expect(Thread).not_to receive(:pass)
       3.times { writer.enqueue(**event) }
+      expect(writer.dropped_queue_overflow).to eq(0)
 
       logged = []
       allow(logger).to receive(:debug) { |&blk| logged << blk.call }
@@ -386,7 +409,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
 
       writer.enqueue(
         flag_key: "f", variant: "on", allocation_key: "",
-        targeting_key: "t", eval_time_ms: 1, attrs: raw,
+        targeting_key: "t", eval_time_ms: 1, attrs: raw, observe_full_evaluation_data: true,
       )
 
       queued = writer.instance_variable_get(:@queue).pop(true)
@@ -406,6 +429,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
           flag_key: "schema-flag", variant: "on", allocation_key: "alloc-1",
           targeting_key: "user-42",
           eval_time_ms: realistic_eval_ms, attrs: {"env" => "prod", "tier" => "gold"},
+          observe_full_evaluation_data: true,
         )
       end
 
@@ -416,12 +440,26 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       expect(row["context"]).to eq("evaluation" => {"env" => "prod", "tier" => "gold"})
     end
 
+    it "omits a nil targeting key" do
+      [false, true].each do |observe_full_evaluation_data|
+        payload = captured_payload do |writer|
+          writer.enqueue(
+            flag_key: "schema-flag", targeting_key: nil, eval_time_ms: realistic_eval_ms,
+            attrs: {}, observe_full_evaluation_data: observe_full_evaluation_data,
+          )
+        end
+
+        expect(payload["flagEvaluations"].first).not_to have_key("targeting_key")
+      end
+    end
+
     it "transcodes valid targeting keys to UTF-8 before serialization" do
       targeting_key = "caf\u00E9".encode(Encoding::ISO_8859_1)
       payload = captured_payload do |writer|
         writer.enqueue(
           flag_key: "encoding-flag", variant: "on", allocation_key: "alloc",
           targeting_key: targeting_key, eval_time_ms: realistic_eval_ms, attrs: {},
+          observe_full_evaluation_data: true,
         )
       end
 
@@ -438,12 +476,13 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
           flag_key: "encoding-flag", variant: "on", allocation_key: "alloc",
           targeting_key: malformed, error_message: malformed,
           eval_time_ms: realistic_eval_ms, attrs: {"value" => malformed},
+          observe_full_evaluation_data: true,
         )
       end
 
       row = payload["flagEvaluations"].first
       expect(row).not_to have_key("targeting_key")
-      expect(row["error"]).to eq("message" => "\uFFFD")
+      expect(row["error"]).to eq("message" => "GENERAL")
       expect(row["context"]).to eq("evaluation" => {"value" => "\uFFFD"})
     end
 
@@ -472,7 +511,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: "custom-value-flag", variant: "on", allocation_key: "alloc",
           targeting_key: "user", eval_time_ms: realistic_eval_ms,
-          attrs: {"custom" => custom_value},
+          attrs: {"custom" => custom_value}, observe_full_evaluation_data: true,
         )
       end
 
@@ -579,6 +618,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: "snapshot-flag", variant: "on", allocation_key: "",
           targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: raw,
+          observe_full_evaluation_data: true,
         )
 
         raw["profile"]["plan"] = "enterprise"
@@ -602,6 +642,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: flag_key, variant: "on", allocation_key: "alloc",
           targeting_key: targeting_key, eval_time_ms: realistic_eval_ms, attrs: {},
+          observe_full_evaluation_data: true,
         )
 
         flag_key.replace("other-flag")
@@ -641,6 +682,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: "cyclic-context-flag", variant: "on", allocation_key: "",
           targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: raw,
+          observe_full_evaluation_data: true,
         )
       end
 
@@ -649,33 +691,35 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       expect(emitted.keys.grep(/self|array/)).to be_empty
     end
 
-    it "emits schema-visible error.message when present" do
+    it "emits a normalized error code in schema-visible error.message" do
       payload = captured_payload do |writer|
         writer.enqueue(
           flag_key: "error-flag", variant: nil, allocation_key: "",
-          error_message: "flag not found", targeting_key: "user-42",
+          error_message: "FLAG_NOT_FOUND", targeting_key: "user-42",
           eval_time_ms: realistic_eval_ms, attrs: {},
+          observe_full_evaluation_data: true,
         )
       end
 
       row = payload["flagEvaluations"].first
       expect(row["runtime_default_used"]).to be(true)
-      expect(row["error"]).to eq("message" => "flag not found")
+      expect(row["error"]).to eq("message" => "FLAG_NOT_FOUND")
       expect(row).not_to have_key("reason")
     end
 
-    it "emits runtime_default_used when the hook marks a typed default with a variant" do
+    it "omits variant and allocation for a runtime default" do
       payload = captured_payload do |writer|
         writer.enqueue(
-          flag_key: "typed-default-flag", variant: "variant-a", allocation_key: "",
+          flag_key: "typed-default-flag", variant: "variant-a", allocation_key: "alloc-1",
           runtime_default: true, targeting_key: "user-42",
           eval_time_ms: realistic_eval_ms, attrs: {},
         )
       end
 
       row = payload["flagEvaluations"].first
-      expect(row["variant"]).to eq("key" => "variant-a")
       expect(row["runtime_default_used"]).to be(true)
+      expect(row).not_to have_key("variant")
+      expect(row).not_to have_key("allocation")
     end
 
     it "does not split aggregates when only stale reason inputs differ" do
@@ -741,6 +785,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       writer.enqueue(
         flag_key: "large", variant: "on", allocation_key: "alloc",
         targeting_key: "user-large", eval_time_ms: realistic_eval_ms, attrs: {"blob" => "x" * 256},
+        observe_full_evaluation_data: true,
       )
       writer.send(:drain_and_flush)
 
@@ -788,12 +833,12 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       writer.enqueue(
         flag_key: "invalid", variant: "on", allocation_key: "alloc",
         targeting_key: "user-invalid", eval_time_ms: realistic_eval_ms,
-        attrs: {"env" => "invalid"},
+        attrs: {"env" => "invalid"}, observe_full_evaluation_data: true,
       )
       writer.enqueue(
         flag_key: "valid", variant: "on", allocation_key: "alloc",
         targeting_key: "user-valid", eval_time_ms: realistic_eval_ms,
-        attrs: {"env" => "prod"},
+        attrs: {"env" => "prod"}, observe_full_evaluation_data: true,
       )
       writer.send(:drain_and_flush)
 
@@ -854,6 +899,72 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
     end
   end
 
+  describe "PII protection (observeFullEvaluationData = false)" do
+    let(:logger) { instance_double(Logger, debug: nil) }
+
+    # Canonical vector from the flag-evaluation privacy contract.
+    it "hashes the canonical vector and omits raw context from the wire" do
+      raw_subject = "jane.doe@datadoghq.com"
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "pii-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: raw_subject,
+          eval_time_ms: realistic_eval_ms, attrs: {"user_email" => raw_subject},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["targeting_key"]).to eq(
+        "sha256_b4698f9b6d186781fa8dc59e533578fa2d8379a46b1cf6db85cda6aa9c99e51b"
+      )
+      expect(row).not_to have_key("context")
+      expect(Datadog::Core::Encoding::JSONEncoder.encode(payload)).not_to include(raw_subject)
+    end
+
+    it "emits an empty targeting key when full evaluation data is disabled" do
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "pii-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: "",
+          eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["targeting_key"]).to eq("")
+    end
+
+    it "omits the error key when observe_full_evaluation_data is false and no error code is present" do
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "err-flag", variant: nil, allocation_key: "",
+          error_message: nil,
+          targeting_key: "jane.doe@datadoghq.com",
+          eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row).not_to have_key("error")
+    end
+
+    it "hashes a non-UTF-8 targeting key over its UTF-8 bytes" do
+      iso = "josé@datadoghq.com".encode(Encoding::ISO_8859_1)
+      payload = captured_payload do |writer|
+        writer.enqueue(
+          flag_key: "pii-flag", variant: "on", allocation_key: "alloc",
+          targeting_key: iso,
+          eval_time_ms: realistic_eval_ms, attrs: {},
+        )
+      end
+
+      row = payload["flagEvaluations"].first
+      expect(row["targeting_key"]).to eq(
+        "sha256_4cc077537cc6902477f44195b98aaf13687f9d90ce37e9d6f70cb1ede363201c"
+      )
+    end
+  end
+
   describe "context-truncation telemetry" do
     let(:logger) { instance_double(Logger, debug: nil) }
     let(:telemetry) { instance_spy(Datadog::Core::Telemetry::Component) }
@@ -868,16 +979,19 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       writer.enqueue(
         flag_key: "wide-flag", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: wide_attrs,
+        observe_full_evaluation_data: true,
       )
       # An oversized string value hits the value-length cap.
       writer.enqueue(
         flag_key: "long-flag", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: {"toobig" => "x" * 257},
+        observe_full_evaluation_data: true,
       )
       # An oversized key hits the key-length cap.
       writer.enqueue(
         flag_key: "long-key-flag", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: {"k" * 257 => "value"},
+        observe_full_evaluation_data: true,
       )
       writer.send(:drain_and_flush)
 
@@ -911,6 +1025,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
         writer.enqueue(
           flag_key: "invalid-context", variant: "on", allocation_key: "",
           targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: invalid_attrs,
+          observe_full_evaluation_data: true,
         )
       end
       writer.send(:drain_and_flush)
@@ -940,6 +1055,7 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       writer.enqueue(
         flag_key: "exact-flag", variant: "on", allocation_key: "",
         targeting_key: "t", eval_time_ms: realistic_eval_ms, attrs: attrs,
+        observe_full_evaluation_data: true,
       )
       writer.send(:drain_and_flush)
 
@@ -948,6 +1064,103 @@ RSpec.describe Datadog::OpenFeature::FlagEvaluation::Writer do
       )
     ensure
       writer&.stop
+    end
+  end
+
+  describe "degraded-tier observe_full_evaluation_data handling" do
+    let(:logger) { instance_double(Logger, debug: nil) }
+
+    it "emits the redacted error code without raw targeting data when full evaluation data is disabled" do
+      raw_subject = "jane.doe@datadoghq.com"
+      payload = captured_payload do |writer|
+        small = Datadog::OpenFeature::FlagEvaluation::Aggregator.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 10)
+        writer.instance_variable_set(:@aggregator, small)
+        writer.enqueue(
+          flag_key: "deg-flag", variant: "a", allocation_key: "alloc-x",
+          targeting_key: "u1", eval_time_ms: realistic_eval_ms, attrs: {"x" => 1},
+        )
+        writer.enqueue(
+          flag_key: "deg-flag", variant: "a", allocation_key: "alloc-x",
+          error_message: "TYPE_MISMATCH", targeting_key: raw_subject,
+          eval_time_ms: realistic_eval_ms, attrs: {"user_email" => raw_subject},
+        )
+      end
+
+      degraded_row = payload["flagEvaluations"].find { |row| !row.key?("targeting_key") }
+      expect(degraded_row["error"]).to eq("message" => "TYPE_MISMATCH")
+      expect(degraded_row).not_to have_key("context")
+      expect(Datadog::Core::Encoding::JSONEncoder.encode(payload)).not_to include(raw_subject)
+    end
+
+    it "normalizes unknown errors in the degraded tier and omits targeting_key and context" do
+      payload = captured_payload do |writer|
+        small = Datadog::OpenFeature::FlagEvaluation::Aggregator.new(global_cap: 1, per_flag_cap: 1, degraded_cap: 10)
+        writer.instance_variable_set(:@aggregator, small)
+        writer.enqueue(
+          flag_key: "deg-flag", variant: "a", allocation_key: "alloc-x",
+          targeting_key: "u1", eval_time_ms: realistic_eval_ms, attrs: {"x" => 1},
+          observe_full_evaluation_data: true,
+        )
+        writer.enqueue(
+          flag_key: "deg-flag", variant: "b", allocation_key: "alloc-x",
+          error_message: "boom", targeting_key: "jane.doe@datadoghq.com",
+          eval_time_ms: realistic_eval_ms, attrs: {"user_email" => "jane.doe@datadoghq.com"},
+          observe_full_evaluation_data: true,
+        )
+      end
+
+      degraded_row = payload["flagEvaluations"].find { |row| !row.key?("targeting_key") }
+      expect(degraded_row["error"]).to eq("message" => "GENERAL")
+      expect(degraded_row).not_to have_key("targeting_key")
+      expect(degraded_row).not_to have_key("context")
+      expect(Datadog::Core::Encoding::JSONEncoder.encode(payload))
+        .not_to include("jane.doe@datadoghq.com")
+    end
+  end
+
+  describe "emit-time context redaction" do
+    let(:realistic_eval_ms) { 1_700_000_000_000 }
+
+    # Stub the otherwise unreachable state to verify the final wire guard.
+    it "uses privacy-preserving entry consent despite a consent-enabled key" do
+      payload = nil
+      transport = instance_double(Datadog::OpenFeature::Transport::HTTP)
+      allow(transport).to receive(:send_flag_evaluations) { |p| payload = p }
+      logger = instance_double(Datadog::Core::Logger, debug: nil, warn: nil, error: nil)
+
+      raw_subject = "jane.doe@datadoghq.com"
+      # The synthetic key says consent is enabled, while the aggregate's AND-folded
+      # consent says at least one evaluation disabled it.
+      key = ["pii-flag", "on", "alloc", false, "", raw_subject, nil, true]
+      entry = {
+        count: 1, first_evaluation: realistic_eval_ms, last_evaluation: realistic_eval_ms,
+        runtime_default: false, error_message: "", targeting_key: raw_subject,
+        context_attrs: {"env" => "prod", "user_email" => raw_subject},
+        observe_full_evaluation_data: false,
+      }
+      snapshot = {full: {key => entry}, degraded: {}, dropped_degraded_overflow: 0}
+
+      writer = described_class.new(transport: transport, logger: logger)
+      aggregator = writer.instance_variable_get(:@aggregator)
+      allow(aggregator).to receive(:flush_and_reset).and_return(snapshot, {full: {}, degraded: {}, dropped_degraded_overflow: 0})
+
+      writer.send(:drain_and_flush)
+      writer.stop
+
+      row = payload["flagEvaluations"].first
+      expect(row).not_to have_key("context")
+      expect(row["targeting_key"]).to start_with("sha256_")
+      wire = Datadog::Core::Encoding::JSONEncoder.encode(payload)
+      expect(wire).not_to include(raw_subject)
+    end
+  end
+
+  describe "TARGETING_KEY_FIELD" do
+    # Guards the duplicated literal documented on TARGETING_KEY_FIELD: on drift, the
+    # targeting key stops being excluded and lands in context.evaluation as raw PII.
+    it "equals the OpenFeature SDK targeting-key field name" do
+      expect(described_class::TARGETING_KEY_FIELD)
+        .to eq(::OpenFeature::SDK::EvaluationContext::TARGETING_KEY.to_s)
     end
   end
 end

--- a/spec/datadog/open_feature/hooks/flag_eval_evp_hook_spec.rb
+++ b/spec/datadog/open_feature/hooks/flag_eval_evp_hook_spec.rb
@@ -10,6 +10,18 @@ require "datadog/open_feature/flag_evaluation/writer"
 RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
   subject(:hook) { described_class.new(writer) }
 
+  let(:documented_error_codes) do
+    %w[
+      PROVIDER_NOT_READY
+      FLAG_NOT_FOUND
+      PARSE_ERROR
+      TYPE_MISMATCH
+      TARGETING_KEY_MISSING
+      INVALID_CONTEXT
+      PROVIDER_FATAL
+      GENERAL
+    ]
+  end
   let(:writer) { instance_double(Datadog::OpenFeature::FlagEvaluation::Writer, enqueue: nil) }
 
   let(:eval_context) { ::OpenFeature::SDK::EvaluationContext.new(targeting_key: "user-7", env: "prod") }
@@ -24,11 +36,14 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
     )
   end
 
-  def build_evaluation_details(variant:, error_message: nil, error_code: nil, flag_metadata: {})
+  def build_evaluation_details(
+    variant:, reason: "TARGETING_MATCH", error_message: nil, error_code: nil, flag_metadata: {}
+  )
     ::OpenFeature::SDK::EvaluationDetails.new(
       flag_key: "my-flag",
       resolution_details: ::OpenFeature::SDK::Provider::ResolutionDetails.new(
         value: "default",
+        reason: reason,
         variant: variant,
         error_message: error_message,
         error_code: error_code,
@@ -41,11 +56,14 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
     let(:evaluation_details) do
       build_evaluation_details(
         variant: "on",
-        flag_metadata: {"__dd_allocation_key" => "alloc-9", "dd.eval.timestamp_ms" => 1_700_000_000_000},
+        flag_metadata: {
+          "__dd_allocation_key" => "alloc-9",
+          "dd.eval.timestamp_ms" => 1_700_000_000_000,
+          Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true,
+        },
       )
     end
 
-    # Variant comes from evaluation_details.variant (the OpenFeature variant), NEVER the value.
     # The hook is never given the evaluated value, so it cannot accidentally emit it.
     it "enqueues the variant from evaluation_details.variant" do
       expect(writer).to receive(:enqueue).with(hash_including(variant: "on"))
@@ -57,13 +75,11 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
       hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
     end
 
-    # allocation_key read from metadata['__dd_allocation_key'] — the SAME source the OTel hook uses.
     it "enqueues allocation_key from the same metadata key the OTel hook reads" do
       expect(writer).to receive(:enqueue).with(hash_including(allocation_key: "alloc-9"))
       hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
     end
 
-    # eval-time read from the provider-stamped 'dd.eval.timestamp_ms' metadata key.
     it "enqueues eval_time_ms from the provider-stamped dd.eval.timestamp_ms metadata" do
       expect(writer).to receive(:enqueue).with(hash_including(eval_time_ms: 1_700_000_000_000))
       hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
@@ -74,29 +90,14 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
         expect(event).to include(
           flag_key: "my-flag",
           targeting_key: "user-7",
-          attrs: {"env" => "prod"},
+          attrs: {"targeting_key" => "user-7", "env" => "prod"},
         )
         expect(event).not_to have_key(:reason)
       end
       hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
     end
 
-    it "extracts targeting key and attrs from a real SDK evaluation context" do
-      sdk_context = ::OpenFeature::SDK::EvaluationContext.new(targeting_key: "user-9", tier: "gold")
-      hook_ctx = build_hook_context(evaluation_context: sdk_context)
-
-      expect(writer).to receive(:enqueue).with(hash_including(targeting_key: "user-9", attrs: {"tier" => "gold"}))
-      hook.finally(hook_context: hook_ctx, evaluation_details: evaluation_details)
-    end
-
-    it "enqueues error_message when present" do
-      details = build_evaluation_details(variant: nil, error_message: "flag not found")
-      expect(writer).to receive(:enqueue).with(hash_including(error_message: "flag not found"))
-      hook.finally(hook_context: hook_context, evaluation_details: details)
-    end
-
     it "does NOT touch the aggregator on the hook path (only enqueues — async boundary)" do
-      # The hook collaborates ONLY with writer#enqueue; it has no aggregator reference at all.
       expect(hook.instance_variables).not_to include(:@aggregator)
       expect(writer).to receive(:enqueue).once
       hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
@@ -104,7 +105,6 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
   end
 
   describe "#finally — runtime-default + missing-metadata edge cases" do
-    # Fallback: when the provider did not stamp a timestamp, fall back to hook-fire time.
     it "falls back to a real hook-fire timestamp when dd.eval.timestamp_ms is absent" do
       details = build_evaluation_details(variant: "on")
       allow(Datadog::Core::Utils::Time).to receive(:now).and_return(::Time.at(1_650_000_000))
@@ -112,27 +112,145 @@ RSpec.describe Datadog::OpenFeature::Hooks::FlagEvalEVPHook do
       hook.finally(hook_context: hook_context, evaluation_details: details)
     end
 
-    # Concern: detect runtime default from ABSENT variant, passed through as nil (aggregator decides).
-    it "passes a nil variant through unchanged (runtime-default signal preserved)" do
-      details = build_evaluation_details(variant: nil)
+    it "marks a DEFAULT reason as runtime default" do
+      details = build_evaluation_details(variant: nil, reason: "DEFAULT")
       expect(writer).to receive(:enqueue).with(hash_including(variant: nil, runtime_default: true))
       hook.finally(hook_context: hook_context, evaluation_details: details)
     end
 
-    it "marks type mismatch as runtime default even when the SDK exposes a variant" do
+    it "does not infer a runtime default from a nil variant without DEFAULT or ERROR reason" do
+      details = build_evaluation_details(variant: nil, reason: "DISABLED")
+      expect(writer).to receive(:enqueue).with(hash_including(runtime_default: false))
+      hook.finally(hook_context: hook_context, evaluation_details: details)
+    end
+
+    it "marks an ERROR reason as runtime default and omits stale variant and allocation data" do
       details = build_evaluation_details(
         variant: "variant-a",
+        reason: "ERROR",
         error_code: ::OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH,
+        flag_metadata: {"__dd_allocation_key" => "alloc-9"},
       )
-      expect(writer).to receive(:enqueue).with(hash_including(variant: "variant-a", runtime_default: true))
+      expect(writer).to receive(:enqueue).with(
+        hash_including(
+          variant: nil,
+          allocation_key: nil,
+          error_message: "TYPE_MISMATCH",
+          runtime_default: true,
+        )
+      )
       hook.finally(hook_context: hook_context, evaluation_details: details)
     end
 
     it "handles a nil evaluation_context without raising" do
       details = build_evaluation_details(variant: "v")
       ctx = build_hook_context(flag_key: "f", evaluation_context: nil)
-      expect(writer).to receive(:enqueue).with(hash_including(targeting_key: nil, attrs: {}))
+      expect(writer).to receive(:enqueue).with(hash_including(targeting_key: nil, attrs: nil))
       expect { hook.finally(hook_context: ctx, evaluation_details: details) }.not_to raise_error
+    end
+  end
+
+  describe "#finally — observe_full_evaluation_data lifecycle" do
+    let(:eval_context) { ::OpenFeature::SDK::EvaluationContext.new(targeting_key: "user-7", env: "prod") }
+    let(:hook_context) { build_hook_context }
+
+    def details_with_observe_full_evaluation_data(observe_full_evaluation_data)
+      metadata = {
+        "dd.eval.timestamp_ms" => 1_700_000_000_000,
+        Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => observe_full_evaluation_data,
+      }
+      build_evaluation_details(variant: "on", flag_metadata: metadata)
+    end
+
+    it "reads observe_full_evaluation_data from evaluation metadata, not from live config" do
+      details = details_with_observe_full_evaluation_data(true)
+      expect(writer).to receive(:enqueue).with(
+        hash_including(
+          observe_full_evaluation_data: true,
+          attrs: {"targeting_key" => "user-7", "env" => "prod"}
+        )
+      )
+      hook.finally(hook_context: hook_context, evaluation_details: details)
+    end
+
+    it "treats every value except true as a privacy-preserving false" do
+      details = [
+        build_evaluation_details(variant: "on", flag_metadata: {"dd.eval.timestamp_ms" => 1}),
+        details_with_observe_full_evaluation_data(false),
+        details_with_observe_full_evaluation_data(nil),
+        details_with_observe_full_evaluation_data("true"),
+      ]
+
+      details.each do |evaluation_details|
+        expect(writer).to receive(:enqueue).with(
+          hash_including(observe_full_evaluation_data: false, attrs: nil)
+        )
+        hook.finally(hook_context: hook_context, evaluation_details: evaluation_details)
+      end
+    end
+
+    it "uses the error code regardless of observe_full_evaluation_data" do
+      [false, true].each do |observe_full_evaluation_data|
+        details = build_evaluation_details(
+          variant: nil,
+          reason: "ERROR",
+          error_message: "user jane.doe@datadoghq.com not in segment",
+          error_code: "FLAG_NOT_FOUND",
+          flag_metadata: {
+            "dd.eval.timestamp_ms" => 1,
+            Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => observe_full_evaluation_data,
+          }
+        )
+        expect(writer).to receive(:enqueue).with(hash_including(error_message: "FLAG_NOT_FOUND"))
+        hook.finally(hook_context: hook_context, evaluation_details: details)
+      end
+    end
+
+    it "uses GENERAL for an ERROR reason without an error code" do
+      details = build_evaluation_details(
+        variant: nil,
+        reason: "ERROR",
+        error_message: "user jane.doe@datadoghq.com not in segment",
+        error_code: nil,
+        flag_metadata: {
+          "dd.eval.timestamp_ms" => 1,
+          Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true,
+        }
+      )
+      expect(writer).to receive(:enqueue).with(hash_including(error_message: "GENERAL"))
+      hook.finally(hook_context: hook_context, evaluation_details: details)
+    end
+
+    it "omits a native informational message for a non-error DEFAULT result" do
+      details = build_evaluation_details(
+        variant: nil,
+        reason: "DEFAULT",
+        error_message: "default allocation is matched and is serving NULL",
+        flag_metadata: {
+          "dd.eval.timestamp_ms" => 1,
+          Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true,
+        }
+      )
+      expect(writer).to receive(:enqueue).with(hash_including(error_message: nil))
+      hook.finally(hook_context: hook_context, evaluation_details: details)
+    end
+
+    it "configures exactly the documented OpenFeature error codes" do
+      expect(Datadog::OpenFeature::Ext::STANDARD_ERROR_CODES).to eq(documented_error_codes)
+    end
+
+    it "preserves every documented OpenFeature error code" do
+      documented_error_codes.each do |error_code|
+        details = build_evaluation_details(
+          variant: nil,
+          reason: "ERROR",
+          error_message: "raw message",
+          error_code: error_code,
+          flag_metadata: {"dd.eval.timestamp_ms" => 1},
+        )
+        expect(writer).to receive(:enqueue).with(hash_including(error_message: error_code))
+        hook.finally(hook_context: hook_context, evaluation_details: details)
+      end
     end
   end
 end

--- a/spec/datadog/open_feature/native_evaluator_spec.rb
+++ b/spec/datadog/open_feature/native_evaluator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
   before do
     stub_const("Datadog::Core::FeatureFlags::Configuration", configuration_class)
     allow(Datadog::Core::FeatureFlags::Configuration)
-      .to receive(:new).with(configuration_json).and_return(configuration)
+      .to receive(:new).and_return(configuration)
     allow(configuration).to receive(:get_assignment).with(flag_key, expected_type, context).and_return(assignment)
   end
 
@@ -22,35 +22,83 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       end
     end
   end
+  let(:resolution_details_class) do
+    Class.new do
+      attr_reader(
+        :value,
+        :reason,
+        :error_code,
+        :error_message,
+        :variant,
+        :flag_metadata,
+        :allocation_key,
+        :serial_id,
+      )
+
+      def log?
+      end
+
+      def error?
+      end
+    end
+  end
   let(:configuration_json) { '{"flags":{}}' }
   let(:configuration) { configuration_class.new(configuration_json) }
   let(:flag_key) { "flag" }
   let(:expected_type) { :boolean }
   let(:context) { {"targeting_key" => "user-1"} }
-  let(:assignment_class) do
-    Class.new do
-      attr_accessor :value
-      attr_reader :reason, :error_code, :error_message, :variant
-
-      def initialize(reason:, error_code:, error_message:, variant:)
-        @reason = reason
-        @error_code = error_code
-        @error_message = error_message
-        @variant = variant
-      end
-    end
-  end
   let(:assignment) do
-    assignment_class.new(reason: reason, error_code: error_code, error_message: error_message, variant: variant)
+    instance_double(
+      resolution_details_class,
+      value: value,
+      reason: reason,
+      error_code: error_code,
+      error_message: error_message,
+      variant: variant,
+      flag_metadata: flag_metadata,
+      allocation_key: allocation_key,
+      serial_id: serial_id,
+      log?: log,
+      error?: error,
+    )
   end
+  let(:value) { true }
   let(:reason) { "TARGETING_MATCH" }
   let(:error_code) { nil }
   let(:error_message) { nil }
   let(:variant) { "on" }
+  let(:flag_metadata) { {"native" => "kept"} }
+  let(:allocation_key) { "allocation-1" }
+  let(:serial_id) { 123 }
+  let(:log) { true }
+  let(:error) { false }
 
   describe "#get_assignment" do
     subject(:result) do
       evaluator.get_assignment(flag_key, default_value: false, expected_type: expected_type, context: context)
+    end
+
+    it "copies the native assignment into OpenFeature resolution details" do
+      expect(result).to be_a(Datadog::OpenFeature::ResolutionDetails)
+      expect(result.value).to be(true)
+      expect(result.reason).to eq("TARGETING_MATCH")
+      expect(result.variant).to eq("on")
+      expect(result.error_code).to be_nil
+      expect(result.error_message).to be_nil
+      expect(result.flag_metadata).to eq("native" => "kept")
+      expect(result.allocation_key).to eq("allocation-1")
+      expect(result.serial_id).to eq(123)
+      expect(result.log?).to be(true)
+      expect(result.error?).to be(false)
+    end
+
+    context "when the native assignment has an object value" do
+      let(:expected_type) { :object }
+      let(:value) { {"feature" => "enabled"} }
+
+      it "copies the parsed object value" do
+        expect(result.value).to eq("feature" => "enabled")
+      end
     end
 
     context "when libdatadog reports an invalid per-flag configuration as caller default" do
@@ -59,8 +107,6 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       let(:variant) { nil }
 
       it "returns an OpenFeature parse error using the caller default" do
-        expect(assignment).not_to receive(:value=)
-
         expect(result.value).to be(false)
         expect(result.reason).to eq("ERROR")
         expect(result.error_code).to eq("PARSE_ERROR")
@@ -75,10 +121,48 @@ RSpec.describe Datadog::OpenFeature::NativeEvaluator do
       let(:variant) { nil }
 
       it "keeps the default result and applies the caller default value" do
-        expect(assignment).to receive(:value=).with(false)
-
-        expect(result).to be(assignment)
+        expect(result).to be_a(Datadog::OpenFeature::ResolutionDetails)
+        expect(result.value).to be(false)
+        expect(result.reason).to eq("DEFAULT")
+        expect(result.variant).to be_nil
+        expect(result.flag_metadata).to eq("native" => "kept")
       end
+    end
+  end
+
+  describe "#observe_full_evaluation_data" do
+    let(:base_ufc) { '{"format":"SERVER","environment":{"name":"test"},"flags":{}}' }
+
+    context "when the field is absent (privacy-preserving default)" do
+      it { expect(described_class.new(base_ufc).observe_full_evaluation_data).to be(false) }
+    end
+
+    context "when the field is false" do
+      let(:ufc) { '{"observeFullEvaluationData":false,"format":"SERVER","environment":{"name":"test"},"flags":{}}' }
+      it { expect(described_class.new(ufc).observe_full_evaluation_data).to be(false) }
+    end
+
+    context "when the UFC root field is true" do
+      let(:ufc) { '{"observeFullEvaluationData":true,"format":"SERVER","environment":{"name":"test"},"flags":{}}' }
+      it { expect(described_class.new(ufc).observe_full_evaluation_data).to be(true) }
+    end
+
+    context "when the field is explicit null" do
+      let(:ufc) { '{"format":"SERVER","observeFullEvaluationData":null,"environment":{"name":"test"},"flags":{}}' }
+      it { expect(described_class.new(ufc).observe_full_evaluation_data).to be(false) }
+    end
+
+    context "when the field is wrong-typed (string)" do
+      let(:ufc) { '{"format":"SERVER","observeFullEvaluationData":"true","environment":{"name":"test"},"flags":{}}' }
+      it { expect(described_class.new(ufc).observe_full_evaluation_data).to be(false) }
+    end
+
+    context "when the JSON is malformed" do
+      it { expect(described_class.new("{not valid json").observe_full_evaluation_data).to be(false) }
+    end
+
+    context "when the configuration is nil" do
+      it { expect(described_class.new(nil).observe_full_evaluation_data).to be(false) }
     end
   end
 end

--- a/spec/datadog/open_feature/provider_spec.rb
+++ b/spec/datadog/open_feature/provider_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe Datadog::OpenFeature::Provider do
 
       let(:details) do
         Datadog::OpenFeature::ResolutionDetails.new(
-          value: "{}", reason: "MATCH", variant: "blue", flag_metadata: {},
+          value: "{}", reason: "MATCH", variant: "blue",
+          flag_metadata: {Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true},
           allocation_key: "joe", extra_logging: {}, log?: true, error?: false
         )
       end
@@ -118,6 +119,9 @@ RSpec.describe Datadog::OpenFeature::Provider do
 
         expect(result.value).to eq("default" => true)
         expect(result.reason).to eq("ERROR")
+        expect(result.flag_metadata).to include(
+          Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true
+        )
       end
     end
   end
@@ -183,7 +187,6 @@ RSpec.describe Datadog::OpenFeature::Provider do
       allow(components).to receive(:open_feature).and_return(open_feature_component)
       allow(open_feature_component).to receive(:flag_eval_metrics_hook).and_return(flag_eval_metrics_hook)
       allow(open_feature_component).to receive(:flag_eval_evp_hook).and_return(flag_eval_evp_hook)
-      # `evaluate` queries the span-enrichment hook via `enrich_span`; nil is a no-op.
       allow(open_feature_component).to receive(:span_enrichment_hook).and_return(nil)
     end
 
@@ -283,7 +286,6 @@ RSpec.describe Datadog::OpenFeature::Provider do
       let(:real_flag_eval_evp_hook) { Datadog::OpenFeature::Hooks::FlagEvalEVPHook.new(writer) }
 
       before do
-        # No bare sleep in shutdown synchronization: stub the background thread, drive flush manually.
         allow_any_instance_of(Datadog::OpenFeature::FlagEvaluation::Writer)
           .to receive(:start_background_thread).and_return(nil)
         allow(open_feature_component).to receive(:flag_eval_metrics_hook).and_return(nil)
@@ -294,7 +296,8 @@ RSpec.describe Datadog::OpenFeature::Provider do
       it "enqueues an event into the Writer when the SDK client evaluates successfully" do
         result = Datadog::OpenFeature::ResolutionDetails.new(
           value: "variant-a", reason: "TARGETING_MATCH", variant: "variant-a",
-          flag_metadata: {}, allocation_key: "alloc-9", extra_logging: {}, log?: false, error?: false
+          flag_metadata: {Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true},
+          allocation_key: "alloc-9", extra_logging: {}, log?: false, error?: false
         )
         allow(engine).to receive(:fetch_value).and_return(result)
 
@@ -302,8 +305,6 @@ RSpec.describe Datadog::OpenFeature::Provider do
           flag_key: "real-flag", default_value: "default", evaluation_context: evaluation_context
         )
 
-        # Drive the writer's drain manually (background thread stubbed) and assert the transport
-        # received the real flagevaluation built from the enqueued event.
         writer.send(:drain_and_flush)
         expect(evp_transport).to have_received(:send_flag_evaluations) do |payload|
           row = payload["flagEvaluations"].first
@@ -317,10 +318,39 @@ RSpec.describe Datadog::OpenFeature::Provider do
         writer.stop
       end
 
-      it "marks SDK-final type mismatches as runtime defaults in the emitted row" do
+      [false, true].each do |do_log|
+        it "protects targeting data through the SDK hook and Writer when DoLog is #{do_log}" do
+          result = Datadog::OpenFeature::ResolutionDetails.new(
+            value: "variant-a", reason: "TARGETING_MATCH", variant: "variant-a",
+            flag_metadata: {},
+            allocation_key: "alloc-9", extra_logging: {}, log?: do_log, error?: false
+          )
+          allow(engine).to receive(:fetch_value).and_return(result)
+
+          client.fetch_string_value(
+            flag_key: "protected-flag", default_value: "default", evaluation_context: evaluation_context
+          )
+
+          writer.send(:drain_and_flush)
+          expect(evp_transport).to have_received(:send_flag_evaluations).once do |payload|
+            expect(payload["flagEvaluations"].size).to eq(1)
+            row = payload["flagEvaluations"].first
+            expect(row["targeting_key"]).to eq(
+              "sha256_c6c289e49e9c05b2145860387b73bcb18df43fb09a1e4a4a9713c76c88bb541b"
+            )
+            expect(row).not_to have_key("context")
+            expect(Datadog::Core::Encoding::JSONEncoder.encode(payload)).not_to include("user-1")
+          end
+        ensure
+          writer.stop
+        end
+      end
+
+      it "normalizes SDK-final type mismatches in the emitted row" do
         result = Datadog::OpenFeature::ResolutionDetails.new(
           value: 123, reason: "TARGETING_MATCH", variant: "variant-a",
-          flag_metadata: {}, allocation_key: nil, extra_logging: {}, log?: false, error?: false
+          flag_metadata: {Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true},
+          allocation_key: "alloc-9", extra_logging: {}, log?: false, error?: false
         )
         allow(engine).to receive(:fetch_value).and_return(result)
 
@@ -333,6 +363,33 @@ RSpec.describe Datadog::OpenFeature::Provider do
           row = payload["flagEvaluations"].first
           expect(row["flag"]["key"]).to eq("typed-default-flag")
           expect(row["runtime_default_used"]).to be(true)
+          expect(row["error"]).to eq("message" => "TYPE_MISMATCH")
+          expect(row).not_to have_key("variant")
+          expect(row).not_to have_key("allocation")
+        end
+      ensure
+        writer.stop
+      end
+
+      it "emits the stable code instead of a raw provider error message" do
+        result = Datadog::OpenFeature::ResolutionDetails.new(
+          value: "default", reason: "ERROR", variant: nil, error_code: "FLAG_NOT_FOUND",
+          error_message: "flag user-1 was not found", flag_metadata: {
+            Datadog::OpenFeature::Ext::METADATA_OBSERVE_FULL_EVALUATION_DATA => true,
+          }, allocation_key: nil, extra_logging: {}, log?: false, error?: true
+        )
+        allow(engine).to receive(:fetch_value).and_return(result)
+
+        client.fetch_string_value(
+          flag_key: "missing-flag", default_value: "default", evaluation_context: evaluation_context
+        )
+
+        writer.send(:drain_and_flush)
+        expect(evp_transport).to have_received(:send_flag_evaluations) do |payload|
+          row = payload["flagEvaluations"].first
+          expect(row["runtime_default_used"]).to be(true)
+          expect(row["error"]).to eq("message" => "FLAG_NOT_FOUND")
+          expect(Datadog::Core::Encoding::JSONEncoder.encode(payload)).not_to include("flag user-1 was not found")
         end
       ensure
         writer.stop
@@ -359,6 +416,7 @@ RSpec.describe Datadog::OpenFeature::Provider do
 
       expect(res.flag_metadata["dd.eval.timestamp_ms"]).to eq(1_700_000_000_000)
       expect(res.flag_metadata["existing"]).to eq("kept")
+      expect(res.flag_metadata["__dd_observe_full_evaluation_data"]).to be(false)
     end
 
     it "does not mutate the engine result metadata when stamping evaluation metadata" do

--- a/vendor/rbs/openfeature-sdk/0/openfeature-sdk.rbs
+++ b/vendor/rbs/openfeature-sdk/0/openfeature-sdk.rbs
@@ -8,6 +8,8 @@ module OpenFeature
       def targeting_key: () -> ::String?
 
       def fields: () -> fields_t
+
+      def attributes: () -> fields_t
     end
 
     module Provider
@@ -45,6 +47,7 @@ module OpenFeature
       def variant: () -> ::String?
       def reason: () -> ::String?
       def error_code: () -> ::String?
+      def error_message: () -> ::String?
       def value: () -> untyped
       def flag_metadata: () -> ::Hash[::String, untyped]?
     end


### PR DESCRIPTION
## Motivation

A server SDK upgrade must not silently ship subject PII (emails, account IDs, evaluation context) to the `flagevaluations` track. This PR makes the no-PII path the default and makes full-fidelity collection an explicit per-environment opt-in.

Tracked by [FFL-2963](https://datadoghq.atlassian.net/browse/FFL-2963), under the server-SDK fan-out FFL-2784. The pilot reference is [dd-trace-java#12042](https://github.com/DataDog/dd-trace-java/pull/12042). The base track for Ruby was [#5896](https://github.com/DataDog/dd-trace-rb/pull/5896) and https://github.com/DataDog/dd-trace-rb/pull/6221. Cross-SDK contract tests were merged in [system-tests#7316](https://github.com/DataDog/system-tests/pull/7316).

## What does this PR do?

Makes the no-PII path the default for server-side `flagevaluation` events. A top-level UFC boolean `observeFullEvaluationData` selects the path.

| `observeFullEvaluationData` | `targeting_key` on the wire | `context.evaluation` on the wire |
| --- | --- | --- |
| `true` | raw, verbatim | included, raw |
| `false` **or absent** (default) | `sha256_` + 64-char lowercase hex (71 chars total) | omitted |

## Change log entry

Yes. OpenFeature flag-evaluation telemetry now protects targeting keys, context, and error details by default unless full evaluation data observation is explicitly enabled.

## How to test the change?

Run `docker compose run --rm --no-deps tracer-4.0 /bin/bash -lc 'bundle exec rake standard && bundle exec rake steep:check && bundle exec rake test:open_feature'`. Both latest and minimum OpenFeature gemfiles pass with 283 examples and 0 failures each.


[FFL-2963]: https://datadoghq.atlassian.net/browse/FFL-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ