### PR TITLE
DI: add global-reject variant to di_instrument benchmark

### DIFF
--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -27,27 +27,30 @@
 # dispatch but not serialize_args. For probes with capture_snapshot=true,
 # the firing-path cost is higher than what this benchmark reports.
 #
-# Typical result:
+# Typical result (local run, Ruby 3.2.3, x86_64-linux-gnu):
 #
 # Comparison:
-#                          method instrumentation - cleared:   170807.4 i/s
-#                                no instrumentation - again:   170507.2 i/s - same-ish: difference falls within error
-#                            line instrumentation - cleared:   169760.6 i/s - same-ish: difference falls within error
-#                                        no instrumentation:   165453.4 i/s - 1.03x  slower
-#              method instrumentation - rate_limit=1 (skip):    90687.8 i/s - 1.88x  slower
-#     line instrumentation - targeted - rate_limit=1 (skip):    81769.3 i/s - 2.09x  slower
-#           method instrumentation - rate_limit=1M (firing):    36179.6 i/s - 4.72x  slower
-#  line instrumentation - targeted - rate_limit=1M (firing):    33589.6 i/s - 5.09x  slower
-#   line instrumentation - untargeted - rate_limit=1 (skip):    29559.6 i/s - 5.78x  slower
-# line instrumentation - untargeted - rate_limit=1M (firing):    19262.5 i/s - 8.87x  slower
+#                                               no instrumentation:   615759.9 i/s
+#                                 method instrumentation - cleared:   586395.9 i/s - same-ish: difference falls within error
+#                                       no instrumentation - again:   582805.3 i/s - same-ish: difference falls within error
+#                                   line instrumentation - cleared:   557115.8 i/s - same-ish: difference falls within error
+#            line instrumentation - targeted - rate_limit=1 (skip):   281647.2 i/s - 2.19x  slower
+#                     method instrumentation - rate_limit=1 (skip):   279444.7 i/s - 2.20x  slower
+#           method instrumentation - rate_limit=1M (global reject):   229992.0 i/s - 2.68x  slower
+#  line instrumentation - targeted - rate_limit=1M (global reject):   213673.2 i/s - 2.88x  slower
+#         line instrumentation - targeted - rate_limit=1M (firing):   118301.0 i/s - 5.21x  slower
+#                  method instrumentation - rate_limit=1M (firing):   112104.9 i/s - 5.49x  slower
+#          line instrumentation - untargeted - rate_limit=1 (skip):    96671.7 i/s - 6.37x  slower
+# line instrumentation - untargeted - rate_limit=1M (global reject):    82990.0 i/s - 7.42x  slower
+#       line instrumentation - untargeted - rate_limit=1M (firing):    61094.8 i/s - 10.08x  slower
 #
 # Per-call wrapper overhead, computed as (1/instr_ips) - (1/baseline_ips)
 # from the numbers above:
 #
-#                                       skip path     firing path
-#   method probe                        ~4.98 us      ~21.60 us
-#   line probe - targeted               ~6.19 us      ~23.73 us
-#   line probe - untargeted             ~27.79 us     ~45.87 us
+#                                       skip path     global reject     firing path
+#   method probe                        ~1.95 us      ~2.72 us          ~7.30 us
+#   line probe - targeted               ~1.93 us      ~3.06 us          ~6.83 us
+#   line probe - untargeted             ~8.72 us      ~10.43 us         ~14.74 us
 #
 # Method-probe firing is ~4x more expensive per call than skip. In
 # production, where the probe rate limit caps firing at 5000/sec per probe
@@ -55,12 +58,17 @@
 # skip number is the per-call cost a customer pays on the overwhelming
 # majority of probed-method invocations.
 #
+# The global-reject variant (per-probe limiter admits, process-wide global
+# limiter rejects) costs more than skip but less than firing, because the
+# wrapper performs the per-probe admission work and the global-limiter
+# consultation before taking the skip branch.
+#
 # Targeted line instrumentation has similar per-call cost to method
-# instrumentation in both firing and skip variants.
+# instrumentation across all three variants.
 #
 # Untargeted line instrumentation is much slower than targeted because the
 # TracePoint fires for every line in the file rather than only the
-# instrumented line. The skip variant is still slow (~27.8 us) because the
+# instrumented line. The skip variant is still slow (~8.7 us) because the
 # per-line TracePoint callback runs even when the rate limiter rejects
 # snapshot delivery. Untargeted line probes remain unsuitable for
 # production use; the skip-variant measurement is the floor cost that even

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -515,12 +515,11 @@ class DIInstrumentBenchmark
       raise "Targeted line instrumentation (rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
     end
 
-    ToggleLimiter.admit = true
-
     # Now, remove all installed hooks and check that the performance of
     # target code is approximately what it was prior to hook installation.
 
     instrumenter.unhook(probe)
+    ToggleLimiter.admit = true
 
     calls = 0
 

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -120,11 +120,18 @@ class DIInstrumentBenchmark
   module ToggleLimiter
     class << self
       attr_accessor :admit
+      # Count of allow? consultations, used by the global-reject variants to
+      # self-check that the wrapper actually reached the global limiter
+      # (calls == 0 alone cannot prove the wrapper ran, since calls is
+      # expected to stay 0 when the limiter rejects).
+      attr_accessor :consulted
       def allow?(*)
-        @admit
+        self.consulted += 1
+        admit
       end
     end
     self.admit = true
+    self.consulted = 0
   end
 
   class BenchInstrumenter < Datadog::DI::Instrumenter
@@ -153,75 +160,60 @@ class DIInstrumentBenchmark
       code_tracker: Datadog::DI.code_tracker)
   end
 
+  # Run one Benchmark.ips measurement for the given report label. The target
+  # block is forwarded straight to benchmark-ips (no per-iteration wrapper) so
+  # the measured cost is the target code plus instrumentation, not the helper.
+  def measure(report:, &target)
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+      x.report(report, &target)
+      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+  end
+
+  # Install a probe, measure it, and unhook it. ToggleLimiter.admit is restored
+  # to true in an ensure so a raised assertion cannot leak the global-reject
+  # state into a later variant.
+  def measure_variant(report:, hook:, probe:, &target)
+    rv = instrumenter.public_send(hook, probe,
+      Datadog::DI::ProcResponder.new(@executed_proc))
+    raise "#{report}: probe was not successfully installed" unless rv
+
+    measure(report: report, &target)
+    instrumenter.unhook(probe)
+  ensure
+    ToggleLimiter.admit = true
+  end
+
   def run_benchmark
     configure
 
     m = Target.instance_method(:test_method_for_line_probe)
     file, line = m.source_location
 
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
+    measure(report: "no instrumentation") { Target.new.test_method }
 
-      x.report("no instrumentation") do
-        Target.new.test_method
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
-
-    # Method instrumentation is run in three variants that decompose the
-    # wrapper's per-call cost. The benchmark toggles global-limiter
-    # admission (ToggleLimiter) so each variant isolates one branch:
-    #
-    #   rate_limit=1M, global admit   - both limiters admit, every call
-    #                                   fires the full snapshot path.
-    #                                   Measures firing-path cost.
-    #   rate_limit=1M, global reject  - per-probe admits, global limiter
-    #                                   rejects, every call takes the
-    #                                   global-rate-limit skip branch.
-    #                                   Measures global-reject cost.
-    #   rate_limit=1                  - per-probe limiter rejects ~99.999% of
-    #                                   calls before the global limiter is
-    #                                   consulted. Measures per-probe skip
-    #                                   cost (the dominant production
-    #                                   overhead).
-    #
-    # Note: this benchmark does not set capture_snapshot, so the firing
-    # variant exercises Context construction + responder dispatch but not
-    # serialize_args. For probes with capture_snapshot=true the firing-path
-    # cost is higher than what is measured here.
-
+    # Shared responder callback. It closes over the local `calls` counter, which
+    # each variant resets before its measurement and asserts on after. Sharing
+    # one callback also lets the post-unhook "cleared" blocks detect a leaked
+    # hook, which would still fire this callback and bump `calls`.
     calls = 0
-    executed_proc = lambda do |context|
+    @executed_proc = lambda do |context|
       calls += 1
     end
 
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
-      rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_method(probe, responder)
-    unless rv
-      raise "Method probe was not successfully installed (rate_limit=1M)"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("method instrumentation - rate_limit=1M (firing)") do
-        Target.new.test_method
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    calls = 0
+    measure_variant(
+      report: "method instrumentation - rate_limit=1M (firing)",
+      hook: :hook_method,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
+        rate_limit: 1_000_000,),
+    ) { Target.new.test_method }
 
     if calls < 1
       raise "Method instrumentation (rate_limit=1M) did not work - callback was never invoked"
@@ -231,31 +223,14 @@ class DIInstrumentBenchmark
       raise "Method instrumentation (rate_limit=1M): expected at least 100_000 firing calls, got #{calls}"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
-      rate_limit: 1,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_method(probe, responder)
-    unless rv
-      raise "Method probe was not successfully installed (rate_limit=1)"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("method instrumentation - rate_limit=1 (skip)") do
-        Target.new.test_method
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure_variant(
+      report: "method instrumentation - rate_limit=1 (skip)",
+      hook: :hook_method,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
+        rate_limit: 1,),
+    ) { Target.new.test_method }
 
     if calls < 1
       raise "Method instrumentation (rate_limit=1) did not work - callback was never invoked"
@@ -268,39 +243,24 @@ class DIInstrumentBenchmark
       raise "Method instrumentation (rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
     ToggleLimiter.admit = false
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
-      rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_method(probe, responder)
-    unless rv
-      raise "Method probe was not successfully installed (rate_limit=1M, global reject)"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("method instrumentation - rate_limit=1M (global reject)") do
-        Target.new.test_method
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    ToggleLimiter.consulted = 0
+    measure_variant(
+      report: "method instrumentation - rate_limit=1M (global reject)",
+      hook: :hook_method,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
+        rate_limit: 1_000_000,),
+    ) { Target.new.test_method }
 
     if calls != 0
       raise "Method instrumentation (rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
     end
 
-    instrumenter.unhook(probe)
-    ToggleLimiter.admit = true
+    if ToggleLimiter.consulted < 100_000 && !VALIDATE_BENCHMARK_MODE
+      raise "Method instrumentation (rate_limit=1M, global reject): wrapper did not reach the global limiter, only #{ToggleLimiter.consulted} consultations"
+    end
 
     # We benchmark untargeted and targeted trace points; untargeted ones
     # are prohibited by default, permit them.
@@ -312,26 +272,12 @@ class DIInstrumentBenchmark
     end
 
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: file, line_no: line + 1, rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (untargeted, rate_limit=1M) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-      x.report("line instrumentation - untargeted - rate_limit=1M (firing)") do
-        Target.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure_variant(
+      report: "line instrumentation - untargeted - rate_limit=1M (firing)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: file, line_no: line + 1, rate_limit: 1_000_000,),
+    ) { Target.new.test_method_for_line_probe }
 
     if calls < 1
       raise "Line instrumentation (untargeted, rate_limit=1M) did not work - callback was never invoked"
@@ -341,29 +287,13 @@ class DIInstrumentBenchmark
       raise "Line instrumentation (untargeted, rate_limit=1M): expected at least 100_000 firing calls, got #{calls}"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: file, line_no: line + 1, rate_limit: 1,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (untargeted, rate_limit=1) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-      x.report("line instrumentation - untargeted - rate_limit=1 (skip)") do
-        Target.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure_variant(
+      report: "line instrumentation - untargeted - rate_limit=1 (skip)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: file, line_no: line + 1, rate_limit: 1,),
+    ) { Target.new.test_method_for_line_probe }
 
     if calls < 1
       raise "Line instrumentation (untargeted, rate_limit=1) did not work - callback was never invoked"
@@ -373,37 +303,23 @@ class DIInstrumentBenchmark
       raise "Line instrumentation (untargeted, rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
     ToggleLimiter.admit = false
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: file, line_no: line + 1, rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (untargeted, rate_limit=1M, global reject) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-      x.report("line instrumentation - untargeted - rate_limit=1M (global reject)") do
-        Target.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    ToggleLimiter.consulted = 0
+    measure_variant(
+      report: "line instrumentation - untargeted - rate_limit=1M (global reject)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: file, line_no: line + 1, rate_limit: 1_000_000,),
+    ) { Target.new.test_method_for_line_probe }
 
     if calls != 0
       raise "Line instrumentation (untargeted, rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
     end
 
-    instrumenter.unhook(probe)
-    ToggleLimiter.admit = true
+    if ToggleLimiter.consulted < 100_000 && !VALIDATE_BENCHMARK_MODE
+      raise "Line instrumentation (untargeted, rate_limit=1M, global reject): wrapper did not reach the global limiter, only #{ToggleLimiter.consulted} consultations"
+    end
 
     Datadog::DI.activate_tracking!
     configure do |c|
@@ -422,27 +338,12 @@ class DIInstrumentBenchmark
     targeted_file, targeted_line = m.source_location
 
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (targeted, rate_limit=1M) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("line instrumentation - targeted - rate_limit=1M (firing)") do
-        DITarget.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure_variant(
+      report: "line instrumentation - targeted - rate_limit=1M (firing)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,),
+    ) { DITarget.new.test_method_for_line_probe }
 
     if calls < 1
       raise "Targeted line instrumentation (rate_limit=1M) did not work - callback was never invoked"
@@ -452,30 +353,13 @@ class DIInstrumentBenchmark
       raise "Targeted line instrumentation (rate_limit=1M): expected at least 100_000 firing calls, got #{calls}"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (targeted, rate_limit=1) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("line instrumentation - targeted - rate_limit=1 (skip)") do
-        DITarget.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure_variant(
+      report: "line instrumentation - targeted - rate_limit=1 (skip)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: targeted_file, line_no: targeted_line + 1, rate_limit: 1,),
+    ) { DITarget.new.test_method_for_line_probe }
 
     if calls < 1
       raise "Targeted line instrumentation (rate_limit=1) did not work - callback was never invoked"
@@ -485,97 +369,42 @@ class DIInstrumentBenchmark
       raise "Targeted line instrumentation (rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
 
-    instrumenter.unhook(probe)
-
     calls = 0
     ToggleLimiter.admit = false
-    probe = Datadog::DI::Probe.new(id: 1, type: :log,
-      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,)
-    responder = Datadog::DI::ProcResponder.new(executed_proc)
-    rv = instrumenter.hook_line(probe, responder)
-    unless rv
-      raise "Line probe (targeted, rate_limit=1M, global reject) was not successfully installed"
-    end
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("line instrumentation - targeted - rate_limit=1M (global reject)") do
-        DITarget.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    ToggleLimiter.consulted = 0
+    measure_variant(
+      report: "line instrumentation - targeted - rate_limit=1M (global reject)",
+      hook: :hook_line,
+      probe: Datadog::DI::Probe.new(id: 1, type: :log,
+        file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,),
+    ) { DITarget.new.test_method_for_line_probe }
 
     if calls != 0
       raise "Targeted line instrumentation (rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
     end
 
+    if ToggleLimiter.consulted < 100_000 && !VALIDATE_BENCHMARK_MODE
+      raise "Targeted line instrumentation (rate_limit=1M, global reject): wrapper did not reach the global limiter, only #{ToggleLimiter.consulted} consultations"
+    end
+
     # Now, remove all installed hooks and check that the performance of
     # target code is approximately what it was prior to hook installation.
 
-    instrumenter.unhook(probe)
-    ToggleLimiter.admit = true
-
     calls = 0
-
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      # This benchmark should produce identical results to the
-      # "no instrumentation" benchmark.
-      x.report("method instrumentation - cleared") do
-        Target.new.test_method
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure(report: "method instrumentation - cleared") { Target.new.test_method }
 
     if calls != 0
       raise "Method instrumentation was not cleared (#{calls} calls recorded)"
     end
 
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      # This benchmark should produce identical results to the
-      # "no instrumentation" benchmark.
-      x.report("line instrumentation - cleared") do
-        Target.new.test_method_for_line_probe
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    calls = 0
+    measure(report: "line instrumentation - cleared") { Target.new.test_method_for_line_probe }
 
     if calls != 0
       raise "Line instrumentation was not cleared (#{calls} calls recorded)"
     end
 
-    Benchmark.ips do |x|
-      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
-      x.config(
-        **benchmark_time,
-      )
-
-      x.report("no instrumentation - again") do
-        Target.new.not_instrumented
-      end
-
-      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
-      x.compare!
-    end
+    measure(report: "no instrumentation - again") { Target.new.not_instrumented }
   end
 end
 

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -262,8 +262,6 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
-    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
-    # every call takes the global-rate-limit skip branch (nothing fires).
     calls = 0
     ToggleLimiter.admit = false
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
@@ -369,8 +367,6 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
-    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
-    # every call takes the global-rate-limit skip branch (nothing fires).
     calls = 0
     ToggleLimiter.admit = false
     probe = Datadog::DI::Probe.new(id: 1, type: :log,
@@ -483,8 +479,6 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
-    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
-    # every call takes the global-rate-limit skip branch (nothing fires).
     calls = 0
     ToggleLimiter.admit = false
     probe = Datadog::DI::Probe.new(id: 1, type: :log,

--- a/benchmarks/di_instrument.rb
+++ b/benchmarks/di_instrument.rb
@@ -1,16 +1,22 @@
 #
 # "Instrumentation" part of Dynamic Instrumentation benchmarks.
 #
-# Each instrumented configuration is measured with two probe rate-limit
-# settings to decompose the wrapper's per-call cost:
+# Each instrumented configuration is measured with three variants that
+# decompose the wrapper's per-call cost. All use a benchmark-only global
+# limiter (see BenchInstrumenter/ToggleLimiter) whose admission the
+# benchmark controls, so each variant isolates one branch of the per-call
+# path:
 #
-#   rate_limit=1_000_000  - the per-probe limiter admits every call, and the
-#                           benchmark neutralizes the process-wide global
-#                           limiter (BenchInstrumenter), so every probe
-#                           invocation fires the full path (firing).
-#   rate_limit=1          - one token initially + 1/sec refill. At the
-#                           benchmark's call rate, ~99.999% of invocations
-#                           hit the rate-limited skip branch (skip).
+#   rate_limit=1M, global admit   - per-probe and global limiter both admit,
+#                                   so every call fires the full path
+#                                   (firing).
+#   rate_limit=1M, global reject  - per-probe admits, global limiter rejects,
+#                                   so every call takes the global-rate-limit
+#                                   skip branch (global reject).
+#   rate_limit=1                  - one token initially + 1/sec refill, so
+#                                   ~99.999% of calls hit the per-probe skip
+#                                   branch before the global limiter is
+#                                   consulted (skip).
 #
 # The skip-path number is the dominant production overhead, since real
 # workloads vastly exceed any per-probe rate limit. The firing-path number
@@ -97,20 +103,25 @@ class DIInstrumentBenchmark
     end
   end
 
-  # The process-wide global rate limiters are orthogonal admission control;
-  # they must not pollute per-call wrapper-cost measurement. Override the
-  # public probe_global_rate_limiter seam to admit every call, restoring the
-  # firing-path measurement from before the global limiters existed.
-  # Production wiring is unchanged; this subclass is benchmark-only.
-  module AlwaysAllow
-    def self.allow?(*)
-      true
+  # The process-wide global rate limiters are orthogonal admission control
+  # and must not pollute per-call wrapper-cost measurement. BenchInstrumenter
+  # overrides the public probe_global_rate_limiter seam to return a limiter
+  # whose admission the benchmark toggles, so a single instrumenter isolates
+  # the firing branch (admit) and the global-reject branch (reject).
+  # Production wiring is unchanged; these are benchmark-only.
+  module ToggleLimiter
+    class << self
+      attr_accessor :admit
+      def allow?(*)
+        @admit
+      end
     end
+    self.admit = true
   end
 
   class BenchInstrumenter < Datadog::DI::Instrumenter
     def probe_global_rate_limiter(*)
-      AlwaysAllow
+      ToggleLimiter
     end
   end
 
@@ -154,18 +165,22 @@ class DIInstrumentBenchmark
       x.compare!
     end
 
-    # Method instrumentation is run twice with deliberately extreme rate
-    # limits to decompose the wrapper's per-call cost:
+    # Method instrumentation is run in three variants that decompose the
+    # wrapper's per-call cost. The benchmark toggles global-limiter
+    # admission (ToggleLimiter) so each variant isolates one branch:
     #
-    #   rate_limit=1_000_000  - benchmark runs below the token-bucket
-    #                           ceiling, every call fires the full snapshot
-    #                           path. Measures firing-path cost.
-    #   rate_limit=1          - one token initially + one refill per second.
-    #                           At ~100k calls/sec, ~99.999% of calls hit
-    #                           the rate-limited skip branch. Measures
-    #                           skip-path cost (the dominant production
-    #                           overhead, since real workloads vastly exceed
-    #                           any per-probe rate limit).
+    #   rate_limit=1M, global admit   - both limiters admit, every call
+    #                                   fires the full snapshot path.
+    #                                   Measures firing-path cost.
+    #   rate_limit=1M, global reject  - per-probe admits, global limiter
+    #                                   rejects, every call takes the
+    #                                   global-rate-limit skip branch.
+    #                                   Measures global-reject cost.
+    #   rate_limit=1                  - per-probe limiter rejects ~99.999% of
+    #                                   calls before the global limiter is
+    #                                   consulted. Measures per-probe skip
+    #                                   cost (the dominant production
+    #                                   overhead).
     #
     # Note: this benchmark does not set capture_snapshot, so the firing
     # variant exercises Context construction + responder dispatch but not
@@ -247,6 +262,40 @@ class DIInstrumentBenchmark
 
     instrumenter.unhook(probe)
 
+    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
+    # every call takes the global-rate-limit skip branch (nothing fires).
+    calls = 0
+    ToggleLimiter.admit = false
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      type_name: "DIInstrumentBenchmark::Target", method_name: "test_method",
+      rate_limit: 1_000_000,)
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_method(probe, responder)
+    unless rv
+      raise "Method probe was not successfully installed (rate_limit=1M, global reject)"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+
+      x.report("method instrumentation - rate_limit=1M (global reject)") do
+        Target.new.test_method
+      end
+
+      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls != 0
+      raise "Method instrumentation (rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
+    end
+
+    instrumenter.unhook(probe)
+    ToggleLimiter.admit = true
+
     # We benchmark untargeted and targeted trace points; untargeted ones
     # are prohibited by default, permit them.
     # In order to install untargeted trace point, we currently need to
@@ -319,6 +368,38 @@ class DIInstrumentBenchmark
     end
 
     instrumenter.unhook(probe)
+
+    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
+    # every call takes the global-rate-limit skip branch (nothing fires).
+    calls = 0
+    ToggleLimiter.admit = false
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      file: file, line_no: line + 1, rate_limit: 1_000_000,)
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
+    unless rv
+      raise "Line probe (untargeted, rate_limit=1M, global reject) was not successfully installed"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+      x.report("line instrumentation - untargeted - rate_limit=1M (global reject)") do
+        Target.new.test_method_for_line_probe
+      end
+
+      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls != 0
+      raise "Line instrumentation (untargeted, rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
+    end
+
+    instrumenter.unhook(probe)
+    ToggleLimiter.admit = true
 
     Datadog::DI.activate_tracking!
     configure do |c|
@@ -399,6 +480,40 @@ class DIInstrumentBenchmark
     if calls > 100 && !VALIDATE_BENCHMARK_MODE
       raise "Targeted line instrumentation (rate_limit=1): rate limit not enforced, got #{calls} firing calls"
     end
+
+    instrumenter.unhook(probe)
+
+    # Per-probe limiter admits (rate_limit=1M); global limiter rejects, so
+    # every call takes the global-rate-limit skip branch (nothing fires).
+    calls = 0
+    ToggleLimiter.admit = false
+    probe = Datadog::DI::Probe.new(id: 1, type: :log,
+      file: targeted_file, line_no: targeted_line + 1, rate_limit: 1_000_000,)
+    responder = Datadog::DI::ProcResponder.new(executed_proc)
+    rv = instrumenter.hook_line(probe, responder)
+    unless rv
+      raise "Line probe (targeted, rate_limit=1M, global reject) was not successfully installed"
+    end
+
+    Benchmark.ips do |x|
+      benchmark_time = VALIDATE_BENCHMARK_MODE ? {time: 0.01, warmup: 0} : {time: 10, warmup: 2}
+      x.config(
+        **benchmark_time,
+      )
+
+      x.report("line instrumentation - targeted - rate_limit=1M (global reject)") do
+        DITarget.new.test_method_for_line_probe
+      end
+
+      x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
+      x.compare!
+    end
+
+    if calls != 0
+      raise "Targeted line instrumentation (rate_limit=1M, global reject): expected 0 firing calls, got #{calls}"
+    end
+
+    ToggleLimiter.admit = true
 
     # Now, remove all installed hooks and check that the performance of
     # target code is approximately what it was prior to hook installation.


### PR DESCRIPTION
> This PR was created with AI assistance and is labeled "AI Generated".

**What does this PR do?**

Adds a third measured variant — "global reject" — to each instrumented configuration in the `di_instrument` benchmark (method, untargeted line, targeted line).

**Motivation:**

The instrumenter has three per-call outcomes: per-probe reject, global reject (per-probe admits but the process-wide global limiter rejects, and fire. The benchmark measured per-probe reject and fire, so the global-reject path was unmeasured, and it is the dominant per-call cost once admitted traffic exceeds the process-wide caps (`GLOBAL_LOG_RATE_LIMIT=5000/s`, `GLOBAL_SNAPSHOT_RATE_LIMIT=20/s`).

**Change log entry**

None.

**Additional Notes:**

**Benchmark validation** (local run, Ruby 3.2.3, x86_64-linux-gnu; 157s wall-clock for all 13 variants):

The global-reject per-call overhead sits between skip and firing for all three configurations, confirming the variant exercises the global-rate-limit skip branch.

CI execution (microbenchmarks job): https://mosaic.us1.ddbuild.io/change-request/10083114517910277162?owner=datadog&repository=dd-trace-rb&taskExecutionId=1991275074&taskId=gitlab

**How to test the change?**

Existing CI
