### PR TITLE
Add runtime_id to the DI snapshot envelope

### DIFF
--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -379,6 +379,9 @@ module Datadog
             thread_id: nil,
             version: 2,
           },
+          # Snake-case to match this envelope's thread_id/thread_name; the
+          # probe-status and symdb event intakes use camelCase runtimeId.
+          runtime_id: Core::Environment::Identity.id,
           # TODO add tests that the trace/span id is correctly propagated
           "dd.trace_id": active_trace&.id&.to_s,
           "dd.span_id": active_span&.id&.to_s,

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -379,7 +379,6 @@ module Datadog
             thread_id: nil,
             version: 2,
           },
-          # Snake-case to match this envelope's thread_id/thread_name.
           runtime_id: Core::Environment::Identity.id,
           # TODO add tests that the trace/span id is correctly propagated
           "dd.trace_id": active_trace&.id&.to_s,

--- a/lib/datadog/di/probe_notification_builder.rb
+++ b/lib/datadog/di/probe_notification_builder.rb
@@ -379,8 +379,7 @@ module Datadog
             thread_id: nil,
             version: 2,
           },
-          # Snake-case to match this envelope's thread_id/thread_name; the
-          # probe-status and symdb event intakes use camelCase runtimeId.
+          # Snake-case to match this envelope's thread_id/thread_name.
           runtime_id: Core::Environment::Identity.id,
           # TODO add tests that the trace/span id is correctly propagated
           "dd.trace_id": active_trace&.id&.to_s,

--- a/spec/datadog/di/integration/everything_from_remote_config_spec.rb
+++ b/spec/datadog/di/integration/everything_from_remote_config_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe "DI integration from remote config" do
       },
       message: nil,
       process_tags: String,
+      runtime_id: String,
       service: "rspec",
       timestamp: Integer,
     }
@@ -486,6 +487,7 @@ RSpec.describe "DI integration from remote config" do
           # second expression fails evaluation
           message: "hello false[evaluation error]",
           process_tags: String,
+          runtime_id: String,
           service: "rspec",
           timestamp: Integer,
         }
@@ -663,6 +665,7 @@ RSpec.describe "DI integration from remote config" do
           # No message since we stopped execution at condition evaluation.
           message: nil,
           process_tags: String,
+          runtime_id: String,
           service: "rspec",
           timestamp: Integer,
         }
@@ -748,6 +751,7 @@ RSpec.describe "DI integration from remote config" do
             },
             message: nil,
             process_tags: String,
+            runtime_id: String,
             service: "rspec",
             timestamp: Integer,
           }

--- a/spec/datadog/di/probe_notification_builder_spec.rb
+++ b/spec/datadog/di/probe_notification_builder_spec.rb
@@ -251,6 +251,11 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
       )
     end
 
+    it "includes the per-process runtime id in the envelope as snake_case" do
+      expect(payload[:runtime_id]).to be_a(String)
+      expect(payload[:runtime_id]).to eq(Datadog::Core::Environment::Identity.id)
+    end
+
     context "with template" do
       let(:probe) do
         Datadog::DI::Probe.new(id: "123", type: :log, file: "X", line_no: 1,
@@ -293,6 +298,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
           },
           duration: 0,
           host: nil,
+          runtime_id: String,
         }
       end
 
@@ -333,6 +339,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
             },
           },
           message: nil,
+          runtime_id: String,
           service: "test service",
           timestamp: Integer,
           logger: {
@@ -409,6 +416,7 @@ RSpec.describe Datadog::DI::ProbeNotificationBuilder do
             },
           },
           message: nil,
+          runtime_id: String,
           service: "test service",
           timestamp: Integer,
           logger: {


### PR DESCRIPTION
**What does this PR do?**

Adds the per-process runtime id (`Datadog::Core::Environment::Identity.id`) to the Live Debugger snapshot envelope, emitted at the envelope root as `runtime_id` (snake_case).

**Motivation:**

This is a requirement for snapshot correlation implementation.

**Change log entry**

Yes. Dynamic Instrumentation: snapshots now include the per-process runtime id in the envelope, to distinguish process restarts within a container.

**Additional Notes:**

None

**How to test the change?**

Unit tests added
