### PR TITLE
[PROF-15827] Profiling: Fix bug in "sample_after_gc" leading to profiler stopping

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -169,6 +169,8 @@ typedef struct {
     unsigned int gc_samples;
     // See thread_context_collector_on_gc_start for details
     unsigned int gc_samples_missed_due_to_missing_context;
+    // See thread_context_collector_sample_after_gc for details
+    unsigned int gc_samples_skipped_nothing_to_flush;
     // How many per-thread samples were skipped because the thread has been continuously suspended
     // (no GVL) since its previous sample, so its Ruby stack cannot have changed.
     unsigned int inactive_thread_samples_skipped;
@@ -983,7 +985,14 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance) {
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   if (state->gc_tracking.wall_time_at_previous_gc_ns == INVALID_TIME) {
-    raise_error(rb_eRuntimeError, "BUG: Unexpected call to sample_after_gc without valid GC information available");
+    // Rarely, we might be called with nothing to do, as an earlier called already flushed the needed info.
+    // This is because Ruby clears the "pending" flag for an entire batch of postponed jobs BEFORE running any of them
+    // (see `rb_postponed_job_flush`). Thus, if another GC happens while an earlier job in the postponed batch is
+    // running (and other parts of the profiler such as the heap profiler can trigger this)
+    // then `on_gc_finish` records that data and asks for a second flush, even though Ruby has not yet run the
+    // first one. Because of this, Ruby can call us once more with nothing left to do.
+    state->stats.gc_samples_skipped_nothing_to_flush++;
+    return Qnil;
   }
 
   int max_labels_needed_for_gc = 7; // Magic number gets validated inside gc_profiling_set_metadata
@@ -1385,6 +1394,7 @@ static VALUE stats_to_ruby_hash(thread_context_collector_state *state, VALUE has
     ID2SYM(rb_intern("sample_count")),                             /* => */ UINT2NUM(state->stats.sample_count),
     ID2SYM(rb_intern("gc_samples")),                               /* => */ UINT2NUM(state->stats.gc_samples),
     ID2SYM(rb_intern("gc_samples_missed_due_to_missing_context")), /* => */ UINT2NUM(state->stats.gc_samples_missed_due_to_missing_context),
+    ID2SYM(rb_intern("gc_samples_skipped_nothing_to_flush")),      /* => */ UINT2NUM(state->stats.gc_samples_skipped_nothing_to_flush),
     ID2SYM(rb_intern("inactive_thread_samples_skipped")),          /* => */ UINT2NUM(state->stats.inactive_thread_samples_skipped),
     ID2SYM(rb_intern("profiler_thread_samples_skipped")),          /* => */ UINT2NUM(state->stats.profiler_thread_samples_skipped),
   };

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -985,7 +985,7 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance) {
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
   if (state->gc_tracking.wall_time_at_previous_gc_ns == INVALID_TIME) {
-    // Rarely, we might be called with nothing to do, as an earlier called already flushed the needed info.
+    // Rarely, we might be called with nothing to do, as an earlier call already flushed the needed info.
     // This is because Ruby clears the "pending" flag for an entire batch of postponed jobs BEFORE running any of them
     // (see `rb_postponed_job_flush`). Thus, if another GC happens while an earlier job in the postponed batch is
     // running (and other parts of the profiler such as the heap profiler can trigger this)

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1486,6 +1486,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           sample_count: 0,
           gc_samples: 0,
           gc_samples_missed_due_to_missing_context: 0,
+          gc_samples_skipped_nothing_to_flush: 0,
           inactive_thread_samples_skipped: 0,
           profiler_thread_samples_skipped: 0,
         }

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -1427,8 +1427,19 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     before { sample }
 
     context "when called before on_gc_start/on_gc_finish" do
-      it do
-        expect { sample_after_gc(allow_exception: true) }.to raise_error(::RuntimeError, /Unexpected call to sample_after_gc/)
+      it "does not record a Garbage Collection sample" do
+        sample_after_gc
+
+        expect(samples.select { |it| it.labels[:"thread name"] == "Garbage Collection" }).to be_empty
+      end
+
+      it "does not increment the gc_samples counter" do
+        expect { sample_after_gc }.to_not change { stats.fetch(:gc_samples) }
+      end
+
+      it "increments the gc_samples_skipped_nothing_to_flush counter" do
+        expect { sample_after_gc }
+          .to change { stats.fetch(:gc_samples_skipped_nothing_to_flush) }.from(0).to(1)
       end
     end
 
@@ -1442,12 +1453,16 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
         @time_after = profiler_system_epoch_time_now_ns
       end
 
+      # Ruby clears the "pending" flag for an entire batch of postponed jobs before running any of them, so it's
+      # expected for us to sometimes get called an extra time with nothing left to flush.
       context "when called more than once in a row" do
-        it do
+        it "only records one Garbage Collection sample" do
+          sample_after_gc
           sample_after_gc
 
-          expect { sample_after_gc(allow_exception: true) }
-            .to raise_error(::RuntimeError, /Unexpected call to sample_after_gc/)
+          expect(samples.count { |it| it.labels.fetch(:"thread name") == "Garbage Collection" }).to be 1
+          expect(stats.fetch(:gc_samples)).to be 1
+          expect(stats.fetch(:gc_samples_skipped_nothing_to_flush)).to be 1
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the profiler stopping with
`BUG: Unexpected call to sample_after_gc without valid GC information available` as reported in https://github.com/DataDog/dd-trace-rb/issues/6241 .

This is a bug in GC profiling that triggers way more often with Ruby 4 heap profiling enabled, due do the "deferring/pending recordings" mechanism.

The root cause of this bug is an incorrect assumption that regardless of how many GCs happen in a row...

* `on_gc_event` with `RUBY_INTERNAL_EVENT_GC_ENTER` --> `thread_context_collector_on_gc_start`
* `on_gc_event` with `RUBY_INTERNAL_EVENT_GC_EXIT` --> `thread_context_collector_on_gc_finish`

...that we will at most run `after_gc_from_postponed_job` once in a row. E.g. that we can't run `after_gc_from_postponed_job` twice in a row without another GC in-between.

This assumption turns out to be false, and I got my AI friend to draw a nice diagram for it:

```
  Registration order gives after_allocation a HIGHER postponed-job
handle than after_gc, and Ruby's flush runs highest-handle-first => alloc runs
first.

    app thread (holds GVL)                        triggered_bitset    wall_time_at_
                                                  (VM-global)         previous_gc_ns
   ==============================================================================
   (1) obj = Foo.new
        on_newobj_event  -> decides to sample
          start_heap_allocation_recording
          DEFERRED RECORDING (Ruby 4 only)
          trigger(alloc) --------------------->   {alloc}             (any)

   (2) GC step
        GC_ENTER -> on_gc_start
        GC_EXIT  -> on_gc_finish
                     arm  ------------------------------------------> T1
                     trigger(gc) ------------->   {alloc, gc}

   (3) interrupt checkpoint
        rb_postponed_job_flush
          batch = ATOMIC_EXCHANGE(bitset, 0) ->   { }     <-- DRAINED UP FRONT
                                                          local batch={alloc,gc}
          POSTPONED_JOB interrupts masked
   ------------------------------------------------------------------------------
   (4)  |-- after_allocation_from_postponed_job          [higher handle, 1st]
        |     heap_recorder_finalize_pending_recordings
        |         GC runs
        |           GC_ENTER -> on_gc_start
        |           GC_EXIT  -> on_gc_finish
        |                        arm  ------------------------------> T2
        |                        trigger(gc) ->  {gc}   <== RE-ARMED

   (5)  |-- after_gc_from_postponed_job                  [from the batch]
        |     sample_after_gc
        |       reads T2  -> valid, records the GC sample
        |       last_flushed = T2
        |       clear -------------------------------------------> INVALID_TIME
        |--
          batch empty -> flush returns, but {gc} is still set
   ------------------------------------------------------------------------------
   (6) next interrupt checkpoint
        rb_postponed_job_flush
          batch = ATOMIC_EXCHANGE(bitset, 0) ->  { }      local batch={gc}

          |-- after_gc_from_postponed_job     <== SECOND run, nothing armed it
                sample_after_gc
                  wall_time_at_previous_gc_ns == INVALID_TIME
                  raise RuntimeError
                    "BUG: Unexpected call to sample_after_gc
                          without valid GC information available"

  The whole bug lives in the gap between (3) and (5): Ruby clears the
trigger bit before running any job, so the T2 at (4) is consumed by the
already-queued after_gc job at (5) then consumes.
```

Thus this situation causes our `after_gc_from_postponed_job` to run twice in a row. The fix is quite simple -- we remove the incorrect assertion, and instead do the correct thing, which is to skip the work in the `after_gc_from_postponed_job`.

(Note that we already fully supported and assumed many GCs could run in a row without a `after_gc_from_postponed_job` running -- see https://github.com/DataDog/dd-trace-rb/pull/6006 for details for instance.
So the part that changes is really the postponed job).

**Note**: While working on this, I've found a "sister issue" with https://github.com/DataDog/dd-trace-rb/pull/6176; I'll open a discussion about that issue separetely.

**Motivation:**

Fix https://github.com/DataDog/dd-trace-rb/issues/6241 .

**Change log entry**

Yes. Profiling: Fix bug in "sample_after_gc" leading to profiler stopping

**Additional Notes:**

While heap profiling on Ruby 4 was  most likely cause of the broken assumption, this could happen in other rare situations.

Looking at our telemetry logs I found
[only one](https://app.datadoghq.com/logs?query=host%3Ainstrumentation-telemetry-data%20%40liblanguage%3Aruby%20sampleaftergc%20%40languageversion%3A3%2A&aggm=count&aggmsource=base&aggt=count&clusteringpatternfieldpath=message&cols=host%2Cservice%2C%40languageversion%2C%40tracerversion&contextevent=AZ-tp16IAAD7ZVOCb6O0TQDf&fromUser=true&messageDisplay=inline&refreshmode=paused&storage=hot&streamsort=time%2Cdesc&viz=stream&fromts=1784647651272&tots=1784651365747&live=false) case where this happened on Ruby 3.x, with all other cases being on Ruby 4.

**How to test the change?**

Surprisingly enough, running with `GC.stress` and enabling all features on Ruby 4 is enough to trigger this issue:

```ruby
require "datadog"

Datadog.configure do |c|
  c.profiling.enabled = true
  c.profiling.allocation_enabled = true
  c.profiling.advanced.experimental_heap_enabled = true
end

GC.stress = true
1000.times { |i| i.to_s }
GC.stress = false
```

Other than that, I've added coverage for the change in logic.