### PR TITLE
Merge org/env-level APM_TRACING configs for Ruby DI (DEBUG-4401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Dynamic Instrumentation: Honor organization- and environment-level remote enablement for Ruby services. ([#6234][])
+
 ## [2.41.0] - 2026-08-13
 
 ### Added
@@ -5576,6 +5580,7 @@ Git diff: https://github.com/DataDog/dd-trace-rb/compare/v0.3.0...v0.3.1
 [#6138]: https://github.com/DataDog/dd-trace-rb/issues/6138
 [#6142]: https://github.com/DataDog/dd-trace-rb/issues/6142
 [#6173]: https://github.com/DataDog/dd-trace-rb/issues/6173
+[#6234]: https://github.com/DataDog/dd-trace-rb/issues/6234
 [@AdrianLC]: https://github.com/AdrianLC
 [@Azure7111]: https://github.com/Azure7111
 [@BabyGroot]: https://github.com/BabyGroot

--- a/docs/DynamicInstrumentation.md
+++ b/docs/DynamicInstrumentation.md
@@ -65,6 +65,12 @@ Dynamic Instrumentation without an application restart.
 The DD_ENV and source code metadata variables (steps 3 and 4 above)
 still need to be set for probes to appear correctly in the UI.
 
+The enablement signal can target a single service and environment, or be
+set as a default for a whole environment or the whole organization. When
+several of these apply to one service, the most specific one wins: a
+service-and-environment setting overrides an environment-wide default,
+which overrides an organization-wide default.
+
 **Precedence:** if `DD_DYNAMIC_INSTRUMENTATION_ENABLED=false` is set
 explicitly, the env-var setting takes precedence and remote-config
 enablement is ignored. Leave the variable unset (do not set it to

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -22,7 +22,7 @@ module Datadog
         # when DI is explicitly disabled, or the runtime cannot run DI
         # (JRuby, Ruby 2.5), that block — including this bit — is skipped.
         # The enable signal itself is delivered in APM_TRACING payloads and
-        # routed here by Tracing::Remote.process_config.
+        # routed here by Tracing::Remote.merge_and_apply_configs.
         CAPABILITIES = [
           1 << 38, # APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION: Implicit DI enablement
         ].freeze
@@ -37,7 +37,7 @@ module Datadog
 
         # Entry point for the RC-driven DI enable/disable path.
         #
-        # Invoked from {Datadog::Tracing::Remote.process_config} when an
+        # Invoked from {Datadog::Tracing::Remote.merge_and_apply_configs} when an
         # APM_TRACING payload carries `dynamic_instrumentation_enabled`. Runs
         # on the remote-config thread; never raises.
         #
@@ -45,7 +45,7 @@ module Datadog
         #   false to stop it. The `DD_DYNAMIC_INSTRUMENTATION_ENABLED=false`
         #   env var blocks an enable here (see {.explicitly_disabled?}).
         # @param repository [Datadog::Core::Remote::Configuration::Repository, nil]
-        #   the RC repository, passed by {Datadog::Tracing::Remote.process_config}
+        #   the RC repository, passed by {Datadog::Tracing::Remote.apply_lib_config}
         #   so that a stopped->started transition can reconcile against probes that
         #   were delivered in an earlier poll. nil when called outside the RC
         #   dispatch path (e.g. unit tests), in which case no reconcile happens.

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -15,10 +15,20 @@ module Datadog
           1 << 13, # APM_TRACING_LOGS_INJECTION: Dynamic trace logs injection configuration
           1 << 14, # APM_TRACING_HTTP_HEADER_TAGS: Dynamic trace HTTP header tags configuration
           1 << 29, # APM_TRACING_SAMPLE_RULES: Dynamic trace sampling rules configuration
+          1 << 45, # APM_TRACING_MULTICONFIG: merge multiple org/env-level APM_TRACING configs
           # APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION (bit 38) is declared in
           # DI::Remote.capabilities, not here, so it is registered only when DI
           # is not explicitly disabled and the runtime supports DI.
         ].freeze
+
+        # Human-readable scope label per specificity priority, for diagnostics.
+        SCOPE_LABELS = {
+          5 => "service+env",
+          4 => "service",
+          3 => "env",
+          2 => "cluster",
+          1 => "org",
+        }.freeze
 
         def products
           [PRODUCT]
@@ -28,9 +38,130 @@ module Datadog
           CAPABILITIES
         end
 
-        def process_config(config, content, repository = nil)
-          lib_config = config["lib_config"]
+        # Merge and apply every active APM_TRACING config in the repository.
+        #
+        # Org/env-level (multi-config) remote enablement delivers several
+        # APM_TRACING configs in parallel — a (service, env)-specific one, an
+        # env-wide one, and/or an org-wide `*` one. They are merged so that, for
+        # each lib_config field, the value from the most-specific matching config
+        # wins. The repository already holds the full current set (deleted
+        # configs are pruned from it), so the merge is recomputed from scratch on
+        # every dispatch; no separate config map is kept.
+        def process_configs(repository)
+          service = Datadog.configuration.service
+          env = Datadog.configuration.env
 
+          # @type var parsed: Array[[::Datadog::Core::Remote::Configuration::Content, ::Hash[::String, untyped]]]
+          parsed = []
+          repository.contents.each do |content|
+            next unless content.path.product == PRODUCT
+
+            begin
+              parsed << [content, parse_content(content)]
+            rescue => e
+              content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
+            end
+          end
+          return if parsed.empty?
+
+          Datadog.logger.debug { "APM_TRACING RC: received #{parsed.length} config(s)" }
+
+          applicable = parsed.select do |content, config|
+            if config_matches?(config, service, env)
+              Datadog.logger.debug do
+                "APM_TRACING RC: config #{content.path.config_id} " \
+                  "scope=#{SCOPE_LABELS[config_priority(config)]} priority=#{config_priority(config)}"
+              end
+              true
+            else
+              Datadog.logger.debug do
+                "APM_TRACING RC: dropped config #{content.path.config_id} " \
+                  "(service_target=#{config["service_target"].inspect}, self=#{service}/#{env})"
+              end
+              false
+            end
+          end
+
+          # Most-specific first; ties broken by config id (ascending) for a
+          # deterministic merge.
+          ordered = applicable.sort_by { |content, config| [-config_priority(config), content.path.config_id] }
+          merged = merge_lib_configs(ordered.map { |_content, config| config })
+
+          apply_lib_config(merged, repository)
+
+          parsed.each { |content, _config| content.applied }
+        rescue => e
+          parsed&.each do |content, _config|
+            content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
+          end
+        end
+
+        # Apply a single already-parsed config. Retained as the single-config
+        # entry point used directly by callers and tests; the production receiver
+        # path goes through {process_configs}, which merges first.
+        def process_config(config, content, repository = nil)
+          apply_lib_config(config["lib_config"], repository)
+          content.applied
+        rescue => e
+          content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
+        end
+
+        # Whether a config targets this tracer. A concrete (non-`*`) service or
+        # env that differs from ours excludes the config; `*` and an absent
+        # service_target match anything.
+        def config_matches?(config, service, env)
+          target = config["service_target"]
+          return true unless target.is_a?(Hash)
+
+          target_service = target["service"]
+          target_env = target["env"]
+          return false if target_service && target_service != "*" && target_service != service
+          return false if target_env && target_env != "*" && target_env != env
+
+          true
+        end
+
+        # Specificity of a config: service+env (5) > service (4) > env (3) >
+        # cluster (2) > org (1). A target counts as concrete only when present
+        # and not `*`. Matches the reference tracers (Java, Go).
+        def config_priority(config)
+          target = config["service_target"]
+          service = target.is_a?(Hash) ? target["service"] : nil
+          env = target.is_a?(Hash) ? target["env"] : nil
+          single_service = !service.nil? && service != "*"
+          single_env = !env.nil? && env != "*"
+
+          return 5 if single_service && single_env
+          return 4 if single_service
+          return 3 if single_env
+          return 2 unless config["k8s_target_v2"].nil?
+
+          1
+        end
+
+        # Merge lib_configs from configs ordered most-specific first: for each
+        # field, the first (most-specific) non-nil value wins. Fields are
+        # independent, so a lower-priority config can supply a field the
+        # higher-priority one omits.
+        def merge_lib_configs(ordered_configs)
+          merged = {}
+          ordered_configs.each do |config|
+            lib_config = config["lib_config"]
+            next unless lib_config.is_a?(Hash)
+
+            lib_config.each do |key, value|
+              next if value.nil?
+
+              merged[key] = value unless merged.key?(key)
+            end
+          end
+          merged
+        end
+
+        # Apply one lib_config: map the dynamic OPTIONS to telemetry, drive DI
+        # enablement from `dynamic_instrumentation_enabled`, and report the
+        # configuration change to telemetry.
+        def apply_lib_config(lib_config, repository)
           env_vars = Datadog::Tracing::Configuration::Dynamic::OPTIONS.map do |name, env_var, option|
             value = lib_config[name]
 
@@ -69,33 +200,22 @@ module Datadog
               components&.symbol_database&.stop_for_di_disable
               components&.remote&.remove_products(*di_products)
             end
+
+            Datadog.logger.debug { "APM_TRACING RC: merged dynamic_instrumentation_enabled=#{di_enabled}" }
           end
 
-          content.applied
-
-          # allow_initialization: false because process_config runs on the
-          # remote-config worker thread. If components haven't been built yet
-          # (e.g. during a teardown/reset window), the default `true` would
-          # synchronously build the entire component tree from this thread.
-          # The &. chain matches the pattern used by DI::Remote.handle_rc_enablement
-          # in the same dispatch path.
+          # allow_initialization: false because this runs on the remote-config
+          # worker thread. If components haven't been built yet (e.g. during a
+          # teardown/reset window), the default `true` would synchronously build
+          # the entire component tree from this thread. The &. chain matches the
+          # pattern used by DI::Remote.handle_rc_enablement in the same dispatch
+          # path.
           Datadog.send(:components, allow_initialization: false)&.telemetry&.client_configuration_change!(env_vars)
-        rescue => e
-          content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
         end
 
         def receivers(_telemetry)
           receiver do |repository, _changes|
-            # DEV: Filter our by product. Given it will be very common
-            # DEV: we can filter this out before we receive the data in this method.
-            # DEV: Apply this refactor to AppSec as well if implemented.
-            repository.contents.map do |content|
-              case content.path.product
-              when PRODUCT
-                config = parse_content(content)
-                process_config(config, content, repository)
-              end
-            end
+            process_configs(repository)
           end
         end
 

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -21,7 +21,7 @@ module Datadog
           # is not explicitly disabled and the runtime supports DI.
         ].freeze
 
-        # Human-readable scope label per specificity priority, for diagnostics.
+        # Diagnostic scope label per specificity priority.
         SCOPE_LABELS = {
           5 => "service+env",
           4 => "service",
@@ -30,24 +30,27 @@ module Datadog
           1 => "org",
         }.freeze
 
+        # @return [Array[String]] the remote config products this module handles
         def products
           [PRODUCT]
         end
 
+        # @return [Array[Integer]] the remote config capability bits advertised
         def capabilities
           CAPABILITIES
         end
 
-        # Merge and apply every active APM_TRACING config in the repository.
+        # Merges every active APM_TRACING config in the repository and applies the
+        # result once. Org/env-level (multi-config) remote enablement delivers
+        # several APM_TRACING configs in parallel (a (service, env)-specific one,
+        # an env-wide one, and/or an org-wide "*" one); for each lib_config field
+        # the value from the most-specific matching config wins. The RC repository
+        # prunes deleted configs, so this recomputes the merge from the repository's
+        # current contents on each dispatch.
         #
-        # Org/env-level (multi-config) remote enablement delivers several
-        # APM_TRACING configs in parallel — a (service, env)-specific one, an
-        # env-wide one, and/or an org-wide `*` one. They are merged so that, for
-        # each lib_config field, the value from the most-specific matching config
-        # wins. The repository already holds the full current set (deleted
-        # configs are pruned from it), so the merge is recomputed from scratch on
-        # every dispatch; no separate config map is kept.
-        def process_configs(repository)
+        # @param repository [Core::Remote::Configuration::Repository] the current RC repository
+        # @return [nil]
+        def merge_and_apply_configs(repository)
           service = Datadog.configuration.service
           env = Datadog.configuration.env
 
@@ -59,10 +62,10 @@ module Datadog
             begin
               parsed << [content, parse_content(content)]
             rescue => e
+              Datadog.logger.debug { "APM_TRACING RC: skipping unparseable config: #{e.class}: #{e.message}" }
               content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
             end
           end
-          return if parsed.empty?
 
           Datadog.logger.debug { "APM_TRACING RC: received #{parsed.length} config(s)" }
 
@@ -87,28 +90,46 @@ module Datadog
           ordered = applicable.sort_by { |content, config| [-config_priority(config), content.path.config_id] }
           merged = merge_lib_configs(ordered.map { |_content, config| config })
 
+          # Applied even when the set is empty: an emptied repository (last config
+          # removed) reverts the tracing overrides to their non-RC values.
           apply_lib_config(merged, repository)
 
           parsed.each { |content, _config| content.applied }
+          nil
         rescue => e
+          Datadog.logger.debug { "APM_TRACING RC: failed to apply configs: #{e.class}: #{e.message}" }
           parsed&.each do |content, _config|
             content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
           end
+          nil
         end
 
-        # Apply a single already-parsed config. Retained as the single-config
-        # entry point used directly by callers and tests; the production receiver
-        # path goes through {process_configs}, which merges first.
+        # Applies a single already-parsed config and marks the content. This is
+        # the single-config apply path; the production receiver goes through
+        # {merge_and_apply_configs}, which merges first.
+        #
+        # @param config [Hash[String, untyped]] a parsed config with a "lib_config" key
+        # @param content [Core::Remote::Configuration::Content] the RC content to acknowledge
+        # @param repository [Core::Remote::Configuration::Repository, nil] the RC repository, forwarded to DI
+        # @return [nil]
         def process_config(config, content, repository = nil)
           apply_lib_config(config["lib_config"], repository)
           content.applied
+          nil
         rescue => e
+          Datadog.logger.debug { "APM_TRACING RC: failed to apply config: #{e.class}: #{e.message}" }
           content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
+          nil
         end
 
-        # Whether a config targets this tracer. A concrete (non-`*`) service or
-        # env that differs from ours excludes the config; `*` and an absent
+        # Whether a config targets this tracer. A concrete (non-"*") service or
+        # env that differs from ours excludes the config; "*" and an absent
         # service_target match anything.
+        #
+        # @param config [Hash[String, untyped]] a parsed config
+        # @param service [String, nil] this tracer's service
+        # @param env [String, nil] this tracer's env
+        # @return [bool] true when the config applies to this tracer
         def config_matches?(config, service, env)
           target = config["service_target"]
           return true unless target.is_a?(Hash)
@@ -121,9 +142,12 @@ module Datadog
           true
         end
 
-        # Specificity of a config: service+env (5) > service (4) > env (3) >
-        # cluster (2) > org (1). A target counts as concrete only when present
-        # and not `*`. Matches the reference tracers (Java, Go).
+        # Specificity of a config, higher meaning more specific: service+env (5),
+        # service (4), env (3), cluster (2), org (1). A target counts as concrete
+        # only when present and not "*".
+        #
+        # @param config [Hash[String, untyped]] a parsed config
+        # @return [Integer] the specificity rank, 1 through 5
         def config_priority(config)
           target = config["service_target"]
           service = target.is_a?(Hash) ? target["service"] : nil
@@ -139,10 +163,13 @@ module Datadog
           1
         end
 
-        # Merge lib_configs from configs ordered most-specific first: for each
+        # Merges lib_configs from configs ordered most-specific first: for each
         # field, the first (most-specific) non-nil value wins. Fields are
         # independent, so a lower-priority config can supply a field the
         # higher-priority one omits.
+        #
+        # @param ordered_configs [Array[Hash[String, untyped]]] configs, most-specific first
+        # @return [Hash[String, untyped]] the merged lib_config
         def merge_lib_configs(ordered_configs)
           merged = {}
           ordered_configs.each do |config|
@@ -158,9 +185,13 @@ module Datadog
           merged
         end
 
-        # Apply one lib_config: map the dynamic OPTIONS to telemetry, drive DI
-        # enablement from `dynamic_instrumentation_enabled`, and report the
+        # Applies one lib_config: maps the dynamic OPTIONS to telemetry, drives DI
+        # enablement from "dynamic_instrumentation_enabled", and reports the
         # configuration change to telemetry.
+        #
+        # @param lib_config [Hash[String, untyped]] the lib_config to apply
+        # @param repository [Core::Remote::Configuration::Repository, nil] forwarded to DI enablement
+        # @return [nil]
         def apply_lib_config(lib_config, repository)
           env_vars = Datadog::Tracing::Configuration::Dynamic::OPTIONS.map do |name, env_var, option|
             value = lib_config[name]
@@ -186,11 +217,11 @@ module Datadog
             if di_enabled
               components&.symbol_database&.resume_pending_upload
               # Advertise the DI products only if the component actually started.
-              # handle_rc_enablement above no-ops when DI cannot run — the
-              # component is nil on an unsupported runtime, or the enable signal
-              # is blocked by DD_DYNAMIC_INSTRUMENTATION_ENABLED=false. Advertising
-              # then would report DI as in use when it is not and invite probe
-              # configs the tracer must refuse; withdraw the products otherwise.
+              # handle_rc_enablement above no-ops when DI cannot run: the component
+              # is nil on an unsupported runtime, or the enable signal is blocked
+              # by DD_DYNAMIC_INSTRUMENTATION_ENABLED=false. Advertising then would
+              # report DI as in use when it is not and invite probe configs the
+              # tracer must refuse; withdraw the products otherwise.
               if components&.dynamic_instrumentation&.started?
                 components&.remote&.add_products(*di_products)
               else
@@ -206,16 +237,19 @@ module Datadog
 
           # allow_initialization: false because this runs on the remote-config
           # worker thread. If components haven't been built yet (e.g. during a
-          # teardown/reset window), the default `true` would synchronously build
+          # teardown/reset window), the default value would synchronously build
           # the entire component tree from this thread. The &. chain matches the
           # pattern used by DI::Remote.handle_rc_enablement in the same dispatch
           # path.
           Datadog.send(:components, allow_initialization: false)&.telemetry&.client_configuration_change!(env_vars)
+          nil
         end
 
+        # @param _telemetry [Core::Telemetry::Component] unused; kept for the receiver contract
+        # @return [Array[Core::Remote::Dispatcher::Receiver]] the APM_TRACING receiver
         def receivers(_telemetry)
           receiver do |repository, _changes|
-            process_configs(repository)
+            merge_and_apply_configs(repository)
           end
         end
 

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -66,7 +66,14 @@ module Datadog
             next unless content.path.product == PRODUCT
 
             begin
-              parsed << [content, parse_content(content)]
+              config = parse_content(content)
+              unless config.is_a?(Hash)
+                # A syntactically valid but non-object payload (null, [], 42)
+                # would later make config_matches? raise outside this per-content
+                # rescue and abort the whole merge, erroring valid configs too.
+                raise TypeError, "APM_TRACING remote config must be a JSON object, got #{config.class}"
+              end
+              parsed << [content, config]
             rescue => e
               Datadog.logger.debug { "APM_TRACING RC: skipping unparseable config: #{e.class}: #{e.message}" }
               Datadog.send(:components, allow_initialization: false)&.telemetry&.report(

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -51,7 +51,13 @@ module Datadog
         # @param repository [Core::Remote::Configuration::Repository] the current RC repository
         # @return [nil]
         def merge_and_apply_configs(repository)
-          service = Datadog.configuration.service
+          # Resolve the service identity the same way the RC client registers
+          # it with the backend (Core::Remote::Client#service_name =
+          # remote.service || service). When a customer sets remote.service,
+          # the backend delivers service_target.service values targeting that
+          # override; matching against the local service instead would drop
+          # every service-scoped config and let a less-specific org config win.
+          service = Datadog.configuration.remote.service || Datadog.configuration.service
           env = Datadog.configuration.env
 
           # @type var parsed: Array[[::Datadog::Core::Remote::Configuration::Content, ::Hash[::String, untyped]]]

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -63,6 +63,10 @@ module Datadog
               parsed << [content, parse_content(content)]
             rescue => e
               Datadog.logger.debug { "APM_TRACING RC: skipping unparseable config: #{e.class}: #{e.message}" }
+              Datadog.send(:components, allow_initialization: false)&.telemetry&.report(
+                e,
+                description: "Failed to parse APM_TRACING remote config",
+              )
               content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
             end
           end
@@ -98,6 +102,10 @@ module Datadog
           nil
         rescue => e
           Datadog.logger.debug { "APM_TRACING RC: failed to apply configs: #{e.class}: #{e.message}" }
+          Datadog.send(:components, allow_initialization: false)&.telemetry&.report(
+            e,
+            description: "Failed to apply APM_TRACING remote configs",
+          )
           parsed&.each do |content, _config|
             content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
           end
@@ -118,6 +126,10 @@ module Datadog
           nil
         rescue => e
           Datadog.logger.debug { "APM_TRACING RC: failed to apply config: #{e.class}: #{e.message}" }
+          Datadog.send(:components, allow_initialization: false)&.telemetry&.report(
+            e,
+            description: "Failed to apply APM_TRACING remote config",
+          )
           content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
           nil
         end

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -73,6 +73,17 @@ module Datadog
                 # rescue and abort the whole merge, erroring valid configs too.
                 raise TypeError, "APM_TRACING remote config must be a JSON object, got #{config.class}"
               end
+              # A present but non-object lib_config (e.g. {"lib_config": []}) is a
+              # schema violation the customer can fix. Acknowledging it as applied
+              # would tell the backend the config was successfully applied when it
+              # was not, and an empty merge would revert active tracing overrides
+              # to their non-RC values. Reject it per content so the malformed
+              # payload is reported errored instead. A null or absent lib_config
+              # carries no overrides and is left as a no-op.
+              lib_config = config["lib_config"]
+              if !lib_config.nil? && !lib_config.is_a?(Hash)
+                raise TypeError, "APM_TRACING lib_config must be a JSON object, got #{lib_config.class}"
+              end
               parsed << [content, config]
             rescue => e
               Datadog.logger.debug { "APM_TRACING RC: skipping unparseable config: #{e.class}: #{e.message}" }

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -112,28 +112,6 @@ module Datadog
           nil
         end
 
-        # Applies a single already-parsed config and marks the content. This is
-        # the single-config apply path; the production receiver goes through
-        # {merge_and_apply_configs}, which merges first.
-        #
-        # @param config [Hash[String, untyped]] a parsed config with a "lib_config" key
-        # @param content [Core::Remote::Configuration::Content] the RC content to acknowledge
-        # @param repository [Core::Remote::Configuration::Repository, nil] the RC repository, forwarded to DI
-        # @return [nil]
-        def process_config(config, content, repository = nil)
-          apply_lib_config(config["lib_config"], repository)
-          content.applied
-          nil
-        rescue => e
-          Datadog.logger.debug { "APM_TRACING RC: failed to apply config: #{e.class}: #{e.message}" }
-          Datadog.send(:components, allow_initialization: false)&.telemetry&.report(
-            e,
-            description: "Failed to apply APM_TRACING remote config",
-          )
-          content.errored("#{e.class}: #{e.message}: #{Array(e.backtrace).join("\n")}")
-          nil
-        end
-
         # Whether a config targets this tracer. A concrete (non-"*") service or
         # env that differs from ours excludes the config; "*" and an absent
         # service_target match anything.
@@ -180,11 +158,11 @@ module Datadog
         # independent, so a lower-priority config can supply a field the
         # higher-priority one omits.
         #
-        # @param ordered_configs [Array[Hash[String, untyped]]] configs, most-specific first
+        # @param configs_most_specific_first [Array[Hash[String, untyped]]] configs, most-specific first
         # @return [Hash[String, untyped]] the merged lib_config
-        def merge_lib_configs(ordered_configs)
+        def merge_lib_configs(configs_most_specific_first)
           merged = {}
-          ordered_configs.each do |config|
+          configs_most_specific_first.each do |config|
             lib_config = config["lib_config"]
             next unless lib_config.is_a?(Hash)
 

--- a/sig/datadog/tracing/remote.rbs
+++ b/sig/datadog/tracing/remote.rbs
@@ -10,17 +10,15 @@ module Datadog
 
       def self.capabilities: () -> ::Array[::Integer]
 
-      def self.merge_and_apply_configs: (Core::Remote::Configuration::Repository repository) -> void
-
       # config and lib_config are parsed JSON of a backend-defined shape, so their
       # element types are genuinely untyped (not yet modelled by a schema).
-      def self.process_config: (::Hash[::String, untyped] config, Core::Remote::Configuration::Content content, ?Core::Remote::Configuration::Repository? repository) -> void
+      def self.merge_and_apply_configs: (Core::Remote::Configuration::Repository repository) -> void
 
       def self.config_matches?: (::Hash[::String, untyped] config, ::String? service, ::String? env) -> bool
 
       def self.config_priority: (::Hash[::String, untyped] config) -> ::Integer
 
-      def self.merge_lib_configs: (::Array[::Hash[::String, untyped]] ordered_configs) -> ::Hash[::String, untyped]
+      def self.merge_lib_configs: (::Array[::Hash[::String, untyped]] configs_most_specific_first) -> ::Hash[::String, untyped]
 
       def self.apply_lib_config: (::Hash[::String, untyped] lib_config, Core::Remote::Configuration::Repository? repository) -> void
 

--- a/sig/datadog/tracing/remote.rbs
+++ b/sig/datadog/tracing/remote.rbs
@@ -2,32 +2,35 @@ module Datadog
   module Tracing
     module Remote
       PRODUCT: "APM_TRACING"
-      CAPABILITIES: Array[Integer]
-      SCOPE_LABELS: Hash[Integer, String]
+      CAPABILITIES: ::Array[::Integer]
+      # Keyed by specificity priority (1..5); value is the diagnostic label.
+      SCOPE_LABELS: ::Hash[::Integer, ::String]
 
-      def self.products: () -> ::Array[String]
+      def self.products: () -> ::Array[::String]
 
-      def self.capabilities: () -> ::Array[Integer]
+      def self.capabilities: () -> ::Array[::Integer]
 
-      def self.process_configs: (Core::Remote::Configuration::Repository repository) -> void
+      def self.merge_and_apply_configs: (Core::Remote::Configuration::Repository repository) -> void
 
-      def self.process_config: (Hash[String, untyped] config, Core::Remote::Configuration::Content content, ?Core::Remote::Configuration::Repository? repository) -> void
+      # config and lib_config are parsed JSON of a backend-defined shape, so their
+      # element types are genuinely untyped (not yet modelled by a schema).
+      def self.process_config: (::Hash[::String, untyped] config, Core::Remote::Configuration::Content content, ?Core::Remote::Configuration::Repository? repository) -> void
 
-      def self.config_matches?: (Hash[String, untyped] config, String? service, String? env) -> bool
+      def self.config_matches?: (::Hash[::String, untyped] config, ::String? service, ::String? env) -> bool
 
-      def self.config_priority: (Hash[String, untyped] config) -> Integer
+      def self.config_priority: (::Hash[::String, untyped] config) -> ::Integer
 
-      def self.merge_lib_configs: (Array[Hash[String, untyped]] ordered_configs) -> Hash[String, untyped]
+      def self.merge_lib_configs: (::Array[::Hash[::String, untyped]] ordered_configs) -> ::Hash[::String, untyped]
 
-      def self.apply_lib_config: (Hash[String, untyped] lib_config, Core::Remote::Configuration::Repository? repository) -> void
+      def self.apply_lib_config: (::Hash[::String, untyped] lib_config, Core::Remote::Configuration::Repository? repository) -> void
 
       def self.receivers: (Datadog::Core::Telemetry::Component) -> ::Array[Core::Remote::Dispatcher::Receiver]
 
-      def self.receiver: (?::Array[String] products) { (Core::Remote::Configuration::Repository repository, Array[Core::Remote::Configuration::Repository::change] changes) -> void } -> ::Array[Core::Remote::Dispatcher::Receiver]
+      def self.receiver: (?::Array[::String] products) { (Core::Remote::Configuration::Repository repository, ::Array[Core::Remote::Configuration::Repository::change] changes) -> void } -> ::Array[Core::Remote::Dispatcher::Receiver]
 
       private
 
-      def self.parse_content: (Core::Remote::Configuration::Content content) -> Hash[String, untyped]
+      def self.parse_content: (Core::Remote::Configuration::Content content) -> ::Hash[::String, untyped]
     end
   end
 end

--- a/sig/datadog/tracing/remote.rbs
+++ b/sig/datadog/tracing/remote.rbs
@@ -3,12 +3,23 @@ module Datadog
     module Remote
       PRODUCT: "APM_TRACING"
       CAPABILITIES: Array[Integer]
+      SCOPE_LABELS: Hash[Integer, String]
 
       def self.products: () -> ::Array[String]
 
       def self.capabilities: () -> ::Array[Integer]
 
+      def self.process_configs: (Core::Remote::Configuration::Repository repository) -> void
+
       def self.process_config: (Hash[String, untyped] config, Core::Remote::Configuration::Content content, ?Core::Remote::Configuration::Repository? repository) -> void
+
+      def self.config_matches?: (Hash[String, untyped] config, String? service, String? env) -> bool
+
+      def self.config_priority: (Hash[String, untyped] config) -> Integer
+
+      def self.merge_lib_configs: (Array[Hash[String, untyped]] ordered_configs) -> Hash[String, untyped]
+
+      def self.apply_lib_config: (Hash[String, untyped] lib_config, Core::Remote::Configuration::Repository? repository) -> void
 
       def self.receivers: (Datadog::Core::Telemetry::Component) -> ::Array[Core::Remote::Dispatcher::Receiver]
 

--- a/spec/datadog/core/remote/client/capabilities_spec.rb
+++ b/spec/datadog/core/remote/client/capabilities_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
   shared_examples "tracing and DI capabilities" do
     it "includes tracing capabilities and the DI enablement bit" do
-      # Bits 12, 13, 14, 29 (tracing) + 38 (DI enablement, registered with the DI block)
-      expect(capabilities.base64_capabilities).to eq("QCAAcAA=")
+      # Bits 12, 13, 14, 29, 45 (tracing) + 38 (DI enablement, registered with the DI block)
+      expect(capabilities.base64_capabilities).to eq("IEAgAHAA")
     end
   end
 
   shared_examples "tracing capabilities only" do
     it "includes only tracing capabilities (DI not registered)" do
-      # Bits 12, 13, 14, 29 (tracing). Bit 38 lives in the DI block, which is
+      # Bits 12, 13, 14, 29, 45 (tracing). Bit 38 lives in the DI block, which is
       # not registered here (DI settings absent or explicitly disabled).
-      expect(capabilities.base64_capabilities).to eq("IABwAA==")
+      expect(capabilities.base64_capabilities).to eq("IAAgAHAA")
     end
   end
 
@@ -338,7 +338,7 @@ RSpec.describe Datadog::Core::Remote::Client::Capabilities do
 
   context "Tracing component" do
     it "register capabilities, products, and receivers" do
-      expect(capabilities.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29)
+      expect(capabilities.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29, 1 << 45)
       expect(capabilities.products).to include("APM_TRACING")
       expect(capabilities.receivers).to include(
         lambda { |r|

--- a/spec/datadog/di/integration/implicit_enablement_spec.rb
+++ b/spec/datadog/di/integration/implicit_enablement_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "DI implicit enablement integration" do
   end
 
   let(:symbol_database) do
-    # Tracing::Remote.process_config replays (resume_pending_upload) or stops
+    # Tracing::Remote.apply_lib_config replays (resume_pending_upload) or stops
     # (stop_for_di_disable) Symbol Database when a dynamic_instrumentation_enabled
     # signal arrives. This test builds only a DI component, so expose a Symbol
     # Database stand-in that accepts the two lifecycle calls. The upload behavior
@@ -61,7 +61,7 @@ RSpec.describe "DI implicit enablement integration" do
   let(:components) do
     # Stand-in for Core::Configuration::Components. handle_rc_enablement
     # reaches the component via Datadog.send(:components).dynamic_instrumentation
-    # and Tracing::Remote.process_config calls reconfigure_sampler on it for
+    # and Tracing::Remote.apply_lib_config calls reconfigure_sampler on it for
     # each tracing dynamic-option update. We expose only what's needed.
     instance_double(
       Datadog::Core::Configuration::Components,
@@ -103,13 +103,26 @@ RSpec.describe "DI implicit enablement integration" do
 
   after { component&.shutdown! }
 
+  # Drives the production RC dispatch path (Tracing::Remote.merge_and_apply_configs)
+  # for a single APM_TRACING payload, returning the Content so apply_state can
+  # be asserted. Replaces the former single-config process_config entry point.
+  def apply_rc_payload(payload)
+    content = Datadog::Core::Remote::Configuration::Content.parse(
+      path: "datadog/1/APM_TRACING/lib_config/config",
+      content: JSON.dump(payload),
+    )
+    repository = instance_double(
+      Datadog::Core::Remote::Configuration::Repository,
+      contents: [content],
+    )
+    Datadog::Tracing::Remote.merge_and_apply_configs(repository)
+    content
+  end
+
   describe "RC enables DI → method probe installs and fires" do
     let(:rc_payload_enable) { {"lib_config" => {"dynamic_instrumentation_enabled" => true}} }
-    let(:rc_content) { instance_double(Datadog::Core::Remote::Configuration::Content) }
 
     before do
-      allow(rc_content).to receive(:applied)
-      allow(rc_content).to receive(:errored)
       allow(telemetry).to receive(:client_configuration_change!)
     end
 
@@ -117,10 +130,10 @@ RSpec.describe "DI implicit enablement integration" do
       expect(component).not_to be_nil
       expect(component.started?).to be false
 
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      content = apply_rc_payload(rc_payload_enable)
 
       expect(component.started?).to be true
-      expect(rc_content).to have_received(:applied)
+      expect(content.apply_state).to eq(2)
     end
 
     it "advertises the DI products via remote config once the component starts" do
@@ -131,7 +144,7 @@ RSpec.describe "DI implicit enablement integration" do
       expect(component.started?).to be false
       expect(remote).to receive(:add_products).with("LIVE_DEBUGGING", "LIVE_DEBUGGING_SYMBOL_DB")
 
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      apply_rc_payload(rc_payload_enable)
 
       expect(component.started?).to be true
     end
@@ -143,7 +156,7 @@ RSpec.describe "DI implicit enablement integration" do
       # state (which other tests in the suite may touch).
       expect(Datadog::DI).to receive(:activate_tracking)
 
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      apply_rc_payload(rc_payload_enable)
     end
 
     context "after the component is started, a LIVE_DEBUGGING method probe arrives" do
@@ -185,7 +198,7 @@ RSpec.describe "DI implicit enablement integration" do
       end
 
       it "is installed after the APM_TRACING enable signal arrives" do
-        Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+        apply_rc_payload(rc_payload_enable)
         expect(component.started?).to be true
 
         di_receiver.call(repository, transaction)
@@ -199,7 +212,6 @@ RSpec.describe "DI implicit enablement integration" do
   describe "RC disable stops the component and unhooks probes" do
     let(:rc_payload_enable) { {"lib_config" => {"dynamic_instrumentation_enabled" => true}} }
     let(:rc_payload_disable) { {"lib_config" => {"dynamic_instrumentation_enabled" => false}} }
-    let(:rc_content) { instance_double(Datadog::Core::Remote::Configuration::Content, applied: nil, errored: nil) }
 
     before do
       allow(telemetry).to receive(:client_configuration_change!)
@@ -207,26 +219,26 @@ RSpec.describe "DI implicit enablement integration" do
     end
 
     it "stops the component when dynamic_instrumentation_enabled=false arrives" do
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      apply_rc_payload(rc_payload_enable)
       expect(component.started?).to be true
 
-      Datadog::Tracing::Remote.process_config(rc_payload_disable, rc_content)
+      apply_rc_payload(rc_payload_disable)
       expect(component.started?).to be false
     end
 
     it "is idempotent: false → false stays stopped without error" do
-      Datadog::Tracing::Remote.process_config(rc_payload_disable, rc_content)
+      apply_rc_payload(rc_payload_disable)
       expect(component.started?).to be false
-      expect { Datadog::Tracing::Remote.process_config(rc_payload_disable, rc_content) }.not_to raise_error
+      expect { apply_rc_payload(rc_payload_disable) }.not_to raise_error
       expect(component.started?).to be false
     end
 
     it "supports restart: true → false → true" do
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      apply_rc_payload(rc_payload_enable)
       expect(component.started?).to be true
-      Datadog::Tracing::Remote.process_config(rc_payload_disable, rc_content)
+      apply_rc_payload(rc_payload_disable)
       expect(component.started?).to be false
-      Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+      apply_rc_payload(rc_payload_enable)
       expect(component.started?).to be true
     end
 
@@ -255,7 +267,7 @@ RSpec.describe "DI implicit enablement integration" do
       end
 
       it "unhooks the probe but preserves it in the repository when the component is stopped via RC disable" do
-        Datadog::Tracing::Remote.process_config(rc_payload_enable, rc_content)
+        apply_rc_payload(rc_payload_enable)
         di_receiver.call(repository, transaction)
         component.probe_notifier_worker.flush
         installed = component.probe_manager.probe_repository.installed_probes
@@ -264,7 +276,7 @@ RSpec.describe "DI implicit enablement integration" do
         # Pre-check: hook installed instrumentation on the target method.
         expect(probe.instrumentation_module).not_to be_nil
 
-        Datadog::Tracing::Remote.process_config(rc_payload_disable, rc_content)
+        apply_rc_payload(rc_payload_disable)
 
         expect(component.started?).to be false
         # stop! calls probe_manager.stop which unhooks installed probes
@@ -438,7 +450,7 @@ RSpec.describe "DI implicit enablement integration" do
 
     before { allow(Datadog::SymbolDatabase).to receive(:supported_runtime?).and_return(true) }
 
-    def repository_with(*hashes)
+    def build_repository(*hashes)
       instance_double(
         Datadog::Core::Remote::Configuration::Repository,
         contents: hashes.each_with_index.map { |h, i| apm_content("c#{i}", h) },
@@ -483,13 +495,13 @@ RSpec.describe "DI implicit enablement integration" do
 
     it "stops the component when a later merge resolves to false" do
       Datadog::Tracing::Remote.merge_and_apply_configs(
-        repository_with({"service_target" => {"service" => "*", "env" => "*"},
+        build_repository({"service_target" => {"service" => "*", "env" => "*"},
           "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
       )
       expect(component.started?).to be true
 
       Datadog::Tracing::Remote.merge_and_apply_configs(
-        repository_with(
+        build_repository(
           {"service_target" => {"service" => "*", "env" => "*"},
            "lib_config" => {"dynamic_instrumentation_enabled" => true}},
           {"service_target" => {"service" => "web", "env" => "prod"},
@@ -499,11 +511,9 @@ RSpec.describe "DI implicit enablement integration" do
       expect(component.started?).to be false
     end
 
-    it "inherits dynamic_instrumentation_enabled from the org config when the service+env config omits it" do
-      # org (less specific) enables DI; the service+env (more specific) config
-      # sets only a sampling rate, so DI is inherited from org and the component starts.
+    it "inherits dynamic_instrumentation_enabled from org when the service+env config supplies only a sampling rate" do
       Datadog::Tracing::Remote.merge_and_apply_configs(
-        repository_with(
+        build_repository(
           {"service_target" => {"service" => "*", "env" => "*"},
            "lib_config" => {"dynamic_instrumentation_enabled" => true}},
           {"service_target" => {"service" => "web", "env" => "prod"},

--- a/spec/datadog/di/integration/implicit_enablement_spec.rb
+++ b/spec/datadog/di/integration/implicit_enablement_spec.rb
@@ -411,4 +411,59 @@ RSpec.describe "DI implicit enablement integration" do
       expect(component.probe_manager.probe_repository.installed_probes.keys).to include("test-probe-earlier-poll")
     end
   end
+
+  describe "RC enables DI via merged org/env-level (multi-config) configs" do
+    def apm_content(config_id, hash)
+      Datadog::Core::Remote::Configuration::Content.parse(
+        path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
+        content: JSON.dump(hash),
+      )
+    end
+
+    let(:repository) do
+      instance_double(Datadog::Core::Remote::Configuration::Repository, contents: contents)
+    end
+
+    before do
+      settings.service = "web"
+      settings.env = "prod"
+      allow(Datadog::SymbolDatabase).to receive(:supported_runtime?).and_return(true)
+    end
+
+    context "with a single org-wide enable" do
+      let(:contents) do
+        [apm_content("org", {"service_target" => {"service" => "*", "env" => "*"},
+          "lib_config" => {"dynamic_instrumentation_enabled" => true}})]
+      end
+
+      it "starts the component end-to-end" do
+        expect(component.started?).to be false
+
+        Datadog::Tracing::Remote.process_configs(repository)
+
+        expect(component.started?).to be true
+        expect(contents.first.apply_state).to eq(2)
+      end
+    end
+
+    context "when a service+env override disables what the org-wide config enables" do
+      let(:contents) do
+        [
+          apm_content("org", {"service_target" => {"service" => "*", "env" => "*"},
+            "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
+          apm_content("svc", {"service_target" => {"service" => "web", "env" => "prod"},
+            "lib_config" => {"dynamic_instrumentation_enabled" => false}}),
+        ]
+      end
+
+      it "does not start the component (most-specific false wins) and marks both applied" do
+        expect(component.started?).to be false
+
+        Datadog::Tracing::Remote.process_configs(repository)
+
+        expect(component.started?).to be false
+        expect(contents.map(&:apply_state)).to eq([2, 2])
+      end
+    end
+  end
 end

--- a/spec/datadog/di/integration/implicit_enablement_spec.rb
+++ b/spec/datadog/di/integration/implicit_enablement_spec.rb
@@ -108,8 +108,10 @@ RSpec.describe "DI implicit enablement integration" do
   # be asserted. Replaces the former single-config process_config entry point.
   def apply_rc_payload(payload)
     content = Datadog::Core::Remote::Configuration::Content.parse(
-      path: "datadog/1/APM_TRACING/lib_config/config",
-      content: JSON.dump(payload),
+      {
+        path: "datadog/1/APM_TRACING/lib_config/config",
+        content: JSON.dump(payload),
+      }
     )
     repository = instance_double(
       Datadog::Core::Remote::Configuration::Repository,
@@ -427,8 +429,10 @@ RSpec.describe "DI implicit enablement integration" do
   describe "RC enables DI via merged org/env-level (multi-config) configs" do
     def apm_content(config_id, hash)
       Datadog::Core::Remote::Configuration::Content.parse(
-        path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
-        content: JSON.dump(hash),
+        {
+          path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
+          content: JSON.dump(hash),
+        }
       )
     end
 

--- a/spec/datadog/di/integration/implicit_enablement_spec.rb
+++ b/spec/datadog/di/integration/implicit_enablement_spec.rb
@@ -420,14 +420,29 @@ RSpec.describe "DI implicit enablement integration" do
       )
     end
 
+    # service/env set at construction (not in-place mutation) so config_matches?
+    # can resolve the service+env target below.
+    let(:settings) do
+      Datadog::Core::Configuration::Settings.new.tap do |s|
+        s.remote.enabled = true
+        s.dynamic_instrumentation.internal.development = true
+        s.dynamic_instrumentation.internal.propagate_all_exceptions = true
+        s.service = "web"
+        s.env = "prod"
+      end
+    end
+
     let(:repository) do
       instance_double(Datadog::Core::Remote::Configuration::Repository, contents: contents)
     end
 
-    before do
-      settings.service = "web"
-      settings.env = "prod"
-      allow(Datadog::SymbolDatabase).to receive(:supported_runtime?).and_return(true)
+    before { allow(Datadog::SymbolDatabase).to receive(:supported_runtime?).and_return(true) }
+
+    def repository_with(*hashes)
+      instance_double(
+        Datadog::Core::Remote::Configuration::Repository,
+        contents: hashes.each_with_index.map { |h, i| apm_content("c#{i}", h) },
+      )
     end
 
     context "with a single org-wide enable" do
@@ -439,7 +454,7 @@ RSpec.describe "DI implicit enablement integration" do
       it "starts the component end-to-end" do
         expect(component.started?).to be false
 
-        Datadog::Tracing::Remote.process_configs(repository)
+        Datadog::Tracing::Remote.merge_and_apply_configs(repository)
 
         expect(component.started?).to be true
         expect(contents.first.apply_state).to eq(2)
@@ -459,11 +474,43 @@ RSpec.describe "DI implicit enablement integration" do
       it "does not start the component (most-specific false wins) and marks both applied" do
         expect(component.started?).to be false
 
-        Datadog::Tracing::Remote.process_configs(repository)
+        Datadog::Tracing::Remote.merge_and_apply_configs(repository)
 
         expect(component.started?).to be false
         expect(contents.map(&:apply_state)).to eq([2, 2])
       end
+    end
+
+    it "stops the component when a later merge resolves to false" do
+      Datadog::Tracing::Remote.merge_and_apply_configs(
+        repository_with({"service_target" => {"service" => "*", "env" => "*"},
+          "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
+      )
+      expect(component.started?).to be true
+
+      Datadog::Tracing::Remote.merge_and_apply_configs(
+        repository_with(
+          {"service_target" => {"service" => "*", "env" => "*"},
+           "lib_config" => {"dynamic_instrumentation_enabled" => true}},
+          {"service_target" => {"service" => "web", "env" => "prod"},
+           "lib_config" => {"dynamic_instrumentation_enabled" => false}},
+        ),
+      )
+      expect(component.started?).to be false
+    end
+
+    it "inherits dynamic_instrumentation_enabled from the org config when the service+env config omits it" do
+      # org (less specific) enables DI; the service+env (more specific) config
+      # sets only a sampling rate, so DI is inherited from org and the component starts.
+      Datadog::Tracing::Remote.merge_and_apply_configs(
+        repository_with(
+          {"service_target" => {"service" => "*", "env" => "*"},
+           "lib_config" => {"dynamic_instrumentation_enabled" => true}},
+          {"service_target" => {"service" => "web", "env" => "prod"},
+           "lib_config" => {"tracing_sampling_rate" => 0.5}},
+        ),
+      )
+      expect(component.started?).to be true
     end
   end
 end

--- a/spec/datadog/di/integration/probe_coverage_spec.rb
+++ b/spec/datadog/di/integration/probe_coverage_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "DI probe coverage across enablement timing" do
   let(:probe_manager) { component.probe_manager }
 
   def simulate_rc_enablement
-    # Mirror what Tracing::Remote.process_config does on
+    # Mirror what Tracing::Remote.apply_lib_config does on
     # `dynamic_instrumentation_enabled: true`. Bypassing the full Remote
     # plumbing here — the integration spec covers that path. This test
     # focuses on the post-enablement probe-install matrix.

--- a/spec/datadog/tracing/contrib/suite/integration_spec.rb
+++ b/spec/datadog/tracing/contrib/suite/integration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "contrib integration testing", :integration do
   describe "dynamic configuration" do
     subject(:update_config) do
       @reconfigured = false
-      allow(Datadog::Tracing::Remote).to receive(:process_config).and_wrap_original do |m, *args|
+      allow(Datadog::Tracing::Remote).to receive(:merge_and_apply_configs).and_wrap_original do |m, *args|
         m.call(*args).tap { @reconfigured = true }
       end
 

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -478,6 +478,49 @@ RSpec.describe Datadog::Tracing::Remote do
       end
     end
 
+    context "when one config has a present but non-object lib_config" do
+      let(:good) do
+        build_content("good", {"service_target" => {"service" => "*", "env" => "*"},
+                            "lib_config" => {"log_injection_enabled" => false}})
+      end
+      let(:bad_lib_config) do
+        build_content("bad_lib_config", {"service_target" => {"service" => "*", "env" => "*"},
+                                    "lib_config" => []})
+      end
+      let(:contents) { [good, bad_lib_config] }
+
+      it "marks the malformed lib_config content errored and still applies the good one" do
+        expect(Datadog.send(:components).telemetry).to receive(:report)
+          .with(kind_of(StandardError), description: "Failed to parse APM_TRACING remote config")
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(good.apply_state).to eq(2)
+        expect(bad_lib_config.apply_state).to eq(3)
+        expect(bad_lib_config.apply_error).to include("lib_config")
+      end
+    end
+
+    context "when a config has a null or absent lib_config" do
+      let(:null_lib_config) do
+        build_content("null_lc", {"service_target" => {"service" => "*", "env" => "*"},
+                               "lib_config" => nil})
+      end
+      let(:absent_lib_config) do
+        build_content("absent_lc", {"service_target" => {"service" => "*", "env" => "*"}})
+      end
+      let(:contents) { [null_lib_config, absent_lib_config] }
+
+      it "treats both as no-op configs and marks them applied" do
+        expect(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(null_lib_config.apply_state).to eq(2)
+        expect(absent_lib_config.apply_state).to eq(2)
+      end
+    end
+
     context "with a non-APM_TRACING content present" do
       let(:other) do
         Datadog::Core::Remote::Configuration::Content.parse(

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Datadog::Tracing::Remote do
   end
 
   it "declares tracing capabilities (DI enablement bit 38 lives in DI::Remote)" do
-    expect(remote.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29)
+    expect(remote.capabilities).to contain_exactly(1 << 12, 1 << 13, 1 << 14, 1 << 29, 1 << 45)
   end
 
   it "declares matches that match APM_TRACING" do
@@ -208,6 +208,188 @@ RSpec.describe Datadog::Tracing::Remote do
             expect(content.apply_state).to eq(2)
           end
         end
+      end
+    end
+  end
+
+  describe "#config_matches?" do
+    it "matches when service_target is absent" do
+      expect(remote.config_matches?({"lib_config" => {}}, "web", "prod")).to be(true)
+    end
+
+    it "matches wildcard service and env" do
+      config = {"service_target" => {"service" => "*", "env" => "*"}}
+      expect(remote.config_matches?(config, "web", "prod")).to be(true)
+    end
+
+    it "matches a concrete service+env equal to ours" do
+      config = {"service_target" => {"service" => "web", "env" => "prod"}}
+      expect(remote.config_matches?(config, "web", "prod")).to be(true)
+    end
+
+    it "drops a config for a different concrete service" do
+      config = {"service_target" => {"service" => "other", "env" => "*"}}
+      expect(remote.config_matches?(config, "web", "prod")).to be(false)
+    end
+
+    it "drops a config for a different concrete env" do
+      config = {"service_target" => {"service" => "*", "env" => "staging"}}
+      expect(remote.config_matches?(config, "web", "prod")).to be(false)
+    end
+  end
+
+  describe "#config_priority" do
+    it "ranks service+env highest (5)" do
+      expect(remote.config_priority({"service_target" => {"service" => "web", "env" => "prod"}})).to eq(5)
+    end
+
+    it "ranks service-only as 4" do
+      expect(remote.config_priority({"service_target" => {"service" => "web", "env" => "*"}})).to eq(4)
+    end
+
+    it "ranks env-only as 3" do
+      expect(remote.config_priority({"service_target" => {"service" => "*", "env" => "prod"}})).to eq(3)
+    end
+
+    it "ranks cluster as 2" do
+      config = {"service_target" => {"service" => "*", "env" => "*"}, "k8s_target_v2" => {"cluster_targets" => ["c"]}}
+      expect(remote.config_priority(config)).to eq(2)
+    end
+
+    it "ranks org-wide lowest (1)" do
+      expect(remote.config_priority({"service_target" => {"service" => "*", "env" => "*"}})).to eq(1)
+    end
+
+    it "treats an absent service_target as org-wide (1)" do
+      expect(remote.config_priority({})).to eq(1)
+    end
+  end
+
+  describe "#merge_lib_configs" do
+    it "takes the most-specific non-nil value per field (ordered most-specific first)" do
+      ordered = [
+        {"lib_config" => {"dynamic_instrumentation_enabled" => false}},
+        {"lib_config" => {"dynamic_instrumentation_enabled" => true}},
+      ]
+      expect(remote.merge_lib_configs(ordered)).to eq("dynamic_instrumentation_enabled" => false)
+    end
+
+    it "inherits a field absent from the most-specific config from the next one" do
+      ordered = [
+        {"lib_config" => {"tracing_sampling_rate" => 0.5}},
+        {"lib_config" => {"dynamic_instrumentation_enabled" => true}},
+      ]
+      expect(remote.merge_lib_configs(ordered)).to eq(
+        "tracing_sampling_rate" => 0.5,
+        "dynamic_instrumentation_enabled" => true,
+      )
+    end
+
+    it "treats false as a winning value over an absent field" do
+      ordered = [
+        {"lib_config" => {"dynamic_instrumentation_enabled" => false}},
+        {"lib_config" => {"tracing_sampling_rate" => 0.1}},
+      ]
+      expect(remote.merge_lib_configs(ordered)).to eq(
+        "dynamic_instrumentation_enabled" => false,
+        "tracing_sampling_rate" => 0.1,
+      )
+    end
+
+    it "returns an empty hash for no configs" do
+      expect(remote.merge_lib_configs([])).to eq({})
+    end
+  end
+
+  describe "#process_configs" do
+    def content_for(config_id, config)
+      Datadog::Core::Remote::Configuration::Content.parse(
+        path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
+        content: JSON.dump(config),
+      )
+    end
+
+    let(:repository) { instance_double(Datadog::Core::Remote::Configuration::Repository, contents: contents) }
+
+    before do
+      allow(Datadog.configuration).to receive(:service).and_return("web")
+      allow(Datadog.configuration).to receive(:env).and_return("prod")
+      allow(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
+    end
+
+    context "with cascading DI enablement configs" do
+      let(:contents) do
+        [
+          content_for("org", {"service_target" => {"service" => "*", "env" => "*"},
+                              "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
+          content_for("svc", {"service_target" => {"service" => "web", "env" => "prod"},
+                              "lib_config" => {"dynamic_instrumentation_enabled" => false}}),
+        ]
+      end
+
+      it "calls handle_rc_enablement once with the most-specific value and marks contents applied" do
+        expect(Datadog::DI::Remote).to receive(:handle_rc_enablement).once.with(false, repository)
+        allow(Datadog::SymbolDatabase::Remote).to receive(:deferred_products).and_return([])
+
+        remote.process_configs(repository)
+
+        expect(contents.map(&:apply_state)).to eq([2, 2])
+      end
+    end
+
+    context "with equal-priority (org) configs setting the same field" do
+      let(:contents) do
+        [
+          content_for("b", {"service_target" => {"service" => "*", "env" => "*"},
+                            "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
+          content_for("a", {"service_target" => {"service" => "*", "env" => "*"},
+                            "lib_config" => {"dynamic_instrumentation_enabled" => false}}),
+        ]
+      end
+
+      it "breaks the tie by config id ascending (a before b)" do
+        expect(Datadog::DI::Remote).to receive(:handle_rc_enablement).once.with(false, repository)
+        allow(Datadog::SymbolDatabase::Remote).to receive(:deferred_products).and_return([])
+
+        remote.process_configs(repository)
+      end
+    end
+
+    context "when a config targets a different service" do
+      let(:contents) do
+        [
+          content_for("other", {"service_target" => {"service" => "other", "env" => "prod"},
+                                "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
+        ]
+      end
+
+      it "drops it from the merge but still marks it applied, and does not touch DI" do
+        expect(Datadog::DI::Remote).not_to receive(:handle_rc_enablement)
+
+        remote.process_configs(repository)
+
+        expect(contents.first.apply_state).to eq(2)
+      end
+    end
+
+    context "when one config has malformed JSON" do
+      let(:good) do
+        content_for("good", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
+      end
+      let(:bad) do
+        Datadog::Core::Remote::Configuration::Content.parse(
+          path: "datadog/1/APM_TRACING/bad/lib_config",
+          content: "{not json",
+        )
+      end
+      let(:contents) { [good, bad] }
+
+      it "marks the malformed content errored and still applies the good one" do
+        remote.process_configs(repository)
+
+        expect(good.apply_state).to eq(2)
+        expect(bad.apply_state).to eq(3)
+        expect(bad.apply_error).to include("JSON")
       end
     end
   end

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -451,6 +451,33 @@ RSpec.describe Datadog::Tracing::Remote do
       end
     end
 
+    context "when one config is valid JSON but not a JSON object" do
+      let(:good) do
+        build_content("good", {"service_target" => {"service" => "*", "env" => "*"},
+                            "lib_config" => {"log_injection_enabled" => false}})
+      end
+      let(:non_object) do
+        Datadog::Core::Remote::Configuration::Content.parse(
+          {
+            path: "datadog/1/APM_TRACING/non_object/lib_config",
+            content: "null",
+          }
+        )
+      end
+      let(:contents) { [good, non_object] }
+
+      it "marks the non-object content errored and still applies the good one" do
+        expect(Datadog.send(:components).telemetry).to receive(:report)
+          .with(kind_of(StandardError), description: "Failed to parse APM_TRACING remote config")
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(good.apply_state).to eq(2)
+        expect(non_object.apply_state).to eq(3)
+        expect(non_object.apply_error).to include("object")
+      end
+    end
+
     context "with a non-APM_TRACING content present" do
       let(:other) do
         Datadog::Core::Remote::Configuration::Content.parse(

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -299,9 +299,19 @@ RSpec.describe Datadog::Tracing::Remote do
     it "returns an empty hash for no configs" do
       expect(remote.merge_lib_configs([])).to eq({})
     end
+
+    it "skips nil field values" do
+      ordered = [{"lib_config" => {"x" => nil, "y" => 1}}]
+      expect(remote.merge_lib_configs(ordered)).to eq("y" => 1)
+    end
+
+    it "skips a config whose lib_config is missing or not a hash" do
+      ordered = [{"lib_config" => nil}, {}, {"lib_config" => {"x" => 1}}]
+      expect(remote.merge_lib_configs(ordered)).to eq("x" => 1)
+    end
   end
 
-  describe "#process_configs" do
+  describe "#merge_and_apply_configs" do
     def content_for(config_id, config)
       Datadog::Core::Remote::Configuration::Content.parse(
         path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
@@ -331,7 +341,7 @@ RSpec.describe Datadog::Tracing::Remote do
         expect(Datadog::DI::Remote).to receive(:handle_rc_enablement).once.with(false, repository)
         allow(Datadog::SymbolDatabase::Remote).to receive(:deferred_products).and_return([])
 
-        remote.process_configs(repository)
+        remote.merge_and_apply_configs(repository)
 
         expect(contents.map(&:apply_state)).to eq([2, 2])
       end
@@ -351,7 +361,7 @@ RSpec.describe Datadog::Tracing::Remote do
         expect(Datadog::DI::Remote).to receive(:handle_rc_enablement).once.with(false, repository)
         allow(Datadog::SymbolDatabase::Remote).to receive(:deferred_products).and_return([])
 
-        remote.process_configs(repository)
+        remote.merge_and_apply_configs(repository)
       end
     end
 
@@ -366,7 +376,7 @@ RSpec.describe Datadog::Tracing::Remote do
       it "drops it from the merge but still marks it applied, and does not touch DI" do
         expect(Datadog::DI::Remote).not_to receive(:handle_rc_enablement)
 
-        remote.process_configs(repository)
+        remote.merge_and_apply_configs(repository)
 
         expect(contents.first.apply_state).to eq(2)
       end
@@ -385,11 +395,84 @@ RSpec.describe Datadog::Tracing::Remote do
       let(:contents) { [good, bad] }
 
       it "marks the malformed content errored and still applies the good one" do
-        remote.process_configs(repository)
+        remote.merge_and_apply_configs(repository)
 
         expect(good.apply_state).to eq(2)
         expect(bad.apply_state).to eq(3)
         expect(bad.apply_error).to include("JSON")
+      end
+    end
+
+    context "with a non-APM_TRACING content present" do
+      let(:other) do
+        Datadog::Core::Remote::Configuration::Content.parse(
+          path: "datadog/1/OTHER_PRODUCT/x/name",
+          content: "{}",
+        )
+      end
+      let(:apm) do
+        content_for("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
+      end
+      let(:contents) { [other, apm] }
+
+      it "skips the non-APM_TRACING content and applies the APM_TRACING one" do
+        remote.merge_and_apply_configs(repository)
+
+        expect(apm.apply_state).to eq(2)
+        expect(other.apply_state).to eq(1) # UNACKNOWLEDGED: never touched
+      end
+    end
+
+    context "with no APM_TRACING contents (last config removed)" do
+      let(:contents) { [] }
+
+      it "applies an empty merged config, resetting the dynamic options and not touching DI" do
+        expect(Datadog::DI::Remote).not_to receive(:handle_rc_enablement)
+        expect(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
+          .with(contain_exactly(
+            ["DD_LOGS_INJECTION", nil],
+            ["DD_TRACE_HEADER_TAGS", nil],
+            ["DD_TRACE_SAMPLE_RATE", nil],
+            ["DD_TRACE_SAMPLING_RULES", nil],
+          ))
+
+        remote.merge_and_apply_configs(repository)
+      end
+    end
+
+    context "when applying the merged config raises" do
+      let(:contents) do
+        [content_for("org", {"service_target" => {"service" => "*", "env" => "*"},
+                            "lib_config" => {"dynamic_instrumentation_enabled" => true}})]
+      end
+
+      it "marks all parsed contents errored" do
+        allow(Datadog::DI::Remote).to receive(:handle_rc_enablement).and_raise("boom")
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(contents.first.apply_state).to eq(3)
+        expect(contents.first.apply_error).to include("boom")
+      end
+    end
+
+    context "diagnostics" do
+      let(:contents) do
+        [
+          content_for("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}}),
+          content_for("other", {"service_target" => {"service" => "other", "env" => "prod"}, "lib_config" => {}}),
+        ]
+      end
+
+      it "emits the APM_TRACING RC diagnostic lines" do
+        messages = []
+        allow(Datadog.logger).to receive(:debug) { |*args, &blk| messages << (blk ? blk.call : args.first) }
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(messages).to include(a_string_matching(/received 2 config\(s\)/))
+        expect(messages).to include(a_string_matching(/config org scope=org priority=1/))
+        expect(messages).to include(a_string_matching(/dropped config other/))
       end
     end
   end

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Datadog::Tracing::Remote do
     subject(:apply_configs) { remote.merge_and_apply_configs(repository) }
     let(:config) { {"lib_config" => {}} }
     let(:content) do
-      Datadog::Core::Remote::Configuration::Content.parse(path: path, content: JSON.dump(config))
+      Datadog::Core::Remote::Configuration::Content.parse({path: path, content: JSON.dump(config)})
     end
     let(:repository) do
       instance_double(Datadog::Core::Remote::Configuration::Repository, contents: [content])
@@ -41,7 +41,7 @@ RSpec.describe Datadog::Tracing::Remote do
     end
 
     context "with an unparseable content" do
-      let(:content) { Datadog::Core::Remote::Configuration::Content.parse(path: path, content: "") }
+      let(:content) { Datadog::Core::Remote::Configuration::Content.parse({path: path, content: ""}) }
 
       it "sets errored apply state and reports the parse failure to telemetry" do
         expect(Datadog.send(:components).telemetry).to receive(:report)
@@ -327,8 +327,10 @@ RSpec.describe Datadog::Tracing::Remote do
   describe "#merge_and_apply_configs" do
     def build_content(config_id, config)
       Datadog::Core::Remote::Configuration::Content.parse(
-        path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
-        content: JSON.dump(config),
+        {
+          path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
+          content: JSON.dump(config),
+        }
       )
     end
 
@@ -400,8 +402,10 @@ RSpec.describe Datadog::Tracing::Remote do
       end
       let(:bad) do
         Datadog::Core::Remote::Configuration::Content.parse(
-          path: "datadog/1/APM_TRACING/bad/lib_config",
-          content: "{not json",
+          {
+            path: "datadog/1/APM_TRACING/bad/lib_config",
+            content: "{not json",
+          }
         )
       end
       let(:contents) { [good, bad] }
@@ -421,8 +425,10 @@ RSpec.describe Datadog::Tracing::Remote do
     context "with a non-APM_TRACING content present" do
       let(:other) do
         Datadog::Core::Remote::Configuration::Content.parse(
-          path: "datadog/1/OTHER_PRODUCT/x/name",
-          content: "{}",
+          {
+            path: "datadog/1/OTHER_PRODUCT/x/name",
+            content: "{}",
+          }
         )
       end
       let(:apm) do

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -24,20 +24,31 @@ RSpec.describe Datadog::Tracing::Remote do
     )
   end
 
-  describe "#process_config" do
-    subject(:process_config) { remote.process_config(config, content) }
-    let(:config) { nil }
-    let(:content) { Datadog::Core::Remote::Configuration::Content.parse({path: path, content: ""}) }
+  describe "#merge_and_apply_configs with a single config" do
+    subject(:apply_configs) { remote.merge_and_apply_configs(repository) }
+    let(:config) { {"lib_config" => {}} }
+    let(:content) do
+      Datadog::Core::Remote::Configuration::Content.parse(path: path, content: JSON.dump(config))
+    end
+    let(:repository) do
+      instance_double(Datadog::Core::Remote::Configuration::Repository, contents: [content])
+    end
 
-    context "with an empty content" do
-      let(:config) { {} }
+    before do
+      allow(Datadog.configuration).to receive(:service).and_return("web")
+      allow(Datadog.configuration).to receive(:env).and_return("prod")
+      allow(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
+    end
 
-      it "sets errored apply state and reports to telemetry" do
+    context "with an unparseable content" do
+      let(:content) { Datadog::Core::Remote::Configuration::Content.parse(path: path, content: "") }
+
+      it "sets errored apply state and reports the parse failure to telemetry" do
         expect(Datadog.send(:components).telemetry).to receive(:report)
-          .with(kind_of(StandardError), description: "Failed to apply APM_TRACING remote config")
-        process_config
+          .with(kind_of(StandardError), description: "Failed to parse APM_TRACING remote config")
+        apply_configs
         expect(content.apply_state).to eq(3)
-        expect(content.apply_error).to include("Error") & include("process_config")
+        expect(content.apply_error).to include("JSON")
       end
     end
 
@@ -54,7 +65,7 @@ RSpec.describe Datadog::Tracing::Remote do
               ["DD_TRACE_SAMPLING_RULES", nil],
             ))
 
-          process_config
+          apply_configs
 
           expect(content.apply_state).to eq(2)
           expect(content.apply_error).to be_nil
@@ -73,7 +84,7 @@ RSpec.describe Datadog::Tracing::Remote do
               ["DD_TRACE_SAMPLING_RULES", nil],
             ))
 
-          process_config
+          apply_configs
 
           expect(content.apply_state).to eq(2)
           expect(content.apply_error).to be_nil
@@ -101,7 +112,7 @@ RSpec.describe Datadog::Tracing::Remote do
               ["DD_TRACE_SAMPLING_RULES", nil],
             ))
 
-          process_config
+          apply_configs
 
           expect(content.apply_state).to eq(2)
           expect(content.apply_error).to be_nil
@@ -131,7 +142,7 @@ RSpec.describe Datadog::Tracing::Remote do
               ["DD_TRACE_SAMPLING_RULES", "[{\"sample_rate\":1.0,\"tags\":{\"service\":\"web-*\"}}]"],
             ))
 
-          process_config
+          apply_configs
 
           expect(content.apply_state).to eq(2)
           expect(content.apply_error).to be_nil
@@ -175,7 +186,7 @@ RSpec.describe Datadog::Tracing::Remote do
               expect(remote_component).to receive(:add_products)
                 .with("LIVE_DEBUGGING", "LIVE_DEBUGGING_SYMBOL_DB")
 
-              process_config
+              apply_configs
 
               expect(content.apply_state).to eq(2)
             end
@@ -189,7 +200,7 @@ RSpec.describe Datadog::Tracing::Remote do
               expect(remote_component).to receive(:remove_products)
                 .with("LIVE_DEBUGGING", "LIVE_DEBUGGING_SYMBOL_DB")
 
-              process_config
+              apply_configs
 
               expect(content.apply_state).to eq(2)
             end
@@ -205,7 +216,7 @@ RSpec.describe Datadog::Tracing::Remote do
             expect(remote_component).to receive(:remove_products)
               .with("LIVE_DEBUGGING", "LIVE_DEBUGGING_SYMBOL_DB")
 
-            process_config
+            apply_configs
 
             expect(content.apply_state).to eq(2)
           end
@@ -314,7 +325,7 @@ RSpec.describe Datadog::Tracing::Remote do
   end
 
   describe "#merge_and_apply_configs" do
-    def content_for(config_id, config)
+    def build_content(config_id, config)
       Datadog::Core::Remote::Configuration::Content.parse(
         path: "datadog/1/APM_TRACING/#{config_id}/lib_config",
         content: JSON.dump(config),
@@ -324,17 +335,16 @@ RSpec.describe Datadog::Tracing::Remote do
     let(:repository) { instance_double(Datadog::Core::Remote::Configuration::Repository, contents: contents) }
 
     before do
-      allow(Datadog.configuration).to receive(:service).and_return("web")
-      allow(Datadog.configuration).to receive(:env).and_return("prod")
+      allow(Datadog.configuration).to receive_messages(service: "web", env: "prod")
       allow(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
     end
 
     context "with cascading DI enablement configs" do
       let(:contents) do
         [
-          content_for("org", {"service_target" => {"service" => "*", "env" => "*"},
+          build_content("org", {"service_target" => {"service" => "*", "env" => "*"},
                               "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
-          content_for("svc", {"service_target" => {"service" => "web", "env" => "prod"},
+          build_content("svc", {"service_target" => {"service" => "web", "env" => "prod"},
                               "lib_config" => {"dynamic_instrumentation_enabled" => false}}),
         ]
       end
@@ -352,9 +362,9 @@ RSpec.describe Datadog::Tracing::Remote do
     context "with equal-priority (org) configs setting the same field" do
       let(:contents) do
         [
-          content_for("b", {"service_target" => {"service" => "*", "env" => "*"},
+          build_content("b", {"service_target" => {"service" => "*", "env" => "*"},
                             "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
-          content_for("a", {"service_target" => {"service" => "*", "env" => "*"},
+          build_content("a", {"service_target" => {"service" => "*", "env" => "*"},
                             "lib_config" => {"dynamic_instrumentation_enabled" => false}}),
         ]
       end
@@ -370,7 +380,7 @@ RSpec.describe Datadog::Tracing::Remote do
     context "when a config targets a different service" do
       let(:contents) do
         [
-          content_for("other", {"service_target" => {"service" => "other", "env" => "prod"},
+          build_content("other", {"service_target" => {"service" => "other", "env" => "prod"},
                                 "lib_config" => {"dynamic_instrumentation_enabled" => true}}),
         ]
       end
@@ -386,7 +396,7 @@ RSpec.describe Datadog::Tracing::Remote do
 
     context "when one config has malformed JSON" do
       let(:good) do
-        content_for("good", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
+        build_content("good", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
       end
       let(:bad) do
         Datadog::Core::Remote::Configuration::Content.parse(
@@ -416,7 +426,7 @@ RSpec.describe Datadog::Tracing::Remote do
         )
       end
       let(:apm) do
-        content_for("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
+        build_content("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})
       end
       let(:contents) { [other, apm] }
 
@@ -424,7 +434,7 @@ RSpec.describe Datadog::Tracing::Remote do
         remote.merge_and_apply_configs(repository)
 
         expect(apm.apply_state).to eq(2)
-        expect(other.apply_state).to eq(1) # UNACKNOWLEDGED: never touched
+        expect(other.apply_state).to eq(Datadog::Core::Remote::Configuration::Content::ApplyState::UNACKNOWLEDGED)
       end
     end
 
@@ -447,7 +457,7 @@ RSpec.describe Datadog::Tracing::Remote do
 
     context "when applying the merged config raises" do
       let(:contents) do
-        [content_for("org", {"service_target" => {"service" => "*", "env" => "*"},
+        [build_content("org", {"service_target" => {"service" => "*", "env" => "*"},
                             "lib_config" => {"dynamic_instrumentation_enabled" => true}})]
       end
 
@@ -466,8 +476,8 @@ RSpec.describe Datadog::Tracing::Remote do
     context "diagnostics" do
       let(:contents) do
         [
-          content_for("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}}),
-          content_for("other", {"service_target" => {"service" => "other", "env" => "prod"}, "lib_config" => {}}),
+          build_content("org", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}}),
+          build_content("other", {"service_target" => {"service" => "other", "env" => "prod"}, "lib_config" => {}}),
         ]
       end
 

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -396,6 +396,35 @@ RSpec.describe Datadog::Tracing::Remote do
       end
     end
 
+    context "when remote.service overrides the local service for RC binding" do
+      let(:contents) do
+        [
+          build_content("svc", {"service_target" => {"service" => "rc-svc", "env" => "*"},
+                              "lib_config" => {"log_injection_enabled" => false}}),
+        ]
+      end
+
+      before do
+        # The RC client registers with the backend as remote.service ||
+        # service, so a service-scoped config arrives targeted at the override.
+        allow(Datadog.configuration.remote).to receive(:service).and_return("rc-svc")
+      end
+
+      it "matches the config against the override and applies it" do
+        expect(Datadog.send(:components).telemetry).to receive(:client_configuration_change!)
+          .with(contain_exactly(
+            ["DD_LOGS_INJECTION", false],
+            ["DD_TRACE_HEADER_TAGS", nil],
+            ["DD_TRACE_SAMPLE_RATE", nil],
+            ["DD_TRACE_SAMPLING_RULES", nil],
+          ))
+
+        remote.merge_and_apply_configs(repository)
+
+        expect(contents.first.apply_state).to eq(2)
+      end
+    end
+
     context "when one config has malformed JSON" do
       let(:good) do
         build_content("good", {"service_target" => {"service" => "*", "env" => "*"}, "lib_config" => {}})

--- a/spec/datadog/tracing/remote_spec.rb
+++ b/spec/datadog/tracing/remote_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe Datadog::Tracing::Remote do
     context "with an empty content" do
       let(:config) { {} }
 
-      it "sets errored apply state" do
+      it "sets errored apply state and reports to telemetry" do
+        expect(Datadog.send(:components).telemetry).to receive(:report)
+          .with(kind_of(StandardError), description: "Failed to apply APM_TRACING remote config")
         process_config
         expect(content.apply_state).to eq(3)
         expect(content.apply_error).to include("Error") & include("process_config")
@@ -394,7 +396,10 @@ RSpec.describe Datadog::Tracing::Remote do
       end
       let(:contents) { [good, bad] }
 
-      it "marks the malformed content errored and still applies the good one" do
+      it "marks the malformed content errored, reports to telemetry, and still applies the good one" do
+        expect(Datadog.send(:components).telemetry).to receive(:report)
+          .with(kind_of(StandardError), description: "Failed to parse APM_TRACING remote config")
+
         remote.merge_and_apply_configs(repository)
 
         expect(good.apply_state).to eq(2)
@@ -446,8 +451,10 @@ RSpec.describe Datadog::Tracing::Remote do
                             "lib_config" => {"dynamic_instrumentation_enabled" => true}})]
       end
 
-      it "marks all parsed contents errored" do
+      it "marks all parsed contents errored and reports to telemetry" do
         allow(Datadog::DI::Remote).to receive(:handle_rc_enablement).and_raise("boom")
+        expect(Datadog.send(:components).telemetry).to receive(:report)
+          .with(kind_of(StandardError), description: "Failed to apply APM_TRACING remote configs")
 
         remote.merge_and_apply_configs(repository)
 


### PR DESCRIPTION
**What does this PR do?**

Ruby Dynamic Instrumentation now merges the multiple org/env-level `APM_TRACING` remote-config payloads it receives in parallel and applies the most-specific match (service+env > service > env > cluster > org), and advertises the `APM_TRACING` multi-config capability so the backend sends those cascading configs.

**Motivation:**

Org/env-level remote enablement (config merging) has been determined as a critical lever to improve customer success when they try to use Live Debugger.

**Change log entry**

Yes. Dynamic Instrumentation now honors organization- and environment-level remote enablement for Ruby services.

**Additional Notes:**

**How to test the change?**

Unit and integration tests added


[DEBUG-4401]: https://datadoghq.atlassian.net/browse/DEBUG-4401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ