### PR TITLE
Make during_sample_enter()/during_sample_exit() reentrant

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -133,7 +133,7 @@ typedef struct {
   //
   // @ivoanjo: Right now we always sample inside `safely_call`; if that ever changes, this flag may need to become
   // volatile/atomic/have some barriers to ensure it's visible during e.g. signal handlers.
-  bool during_sample;
+  int during_sample;
 
   #ifndef NO_GVL_INSTRUMENTATION
   // Only set when sampling is active (gets created at start and cleaned on stop)
@@ -418,8 +418,6 @@ static VALUE _native_new(VALUE klass) {
   state->failure_exception = Qnil;
   state->failure_exception_during_operation = NULL;
   state->stop_thread = Qnil;
-
-  during_sample_exit(state);
 
   #ifndef NO_GVL_INSTRUMENTATION
     state->gvl_profiling_hook = NULL;
@@ -1706,7 +1704,7 @@ static inline void during_sample_enter(cpu_and_wall_time_worker_state* state) {
   // get clever and reordered things in such a way that makes us miss the flag update.
   //
   // See https://github.com/ruby/ruby/pull/11036 for a similar change made to the Ruby VM with more context.
-  state->during_sample = true;
+  state->during_sample++;
   atomic_signal_fence(memory_order_seq_cst);
 }
 
@@ -1714,5 +1712,5 @@ static inline void during_sample_exit(cpu_and_wall_time_worker_state* state) {
   // See `during_sample_enter` for more context; in this case we set the fence before to make sure anything that
   // happens before the fence is not reordered with the flag update.
   atomic_signal_fence(memory_order_seq_cst);
-  state->during_sample = false;
+  state->during_sample--;
 }


### PR DESCRIPTION
* Previously with nested calls during_sample would be false after exiting the nested call, before the outer call is done.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
Correctness when during_sample_enter() is called twice in a row.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
