### PR TITLE
[PROF-15829] Profiling: Fix incorrect usage of during_sample flag

### DIFF
--- a/benchmarks/profiling_gc.rb
+++ b/benchmarks/profiling_gc.rb
@@ -29,7 +29,7 @@ class ProfilerGcBenchmark
       x.report("profiler gc") do
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector, false)
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
       end
 
       x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE
@@ -52,7 +52,7 @@ class ProfilerGcBenchmark
         estimated_gc_per_minute.times do
           Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_start(@collector)
           Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gc_finish(@collector)
-          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector, false)
+          Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gc(@collector)
         end
 
         @recorder.serialize

--- a/benchmarks/profiling_memory_sample_serialize.rb
+++ b/benchmarks/profiling_memory_sample_serialize.rb
@@ -12,24 +12,19 @@ puts "Libdatadog from: #{Libdatadog.pkgconfig_folder}"
 # This benchmark measures the performance of sampling + serializing memory profiles. It enables us to evaluate changes to
 # the profiler and/or libdatadog that may impact both individual samples, as well as samples over time.
 #
-METRIC_VALUES = {"cpu-time" => 0, "cpu-samples" => 0, "wall-time" => 0, "alloc-samples" => 1, "timeline" => 0, "heap_sample" => true}.freeze
+METRIC_VALUES = {"cpu-time" => 0, "cpu-samples" => 0, "wall-time" => 0, "alloc-samples" => 1, "timeline" => 0}.freeze
 OBJECT_CLASS = "object".freeze
 
 def sample_object(recorder, depth = 0)
   if depth <= 0
     obj = Object.new
-    Datadog::Profiling::StackRecorder::Testing._native_track_object(
-      recorder,
-      obj,
-      1,
-      OBJECT_CLASS,
-    )
     Datadog::Profiling::Collectors::Stack::Testing._native_sample(
       Thread.current,
       recorder,
       METRIC_VALUES,
       [],
       [],
+      heap_sample: {new_object: obj, alloc_class: OBJECT_CLASS},
     )
     # Heap recordings are deferred and need to be committed after the sample is recorded; in the real profiler this
     # is driven by a postponed job.

--- a/benchmarks/profiling_memory_sample_serialize.rb
+++ b/benchmarks/profiling_memory_sample_serialize.rb
@@ -33,7 +33,7 @@ def sample_object(recorder, depth = 0)
     )
     # Heap recordings are deferred and need to be committed after the sample is recorded; in the real profiler this
     # is driven by a postponed job.
-    Datadog::Profiling::StackRecorder::Testing._native_commit_pending_heap_recordings(recorder)
+    Datadog::Profiling::StackRecorder::Testing._native_commit_heap_recordings(recorder)
     obj
   else
     sample_object(recorder, depth - 1)

--- a/benchmarks/profiling_sample_gvl.rb
+++ b/benchmarks/profiling_sample_gvl.rb
@@ -56,7 +56,7 @@ class ProfilerSampleGvlBenchmark
       x.report("gvl benchmark samples") do
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gvl_waiting(@target_thread)
         Datadog::Profiling::Collectors::ThreadContext::Testing._native_on_gvl_running(@target_thread, WAITING_FOR_GVL_THRESHOLD_NS)
-        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gvl_running(@collector, @target_thread, false)
+        Datadog::Profiling::Collectors::ThreadContext::Testing._native_sample_after_gvl_running(@collector, @target_thread)
       end
 
       x.save! "#{File.basename(__FILE__, ".rb")}-results.json" unless VALIDATE_BENCHMARK_MODE

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1722,7 +1722,9 @@ static void commit_heap_recordings_from_postponed_job_may_lose_gvl(DDTRACE_UNUSE
 
   if (state == NULL || !ddtrace_rb_ractor_main_p()) return;
 
-  // Protect against nested operations.
+  // Protect against nested operations, such as being called from inside `on_newobj_event` (which could be
+  // mutating the heap profiler). `during_sample` by itself doesn't prevent all concurrency inside the heap profiler,
+  // see "note on locking" inside `heap_profiler.c` for details.
   //
   // Note that, unlike the other sampling operations in this file, we only **check** the `during_sample` flag but
   // deliberately don't hold it as the below function can release the GVL and `during_sample` shouldn't be held

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -274,6 +274,7 @@ static VALUE _native_resume_signals(DDTRACE_UNUSED VALUE self);
 static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE instance);
 static VALUE handle_sampling_failure_rescued_sample_from_postponed_job(VALUE self_instance, VALUE exception);
 static VALUE handle_sampling_failure_thread_context_collector_sample_after_gc(VALUE self_instance, VALUE exception);
+static VALUE handle_sampling_failure_thread_context_collector_heap_update(VALUE self_instance, VALUE exception);
 static VALUE handle_sampling_failure_rescued_sample_allocation(VALUE self_instance, VALUE exception);
 static VALUE handle_sampling_failure_rescued_commit_heap_recordings(VALUE self_instance, VALUE exception);
 static inline void during_sample_enter(cpu_and_wall_time_worker_state* state);
@@ -1113,6 +1114,15 @@ static void after_gc_from_postponed_job(DDTRACE_UNUSED void *_unused) {
   );
 
   during_sample_exit(state);
+
+  // This part runs separately from above because it may lose the GVL and we don't want `during_sample` to be set in
+  // such a situation
+  safely_call(
+    thread_context_collector_heap_update_may_lose_gvl,
+    state->thread_context_collector_instance,
+    state->self_instance,
+    handle_sampling_failure_thread_context_collector_heap_update
+  );
 }
 
 // Equivalent to Ruby begin/rescue call, where we call a C function and jump to the exception handler if an
@@ -1670,6 +1680,11 @@ static VALUE handle_sampling_failure_rescued_sample_from_postponed_job(VALUE sel
 
 static VALUE handle_sampling_failure_thread_context_collector_sample_after_gc(VALUE self_instance, VALUE exception) {
   stop(self_instance, exception, "thread_context_collector_sample_after_gc");
+  return Qnil;
+}
+
+static VALUE handle_sampling_failure_thread_context_collector_heap_update(VALUE self_instance, VALUE exception) {
+  stop(self_instance, exception, "thread_context_collector_heap_update_may_lose_gvl");
   return Qnil;
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1700,10 +1700,12 @@ static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
 
   if (state == NULL || !ddtrace_rb_ractor_main_p()) return;
 
-  // Protect against nested operations
+  // Protect against nested operations.
+  //
+  // Note that, unlike the other sampling operations in this file, we only **check** the `during_sample` flag but
+  // deliberately don't hold it as the below function can release the GVL and `during_sample` shouldn't be held
+  // in such a situation.
   if (state->during_sample) return;
-
-  during_sample_enter(state);
 
   // NOTE: We're not updating the allocation_sampler here.
   // This means work done in this function isn't accounted for as profiler overhead.
@@ -1714,8 +1716,6 @@ static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
     state->self_instance,
     handle_sampling_failure_rescued_after_allocation
   );
-
-  during_sample_exit(state);
 }
 
 static inline void during_sample_enter(cpu_and_wall_time_worker_state* state) {

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -876,7 +876,7 @@ static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused) {
 
   during_sample_exit(state);
 
-  // Extracting the otel span key can lose the GVL, so we it outside `during_sample`
+  // Extracting the otel span key can lose the GVL, so we move it outside `during_sample`
   // (It can't raise: it rescues its own exceptions)
   if (needs_otel_span_key == Qtrue) {
     thread_context_collector_resolve_otel_span_key_may_lose_gvl(state->thread_context_collector_instance);

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -141,7 +141,8 @@ typedef struct {
   // because effectively that would stop the profiler from working until control
   // goes back to that special thread, which on a contended Ruby app, can take hundreds of ms (or more).
   //
-  // Similar to a lock, it's also not supposed to be re-entrant. (TODO: We should have checks for this)
+  // Because what we want is "profiler doesn't recurse on itself" we want this to behave as a non-reentrant lock
+  // (FIXME: We should have checks for this)
   //
   // @ivoanjo: Right now we always sample inside `safely_call`; if that ever changes, this flag may need to become
   // volatile/atomic/have some barriers to ensure it's visible during e.g. signal handlers.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1496,14 +1496,14 @@ static VALUE rescued_sample_allocation(VALUE arg) {
   // To control bias from sampling, we clamp the maximum weight attributed to a single allocation sample. This avoids
   // assigning a very large number to a sample, if for instance the dynamic sampling mechanism chose a really big interval.
   unsigned int weight = allocations_since_last_sample > MAX_ALLOC_WEIGHT ? MAX_ALLOC_WEIGHT : (unsigned int) allocations_since_last_sample;
-  bool needs_after_allocation = thread_context_collector_sample_allocation(state->thread_context_collector_instance, thread_context, weight, new_object);
+  bool needs_commit = thread_context_collector_sample_allocation(state->thread_context_collector_instance, thread_context, weight, new_object);
   // ...but we still represent the skipped samples in the profile, thus the data will account for all allocations.
   if (weight < allocations_since_last_sample) {
     uint32_t skipped_samples = (uint32_t) uint64_min_of(allocations_since_last_sample - weight, UINT32_MAX);
     thread_context_collector_sample_skipped_allocation_samples(state->thread_context_collector_instance, skipped_samples);
   }
 
-  if (needs_after_allocation) {
+  if (needs_commit) {
     #ifndef NO_POSTPONED_TRIGGER
       rb_postponed_job_trigger(commit_heap_recordings_from_postponed_job_may_lose_gvl_handle);
     #else

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -91,7 +91,7 @@ unsigned int MAX_ALLOC_WEIGHT = 10000;
   static rb_postponed_job_handle_t sample_from_postponed_job_handle;
   static rb_postponed_job_handle_t after_gc_from_postponed_job_handle;
   static rb_postponed_job_handle_t after_gvl_running_from_postponed_job_handle;
-  static rb_postponed_job_handle_t after_allocation_from_postponed_job_handle;
+  static rb_postponed_job_handle_t commit_heap_recordings_from_postponed_job_may_lose_gvl_handle;
 #endif
 
 // Contains state for a single CpuAndWallTimeWorker instance
@@ -259,7 +259,7 @@ static void on_newobj_event(DDTRACE_UNUSED VALUE unused1, DDTRACE_UNUSED void *u
 static void disable_tracepoints(cpu_and_wall_time_worker_state *state);
 static VALUE _native_with_blocked_sigprof(DDTRACE_UNUSED VALUE self);
 static VALUE rescued_sample_allocation(VALUE tracepoint_data);
-static VALUE rescued_after_allocation(VALUE self_instance);
+static VALUE rescued_commit_heap_recordings_may_lose_gvl(VALUE self_instance);
 static void delayed_error(cpu_and_wall_time_worker_state *state, const char *error);
 static void delayed_error_clock_failure(cpu_and_wall_time_worker_state *state);
 static VALUE _native_delayed_error(DDTRACE_UNUSED VALUE self, VALUE instance, VALUE error_msg);
@@ -275,10 +275,10 @@ static VALUE _native_gvl_profiling_hook_active(DDTRACE_UNUSED VALUE self, VALUE 
 static VALUE handle_sampling_failure_rescued_sample_from_postponed_job(VALUE self_instance, VALUE exception);
 static VALUE handle_sampling_failure_thread_context_collector_sample_after_gc(VALUE self_instance, VALUE exception);
 static VALUE handle_sampling_failure_rescued_sample_allocation(VALUE self_instance, VALUE exception);
-static VALUE handle_sampling_failure_rescued_after_allocation(VALUE self_instance, VALUE exception);
+static VALUE handle_sampling_failure_rescued_commit_heap_recordings(VALUE self_instance, VALUE exception);
 static inline void during_sample_enter(cpu_and_wall_time_worker_state* state);
 static inline void during_sample_exit(cpu_and_wall_time_worker_state* state);
-static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused);
+static void commit_heap_recordings_from_postponed_job_may_lose_gvl(DDTRACE_UNUSED void *_unused);
 
 // We're using `on_newobj_event` function with `rb_add_event_hook2`, which requires in its public signature a function
 // with signature `rb_event_hook_func_t` which doesn't match `on_newobj_event`.
@@ -335,13 +335,14 @@ void collectors_cpu_and_wall_time_worker_init(VALUE profiling_module) {
     sample_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, sample_from_postponed_job, NULL);
     after_gc_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_gc_from_postponed_job, NULL);
     after_gvl_running_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_gvl_running_from_postponed_job, NULL);
-    after_allocation_from_postponed_job_handle = rb_postponed_job_preregister(unused_flags, after_allocation_from_postponed_job, NULL);
+    commit_heap_recordings_from_postponed_job_may_lose_gvl_handle =
+      rb_postponed_job_preregister(unused_flags, commit_heap_recordings_from_postponed_job_may_lose_gvl, NULL);
 
     if (
       sample_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
       after_gc_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
       after_gvl_running_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID ||
-      after_allocation_from_postponed_job_handle == POSTPONED_JOB_HANDLE_INVALID
+      commit_heap_recordings_from_postponed_job_may_lose_gvl_handle == POSTPONED_JOB_HANDLE_INVALID
     ) {
       raise_error(rb_eRuntimeError, "Failed to register profiler postponed jobs (got POSTPONED_JOB_HANDLE_INVALID)");
     }
@@ -1488,9 +1489,9 @@ static VALUE rescued_sample_allocation(VALUE arg) {
 
   if (needs_after_allocation) {
     #ifndef NO_POSTPONED_TRIGGER
-      rb_postponed_job_trigger(after_allocation_from_postponed_job_handle);
+      rb_postponed_job_trigger(commit_heap_recordings_from_postponed_job_may_lose_gvl_handle);
     #else
-      rb_postponed_job_register_one(0, after_allocation_from_postponed_job, NULL);
+      rb_postponed_job_register_one(0, commit_heap_recordings_from_postponed_job_may_lose_gvl, NULL);
     #endif
   }
 
@@ -1677,16 +1678,16 @@ static VALUE handle_sampling_failure_rescued_sample_allocation(VALUE self_instan
   return Qnil;
 }
 
-static VALUE handle_sampling_failure_rescued_after_allocation(VALUE self_instance, VALUE exception) {
-  stop(self_instance, exception, "rescued_after_allocation");
+static VALUE handle_sampling_failure_rescued_commit_heap_recordings(VALUE self_instance, VALUE exception) {
+  stop(self_instance, exception, "rescued_commit_heap_recordings_may_lose_gvl");
   return Qnil;
 }
 
-static VALUE rescued_after_allocation(VALUE self_instance) {
+static VALUE rescued_commit_heap_recordings_may_lose_gvl(VALUE self_instance) {
   cpu_and_wall_time_worker_state *state;
   TypedData_Get_Struct(self_instance, cpu_and_wall_time_worker_state, &cpu_and_wall_time_worker_typed_data, state);
 
-  thread_context_collector_after_allocation(state->thread_context_collector_instance);
+  thread_context_collector_commit_heap_recordings_may_lose_gvl(state->thread_context_collector_instance);
 
   // Return a dummy VALUE because we're called from rb_rescue2 which requires it
   return Qnil;
@@ -1695,7 +1696,7 @@ static VALUE rescued_after_allocation(VALUE self_instance) {
 // This postponed job callback is used to commit heap allocation recordings.
 // During on_newobj_event, we can't take the weak reference the heap recorder needs to track the object, so we defer
 // that until after the event completes.
-static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
+static void commit_heap_recordings_from_postponed_job_may_lose_gvl(DDTRACE_UNUSED void *_unused) {
   cpu_and_wall_time_worker_state *state = active_sampler_instance_state;
 
   if (state == NULL || !ddtrace_rb_ractor_main_p()) return;
@@ -1711,10 +1712,10 @@ static void after_allocation_from_postponed_job(DDTRACE_UNUSED void *_unused) {
   // This means work done in this function isn't accounted for as profiler overhead.
   // This is acceptable as the amount of work done here is expected to be small.
   safely_call(
-    rescued_after_allocation,
+    rescued_commit_heap_recordings_may_lose_gvl,
     state->self_instance,
     state->self_instance,
-    handle_sampling_failure_rescued_after_allocation
+    handle_sampling_failure_rescued_commit_heap_recordings
   );
 }
 

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -129,9 +129,20 @@ typedef struct {
 
   // Others
 
-  // Used to detect/avoid nested sampling, e.g. when on_newobj_event gets triggered by a memory allocation
+  // Used to detect/avoid nested sampling, and intended to behave as a lock to ensure the profiler doesn't recurse on itself,
+  // e.g. when on_newobj_event gets triggered by a memory allocation
   // that happens during another sample, or when the signal handler gets triggered while we're already in the middle of
   // sampling.
+  //
+  // It's not an actual lock because we rely on the GVL for correct synchronization
+  // (and thus this flag is only valid when we know we have the GVL).
+  //
+  // Similar to a lock, it should not be held across long-running operations,
+  // **in particular it MUST NEVER be held during operations where we might lose the GVL**
+  // because effectively that would stop the profiler from working working until control
+  // goes back to that special thread, which on a contended Ruby app, can take hundreds of ms (or more).
+  //
+  // Similar to a lock, it's also not supposed to be re-entrant. (TODO: We should have checks for this)
   //
   // @ivoanjo: Right now we always sample inside `safely_call`; if that ever changes, this flag may need to become
   // volatile/atomic/have some barriers to ensure it's visible during e.g. signal handlers.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -130,9 +130,8 @@ typedef struct {
   // Others
 
   // Used to detect/avoid nested sampling, and intended to behave as a lock to ensure the profiler doesn't recurse on itself,
-  // e.g. when on_newobj_event gets triggered by a memory allocation
-  // that happens during another sample, or when the signal handler gets triggered while we're already in the middle of
-  // sampling.
+  // e.g. when on_newobj_event gets triggered by a memory allocation that happens during another sample, or when the
+  // signal handler gets triggered while we're already in the middle of sampling.
   //
   // It's not an actual lock because we rely on the GVL for correct synchronization
   // (and thus this flag is only valid when we know we have the GVL).

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1722,14 +1722,10 @@ static void commit_heap_recordings_from_postponed_job_may_lose_gvl(DDTRACE_UNUSE
 
   if (state == NULL || !ddtrace_rb_ractor_main_p()) return;
 
-  // Protect against nested operations, such as being called from inside `on_newobj_event` (which could be
-  // mutating the heap profiler). `during_sample` by itself doesn't prevent all concurrency inside the heap profiler,
-  // see "note on locking" inside `heap_profiler.c` for details.
-  //
-  // Note that, unlike the other sampling operations in this file, we only **check** the `during_sample` flag but
-  // deliberately don't hold it as the below function can release the GVL and `during_sample` shouldn't be held
-  // in such a situation.
-  if (state->during_sample) return;
+  if (state->during_sample) {
+    delayed_error(state, "commit_heap_recordings_from_postponed_job_may_lose_gvl called during_sample");
+    return;
+  }
 
   // NOTE: We're not updating the allocation_sampler here.
   // This means work done in this function isn't accounted for as profiler overhead.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -867,7 +867,7 @@ static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused) {
   during_sample_enter(state);
 
   // Rescue against any exceptions that happen during sampling
-  safely_call(
+  VALUE needs_otel_span_key = safely_call(
     rescued_sample_from_postponed_job,
     state->self_instance,
     state->self_instance,
@@ -875,6 +875,12 @@ static void sample_from_postponed_job(DDTRACE_UNUSED void *_unused) {
   );
 
   during_sample_exit(state);
+
+  // Extracting the otel span key can lose the GVL, so we it outside `during_sample`
+  // (It can't raise: it rescues its own exceptions)
+  if (needs_otel_span_key == Qtrue) {
+    thread_context_collector_resolve_otel_span_key_may_lose_gvl(state->thread_context_collector_instance);
+  }
 }
 
 static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
@@ -885,12 +891,13 @@ static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
 
   if (state->dynamic_sampling_rate_enabled && !dynamic_sampling_rate_should_sample(&state->cpu_dynamic_sampling_rate, wall_time_ns_before_sample)) {
     state->stats.cpu_skipped++;
-    return Qnil;
+    return Qfalse;
   }
 
   state->stats.cpu_sampled++;
 
-  thread_context_collector_sample(state->thread_context_collector_instance, wall_time_ns_before_sample);
+  bool needs_otel_span_key =
+    thread_context_collector_sample(state->thread_context_collector_instance, wall_time_ns_before_sample);
 
   long wall_time_ns_after_sample = monotonic_wall_time_now_ns(RAISE_ON_FAILURE);
   long delta_ns = wall_time_ns_after_sample - wall_time_ns_before_sample;
@@ -904,8 +911,7 @@ static VALUE rescued_sample_from_postponed_job(VALUE self_instance) {
 
   dynamic_sampling_rate_after_sample(&state->cpu_dynamic_sampling_rate, wall_time_ns_after_sample, sampling_time_ns);
 
-  // Return a dummy VALUE because we're called from rb_rescue2 which requires it
-  return Qnil;
+  return needs_otel_span_key ? Qtrue : Qfalse;
 }
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::CpuAndWallTimeWorker behavior using RSpec.

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -139,7 +139,7 @@ typedef struct {
   //
   // Similar to a lock, it should not be held across long-running operations,
   // **in particular it MUST NEVER be held during operations where we might lose the GVL**
-  // because effectively that would stop the profiler from working working until control
+  // because effectively that would stop the profiler from working until control
   // goes back to that special thread, which on a contended Ruby app, can take hundreds of ms (or more).
   //
   // Similar to a lock, it's also not supposed to be re-entrant. (TODO: We should have checks for this)

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -130,8 +130,16 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
   ENFORCE_BOOLEAN(show_classes);
 
   VALUE zero = INT2NUM(0);
-  VALUE heap_sample = rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("heap_sample"), Qfalse);
-  ENFORCE_BOOLEAN(heap_sample);
+  // Pass `heap_sample: {new_object: ..., alloc_class: ...}` to also record this sample for heap profiling
+  VALUE heap_sample_options = rb_hash_lookup2(options, ID2SYM(rb_intern("heap_sample")), Qnil);
+  heap_sample_values heap_sample = {.new_object = Qnil};
+  if (heap_sample_options != Qnil) {
+    ENFORCE_TYPE(heap_sample_options, T_HASH);
+    heap_sample.new_object = rb_hash_fetch(heap_sample_options, ID2SYM(rb_intern("new_object")));
+    heap_sample.alloc_class =
+      char_slice_from_ruby_string(rb_hash_fetch(heap_sample_options, ID2SYM(rb_intern("alloc_class"))));
+  }
+
   sample_values values = {
     .cpu_time_ns   = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-time"),      zero)),
     .cpu_or_wall_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("cpu-samples"), zero)),
@@ -139,7 +147,7 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
     .alloc_samples = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples"), zero)),
     .alloc_samples_unscaled = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("alloc-samples-unscaled"), zero)),
     .timeline_wall_time_ns = NUM2UINT(rb_hash_lookup2(metric_values_hash, rb_str_new_cstr("timeline"), zero)),
-    .heap_sample = heap_sample == Qtrue,
+    .heap_sample = heap_sample_options != Qnil ? &heap_sample : NULL,
   };
 
   long labels_count = RARRAY_LEN(labels_array) + RARRAY_LEN(numeric_labels_array);

--- a/ext/datadog_profiling_native_extension/collectors_stack.c
+++ b/ext/datadog_profiling_native_extension/collectors_stack.c
@@ -132,7 +132,7 @@ static VALUE _native_sample(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _self) {
   VALUE zero = INT2NUM(0);
   // Pass `heap_sample: {new_object: ..., alloc_class: ...}` to also record this sample for heap profiling
   VALUE heap_sample_options = rb_hash_lookup2(options, ID2SYM(rb_intern("heap_sample")), Qnil);
-  heap_sample_values heap_sample = {.new_object = Qnil};
+  heap_sample_values heap_sample = {};
   if (heap_sample_options != Qnil) {
     ENFORCE_TYPE(heap_sample_options, T_HASH);
     heap_sample.new_object = rb_hash_fetch(heap_sample_options, ID2SYM(rb_intern("new_object")));

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1020,11 +1020,21 @@ VALUE thread_context_collector_sample_after_gc(VALUE self_instance) {
 
   state->stats.gc_samples++;
 
-  // Let recorder do any cleanup/updates it requires after a GC step.
-  recorder_after_gc_step(state->recorder_instance);
-
   // Return a VALUE to make it easier to call this function from Ruby APIs that expect a return value (such as rb_rescue2)
   return Qnil;
+}
+
+// Let the recorder do any cleanup/updates it requires after a GC step.
+//
+// Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
+// Assumption 2: This function is allowed to raise exceptions. Caller is responsible for handling them, if needed.
+VALUE thread_context_collector_heap_update_may_lose_gvl(VALUE self_instance) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
+  recorder_heap_update_may_lose_gvl(state->recorder_instance);
+
+  return Qnil; // for rb_rescue2
 }
 
 static void trigger_sample_for_thread(

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1521,11 +1521,11 @@ VALUE enforce_thread_context_collector_instance(VALUE object) {
 // Finalize any pending heap allocation recordings.
 // On Ruby 4+, heap allocations are recorded in two phases: during on_newobj_event we capture
 // the object reference, then later we safely call rb_obj_id() to get the object ID.
-void thread_context_collector_after_allocation(VALUE self_instance) {
+void thread_context_collector_commit_heap_recordings_may_lose_gvl(VALUE self_instance) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
-  recorder_after_sample(state->recorder_instance);
+  recorder_commit_heap_recordings_may_lose_gvl(state->recorder_instance);
 }
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
@@ -1671,8 +1671,8 @@ bool thread_context_collector_prepare_sample_inside_signal_handler(void) {
 // This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
 // Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 //
-// Returns true if the after_allocation needs to be called (to do work that can't be done from inside the
-// tracepoint, such as allocate new objects), and false if it doesn't
+// Returns true if `thread_context_collector_commit_heap_recordings_may_lose_gvl` needs to be called (to do work
+// that can't be done from inside the tracepoint, such as allocate new objects), and false if it doesn't
 //
 // The callers must ensure thread_context is non-NULL.
 bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_context *thread_context, unsigned int sample_weight, VALUE new_object) {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1833,6 +1833,10 @@ static VALUE read_otel_current_span_key_const(DDTRACE_UNUSED VALUE _unused) {
   return rb_const_get(trace_module, rb_intern("CURRENT_SPAN_KEY"));
 }
 
+static VALUE otel_current_span_key_not_found(DDTRACE_UNUSED VALUE _unused, DDTRACE_UNUSED VALUE _exception) {
+  return Qnil;
+}
+
 static VALUE get_otel_current_span_key(thread_context_collector_state *state, bool is_safe_to_allocate_objects) {
   if (state->otel_current_span_key == Qtrue) { // Qtrue means we haven't tried to extract it yet
     if (!is_safe_to_allocate_objects) {
@@ -1842,9 +1846,19 @@ static VALUE get_otel_current_span_key(thread_context_collector_state *state, bo
     }
 
     // If this fails, we want to fail gracefully, rather than raise an exception (e.g. if the opentelemetry gem
-    // gets refactored, we should not fall on our face)
-    VALUE span_key = rb_protect(read_otel_current_span_key_const, Qnil, NULL);
-    rb_set_errinfo(Qnil); // **Clear any pending exception after ignoring it**
+    // gets refactored, we should not fall on our face).
+    //
+    // Note that we use `rb_rescue2` and not `rb_protect` so that we only swallow exceptions: anything else that can
+    // unwind through here (e.g. a `Thread#kill`) is not ours to swallow. `rb_rescue2` also takes care of restoring
+    // any previously-pending exception for us.
+    VALUE span_key = rb_rescue2(
+      read_otel_current_span_key_const,
+      Qnil,
+      otel_current_span_key_not_found,
+      Qnil,
+      rb_eException, // rb_eException is the base class of all Ruby exceptions
+      0 // Required by API to be the last argument
+    );
 
     // Note that this gets set to Qnil if we failed to extract the correct value, and thus we won't try to extract it again
     state->otel_current_span_key = span_key;

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -323,8 +323,7 @@ static void trigger_sample_for_thread(
   long current_monotonic_wall_time_ns,
   ddog_CharSlice *ruby_vm_type,
   ddog_CharSlice *class_name,
-  bool is_gvl_waiting_state,
-  bool is_safe_to_allocate_objects
+  bool is_gvl_waiting_state
 );
 static VALUE _native_thread_list(VALUE self);
 static void check_frozen_thread(VALUE thread);
@@ -344,8 +343,7 @@ static VALUE _native_gc_tracking(VALUE self, VALUE collector_instance);
 static void trace_identifiers_for(
   thread_context_collector_state *state,
   VALUE thread,
-  trace_identifiers *trace_identifiers_result,
-  bool is_safe_to_allocate_objects
+  trace_identifiers *trace_identifiers_result
 );
 static bool should_collect_resource(VALUE root_span);
 static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
@@ -359,8 +357,7 @@ static void ddtrace_otel_trace_identifiers_for(
   VALUE *root_span,
   VALUE *numeric_span_id,
   VALUE active_span,
-  VALUE otel_values,
-  bool is_safe_to_allocate_objects
+  VALUE otel_values
 );
 static VALUE _native_sample_skipped_allocation_samples(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE skipped_samples);
 static bool handle_gvl_waiting(
@@ -380,8 +377,7 @@ static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSE
 static void otel_without_ddtrace_trace_identifiers_for(
   thread_context_collector_state *state,
   VALUE thread,
-  trace_identifiers *trace_identifiers_result,
-  bool is_safe_to_allocate_objects
+  trace_identifiers *trace_identifiers_result
 );
 static otel_span otel_span_from(VALUE otel_context, VALUE otel_current_span_key);
 static bool is_otel_current_span_key_needed(thread_context_collector_state *state);
@@ -831,8 +827,7 @@ static void update_metrics_and_sample(
     current_monotonic_wall_time_ns,
     NULL,
     NULL,
-    is_gvl_waiting_state,
-    /* is_safe_to_allocate_objects: */ true // We called from a context that's safe to run any regular code, including allocations
+    is_gvl_waiting_state
   );
 }
 
@@ -1057,10 +1052,7 @@ static void trigger_sample_for_thread(
   // These two labels are only used for allocation profiling; @ivoanjo: may want to refactor this at some point?
   ddog_CharSlice *ruby_vm_type,
   ddog_CharSlice *class_name,
-  bool is_gvl_waiting_state,
-  // If the Ruby VM is at a state that can allocate objects safely, or not. Added for allocation profiling: we're not
-  // allowed to allocate objects (or raise exceptions) when inside the NEWOBJ tracepoint.
-  bool is_safe_to_allocate_objects
+  bool is_gvl_waiting_state
 ) {
   int max_label_count =
     1 + // thread id
@@ -1098,11 +1090,11 @@ static void trigger_sample_for_thread(
   }
 
   trace_identifiers trace_identifiers_result = {.valid = false, .trace_endpoint = Qnil};
-  trace_identifiers_for(state, thread_being_sampled, &trace_identifiers_result, is_safe_to_allocate_objects);
+  trace_identifiers_for(state, thread_being_sampled, &trace_identifiers_result);
 
   if (!trace_identifiers_result.valid && state->otel_context_enabled != OTEL_CONTEXT_ENABLED_FALSE) {
     // If we couldn't get something with ddtrace, let's see if we can get some trace identifiers from opentelemetry directly
-    otel_without_ddtrace_trace_identifiers_for(state, thread_being_sampled, &trace_identifiers_result, is_safe_to_allocate_objects);
+    otel_without_ddtrace_trace_identifiers_for(state, thread_being_sampled, &trace_identifiers_result);
   }
 
   if (trace_identifiers_result.valid) {
@@ -1571,8 +1563,7 @@ static VALUE _native_gc_tracking(DDTRACE_UNUSED VALUE _self, VALUE collector_ins
 static void trace_identifiers_for(
   thread_context_collector_state *state,
   VALUE thread,
-  trace_identifiers *trace_identifiers_result,
-  bool is_safe_to_allocate_objects
+  trace_identifiers *trace_identifiers_result
 ) {
   if (state->otel_context_enabled == OTEL_CONTEXT_ENABLED_ONLY) return;
   if (state->tracer_context_key == MISSING_TRACER_CONTEXT_KEY) return;
@@ -1593,7 +1584,7 @@ static void trace_identifiers_for(
   VALUE numeric_span_id = Qnil;
 
   if (otel_values != Qnil) {
-    ddtrace_otel_trace_identifiers_for(state, &active_trace, &root_span, &numeric_span_id, active_span, otel_values, is_safe_to_allocate_objects);
+    ddtrace_otel_trace_identifiers_for(state, &active_trace, &root_span, &numeric_span_id, active_span, otel_values);
   }
 
   if (root_span == Qnil || (active_span == Qnil && numeric_span_id == Qnil)) return;
@@ -1773,8 +1764,7 @@ bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_
     INVALID_TIME, // For now we're not collecting timestamps for allocation events, as per profiling team internal discussions
     &ruby_vm_type,
     &class_name,
-    /* is_gvl_waiting_state: */ false,
-    /* is_safe_to_allocate_objects: */ false // Not safe to allocate further inside the NEWOBJ tracepoint
+    /* is_gvl_waiting_state: */ false
   );
 
   return needs_after_allocation;
@@ -1850,7 +1840,7 @@ static VALUE otel_current_span_key_not_found(DDTRACE_UNUSED VALUE _unused, DDTRA
   return Qnil;
 }
 
-static VALUE get_otel_current_span_key(thread_context_collector_state *state, bool is_safe_to_allocate_objects) {
+static VALUE get_otel_current_span_key(thread_context_collector_state *state) {
   if (state->otel_current_span_key == OTEL_CURRENT_SPAN_KEY_NOT_EXTRACTED) {
     // Extracting this needs calling into Ruby code, which we don't want to do in the middle of a sample.
     // So instead we signal that we want this, and let it be resolved separately.
@@ -1905,8 +1895,7 @@ static void ddtrace_otel_trace_identifiers_for(
   VALUE *root_span,
   VALUE *numeric_span_id,
   VALUE active_span,
-  VALUE otel_values,
-  bool is_safe_to_allocate_objects
+  VALUE otel_values
 ) {
   VALUE resolved_numeric_span_id =
     active_span == Qnil ?
@@ -1917,7 +1906,7 @@ static void ddtrace_otel_trace_identifiers_for(
 
   if (resolved_numeric_span_id == Qnil) return;
 
-  VALUE otel_current_span_key = get_otel_current_span_key(state, is_safe_to_allocate_objects);
+  VALUE otel_current_span_key = get_otel_current_span_key(state);
   if (otel_current_span_key == Qnil) return;
   VALUE current_trace = *active_trace;
 
@@ -2037,15 +2026,14 @@ static VALUE _native_sample_skipped_allocation_samples(DDTRACE_UNUSED VALUE self
 static void otel_without_ddtrace_trace_identifiers_for(
   thread_context_collector_state *state,
   VALUE thread,
-  trace_identifiers *trace_identifiers_result,
-  bool is_safe_to_allocate_objects
+  trace_identifiers *trace_identifiers_result
 ) {
   VALUE context_storage = otel_context_storage_for(state, thread);
 
   // If it exists, context_storage is expected to be an Array[OpenTelemetry::Context]
   if (context_storage == Qnil || !RB_TYPE_P(context_storage, T_ARRAY)) return;
 
-  VALUE otel_current_span_key = get_otel_current_span_key(state, is_safe_to_allocate_objects);
+  VALUE otel_current_span_key = get_otel_current_span_key(state);
   if (otel_current_span_key == Qnil) return;
 
   long active_context_index = RARRAY_LEN(context_storage) - 1;
@@ -2441,8 +2429,7 @@ static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread) {
         gvl_waiting_started_wall_time_ns,
         NULL,
         NULL,
-        /* is_gvl_waiting_state: */ false, // This is the extra sample before the wait begun; only the next sample will be in the gvl waiting state
-        /* is_safe_to_allocate_objects: */ true // This is similar to a regular cpu/wall sample, so it's also safe
+        /* is_gvl_waiting_state: */ false // This is the extra sample before the wait begun; only the next sample will be in the gvl waiting state
       );
     }
 

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -300,7 +300,7 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
 static VALUE _native_sample(VALUE self, VALUE collector_instance, VALUE allow_exception);
 static VALUE _native_on_gc_start(VALUE self, VALUE collector_instance);
 static VALUE _native_on_gc_finish(VALUE self, VALUE collector_instance);
-static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE allow_exception);
+static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
 static void update_metrics_and_sample(
   thread_context_collector_state *state,
   VALUE thread_being_sampled,
@@ -412,7 +412,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_sample_allocation", _native_sample_allocation, 3);
   rb_define_singleton_method(testing_module, "_native_on_gc_start", _native_on_gc_start, 1);
   rb_define_singleton_method(testing_module, "_native_on_gc_finish", _native_on_gc_finish, 1);
-  rb_define_singleton_method(testing_module, "_native_sample_after_gc", _native_sample_after_gc, 2);
+  rb_define_singleton_method(testing_module, "_native_sample_after_gc", _native_sample_after_gc, 1);
   rb_define_singleton_method(testing_module, "_native_thread_list", _native_thread_list, 0);
   rb_define_singleton_method(testing_module, "_native_per_thread_context", _native_per_thread_context, 1);
   rb_define_singleton_method(testing_module, "_native_stats", _native_stats, 1);
@@ -679,14 +679,12 @@ static VALUE _native_on_gc_finish(DDTRACE_UNUSED VALUE self, VALUE collector_ins
   return Qtrue;
 }
 
-static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE allow_exception) {
-  ENFORCE_BOOLEAN(allow_exception);
-
-  if (allow_exception == Qfalse) debug_enter_unsafe_context();
+static VALUE _native_sample_after_gc(DDTRACE_UNUSED VALUE self, VALUE collector_instance) {
+  debug_enter_unsafe_context();
 
   thread_context_collector_sample_after_gc(collector_instance);
 
-  if (allow_exception == Qfalse) debug_leave_unsafe_context();
+  debug_leave_unsafe_context();
 
   return Qtrue;
 }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -74,6 +74,11 @@
 #define THREAD_ID_LIMIT_CHARS 44 // Why 44? "#{2**64} (#{2**64})".size + 1 for \0
 #define THREAD_INVOKE_LOCATION_LIMIT_CHARS 512
 #define MISSING_TRACER_CONTEXT_KEY 0
+
+// Used as markers in the code
+#define OTEL_CURRENT_SPAN_KEY_NOT_EXTRACTED INT2FIX(1)
+#define OTEL_CURRENT_SPAN_KEY_EXTRACTION_NEEDED INT2FIX(2)
+
 #define TIME_BETWEEN_GC_EVENTS_NS MILLIS_AS_NS(10)
 #define GVL_SUSPENDED ((uint64_t)1)
 #define GVL_RUNNING ((uint64_t)0)
@@ -148,8 +153,9 @@ typedef struct {
   // Used to identify the main thread, to give it a fallback name
   VALUE main_thread;
   // Used when extracting trace identifiers from otel spans. Lazily initialized.
-  // Qtrue serves as a marker we've not yet extracted it; when we try to extract it, we set it to an object if
-  // successful and Qnil if not.
+  // * `OTEL_CURRENT_SPAN_KEY_NOT_EXTRACTED`: we've not needed it yet
+  // * `OTEL_CURRENT_SPAN_KEY_EXTRACTION_NEEDED`: a sample needed it, and it's waiting to be extracted
+  // * anything else: the extracted value, or Qnil if we tried to extract it and failed
   VALUE otel_current_span_key;
   // Used to enable native filenames in stack traces
   bool native_filenames_enabled;
@@ -368,7 +374,7 @@ static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread);
 #ifndef NO_GVL_INSTRUMENTATION
   static VALUE _native_gvl_waiting_at_for(DDTRACE_UNUSED VALUE self, VALUE thread);
   static VALUE _native_on_gvl_running(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE waiting_for_gvl_threshold_ns);
-  static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception);
+  static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread);
 #endif
 static VALUE _native_apply_delta_to_cpu_time_at_previous_sample_ns(DDTRACE_UNUSED VALUE self, VALUE thread, VALUE delta_ns);
 static void otel_without_ddtrace_trace_identifiers_for(
@@ -378,6 +384,7 @@ static void otel_without_ddtrace_trace_identifiers_for(
   bool is_safe_to_allocate_objects
 );
 static otel_span otel_span_from(VALUE otel_context, VALUE otel_current_span_key);
+static bool is_otel_current_span_key_needed(thread_context_collector_state *state);
 static uint64_t otel_span_id_to_uint(VALUE otel_span_id);
 static VALUE safely_lookup_hash_without_going_into_ruby_code(VALUE hash, VALUE key);
 static VALUE _native_system_epoch_time_now_ns(DDTRACE_UNUSED VALUE self, VALUE collector_instance);
@@ -429,7 +436,7 @@ void collectors_thread_context_init(VALUE profiling_module) {
   #ifndef NO_GVL_INSTRUMENTATION
     rb_define_singleton_method(testing_module, "_native_gvl_waiting_at_for", _native_gvl_waiting_at_for, 1);
     rb_define_singleton_method(testing_module, "_native_on_gvl_running", _native_on_gvl_running, 2);
-    rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 3);
+    rb_define_singleton_method(testing_module, "_native_sample_after_gvl_running", _native_sample_after_gvl_running, 2);
   #endif
   rb_define_singleton_method(testing_module, "_native_apply_delta_to_cpu_time_at_previous_sample_ns", _native_apply_delta_to_cpu_time_at_previous_sample_ns, 2);
 
@@ -565,7 +572,7 @@ static VALUE _native_new(VALUE klass) {
   state->time_converter_state = (monotonic_to_system_epoch_state) MONOTONIC_TO_SYSTEM_EPOCH_INITIALIZER;
   VALUE main_thread = rb_thread_main();
   state->main_thread = main_thread;
-  state->otel_current_span_key = Qtrue;
+  state->otel_current_span_key = OTEL_CURRENT_SPAN_KEY_NOT_EXTRACTED;
   state->gc_tracking.wall_time_at_previous_gc_ns = INVALID_TIME;
   state->gc_tracking.wall_time_at_last_flushed_gc_event_ns = 0;
 
@@ -648,9 +655,13 @@ static VALUE _native_sample(DDTRACE_UNUSED VALUE _self, VALUE collector_instance
 
   if (allow_exception == Qfalse) debug_enter_unsafe_context();
 
-  thread_context_collector_sample(collector_instance, monotonic_wall_time_now_ns(RAISE_ON_FAILURE));
+  bool needs_otel_span_key =
+    thread_context_collector_sample(collector_instance, monotonic_wall_time_now_ns(RAISE_ON_FAILURE));
 
   if (allow_exception == Qfalse) debug_leave_unsafe_context();
+
+  // Same as the CpuAndWallTimeWorker does: this can't happen during a sample (and thus not inside the unsafe context)
+  if (needs_otel_span_key) thread_context_collector_resolve_otel_span_key_may_lose_gvl(collector_instance);
 
   return Qtrue;
 }
@@ -735,7 +746,7 @@ static void record_sampling_overhead(thread_context_collector_state *state, per_
 // Assumption 4: This function IS NOT called in a reentrant way.
 // Assumption 5: This function is called from the main Ractor (if Ruby has support for Ractors).
 //
-void thread_context_collector_sample(VALUE self_instance, long current_monotonic_wall_time_ns) {
+bool thread_context_collector_sample(VALUE self_instance, long current_monotonic_wall_time_ns) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
 
@@ -775,6 +786,8 @@ void thread_context_collector_sample(VALUE self_instance, long current_monotonic
   if (!current_thread_context->is_profiler_internal_thread) {
     record_sampling_overhead(state, current_thread_context);
   }
+
+  return is_otel_current_span_key_needed(state);
 }
 
 static void update_metrics_and_sample(
@@ -1838,33 +1851,50 @@ static VALUE otel_current_span_key_not_found(DDTRACE_UNUSED VALUE _unused, DDTRA
 }
 
 static VALUE get_otel_current_span_key(thread_context_collector_state *state, bool is_safe_to_allocate_objects) {
-  if (state->otel_current_span_key == Qtrue) { // Qtrue means we haven't tried to extract it yet
-    if (!is_safe_to_allocate_objects) {
-      // Calling read_otel_current_span_key_const below can trigger exceptions and arbitrary Ruby code running (e.g.
-      // `const_missing`, etc). Not safe to call in this situation, so we just skip otel info for this sample.
-      return Qnil;
-    }
-
-    // If this fails, we want to fail gracefully, rather than raise an exception (e.g. if the opentelemetry gem
-    // gets refactored, we should not fall on our face).
-    //
-    // Note that we use `rb_rescue2` and not `rb_protect` so that we only swallow exceptions: anything else that can
-    // unwind through here (e.g. a `Thread#kill`) is not ours to swallow. `rb_rescue2` also takes care of restoring
-    // any previously-pending exception for us.
-    VALUE span_key = rb_rescue2(
-      read_otel_current_span_key_const,
-      Qnil,
-      otel_current_span_key_not_found,
-      Qnil,
-      rb_eException, // rb_eException is the base class of all Ruby exceptions
-      0 // Required by API to be the last argument
-    );
-
-    // Note that this gets set to Qnil if we failed to extract the correct value, and thus we won't try to extract it again
-    state->otel_current_span_key = span_key;
+  if (state->otel_current_span_key == OTEL_CURRENT_SPAN_KEY_NOT_EXTRACTED) {
+    // Extracting this needs calling into Ruby code, which we don't want to do in the middle of a sample.
+    // So instead we signal that we want this, and let it be resolved separately.
+    state->otel_current_span_key = OTEL_CURRENT_SPAN_KEY_EXTRACTION_NEEDED;
+    return Qnil;
   }
 
+  // We asked for it, but it hasn't been extracted yet
+  if (is_otel_current_span_key_needed(state)) return Qnil;
+
   return state->otel_current_span_key;
+}
+
+static bool is_otel_current_span_key_needed(thread_context_collector_state *state) {
+  return state->otel_current_span_key == OTEL_CURRENT_SPAN_KEY_EXTRACTION_NEEDED;
+}
+
+// Extracts `otel_current_span_key`, if a sample asked for it (see `get_otel_current_span_key`).
+// This is deliberately not done during sampling because we can lose the GVL.
+//
+// Assumption 1: This function is called in a thread that is holding the Global VM Lock. Caller is responsible for enforcing this.
+void thread_context_collector_resolve_otel_span_key_may_lose_gvl(VALUE self_instance) {
+  thread_context_collector_state *state;
+  TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
+
+  if (!is_otel_current_span_key_needed(state)) return;
+
+  // If this fails, we want to fail gracefully, rather than raise an exception (e.g. if the opentelemetry gem
+  // gets refactored, we should not fall on our face).
+  //
+  // Note that we use `rb_rescue2` and not `rb_protect` so that we only swallow exceptions: anything else that can
+  // unwind through here (e.g. a `Thread#kill`) is not ours to swallow. `rb_rescue2` also takes care of restoring
+  // any previously-pending exception for us.
+  VALUE span_key = rb_rescue2(
+    read_otel_current_span_key_const,
+    Qnil,
+    otel_current_span_key_not_found,
+    Qnil,
+    rb_eException, // rb_eException is the base class of all Ruby exceptions
+    0 // Required by API to be the last argument
+  );
+
+  // Note that this gets set to Qnil if we failed to extract the correct value, and thus we won't try to extract it again
+  state->otel_current_span_key = span_key;
 }
 
 // This method gets used when ddtrace is being used indirectly via the opentelemetry APIs. Information gets stored slightly
@@ -2453,11 +2483,10 @@ static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread) {
     return result;
   }
 
-  static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread, VALUE allow_exception) {
+  static VALUE _native_sample_after_gvl_running(DDTRACE_UNUSED VALUE self, VALUE collector_instance, VALUE thread) {
     ENFORCE_THREAD(thread);
-    ENFORCE_BOOLEAN(allow_exception);
 
-    if (allow_exception == Qfalse) debug_enter_unsafe_context();
+    debug_enter_unsafe_context();
 
     VALUE result = thread_context_collector_sample_after_gvl_running(
       collector_instance,
@@ -2465,7 +2494,7 @@ static VALUE _native_on_gvl_released(DDTRACE_UNUSED VALUE self, VALUE thread) {
       monotonic_wall_time_now_ns(RAISE_ON_FAILURE)
     );
 
-    if (allow_exception == Qfalse) debug_leave_unsafe_context();
+    debug_leave_unsafe_context();
 
     return result;
   }

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.c
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.c
@@ -1531,9 +1531,9 @@ VALUE enforce_thread_context_collector_instance(VALUE object) {
   return object;
 }
 
-// Finalize any pending heap allocation recordings.
-// On Ruby 4+, heap allocations are recorded in two phases: during on_newobj_event we capture
-// the object reference, then later we safely call rb_obj_id() to get the object ID.
+// Commit any pending heap allocation recordings.
+// Recording an allocation only puts it on a pending list, because taking the weak reference the heap profiler needs
+// can't be done from inside the NEWOBJ tracepoint -- see `heap_recorder_commit_recordings_may_lose_gvl`.
 void thread_context_collector_commit_heap_recordings_may_lose_gvl(VALUE self_instance) {
   thread_context_collector_state *state;
   TypedData_Get_Struct(self_instance, thread_context_collector_state, &thread_context_collector_typed_data, state);
@@ -1752,22 +1752,22 @@ bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_
     class_name = ruby_vm_type; // For other weird internal things we just use the VM type
   }
 
-  bool needs_after_allocation = track_object(state->recorder_instance, new_object, sample_weight, class_name);
-
   VALUE current_thread = rb_thread_current();
+
+  heap_sample_values heap_sample = {.new_object = new_object, .alloc_class = class_name};
 
   trigger_sample_for_thread(
     state,
     current_thread,
     thread_context,
-    (sample_values) {.alloc_samples = sample_weight, .alloc_samples_unscaled = 1, .heap_sample = true},
+    (sample_values) {.alloc_samples = sample_weight, .alloc_samples_unscaled = 1, .heap_sample = &heap_sample},
     INVALID_TIME, // For now we're not collecting timestamps for allocation events, as per profiling team internal discussions
     &ruby_vm_type,
     &class_name,
     /* is_gvl_waiting_state: */ false
   );
 
-  return needs_after_allocation;
+  return heap_sample.out_needs_commit;
 }
 
 // This method exists only to enable testing Datadog::Profiling::Collectors::ThreadContext behavior using RSpec.
@@ -1780,13 +1780,13 @@ static VALUE _native_sample_allocation(DDTRACE_UNUSED VALUE self, VALUE collecto
 
   debug_enter_unsafe_context();
 
-  bool needs_after_allocation = thread_context_collector_sample_allocation(collector_instance, thread_context, NUM2UINT(sample_weight), new_object);
+  bool needs_commit = thread_context_collector_sample_allocation(collector_instance, thread_context, NUM2UINT(sample_weight), new_object);
 
   debug_leave_unsafe_context();
 
   // We could instead choose to automatically trigger the after allocation here; yet, it seems kinda nice to keep it manual for
   // the tests so we can pull on each lever separately and observe "the sausage being made" in steps
-  return needs_after_allocation ? Qtrue : Qfalse;
+  return needs_commit ? Qtrue : Qfalse;
 }
 
 static VALUE new_empty_thread_inner(DDTRACE_UNUSED void *arg) {

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -12,7 +12,7 @@ void thread_context_collector_sample(
 );
 __attribute__((warn_unused_result)) bool thread_context_collector_prepare_sample_inside_signal_handler(void);
 __attribute__((warn_unused_result)) bool thread_context_collector_sample_allocation(VALUE self_instance, per_thread_context *thread_context, unsigned int sample_weight, VALUE new_object);
-void thread_context_collector_after_allocation(VALUE self_instance);
+void thread_context_collector_commit_heap_recordings_may_lose_gvl(VALUE self_instance);
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -15,6 +15,7 @@ __attribute__((warn_unused_result)) bool thread_context_collector_sample_allocat
 void thread_context_collector_commit_heap_recordings_may_lose_gvl(VALUE self_instance);
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
+VALUE thread_context_collector_heap_update_may_lose_gvl(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 __attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);

--- a/ext/datadog_profiling_native_extension/collectors_thread_context.h
+++ b/ext/datadog_profiling_native_extension/collectors_thread_context.h
@@ -6,7 +6,9 @@
 
 #include "gvl_profiling_helper.h"
 
-void thread_context_collector_sample(
+// Returns true if `thread_context_collector_resolve_otel_span_key_may_lose_gvl` needs to be called (which the caller
+// must only do once the sample is over)
+__attribute__((warn_unused_result)) bool thread_context_collector_sample(
   VALUE self_instance,
   long current_monotonic_wall_time_ns
 );
@@ -16,6 +18,7 @@ void thread_context_collector_commit_heap_recordings_may_lose_gvl(VALUE self_ins
 void thread_context_collector_sample_skipped_allocation_samples(VALUE self_instance, unsigned int skipped_samples);
 VALUE thread_context_collector_sample_after_gc(VALUE self_instance);
 VALUE thread_context_collector_heap_update_may_lose_gvl(VALUE self_instance);
+void thread_context_collector_resolve_otel_span_key_may_lose_gvl(VALUE self_instance);
 void thread_context_collector_on_gc_start(VALUE self_instance);
 __attribute__((warn_unused_result)) bool thread_context_collector_on_gc_finish(VALUE self_instance);
 VALUE enforce_thread_context_collector_instance(VALUE object);

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -275,7 +275,7 @@ static int st_object_record_update(st_data_t, st_data_t, st_data_t);
 static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
 static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t extra);
 static void inc_tracked_objects_or_fail(heap_record *heap_record);
-static void commit_recording(heap_recorder *, heap_record *, object_record *new_record);
+static void commit_recording(heap_recorder *, pending_recording);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
 static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_as_value);
@@ -621,9 +621,7 @@ static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_reco
     // This is the "can release the GVL" bit
     ruby_weak_map_set_may_lose_gvl_and_allocate_objects(heap_recorder->weak_objects, LONG2FIX(pending.record_id), pending.object_ref);
 
-    object_record *record = object_record_new(pending);
-
-    commit_recording(heap_recorder, pending.heap_record, record);
+    commit_recording(heap_recorder, pending);
 
     // Ensure that the object we've just recorded is not collected until we've done all the bookeeping
     RB_GC_GUARD(pending.object_ref);
@@ -985,10 +983,8 @@ static void inc_tracked_objects_or_fail(heap_record *heap_record) {
   heap_record->num_tracked_objects++;
 }
 
-static void commit_recording(heap_recorder *heap_recorder, heap_record *heap_record, object_record *new_record) {
-  // Link the object record with the corresponding heap record. This was the last remaining thing we
-  // needed to fully build the object_record.
-  new_record->heap_record = heap_record;
+static void commit_recording(heap_recorder *heap_recorder, pending_recording pending) {
+  object_record *new_record = object_record_new(pending);
 
   int existing = st_insert(heap_recorder->object_records, new_record->record_id, (st_data_t) new_record);
   if (existing) {
@@ -1060,6 +1056,7 @@ static void on_committed_object_record_cleanup(heap_recorder *heap_recorder, obj
 static object_record* object_record_new(pending_recording pending) {
   object_record *record = calloc(1, sizeof(object_record)); // See "note on calloc vs ruby_xcalloc use" above
   record->record_id = pending.record_id;
+  // Link the object record with the corresponding heap record
   record->heap_record = pending.heap_record;
   record->object_data = pending.object_data;
   return record;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -470,6 +470,14 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   heap_recorder->recording_in_progress = true;
   heap_recorder->recording_skipped = false;
 
+  // We always return need_commit, even if it's because a previous allocation was put on the pending_recordings.
+  //
+  // This can mean we "spam" a bit the postponed jobs mechanism (e.g. perhaps our postponed job hasn't run
+  // because there's a native extension doing Ruby object allocations in a row without giving Ruby the chance to
+  // run interrupts.
+  // That shouldn't be a problem because the allocation profiler has the dynamic sampling rate mechanism +
+  // triggering postponed jobs is cheap on current Rubies.
+  // (Note that asking for the same job multiple times de-duplicates -- Ruby will only run it once when it gets the chance)
   bool need_commit = heap_recorder->pending_recordings_count > 0;
 
   if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -614,7 +614,7 @@ static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_reco
   //
   // Note as well that `ruby_weak_map_set_may_lose_gvl_and_allocate_objects` below can lose the GVL (and, on older
   // Rubies, allocate). This function gets called while holding the heap recorder lock so that no other heap recorder
-  // operation can concurrently with us in that window (including recording more allocations, which on older Rubies
+  // operation can concurrently execute with us in that window (including recording more allocations, which on older Rubies
   // would otherwise add entries to the very buffer we're draining).
   while (heap_recorder->pending_recordings_count > 0) {
     pending_recording pending = heap_recorder->pending_recordings[heap_recorder->pending_recordings_count - 1];

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -317,7 +317,7 @@ static VALUE ruby_weak_map_new(void) {
 // means "the value was garbage collected".
 //
 // Note: GVL can be released and other threads may get to run before this method returns
-static VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
+static VALUE ruby_weak_map_get_may_lose_gvl(VALUE weak_map, VALUE key) {
   return rb_funcall(weak_map, aref_id, 1, key);
 }
 
@@ -889,7 +889,7 @@ static int st_object_record_update(st_data_t key, st_data_t value, st_data_t ext
   }
 
   // Note: This function call can cause the GVL to be released
-  VALUE ref = ruby_weak_map_get(recorder->weak_objects, LONG2FIX(record_id));
+  VALUE ref = ruby_weak_map_get_may_lose_gvl(recorder->weak_objects, LONG2FIX(record_id));
   if (ref == Qnil) {
     // The weak reference is gone, meaning the object was garbage collected. Need to delete this object record!
     on_committed_object_record_cleanup(recorder, record);
@@ -1084,7 +1084,7 @@ static VALUE object_record_inspect(heap_recorder *recorder, object_record *recor
     rb_str_catf(inspect, "class=%"PRIsVALUE" ", class);
   }
 
-  VALUE ref = ruby_weak_map_get(recorder->weak_objects, LONG2FIX(record->record_id));
+  VALUE ref = ruby_weak_map_get_may_lose_gvl(recorder->weak_objects, LONG2FIX(record->record_id));
   if (ref == Qnil) {
     rb_str_catf(inspect, "object=<invalid>");
   } else {
@@ -1229,7 +1229,7 @@ static int st_object_record_id_for(st_data_t key, DDTRACE_UNUSED st_data_t value
   record_id_for_context *context = (record_id_for_context*) extra;
   long record_id = (long) key;
 
-  VALUE ref = ruby_weak_map_get(context->recorder->weak_objects, LONG2FIX(record_id));
+  VALUE ref = ruby_weak_map_get_may_lose_gvl(context->recorder->weak_objects, LONG2FIX(record_id));
   if (ref != Qnil && ref == context->target) {
     context->result = LONG2FIX(record_id);
     return ST_STOP;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -521,26 +521,41 @@ void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder) {
     return; // Nothing to do
   }
 
-  heap_recorder->stats_lifetime.deferred_recordings_committed += heap_recorder->pending_recordings_count;
-
   // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
   // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark
   // already-processed pending_recordings (slower and would extend the lifetime of these recordings if not cleared) and
   // (c) if one of the steps below raises we don't reprocess the entries we already committed, i.e., we're idempotent.
+  //
+  // Note as well that `ruby_weak_map_set` below can release the GVL, and thus this function needs to tolerate other
+  // profiler operations being interleaved with it -- in particular an allocation sample (which appends to
+  // `pending_recordings`) or even another call to this function. (Unlike most of the profiler, our caller
+  // `after_allocation_from_postponed_job` deliberately does not hold the `during_sample` flag, exactly because we may
+  // lose the GVL here.) This is safe because:
+  //
+  // * We copy the pending_recording to the stack and decrement the count **before** we can lose the GVL, so from that
+  //   point on the slot is no longer ours: an allocation sample that gets to run will write to that same slot, and our
+  //   own next iteration will then pick that new recording up (nothing gets lost or processed twice).
+  // * `start_heap_allocation_recording` checks the `MAX_PENDING_RECORDINGS` limit after our decrement, so there's
+  //   always room for such a recording.
+  // * `record_id`s are unique, so an interleaved commit can't trip the duplicate check in `commit_recording`, and an
+  //   interleaved run of this function consumes different slots than we do.
+  // * `pending.heap_record` can't be freed from under us because `start_heap_allocation_recording` already accounted
+  //   for this recording in `num_tracked_objects` (see `inc_tracked_objects_or_fail`), so a `heap_recorder_update`
+  //   that gets to run will not consider that heap record unused.
   while (heap_recorder->pending_recordings_count > 0) {
-    // Copy the pending_recording on the stack because the call below can release the GVL, which means anything can run
-    // and possibly something that can mutate `pending_recordings[pending_recordings_count]`.
-    // Though at least on_newobj_event() and after_allocation_from_postponed_job() are guarded by
-    // the during_sample flag and during_sample_enter()/during_sample_exit().
     pending_recording pending = heap_recorder->pending_recordings[--heap_recorder->pending_recordings_count];
 
-    // This is the step we couldn't do during the original sample call -- we're now expected to be called in a context
-    // where it's finally safe to call this
+    heap_recorder->stats_lifetime.deferred_recordings_committed++;
+
+    // This is the "can release the GVL" bit
     ruby_weak_map_set(heap_recorder->weak_objects, LONG2FIX(pending.record_id), pending.object_ref);
 
     object_record *record = object_record_new(pending);
 
     commit_recording(heap_recorder, pending.heap_record, record);
+
+    // Ensure that the object we've just recorded is not collected until we've done all the bookeeping
+    RB_GC_GUARD(pending.object_ref);
   }
 }
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -422,7 +422,7 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     return true; // If the buffer is full, we keep asking for a callback (see `needs_after_allocation` below)
   }
 
-  // The intuition here is: We start by asking for an `after_allocation` callback when the buffer is about to go
+  // The intuition here is: We start by asking for a commit callback when the buffer is about to go
   // from empty -> non-empty, because this is going to be mapped onto a postponed job, so after it gets queued once
   // it doesn't seem worth it to keep spamming requests.
   //
@@ -516,7 +516,7 @@ void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
   heap_recorder_update(heap_recorder, /* full_update: */ false);
 }
 
-void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder) {
+void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) {
   if (heap_recorder == NULL) {
     return; // Nothing to do
   }
@@ -529,8 +529,8 @@ void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder) {
   // Note as well that `ruby_weak_map_set` below can release the GVL, and thus this function needs to tolerate other
   // profiler operations being interleaved with it -- in particular an allocation sample (which appends to
   // `pending_recordings`) or even another call to this function. (Unlike most of the profiler, our caller
-  // `after_allocation_from_postponed_job` deliberately does not hold the `during_sample` flag, exactly because we may
-  // lose the GVL here.) This is safe because:
+  // `commit_heap_recordings_from_postponed_job_may_lose_gvl` deliberately does not hold the `during_sample` flag,
+  // exactly because we may lose the GVL here.) This is safe because:
   //
   // * We copy the pending_recording to the stack and decrement the count **before** we can lose the GVL, so from that
   //   point on the slot is no longer ours: an allocation sample that gets to run will write to that same slot, and our

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -595,7 +595,6 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
     return;
   }
 
-  // Wrap the next steps with `rb_ensure` so that we always get to release the lock
   rb_ensure(
     heap_recorder_commit_recordings_may_lose_gvl_locked,
     (VALUE) heap_recorder,
@@ -629,7 +628,7 @@ static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_reco
     heap_recorder->stats_lifetime.deferred_recordings_committed++;
   }
 
-  return Qnil; // for rb_ensure
+  return Qnil;
 }
 
 // Mark the Ruby objects the heap recorder holds on to.
@@ -666,7 +665,6 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
     return;
   }
 
-  // Wrap the next steps with `rb_ensure` so that we always get to release the lock
   heap_recorder_update_locked_args args = {.heap_recorder = heap_recorder, .full_update = full_update};
   rb_ensure(heap_recorder_update_locked, (VALUE) &args, heap_recorder_unlock_ensure, (VALUE) heap_recorder);
 }
@@ -729,7 +727,7 @@ static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_
     heap_recorder->stats_lifetime.ewma_objects_skipped = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_skipped, heap_recorder->stats_last_update.objects_skipped);
   }
 
-  return Qnil; // for rb_ensure
+  return Qnil;
 }
 
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -124,8 +124,8 @@ struct heap_recorder {
   // mutation of the data so iteration can occur without acquiring a lock.
   // NOTE: Contrary to object_records, this table has no ownership of its data.
   st_table *object_records_snapshot;
-  // Are we currently updating or not?
-  bool updating;
+  // "Lock" protecting the heap recorder bookkeeping; see "note on locking" below
+  uint8_t lock;
   // The GC gen/epoch/count in which we are updating (or last updated if not currently updating).
   //
   // This enables us to calculate the age of objects considered in the update by comparing it
@@ -199,10 +199,72 @@ struct heap_recorder {
   } stats_lifetime;
 };
 
+// note on locking:
+//
+// The state of the heap profiler (`pending_recordings`, `object_records`, `heap_records`, `weak_objects`) gets mutated from a
+// few different places and, unlike most of the profiler, some of those operations lose the GVL while they work.
+// Thus, unlike most of the profiler, relying only on knowing "we get called with the GVL" is not enough to keep them
+// from stepping on each other, hence this extra "uint8_t lock".
+//
+// Yet, because we only ever touch while holding the GVL, and never lose the GVL between checking it and setting it, a
+// plain field is enough -- no atomics needed. (Hence the "lock" and not a full actual lock)
+//
+// Operations that can be skipped use `heap_recorder_try_lock` and walk away when it's taken (which is almost all of them).
+// The one operation that can't be skipped -- the full update that runs before serialization -- uses
+// `heap_recorder_lock`, which waits.
+#define HEAP_RECORDER_LOCK_HELD 0x1
+#define HEAP_RECORDER_LOCK_WANTED 0x2
+
+// Is someone in the middle of a locked operation? (Which, because they may lose the GVL, may be true even though we're
+// the ones currently holding the GVL.)
+static inline bool heap_recorder_is_locked(heap_recorder *heap_recorder) {
+  return (heap_recorder->lock & HEAP_RECORDER_LOCK_HELD) != 0;
+}
+
+// Takes the lock, unless it's held or someone is waiting for it. Returns whether it was taken.
+__attribute__((warn_unused_result))
+static inline bool heap_recorder_try_lock(heap_recorder *heap_recorder) {
+  if (heap_recorder->lock != 0) return false;
+
+  heap_recorder->lock = HEAP_RECORDER_LOCK_HELD;
+  return true;
+}
+
+// Takes the lock, waiting for the current holder to finish if needed. See "note on locking" above for why this wait is
+// expected to be bounded.
+//
+// WARN: Do not call this while already holding the lock -- it would wait forever.
+static void heap_recorder_lock(heap_recorder *heap_recorder) {
+  while (heap_recorder_is_locked(heap_recorder)) {
+    heap_recorder->lock |= HEAP_RECORDER_LOCK_WANTED;
+    rb_thread_schedule();
+  }
+
+  // Note that we go from observing the lock as free to taking it without ever losing the GVL, and thus without giving
+  // anyone else a chance to take it from under us
+  heap_recorder->lock = HEAP_RECORDER_LOCK_HELD;
+}
+
+static inline void heap_recorder_unlock(heap_recorder *heap_recorder) {
+  // Deliberately preserves `HEAP_RECORDER_LOCK_WANTED` (rather than just zero-ing the lock)
+  heap_recorder->lock &= ~HEAP_RECORDER_LOCK_HELD;
+}
+
+// Same as the above, in the shape `rb_ensure` wants
+static VALUE heap_recorder_unlock_ensure(VALUE heap_recorder_as_value) {
+  heap_recorder_unlock((heap_recorder *) heap_recorder_as_value);
+  return Qnil;
+}
+
 typedef struct {
   heap_recorder *heap_recorder;
   ddog_prof_Slice_Location locations;
 } end_heap_allocation_args;
+
+typedef struct {
+  heap_recorder *heap_recorder;
+  bool full_update;
+} heap_recorder_update_locked_args;
 
 static heap_record* get_or_create_heap_record(heap_recorder*, ddog_prof_Slice_Location);
 static void cleanup_heap_record_if_unused(heap_recorder*, heap_record*);
@@ -216,7 +278,8 @@ static void inc_tracked_objects_or_fail(heap_record *heap_record);
 static void commit_recording(heap_recorder *, heap_record *, object_record *new_record);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
-static VALUE update_object_records(VALUE heap_recorder_as_value);
+static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_as_value);
+static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_recorder_as_value);
 static inline double ewma_stat(double previous, double current);
 static void unintern_or_raise(heap_recorder *, ddog_prof_ManagedStringId);
 static void unintern_all_or_raise(heap_recorder *recorder, ddog_prof_Slice_ManagedStringId ids);
@@ -380,8 +443,8 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
     heap_recorder_finish_iteration(heap_recorder);
   }
 
-  // This could also be left over if fork happens during an update
-  heap_recorder->updating = false;
+  // This could also be left over if fork happens in the middle of a locked operation
+  heap_recorder->lock = 0;
 
   // Clear lifetime stats since this is essentially a new heap recorder
   heap_recorder->stats_lifetime = (struct stats_lifetime) {0};
@@ -406,10 +469,10 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   bool need_commit = heap_recorder->pending_recordings_count > 0;
 
   if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate
-      // If we got really unlucky and an allocation showed up during an update (because it triggered an allocation
-      // directly OR because the GVL got released in the middle of an update), let's skip this sample as well.
-      // See notes on `heap_recorder_update` for details.
-      || heap_recorder->updating
+      // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
+      // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
+      // (Note we don't take the lock ourselves: recording never loses the GVL, and is thus already atomic.)
+      || heap_recorder_is_locked(heap_recorder)
     ) {
     heap_recorder->recording_skipped = true;
     return need_commit;
@@ -523,34 +586,33 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
     return; // Nothing to do
   }
 
-  if (heap_recorder->updating) {
-    // Because, like us, `heap_recorder_update` can lose the GVL, we don't want to run while it's also running.
-    // Skipping is fine -- `start_heap_allocation_recording` will ask for us to be called again on a later allocation.
+  if (!heap_recorder_try_lock(heap_recorder)) {
+    // Something else is busy; `start_heap_allocation_recording` will ask for us to be called again later
     return;
   }
+
+  // Wrap the next steps with `rb_ensure` so that we always get to release the lock
+  rb_ensure(
+    heap_recorder_commit_recordings_may_lose_gvl_locked,
+    (VALUE) heap_recorder,
+    heap_recorder_unlock_ensure,
+    (VALUE) heap_recorder
+  );
+}
+
+static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_recorder_as_value) {
+  heap_recorder *heap_recorder = (struct heap_recorder *) heap_recorder_as_value;
 
   // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
   // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark
   // already-processed pending_recordings (slower and would extend the lifetime of these recordings if not cleared) and
   // (c) if one of the steps below raises we don't reprocess the entries we already committed, i.e., we're idempotent.
   //
-  // Note as well that `ruby_weak_map_set_may_lose_gvl_and_allocate_objects` below can release the GVL (and, on older
-  // Rubies, allocate), and thus this function needs to tolerate other
-  // profiler operations being interleaved with it -- in particular an allocation sample (which appends to
-  // `pending_recordings`) or even another call to this function. (Unlike most of the profiler, our caller
-  // `commit_heap_recordings_from_postponed_job_may_lose_gvl` deliberately does not hold the `during_sample` flag,
-  // exactly because we may lose the GVL here.) This is safe because:
+  // Note as well that `ruby_weak_map_set_may_lose_gvl_and_allocate_objects` below can lose the GVL (and, on older
+  // Rubies, allocate). This function gets called while holding the heap recorder lock so that no other heap recorder
+  // operation can run in that window (including recording more allocations).
   //
-  // * We copy the pending_recording to the stack and decrement the count **before** we can lose the GVL, so from that
-  //   point on the slot is no longer ours: an allocation sample that gets to run will write to that same slot, and our
-  //   own next iteration will then pick that new recording up (nothing gets lost or processed twice).
-  // * `start_heap_allocation_recording` checks the `MAX_PENDING_RECORDINGS` limit after our decrement, so there's
-  //   always room for such a recording.
-  // * `record_id`s are unique, so an interleaved commit can't trip the duplicate check in `commit_recording`, and an
-  //   interleaved run of this function consumes different slots than we do.
-  // * `pending.heap_record` can't be freed from under us because `start_heap_allocation_recording` already accounted
-  //   for this recording in `num_tracked_objects` (see `inc_tracked_objects_or_fail`), so a `heap_recorder_update`
-  //   that gets to run will not consider that heap record unused.
+  // Finally, note that a GC can still happen.
   while (heap_recorder->pending_recordings_count > 0) {
     pending_recording pending = heap_recorder->pending_recordings[--heap_recorder->pending_recordings_count];
 
@@ -566,6 +628,8 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
     // Ensure that the object we've just recorded is not collected until we've done all the bookeeping
     RB_GC_GUARD(pending.object_ref);
   }
+
+  return Qnil; // for rb_ensure
 }
 
 // Mark the Ruby objects the heap recorder holds on to.
@@ -593,24 +657,24 @@ void heap_recorder_mark(heap_recorder *heap_recorder) {
 //       so we can't assume a single update happens in a single "atomic" step -- other threads may get some running time
 //       in the meanwhile.
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update) {
-  if (heap_recorder->updating) {
-    if (full_update) {
-      // There's another thread that's already doing an update :(
-      //
-      // Because there's a lock on the `StackRecorder` (see @no_concurrent_serialize_mutex) then it's not possible that
-      // the other update is a full update.
-      // Thus we expect is happening is that the GVL got released by the other thread in the middle of a non-full update
-      // and the scheduler thread decided now was a great time to serialize the profile.
-      //
-      // So, let's yield the time on the current thread until Ruby goes back to the other thread doing the update and
-      // it finishes cleanly.
-      while (heap_recorder->updating) { rb_thread_schedule(); }
-    } else {
-      // Non-full updates are optional, so let's walk away
-      heap_recorder->stats_lifetime.updates_skipped_concurrent++;
-      return;
-    }
+  if (full_update) {
+    // A full update runs as part of serialization and can't be skipped, so we wait for our turn if needed
+    heap_recorder_lock(heap_recorder);
+  } else if (!heap_recorder_try_lock(heap_recorder)) {
+    // Non-full updates are optional, so let's walk away
+    heap_recorder->stats_lifetime.updates_skipped_concurrent++;
+    return;
   }
+
+  // Wrap the next steps with `rb_ensure` so that we always get to release the lock
+  heap_recorder_update_locked_args args = {.heap_recorder = heap_recorder, .full_update = full_update};
+  rb_ensure(heap_recorder_update_locked, (VALUE) &args, heap_recorder_unlock_ensure, (VALUE) heap_recorder);
+}
+
+static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_as_value) {
+  heap_recorder_update_locked_args *args = (heap_recorder_update_locked_args *) heap_recorder_update_locked_args_as_value;
+  heap_recorder *heap_recorder = args->heap_recorder;
+  bool full_update = args->full_update;
 
   if (heap_recorder->object_records_snapshot != NULL) {
     // While serialization is happening, it runs without the GVL and uses the object_records_snapshot.
@@ -618,7 +682,7 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
     // snapshotted for efficiency reasons (e.g. heap_records). Since updating may invalidate
     // some of that non-snapshotted data, let's refrain from doing updates during iteration. This also enforces the
     // semantic that iteration will operate as a point-in-time snapshot.
-    return;
+    return Qnil;
   }
 
   size_t current_gc_gen = rb_gc_count();
@@ -633,31 +697,23 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
       // object records to do an update, let's wait until all steps for a particular GC generation
       // have finished to do so. We may revisit this once we have a better liveness checking mechanism.
       heap_recorder->stats_lifetime.updates_skipped_gcgen++;
-      return;
+      return Qnil;
     }
 
     if (now_ns > 0 && (now_ns - heap_recorder->last_update_ns) < MIN_TIME_BETWEEN_HEAP_RECORDER_UPDATES_NS) {
       // We did an update not too long ago. Let's skip this one to avoid over-taxing the system.
       heap_recorder->stats_lifetime.updates_skipped_time++;
-      return;
+      return Qnil;
     }
   }
 
-  heap_recorder->updating = true;
   // Reset last update stats, we'll be building them from scratch during the st_foreach call below
   heap_recorder->stats_last_update = (struct stats_last_update) {0};
 
   heap_recorder->update_gen = current_gc_gen;
   heap_recorder->update_include_old = full_update;
 
-  // Wrap this update to make sure `updating` doesn't stay stuck if an exception happens; this is important because of
-  // the `while (heap_recorder->updating) { rb_thread_schedule(); }` loop above
-  int exception_state;
-  rb_protect(update_object_records, (VALUE) heap_recorder, &exception_state);
-  if (exception_state) {
-    heap_recorder->updating = false;
-    rb_jump_tag(exception_state); // Re-raise, now that we've cleaned up
-  }
+  st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
 
   heap_recorder->last_update_ns = now_ns;
   heap_recorder->stats_lifetime.updates_successful++;
@@ -673,13 +729,7 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
     heap_recorder->stats_lifetime.ewma_objects_skipped = ewma_stat(heap_recorder->stats_lifetime.ewma_objects_skipped, heap_recorder->stats_last_update.objects_skipped);
   }
 
-  heap_recorder->updating = false;
-}
-
-static VALUE update_object_records(VALUE heap_recorder_as_value) {
-  heap_recorder *recorder = (heap_recorder *) heap_recorder_as_value;
-  st_foreach(recorder->object_records, st_object_record_update, (st_data_t) recorder);
-  return Qnil; // for rb_protect
+  return Qnil; // for rb_ensure
 }
 
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -159,8 +159,6 @@ struct heap_recorder {
   VALUE active_deferred_object;
   live_object_data active_deferred_object_data;
   uint16_t pending_recordings_count;
-  // Did a commit of the pending recordings get skipped?
-  bool commit_skipped;
 
   // Reusable arrays, implementing a flyweight pattern for things like iteration
   #define REUSABLE_LOCATIONS_SIZE MAX_FRAMES_LIMIT
@@ -386,6 +384,8 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
 
 // This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
 // Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
+//
+// Returns whether there are pending recordings waiting to be committed (see header for details)
 bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class) {
   if (heap_recorder == NULL) {
     return false;
@@ -398,6 +398,8 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   heap_recorder->recording_in_progress = true;
   heap_recorder->recording_skipped = false;
 
+  bool need_commit = heap_recorder->pending_recordings_count > 0;
+
   if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate
       // If we got really unlucky and an allocation showed up during an update (because it triggered an allocation
       // directly OR because the GVL got released in the middle of an update), let's skip this sample as well.
@@ -405,12 +407,11 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
       || heap_recorder->updating
     ) {
     heap_recorder->recording_skipped = true;
-    return false;
+    return need_commit;
   }
 
-  // Do not sample internal objects in the heap profiler because
-  // they are added to a ObjectSpace::WeakMap, which would not be safe.
-  // This means we ignore internal objects samples for the heap profiler,
+  // Do not sample internal objects in the heap profiler because they are added to a ObjectSpace::WeakMap, which would not be safe.
+  // This means we ignore internal VM objects samples for the heap profiler,
   // which is a trade-off discussed in https://github.com/DataDog/dd-trace-rb/pull/6176#discussion_r3819776251
   //
   // Note this is checked after the sample rate above, as the sample rate is in number of allocation profiler samples,
@@ -418,26 +419,15 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   // next allocation sample still gets a chance to be tracked.
   if (ddtrace_is_internal_object_p(new_obj)) {
     heap_recorder->recording_skipped = true;
-    return false;
+    return need_commit;
   }
 
   // Skip if we've hit the pending recordings limit
   if (heap_recorder->pending_recordings_count >= MAX_PENDING_RECORDINGS) {
     heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full++;
     heap_recorder->recording_skipped = true;
-    return true; // If the buffer is full, we keep asking for a callback (see `needs_after_allocation` below)
+    return true; // Buffer is full, there's definitely things to commit
   }
-
-  // The intuition here is: We start by asking for a commit callback when the buffer is about to go
-  // from empty -> non-empty, because this is going to be mapped onto a postponed job, so after it gets queued once
-  // it doesn't seem worth it to keep spamming requests (or when the commit was skipped).
-  //
-  // As a fallback, if the buffer starts accumulating too much we
-  // start always requesting the callback to happen so that we eventually empty the buffer.
-  bool needs_after_allocation =
-    heap_recorder->pending_recordings_count == 0 ||
-    heap_recorder->commit_skipped ||
-    heap_recorder->pending_recordings_count >= (MAX_PENDING_RECORDINGS / 2);
 
   heap_recorder->num_recordings_skipped = 0;
 
@@ -450,7 +440,7 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
     .alloc_gen = rb_gc_count(),
   };
 
-  return needs_after_allocation;
+  return true; // We're tracking a new object, so there will be something to commit (after end_heap_allocation_recording runs)
 }
 
 // end_heap_allocation_recording_with_rb_protect gets called while the stack_recorder is holding one of the profile
@@ -531,11 +521,8 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
   if (heap_recorder->updating) {
     // Because, like us, `heap_recorder_update` can lose the GVL, we don't want to run while it's also running.
     // Skipping is fine -- `start_heap_allocation_recording` will ask for us to be called again on a later allocation.
-    heap_recorder->commit_skipped = true;
     return;
   }
-
-  heap_recorder->commit_skipped = false;
 
   // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
   // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -250,7 +250,8 @@ static VALUE ruby_weak_map_new(void) {
 // Native wrapper to get an object from an `ObjectSpace::WeakMap`.
 // Returns the object on success and nil if the entry is gone, meaning
 // the object has been garbage collected.
-// We never store nil as a value, see ruby_weak_map_set(), so nil unambiguously means "the value was garbage collected".
+// We never store nil as a value, see ruby_weak_map_set_may_lose_gvl_and_allocate_objects(), so nil unambiguously
+// means "the value was garbage collected".
 //
 // Note: GVL can be released and other threads may get to run before this method returns
 static VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
@@ -260,8 +261,12 @@ static VALUE ruby_weak_map_get(VALUE weak_map, VALUE key) {
 // Native wrapper to add an entry to an `ObjectSpace::WeakMap`.
 // Raises RuntimeError if passed nil as a value.
 //
-// Note: GVL can be released and other threads may get to run before this method returns
-static void ruby_weak_map_set(VALUE weak_map, VALUE key, VALUE value) {
+// Note: GVL can be released and other threads may get to run before this method returns.
+//
+// On Ruby < 3.3 this allocates Ruby objects (because underneath the weak map registers
+// finalizers for the objects, which requires allocations). Later Rubies improved WeakMap to not need this.
+// This we need to be careful not to recurse on the profiler (e.g. NEWOBJ tracepoint).
+static void ruby_weak_map_set_may_lose_gvl_and_allocate_objects(VALUE weak_map, VALUE key, VALUE value) {
   if (value == Qnil) {
     raise_error(rb_eRuntimeError, "Can't use nil as the value in the WeakMap, otherwise #[] can't differentiate alive vs nil value");
   }
@@ -529,7 +534,8 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
   // already-processed pending_recordings (slower and would extend the lifetime of these recordings if not cleared) and
   // (c) if one of the steps below raises we don't reprocess the entries we already committed, i.e., we're idempotent.
   //
-  // Note as well that `ruby_weak_map_set` below can release the GVL, and thus this function needs to tolerate other
+  // Note as well that `ruby_weak_map_set_may_lose_gvl_and_allocate_objects` below can release the GVL (and, on older
+  // Rubies, allocate), and thus this function needs to tolerate other
   // profiler operations being interleaved with it -- in particular an allocation sample (which appends to
   // `pending_recordings`) or even another call to this function. (Unlike most of the profiler, our caller
   // `commit_heap_recordings_from_postponed_job_may_lose_gvl` deliberately does not hold the `during_sample` flag,
@@ -551,7 +557,7 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
     heap_recorder->stats_lifetime.deferred_recordings_committed++;
 
     // This is the "can release the GVL" bit
-    ruby_weak_map_set(heap_recorder->weak_objects, LONG2FIX(pending.record_id), pending.object_ref);
+    ruby_weak_map_set_may_lose_gvl_and_allocate_objects(heap_recorder->weak_objects, LONG2FIX(pending.record_id), pending.object_ref);
 
     object_record *record = object_record_new(pending);
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -475,7 +475,7 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate
       // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
       // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
-      // (Note we don't take the lock ourselves: recording never loses the GVL, and is thus already atomic.)
+      // (Note we don't take the lock ourselves: the current function never loses the GVL, and is thus already atomic.)
       || heap_recorder_is_locked(heap_recorder)
     ) {
     heap_recorder->recording_skipped = true;

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -159,6 +159,8 @@ struct heap_recorder {
   VALUE active_deferred_object;
   live_object_data active_deferred_object_data;
   uint16_t pending_recordings_count;
+  // Did a commit of the pending recordings get skipped?
+  bool commit_skipped;
 
   // Reusable arrays, implementing a flyweight pattern for things like iteration
   #define REUSABLE_LOCATIONS_SIZE MAX_FRAMES_LIMIT
@@ -424,13 +426,14 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 
   // The intuition here is: We start by asking for a commit callback when the buffer is about to go
   // from empty -> non-empty, because this is going to be mapped onto a postponed job, so after it gets queued once
-  // it doesn't seem worth it to keep spamming requests.
+  // it doesn't seem worth it to keep spamming requests (or when the commit was skipped).
   //
-  // Yet, if for some reason the postponed job doesn't commit the pending list (or if e.g. it ran with `during_sample == true` and thus
-  // was skipped) we need to have some mechanism to recover -- and so if the buffer starts accumulating too much we
+  // As a fallback, if the buffer starts accumulating too much we
   // start always requesting the callback to happen so that we eventually empty the buffer.
   bool needs_after_allocation =
-    heap_recorder->pending_recordings_count == 0 || heap_recorder->pending_recordings_count >= (MAX_PENDING_RECORDINGS / 2);
+    heap_recorder->pending_recordings_count == 0 ||
+    heap_recorder->commit_skipped ||
+    heap_recorder->pending_recordings_count >= (MAX_PENDING_RECORDINGS / 2);
 
   heap_recorder->num_recordings_skipped = 0;
 
@@ -520,6 +523,15 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
   if (heap_recorder == NULL) {
     return; // Nothing to do
   }
+
+  if (heap_recorder->updating) {
+    // Because, like us, `heap_recorder_update` can lose the GVL, we don't want to run while it's also running.
+    // Skipping is fine -- `start_heap_allocation_recording` will ask for us to be called again on a later allocation.
+    heap_recorder->commit_skipped = true;
+    return;
+  }
+
+  heap_recorder->commit_skipped = false;
 
   // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
   // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -472,12 +472,15 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
 
   bool need_commit = heap_recorder->pending_recordings_count > 0;
 
-  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate
-      // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
-      // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
-      // (Note we don't take the lock ourselves: the current function never loses the GVL, and is thus already atomic.)
-      || heap_recorder_is_locked(heap_recorder)
-    ) {
+  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) {
+    heap_recorder->recording_skipped = true;
+    return need_commit;
+  }
+
+  if (heap_recorder_is_locked(heap_recorder)) {
+    // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
+    // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
+    // (Note we don't take the lock ourselves: the current function never loses the GVL, and is thus already atomic.)
     heap_recorder->recording_skipped = true;
     return need_commit;
   }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -253,14 +253,6 @@ static VALUE heap_recorder_unlock_ensure(VALUE heap_recorder_as_value) {
 
 typedef struct {
   heap_recorder *heap_recorder;
-  VALUE new_object;
-  unsigned int weight;
-  ddog_CharSlice alloc_class;
-  ddog_prof_Slice_Location locations;
-} record_allocation_args;
-
-typedef struct {
-  heap_recorder *heap_recorder;
   bool full_update;
 } heap_recorder_update_locked_args;
 
@@ -274,7 +266,6 @@ static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
 static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t extra);
 static void inc_tracked_objects_or_fail(heap_record *heap_record);
 static void commit_recording(heap_recorder *, pending_recording);
-static VALUE record_allocation(VALUE record_allocation_args_as_value);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
 static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_as_value);
 static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_recorder_as_value);
@@ -450,12 +441,8 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
 // This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
 // Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 //
-// It gets called while the stack_recorder is holding one of the profile locks, so to enable our caller to correctly
-// unlock the profile on exception, we wrap the part that can raise with an `rb_protect`.
-//
 // See the header for details on the arguments and on `needs_commit`.
-__attribute__((warn_unused_result))
-int heap_recorder_record_allocation_with_rb_protect(
+void heap_recorder_record_allocation(
   heap_recorder *heap_recorder,
   VALUE new_object,
   unsigned int weight,
@@ -465,7 +452,7 @@ int heap_recorder_record_allocation_with_rb_protect(
 ) {
   if (heap_recorder == NULL) {
     *needs_commit = false;
-    return 0;
+    return;
   }
 
   // We always report `needs_commit` when there's anything pending, even if it's from a previous allocation.
@@ -478,13 +465,13 @@ int heap_recorder_record_allocation_with_rb_protect(
   // (Note that asking for the same job multiple times de-duplicates -- Ruby will only run it once when it gets the chance)
   *needs_commit = heap_recorder->pending_recordings_count > 0;
 
-  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) return 0;
+  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) return;
 
   if (heap_recorder_is_locked(heap_recorder)) {
     // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
     // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
     // (Note we don't take the lock ourselves: the current function never loses the GVL, and is thus already atomic.)
-    return 0;
+    return;
   }
 
   // Do not sample internal objects in the heap profiler because they are added to a ObjectSpace::WeakMap, which would not be safe.
@@ -494,41 +481,21 @@ int heap_recorder_record_allocation_with_rb_protect(
   // Note this is checked after the sample rate above, as the sample rate is in number of allocation profiler samples,
   // not in number of non-internal samples. Like the skips above, num_recordings_skipped is not reset here, so the
   // next allocation sample still gets a chance to be tracked.
-  if (ddtrace_is_internal_object_p(new_object)) return 0;
+  if (ddtrace_is_internal_object_p(new_object)) return;
 
   // Skip if we've hit the pending recordings limit
   if (heap_recorder->pending_recordings_count >= MAX_PENDING_RECORDINGS) {
     heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full++;
-    return 0; // `needs_commit` is already true: a full buffer definitely has something to commit
+    return; // `needs_commit` is already true: a full buffer definitely has something to commit
   }
 
   heap_recorder->num_recordings_skipped = 0;
 
-  record_allocation_args args = {
-    .heap_recorder = heap_recorder,
-    .new_object = new_object,
-    .weight = weight,
-    .alloc_class = alloc_class,
-    .locations = locations,
-  };
-
-  int exception_state;
-  rb_protect(record_allocation, (VALUE) &args, &exception_state);
-  if (exception_state) return exception_state;
-
-  *needs_commit = true; // We just added a recording
-  return 0;
-}
-
-static VALUE record_allocation(VALUE record_allocation_args_as_value) {
-  record_allocation_args *args = (record_allocation_args *) record_allocation_args_as_value;
-  heap_recorder *heap_recorder = args->heap_recorder;
-
   // Note: Everything that can raise happens before we add the recording to `pending_recordings` below, so that a
   // failure never leaves a half-built entry behind
   live_object_data object_data = {
-    .weight = args->weight * heap_recorder->sample_rate,
-    .class = intern_or_raise(heap_recorder->string_storage, args->alloc_class),
+    .weight = weight * heap_recorder->sample_rate,
+    .class = intern_or_raise(heap_recorder->string_storage, alloc_class),
     .alloc_gen = rb_gc_count(),
   };
 
@@ -540,19 +507,19 @@ static VALUE record_allocation(VALUE record_allocation_args_as_value) {
     raise_error(rb_eRuntimeError, "Heap profiling: Exhausted usable record_ids");
   }
 
-  heap_record *heap_record = get_or_create_heap_record(heap_recorder, args->locations);
+  heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
   inc_tracked_objects_or_fail(heap_record);
 
   // We can't add the object to `weak_objects` from inside the NEWOBJ tracepoint, so the recording stays pending until
   // `heap_recorder_commit_recordings_may_lose_gvl` gets to it
   heap_recorder->pending_recordings[heap_recorder->pending_recordings_count++] = (pending_recording) {
-    .object_ref = args->new_object,
+    .object_ref = new_object,
     .record_id = record_id,
     .heap_record = heap_record,
     .object_data = object_data,
   };
 
-  return Qnil; // for rb_protect
+  *needs_commit = true; // We just added a recording
 }
 
 void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
@@ -569,7 +536,7 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
   }
 
   if (!heap_recorder_try_lock(heap_recorder)) {
-    // Something else is busy; `heap_recorder_record_allocation_with_rb_protect` will ask for us to be called again later
+    // Something else is busy; `heap_recorder_record_allocation` will ask for us to be called again later
     return;
   }
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -218,6 +218,7 @@ static void inc_tracked_objects_or_fail(heap_record *heap_record);
 static void commit_recording(heap_recorder *, heap_record *, object_record *new_record);
 static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
+static VALUE update_object_records(VALUE heap_recorder_as_value);
 static inline double ewma_stat(double previous, double current);
 static void unintern_or_raise(heap_recorder *, ddog_prof_ManagedStringId);
 static void unintern_all_or_raise(heap_recorder *recorder, ddog_prof_Slice_ManagedStringId ids);
@@ -656,7 +657,14 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
   heap_recorder->update_gen = current_gc_gen;
   heap_recorder->update_include_old = full_update;
 
-  st_foreach(heap_recorder->object_records, st_object_record_update, (st_data_t) heap_recorder);
+  // Wrap this update to make sure `updating` doesn't stay stuck if an exception happens; this is important because of
+  // the `while (heap_recorder->updating) { rb_thread_schedule(); }` loop above
+  int exception_state;
+  rb_protect(update_object_records, (VALUE) heap_recorder, &exception_state);
+  if (exception_state) {
+    heap_recorder->updating = false;
+    rb_jump_tag(exception_state); // Re-raise, now that we've cleaned up
+  }
 
   heap_recorder->last_update_ns = now_ns;
   heap_recorder->stats_lifetime.updates_successful++;
@@ -673,6 +681,12 @@ static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update)
   }
 
   heap_recorder->updating = false;
+}
+
+static VALUE update_object_records(VALUE heap_recorder_as_value) {
+  heap_recorder *recorder = (heap_recorder *) heap_recorder_as_value;
+  st_foreach(recorder->object_records, st_object_record_update, (st_data_t) recorder);
+  return Qnil; // for rb_protect
 }
 
 void heap_recorder_prepare_iteration(heap_recorder *heap_recorder) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -212,6 +212,10 @@ struct heap_recorder {
 // Operations that can be skipped use `heap_recorder_try_lock` and walk away when it's taken (which is almost all of them).
 // The one operation that can't be skipped -- the full update that runs before serialization -- uses
 // `heap_recorder_lock`, which waits.
+//
+// `heap_recorder_lock` is expected to be bounded because once `LOCK_WANTED` gets set, no `try_lock` will succeed, so
+// the `heap_recorder_lock` will only need to wait for the previous user of the lock to finish it's work + Ruby to
+// switch back to is thread.
 #define HEAP_RECORDER_LOCK_HELD 0x1
 #define HEAP_RECORDER_LOCK_WANTED 0x2
 

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -145,19 +145,10 @@ struct heap_recorder {
   // Source for the ids used as keys in `object_records` and `weak_objects`. Ids are never reused.
   long next_record_id;
 
-  // Is there a heap recording that was started but not yet ended?
-  bool recording_in_progress;
-  // Was the recording in progress one we decided not to keep (e.g. due to the sample rate)? If so, the matching
-  // end call has nothing to do.
-  bool recording_skipped;
-
   // Recordings that are waiting to be committed after on_newobj_event completes.
   // We can't add the object to `weak_objects` during the newobj event, so we store the
   // VALUE reference here and commit it via a postponed job.
   pending_recording pending_recordings[MAX_PENDING_RECORDINGS];
-  // Temporary storage for the recording in progress, used between start and end
-  VALUE active_deferred_object;
-  live_object_data active_deferred_object_data;
   uint16_t pending_recordings_count;
 
   // Reusable arrays, implementing a flyweight pattern for things like iteration
@@ -262,8 +253,11 @@ static VALUE heap_recorder_unlock_ensure(VALUE heap_recorder_as_value) {
 
 typedef struct {
   heap_recorder *heap_recorder;
+  VALUE new_object;
+  unsigned int weight;
+  ddog_CharSlice alloc_class;
   ddog_prof_Slice_Location locations;
-} end_heap_allocation_args;
+} record_allocation_args;
 
 typedef struct {
   heap_recorder *heap_recorder;
@@ -280,7 +274,7 @@ static int st_object_records_iterate(st_data_t, st_data_t, st_data_t);
 static int st_object_records_debug(st_data_t key, st_data_t value, st_data_t extra);
 static void inc_tracked_objects_or_fail(heap_record *heap_record);
 static void commit_recording(heap_recorder *, pending_recording);
-static VALUE end_heap_allocation_recording(VALUE end_heap_allocation_args);
+static VALUE record_allocation(VALUE record_allocation_args_as_value);
 static void heap_recorder_update(heap_recorder *heap_recorder, bool full_update);
 static VALUE heap_recorder_update_locked(VALUE heap_recorder_update_locked_args_as_value);
 static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_recorder_as_value);
@@ -361,7 +355,6 @@ heap_recorder* heap_recorder_new(ddog_prof_ManagedStringStorage string_storage) 
   recorder->size_enabled = true;
   recorder->sample_rate = 1; // By default do no sampling on top of what allocation profiling already does
   recorder->string_storage = string_storage;
-  recorder->active_deferred_object = Qnil;
   // Note: This allocates, and thus can trigger a GC. That's fine: our caller only publishes the heap recorder on the
   // stack recorder state after we return, so `heap_recorder_mark` will not observe a half-initialized recorder.
   recorder->weak_objects = ruby_weak_map_new();
@@ -457,20 +450,25 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
 // This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
 // Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 //
-// Returns whether there are pending recordings waiting to be committed (see header for details)
-bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class) {
+// It gets called while the stack_recorder is holding one of the profile locks, so to enable our caller to correctly
+// unlock the profile on exception, we wrap the part that can raise with an `rb_protect`.
+//
+// See the header for details on the arguments and on `needs_commit`.
+__attribute__((warn_unused_result))
+int heap_recorder_record_allocation_with_rb_protect(
+  heap_recorder *heap_recorder,
+  VALUE new_object,
+  unsigned int weight,
+  ddog_CharSlice alloc_class,
+  ddog_prof_Slice_Location locations,
+  bool *needs_commit
+) {
   if (heap_recorder == NULL) {
-    return false;
+    *needs_commit = false;
+    return 0;
   }
 
-  if (heap_recorder->recording_in_progress) {
-    raise_error(rb_eRuntimeError, "Detected consecutive heap allocation recording starts without end.");
-  }
-
-  heap_recorder->recording_in_progress = true;
-  heap_recorder->recording_skipped = false;
-
-  // We always return need_commit, even if it's because a previous allocation was put on the pending_recordings.
+  // We always report `needs_commit` when there's anything pending, even if it's from a previous allocation.
   //
   // This can mean we "spam" a bit the postponed jobs mechanism (e.g. perhaps our postponed job hasn't run
   // because there's a native extension doing Ruby object allocations in a row without giving Ruby the chance to
@@ -478,19 +476,15 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   // That shouldn't be a problem because the allocation profiler has the dynamic sampling rate mechanism +
   // triggering postponed jobs is cheap on current Rubies.
   // (Note that asking for the same job multiple times de-duplicates -- Ruby will only run it once when it gets the chance)
-  bool need_commit = heap_recorder->pending_recordings_count > 0;
+  *needs_commit = heap_recorder->pending_recordings_count > 0;
 
-  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) {
-    heap_recorder->recording_skipped = true;
-    return need_commit;
-  }
+  if (++heap_recorder->num_recordings_skipped < heap_recorder->sample_rate) return 0;
 
   if (heap_recorder_is_locked(heap_recorder)) {
     // If we got unlucky and an allocation showed up in the middle of a locked operation (because it triggered
     // an allocation directly OR because that operation lost the GVL), let's skip this sample as well.
     // (Note we don't take the lock ourselves: the current function never loses the GVL, and is thus already atomic.)
-    heap_recorder->recording_skipped = true;
-    return need_commit;
+    return 0;
   }
 
   // Do not sample internal objects in the heap profiler because they are added to a ObjectSpace::WeakMap, which would not be safe.
@@ -500,69 +494,43 @@ bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj
   // Note this is checked after the sample rate above, as the sample rate is in number of allocation profiler samples,
   // not in number of non-internal samples. Like the skips above, num_recordings_skipped is not reset here, so the
   // next allocation sample still gets a chance to be tracked.
-  if (ddtrace_is_internal_object_p(new_obj)) {
-    heap_recorder->recording_skipped = true;
-    return need_commit;
-  }
+  if (ddtrace_is_internal_object_p(new_object)) return 0;
 
   // Skip if we've hit the pending recordings limit
   if (heap_recorder->pending_recordings_count >= MAX_PENDING_RECORDINGS) {
     heap_recorder->stats_lifetime.deferred_recordings_skipped_buffer_full++;
-    heap_recorder->recording_skipped = true;
-    return true; // Buffer is full, there's definitely things to commit
+    return 0; // `needs_commit` is already true: a full buffer definitely has something to commit
   }
 
   heap_recorder->num_recordings_skipped = 0;
 
-  // We can't add the object to `weak_objects` during on_newobj_event, so we store the VALUE reference and will do
-  // it later via a postponed job.
-  heap_recorder->active_deferred_object = new_obj;
-  heap_recorder->active_deferred_object_data = (live_object_data) {
-    .weight = weight * heap_recorder->sample_rate,
-    .class = intern_or_raise(heap_recorder->string_storage, alloc_class),
-    .alloc_gen = rb_gc_count(),
-  };
-
-  return true; // We're tracking a new object, so there will be something to commit (after end_heap_allocation_recording runs)
-}
-
-// end_heap_allocation_recording_with_rb_protect gets called while the stack_recorder is holding one of the profile
-// locks. To enable us to correctly unlock the profile on exception, we wrap the call to end_heap_allocation_recording
-// with an rb_protect.
-__attribute__((warn_unused_result))
-int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations) {
-  if (heap_recorder == NULL) {
-    return 0;
-  }
-  if (heap_recorder->recording_skipped) {
-    // Short circuit, in this case there's nothing to be done
-    heap_recorder->recording_skipped = false;
-    heap_recorder->recording_in_progress = false;
-    return 0;
-  }
-
-  int exception_state;
-  end_heap_allocation_args args = {
+  record_allocation_args args = {
     .heap_recorder = heap_recorder,
+    .new_object = new_object,
+    .weight = weight,
+    .alloc_class = alloc_class,
     .locations = locations,
   };
-  rb_protect(end_heap_allocation_recording, (VALUE) &args, &exception_state);
-  return exception_state;
+
+  int exception_state;
+  rb_protect(record_allocation, (VALUE) &args, &exception_state);
+  if (exception_state) return exception_state;
+
+  *needs_commit = true; // We just added a recording
+  return 0;
 }
 
-static VALUE end_heap_allocation_recording(VALUE protect_args) {
-  end_heap_allocation_args *args = (end_heap_allocation_args *) protect_args;
-
+static VALUE record_allocation(VALUE record_allocation_args_as_value) {
+  record_allocation_args *args = (record_allocation_args *) record_allocation_args_as_value;
   heap_recorder *heap_recorder = args->heap_recorder;
-  ddog_prof_Slice_Location locations = args->locations;
 
-  if (!heap_recorder->recording_in_progress) {
-    // Recording ended without having been started?
-    raise_error(rb_eRuntimeError, "Ended a heap recording that was not started");
-  }
-  // From now on, mark the recording as no longer in progress so we can short-circuit at any point
-  // and not end up with a still active recording.
-  heap_recorder->recording_in_progress = false;
+  // Note: Everything that can raise happens before we add the recording to `pending_recordings` below, so that a
+  // failure never leaves a half-built entry behind
+  live_object_data object_data = {
+    .weight = args->weight * heap_recorder->sample_rate,
+    .class = intern_or_raise(heap_recorder->string_storage, args->alloc_class),
+    .alloc_gen = rb_gc_count(),
+  };
 
   long record_id = ++heap_recorder->next_record_id;
   if (record_id > RUBY_FIXNUM_MAX) {
@@ -572,20 +540,19 @@ static VALUE end_heap_allocation_recording(VALUE protect_args) {
     raise_error(rb_eRuntimeError, "Heap profiling: Exhausted usable record_ids");
   }
 
-  heap_record *heap_record = get_or_create_heap_record(heap_recorder, locations);
+  heap_record *heap_record = get_or_create_heap_record(heap_recorder, args->locations);
   inc_tracked_objects_or_fail(heap_record);
 
-  // Commit is delayed, so we need to record all we'll need for it
-  pending_recording *pending = &heap_recorder->pending_recordings[heap_recorder->pending_recordings_count++];
-  pending->object_ref = heap_recorder->active_deferred_object;
-  pending->record_id = record_id;
-  pending->heap_record = heap_record;
-  pending->object_data = heap_recorder->active_deferred_object_data;
+  // We can't add the object to `weak_objects` from inside the NEWOBJ tracepoint, so the recording stays pending until
+  // `heap_recorder_commit_recordings_may_lose_gvl` gets to it
+  heap_recorder->pending_recordings[heap_recorder->pending_recordings_count++] = (pending_recording) {
+    .object_ref = args->new_object,
+    .record_id = record_id,
+    .heap_record = heap_record,
+    .object_data = object_data,
+  };
 
-  heap_recorder->active_deferred_object = Qnil;
-  heap_recorder->active_deferred_object_data = (live_object_data) {0};
-
-  return Qnil;
+  return Qnil; // for rb_protect
 }
 
 void heap_recorder_update_young_objects(heap_recorder *heap_recorder) {
@@ -602,7 +569,7 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
   }
 
   if (!heap_recorder_try_lock(heap_recorder)) {
-    // Something else is busy; `start_heap_allocation_recording` will ask for us to be called again later
+    // Something else is busy; `heap_recorder_record_allocation_with_rb_protect` will ask for us to be called again later
     return;
   }
 
@@ -656,8 +623,6 @@ void heap_recorder_mark(heap_recorder *heap_recorder) {
   for (uint i = 0; i < heap_recorder->pending_recordings_count; i++) {
     rb_gc_mark(heap_recorder->pending_recordings[i].object_ref);
   }
-
-  rb_gc_mark(heap_recorder->active_deferred_object);
 
   rb_gc_mark(heap_recorder->weak_objects);
 }
@@ -1259,6 +1224,14 @@ VALUE heap_recorder_testonly_record_id_for(heap_recorder *heap_recorder, VALUE o
   st_foreach(heap_recorder->object_records, st_object_record_id_for, (st_data_t) &context);
 
   return context.result;
+}
+
+void heap_recorder_testonly_exhaust_record_ids(heap_recorder *heap_recorder) {
+  if (heap_recorder == NULL) {
+    raise_error(rb_eArgError, "heap_recorder is NULL");
+  }
+
+  heap_recorder->next_record_id = RUBY_FIXNUM_MAX;
 }
 
 void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder) {

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -376,6 +376,9 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder) {
     heap_recorder_finish_iteration(heap_recorder);
   }
 
+  // This could also be left over if fork happens during an update
+  heap_recorder->updating = false;
+
   // Clear lifetime stats since this is essentially a new heap recorder
   heap_recorder->stats_lifetime = (struct stats_lifetime) {0};
 }

--- a/ext/datadog_profiling_native_extension/heap_recorder.c
+++ b/ext/datadog_profiling_native_extension/heap_recorder.c
@@ -603,28 +603,26 @@ void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder) 
 static VALUE heap_recorder_commit_recordings_may_lose_gvl_locked(VALUE heap_recorder_as_value) {
   heap_recorder *heap_recorder = (struct heap_recorder *) heap_recorder_as_value;
 
-  // Note: We consume the buffer back-to-front, decrementing the count as we go, so that (a) the entries we have
-  // not gotten to yet stay marked (see `heap_recorder_mark`) across any GC triggered below, (b) we don't mark
-  // already-processed pending_recordings (slower and would extend the lifetime of these recordings if not cleared) and
-  // (c) if one of the steps below raises we don't reprocess the entries we already committed, i.e., we're idempotent.
+  // Note: We consume the buffer back-to-front, and only drop each entry once it's fully committed. That makes the
+  // "can lose the GVL" bit below safe to retry: if anything raises, or another thread unwinds us, the entry stays
+  // pending and a later commit picks it up -- and setting the same entry on the weak map again is harmless. It also
+  // means the entry we're working on stays marked (see `heap_recorder_mark`) across any GC that happens while we don't
+  // have the GVL.
   //
   // Note as well that `ruby_weak_map_set_may_lose_gvl_and_allocate_objects` below can lose the GVL (and, on older
   // Rubies, allocate). This function gets called while holding the heap recorder lock so that no other heap recorder
-  // operation can run in that window (including recording more allocations).
-  //
-  // Finally, note that a GC can still happen.
+  // operation can concurrently with us in that window (including recording more allocations, which on older Rubies
+  // would otherwise add entries to the very buffer we're draining).
   while (heap_recorder->pending_recordings_count > 0) {
-    pending_recording pending = heap_recorder->pending_recordings[--heap_recorder->pending_recordings_count];
+    pending_recording pending = heap_recorder->pending_recordings[heap_recorder->pending_recordings_count - 1];
 
-    heap_recorder->stats_lifetime.deferred_recordings_committed++;
-
-    // This is the "can release the GVL" bit
     ruby_weak_map_set_may_lose_gvl_and_allocate_objects(heap_recorder->weak_objects, LONG2FIX(pending.record_id), pending.object_ref);
 
-    commit_recording(heap_recorder, pending);
+    // After here, we can no longer lose the GVL until we loop around again, so these steps are "atomic"
 
-    // Ensure that the object we've just recorded is not collected until we've done all the bookeeping
-    RB_GC_GUARD(pending.object_ref);
+    commit_recording(heap_recorder, pending);
+    heap_recorder->pending_recordings_count--;
+    heap_recorder->stats_lifetime.deferred_recordings_committed++;
   }
 
   return Qnil; // for rb_ensure

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -109,7 +109,7 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder);
 //
 // WARN: It needs to be paired with a ::end_heap_allocation_recording call.
 // Returns needs_after_allocation: true whenever the pending_recordings buffer goes from empty to non-empty and thus
-// a after_sample callback is required to flush it
+// a `heap_recorder_commit_recordings_may_lose_gvl` callback is required to flush it
 bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class);
 
 // End a previously started heap allocation recording on the heap recorder.
@@ -130,7 +130,7 @@ void heap_recorder_update_young_objects(heap_recorder *heap_recorder);
 
 // Commit any pending heap allocation recordings by taking a weak reference to their objects.
 // This should be called via a postponed job, after the on_newobj_event has completed.
-void heap_recorder_commit_pending_recordings(heap_recorder *heap_recorder);
+void heap_recorder_commit_recordings_may_lose_gvl(heap_recorder *heap_recorder);
 
 // Mark the Ruby objects the heap recorder holds on to: the objects of any pending recordings (so that GC does not
 // collect them while they're waiting to be committed) and the weak map itself.

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -99,17 +99,14 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder);
 // This heap allocation recording needs to be ended via ::end_heap_allocation_recording
 // before it will become fully committed and able to be iterated on.
 //
-// Some objects are never tracked (e.g. internal objects, or because of the sample rate); this is handled internally
-// by skipping the recording, so callers always need to pair this with ::end_heap_allocation_recording anyway.
-//
 // @param new_obj
 //   The newly allocated Ruby object/value.
 // @param weight
 //   The sampling weight of this object.
 //
 // WARN: It needs to be paired with a ::end_heap_allocation_recording call.
-// Returns needs_after_allocation: true whenever the pending_recordings buffer goes from empty to non-empty and thus
-// a `heap_recorder_commit_recordings_may_lose_gvl` callback is required to flush it
+// Returns true whenever there are pending recordings, and thus a `heap_recorder_commit_recordings_may_lose_gvl`
+// callback is needed to commit them
 bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class);
 
 // End a previously started heap allocation recording on the heap recorder.

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -80,9 +80,9 @@ void heap_recorder_set_size_enabled(heap_recorder *heap_recorder, bool size_enab
 // Controls how many recordings will be ignored before committing a heap allocation and
 // the weight of the committed heap allocation.
 //
-// A value of 1 will effectively track all objects that are passed through
-// start/end_heap_allocation_recording pairs. A value of 10 will only track every 10th
-// object passed through such calls and its effective weight for the purposes of heap
+// A value of 1 will effectively track all objects that are passed to
+// `heap_recorder_record_allocation_with_rb_protect`. A value of 10 will only track every 10th
+// object passed to it and its effective weight for the purposes of heap
 // profiling will be multiplied by 10.
 //
 // NOTE: Default is 1, i.e., track all heap allocation recordings.
@@ -94,31 +94,38 @@ void heap_recorder_set_sample_rate(heap_recorder *heap_recorder, int sample_rate
 // WARN: Assumes this gets called before profiler is reinitialized on the fork
 void heap_recorder_after_fork(heap_recorder *heap_recorder);
 
-// Start a heap allocation recording on the heap recorder for a new object.
+// Record a heap allocation on the heap recorder.
 //
-// This heap allocation recording needs to be ended via ::end_heap_allocation_recording
-// before it will become fully committed and able to be iterated on.
+// The recording is added to a pending list, and only becomes fully tracked and able to be iterated on once
+// `heap_recorder_commit_recordings_may_lose_gvl` gets to it.
 //
-// @param new_obj
+// @param new_object
 //   The newly allocated Ruby object/value.
 // @param weight
 //   The sampling weight of this object.
+// @param alloc_class
+//   The class of the newly allocated object.
+// @param locations
+//   The stacktrace representing the location of the allocation.
+// @param needs_commit
+//   Out: set to whether there are pending recordings, and thus a `heap_recorder_commit_recordings_may_lose_gvl`
+//   callback is needed to commit them. Note that we answer this on every call, including the ones where we don't
+//   record anything: asking again is how we recover if a commit gets skipped for any reason.
 //
-// WARN: It needs to be paired with a ::end_heap_allocation_recording call.
-// Returns true whenever there are pending recordings, and thus a `heap_recorder_commit_recordings_may_lose_gvl`
-// callback is needed to commit them
-bool start_heap_allocation_recording(heap_recorder *heap_recorder, VALUE new_obj, unsigned int weight, ddog_CharSlice alloc_class);
-
-// End a previously started heap allocation recording on the heap recorder.
-//
-// It is at this point that an allocated object will become fully tracked and able to be iterated on.
-//
-// @param locations The stacktrace representing the location of the allocation.
-//
-// WARN: It is illegal to call this without previously having called ::start_heap_allocation_recording.
-// WARN: This method rescues exceptions with `rb_protect`, returning the exception state integer for the caller to handle.
+// WARN: This gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint, so it neither allocates in the Ruby
+// heap nor releases the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
+// WARN: This also gets called while the stack recorder holds one of the profile locks, which is why it rescues
+// exceptions with `rb_protect`, returning the exception state integer for the caller to handle (so that the caller
+// gets a chance to unlock the profile before the exception propagates).
 __attribute__((warn_unused_result))
-int end_heap_allocation_recording_with_rb_protect(heap_recorder *heap_recorder, ddog_prof_Slice_Location locations);
+int heap_recorder_record_allocation_with_rb_protect(
+  heap_recorder *heap_recorder,
+  VALUE new_object,
+  unsigned int weight,
+  ddog_CharSlice alloc_class,
+  ddog_prof_Slice_Location locations,
+  bool *needs_commit
+);
 
 // Update the heap recorder, **checking young objects only**. The idea here is to align with GC: most young objects never
 // survive enough GC generations, and thus periodically running this method reduces memory usage (we get rid of
@@ -189,5 +196,12 @@ VALUE heap_recorder_testonly_record_id_for(heap_recorder *heap_recorder, VALUE o
 
 // Used to ensure that a GC actually triggers an update of the objects
 void heap_recorder_testonly_reset_last_update(heap_recorder *heap_recorder);
+
+// Exhausts the usable record ids, so that all subsequent heap recordings raise (the id keeps being incremented, so
+// there's no going back). Used to test that our callers correctly handle a heap recorder that raises in the middle of
+// recording a sample.
+//
+// WARN: This should only be used for testing.
+void heap_recorder_testonly_exhaust_record_ids(heap_recorder *heap_recorder);
 
 void heap_recorder_testonly_benchmark_intern(heap_recorder *heap_recorder, ddog_CharSlice string, int times, bool use_all);

--- a/ext/datadog_profiling_native_extension/heap_recorder.h
+++ b/ext/datadog_profiling_native_extension/heap_recorder.h
@@ -81,7 +81,7 @@ void heap_recorder_set_size_enabled(heap_recorder *heap_recorder, bool size_enab
 // the weight of the committed heap allocation.
 //
 // A value of 1 will effectively track all objects that are passed to
-// `heap_recorder_record_allocation_with_rb_protect`. A value of 10 will only track every 10th
+// `heap_recorder_record_allocation`. A value of 10 will only track every 10th
 // object passed to it and its effective weight for the purposes of heap
 // profiling will be multiplied by 10.
 //
@@ -114,11 +114,7 @@ void heap_recorder_after_fork(heap_recorder *heap_recorder);
 //
 // WARN: This gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint, so it neither allocates in the Ruby
 // heap nor releases the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
-// WARN: This also gets called while the stack recorder holds one of the profile locks, which is why it rescues
-// exceptions with `rb_protect`, returning the exception state integer for the caller to handle (so that the caller
-// gets a chance to unlock the profile before the exception propagates).
-__attribute__((warn_unused_result))
-int heap_recorder_record_allocation_with_rb_protect(
+void heap_recorder_record_allocation(
   heap_recorder *heap_recorder,
   VALUE new_object,
   unsigned int weight,

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -662,7 +662,7 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
 // This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
 // Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
 //
-// Returns needs_after_allocation: true whenever an after_sample callback is required
+// Returns needs_after_allocation: true whenever a `recorder_commit_heap_recordings_may_lose_gvl` callback is required
 bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
@@ -694,11 +694,11 @@ void recorder_after_gc_step(VALUE recorder_instance) {
   if (state->heap_clean_after_gc_enabled) heap_recorder_update_young_objects(state->heap_recorder);
 }
 
-void recorder_after_sample(VALUE recorder_instance) {
+void recorder_commit_heap_recordings_may_lose_gvl(VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_commit_pending_recordings(state->heap_recorder);
+  heap_recorder_commit_recordings_may_lose_gvl(state->heap_recorder);
 }
 
 #define MAX_LEN_HEAP_ITERATION_ERROR_MSG 256
@@ -1169,7 +1169,7 @@ static VALUE _native_commit_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, 
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  heap_recorder_commit_pending_recordings(state->heap_recorder);
+  heap_recorder_commit_recordings_may_lose_gvl(state->heap_recorder);
 
   return Qtrue;
 }

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -252,7 +252,6 @@ static VALUE _native_reset_after_fork(DDTRACE_UNUSED VALUE self, VALUE recorder_
 static void serializer_set_start_timestamp_for_next_profile(stack_recorder_state *state, ddog_Timespec start_time);
 static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE local_root_span_id, VALUE endpoint);
 static void reset_profile_slot(profile_slot *slot, ddog_Timespec start_timestamp);
-static VALUE _native_track_object(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE new_obj, VALUE weight, VALUE alloc_class);
 static VALUE _native_start_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_end_fake_slow_heap_serialization(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_debug_heap_recorder(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
@@ -261,6 +260,7 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
 static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE record_id);
 static VALUE _native_record_id_for(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE obj);
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_heap_recorder_exhaust_record_ids(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_recorder_heap_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_benchmark_intern(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE string, VALUE times, VALUE use_all);
 static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE_UNUSED VALUE _self);
@@ -289,7 +289,6 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_slot_one_mutex_locked?", _native_is_slot_one_mutex_locked, 1);
   rb_define_singleton_method(testing_module, "_native_slot_two_mutex_locked?", _native_is_slot_two_mutex_locked, 1);
   rb_define_singleton_method(testing_module, "_native_record_endpoint", _native_record_endpoint, 3);
-  rb_define_singleton_method(testing_module, "_native_track_object", _native_track_object, 4);
   rb_define_singleton_method(testing_module, "_native_start_fake_slow_heap_serialization",
       _native_start_fake_slow_heap_serialization, 1);
   rb_define_singleton_method(testing_module, "_native_end_fake_slow_heap_serialization",
@@ -299,6 +298,7 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_is_object_recorded?", _native_is_object_recorded, 2);
   rb_define_singleton_method(testing_module, "_native_record_id_for", _native_record_id_for, 2);
   rb_define_singleton_method(testing_module, "_native_heap_recorder_reset_last_update", _native_heap_recorder_reset_last_update, 1);
+  rb_define_singleton_method(testing_module, "_native_heap_recorder_exhaust_record_ids", _native_heap_recorder_exhaust_record_ids, 1);
   rb_define_singleton_method(testing_module, "_native_recorder_heap_update", _native_recorder_heap_update, 1);
   rb_define_singleton_method(testing_module, "_native_benchmark_intern", _native_benchmark_intern, 4);
   rb_define_singleton_method(testing_module, "_native_test_managed_string_storage_produces_valid_profiles", _native_test_managed_string_storage_produces_valid_profiles, 0);
@@ -623,16 +623,18 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   metric_values[position_for[ALLOC_SAMPLES_UNSCALED_VALUE_ID]] = values.alloc_samples_unscaled;
   metric_values[position_for[TIMELINE_VALUE_ID]]      = values.timeline_wall_time_ns;
 
-  if (values.heap_sample) {
-    // If we got an allocation sample end the heap allocation recording to commit the heap sample.
-    // FIXME: Heap sampling currently has to be done in 2 parts because the construction of locations is happening
-    //        very late in the allocation-sampling path (which is shared with the cpu sampling path). This can
-    //        be fixed with some refactoring but for now this leads to a less impactful change.
-    //
+  if (values.heap_sample != NULL) {
     // NOTE: The heap recorder is allowed to raise exceptions if something's wrong. But we also need to handle it
     // on this side to make sure we properly unlock the active slot mutex on our way out. Otherwise, this would
     // later lead to deadlocks (since the active slot mutex is not expected to be locked forever).
-    int exception_state = end_heap_allocation_recording_with_rb_protect(state->heap_recorder, locations);
+    int exception_state = heap_recorder_record_allocation_with_rb_protect(
+      state->heap_recorder,
+      values.heap_sample->new_object,
+      values.alloc_samples,
+      values.heap_sample->alloc_class,
+      locations,
+      &values.heap_sample->out_needs_commit
+    );
     if (exception_state) {
       sampler_unlock_active_profile(active_slot);
       rb_jump_tag(exception_state);
@@ -657,19 +659,6 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   if (result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
     raise_error(rb_eArgError, "Failed to record sample: %"PRIsVALUE, get_error_details_and_drop(&result.err));
   }
-}
-
-// This method gets called from inside the RUBY_INTERNAL_EVENT_NEWOBJ tracepoint so it should neither allocate in the
-// Ruby heap nor release the GVL (https://github.com/DataDog/dd-trace-rb/pull/4240).
-//
-// Returns needs_after_allocation: true whenever a `recorder_commit_heap_recordings_may_lose_gvl` callback is required
-bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class) {
-  stack_recorder_state *state;
-  TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
-  // FIXME: Heap sampling currently has to be done in 2 parts because the construction of locations is happening
-  //        very late in the allocation-sampling path (which is shared with the cpu sampling path). This can
-  //        be fixed with some refactoring but for now this leads to a less impactful change.
-  return start_heap_allocation_recording(state->heap_recorder, new_object, sample_weight, alloc_class);
 }
 
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint) {
@@ -943,15 +932,6 @@ static VALUE _native_record_endpoint(DDTRACE_UNUSED VALUE _self, VALUE recorder_
   return Qtrue;
 }
 
-static VALUE _native_track_object(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE new_obj, VALUE weight, VALUE alloc_class) {
-  ENFORCE_TYPE(weight, T_FIXNUM);
-  bool needs_after_allocation = track_object(recorder_instance, new_obj, NUM2UINT(weight), char_slice_from_ruby_string(alloc_class));
-
-  // We could instead choose to automatically trigger the after allocation here; yet, it seems kinda nice to keep it manual for
-  // the tests so we can pull on each lever separately and observe "the sausage being made" in steps
-  return needs_after_allocation ? Qtrue : Qfalse;
-}
-
 static void reset_profile_slot(profile_slot *slot, ddog_Timespec start_timestamp) {
   ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(&slot->profile);
   if (reset_result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
@@ -1043,6 +1023,14 @@ static VALUE _native_record_id_for(DDTRACE_UNUSED VALUE _self, VALUE recorder_in
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
   return heap_recorder_testonly_record_id_for(state->heap_recorder, obj);
+}
+
+static VALUE _native_heap_recorder_exhaust_record_ids(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+  stack_recorder_state *state;
+  TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
+
+  heap_recorder_testonly_exhaust_record_ids(state->heap_recorder);
+  return Qtrue;
 }
 
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -231,6 +231,18 @@ typedef struct {
   bool serialize_ran;
 } call_serialize_without_gvl_arguments;
 
+typedef struct {
+  // Set by caller
+  stack_recorder_state *state;
+  locked_profile_slot active_slot;
+  ddog_prof_Slice_Location locations;
+  sample_values values;
+  sample_labels labels;
+
+  // Set by callee
+  ddog_prof_Profile_Result result;
+} record_sample_arguments;
+
 static VALUE _native_new(VALUE klass);
 static void initialize_slot_concurrency_control(stack_recorder_state *state);
 static void stack_recorder_typed_data_mark(void *data);
@@ -240,6 +252,8 @@ static VALUE _native_initialize(int argc, VALUE *argv, DDTRACE_UNUSED VALUE _sel
 static VALUE _native_serialize(VALUE self, VALUE recorder_instance);
 static VALUE ruby_time_from(ddog_Timespec ddprof_time);
 static void *call_serialize_without_gvl(void *call_args);
+static VALUE record_sample_locked(VALUE record_sample_arguments_as_value);
+static VALUE record_sample_unlock_ensure(VALUE record_sample_arguments_as_value);
 static locked_profile_slot sampler_lock_active_profile(stack_recorder_state *state);
 static void sampler_unlock_active_profile(locked_profile_slot active_slot);
 static profile_slot* serializer_flip_active_and_inactive_slots(stack_recorder_state *state);
@@ -607,7 +621,28 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
-  locked_profile_slot active_slot = sampler_lock_active_profile(state);
+  record_sample_arguments args = {
+    .state = state,
+    .active_slot = sampler_lock_active_profile(state),
+    .locations = locations,
+    .values = values,
+    .labels = labels,
+  };
+
+  // NOTE: The heap recorder is allowed to raise exceptions if something's wrong. We use `rb_ensure` to make sure we
+  // properly unlock the active slot mutex on our way out. Otherwise, this would later lead to deadlocks (since the
+  // active slot mutex is not expected to be locked forever).
+  rb_ensure(record_sample_locked, (VALUE) &args, record_sample_unlock_ensure, (VALUE) &args);
+
+  if (args.result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
+    raise_error(rb_eArgError, "Failed to record sample: %"PRIsVALUE, get_error_details_and_drop(&args.result.err));
+  }
+}
+
+static VALUE record_sample_locked(VALUE record_sample_arguments_as_value) {
+  record_sample_arguments *args = (record_sample_arguments *) record_sample_arguments_as_value;
+  stack_recorder_state *state = args->state;
+  sample_values values = args->values;
 
   // Note: We initialize this array to have ALL_VALUE_TYPES_COUNT but only tell libdatadog to use the first
   // state->enabled_values_count values. This simplifies handling disabled value types -- we still put them on the
@@ -624,41 +659,38 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
   metric_values[position_for[TIMELINE_VALUE_ID]]      = values.timeline_wall_time_ns;
 
   if (values.heap_sample != NULL) {
-    // NOTE: The heap recorder is allowed to raise exceptions if something's wrong. But we also need to handle it
-    // on this side to make sure we properly unlock the active slot mutex on our way out. Otherwise, this would
-    // later lead to deadlocks (since the active slot mutex is not expected to be locked forever).
-    int exception_state = heap_recorder_record_allocation_with_rb_protect(
+    heap_recorder_record_allocation(
       state->heap_recorder,
       values.heap_sample->new_object,
       values.alloc_samples,
       values.heap_sample->alloc_class,
-      locations,
+      args->locations,
       &values.heap_sample->out_needs_commit
     );
-    if (exception_state) {
-      sampler_unlock_active_profile(active_slot);
-      rb_jump_tag(exception_state);
-    }
   }
 
-  ddog_prof_Profile_Result result = ddog_prof_Profile_add(
-    &active_slot.data->profile,
+  args->result = ddog_prof_Profile_add(
+    &args->active_slot.data->profile,
     (ddog_prof_Sample) {
-      .locations = locations,
+      .locations = args->locations,
       .values = (ddog_Slice_I64) {.ptr = metric_values, .len = state->enabled_values_count},
-      .labels = labels.labels
+      .labels = args->labels.labels
     },
     /* To disable end_timestamp_ns to get aggregated profiles in pprof, replace the below with `0` */
-    labels.end_timestamp_ns
+    args->labels.end_timestamp_ns
   );
 
-  active_slot.data->stats.recorded_samples++;
+  args->active_slot.data->stats.recorded_samples++;
 
-  sampler_unlock_active_profile(active_slot);
+  return Qnil; // Unused
+}
 
-  if (result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
-    raise_error(rb_eArgError, "Failed to record sample: %"PRIsVALUE, get_error_details_and_drop(&result.err));
-  }
+static VALUE record_sample_unlock_ensure(VALUE record_sample_arguments_as_value) {
+  record_sample_arguments *args = (record_sample_arguments *) record_sample_arguments_as_value;
+
+  sampler_unlock_active_profile(args->active_slot);
+
+  return Qnil; // Unused
 }
 
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint) {

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -264,7 +264,7 @@ static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self,
 static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_benchmark_intern(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE string, VALUE times, VALUE use_all);
 static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE_UNUSED VALUE _self);
-static VALUE _native_commit_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_commit_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 
 void stack_recorder_init(VALUE profiling_module) {
   VALUE stack_recorder_class = rb_define_class_under(profiling_module, "StackRecorder", rb_cObject);
@@ -302,7 +302,7 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_recorder_after_gc_step", _native_recorder_after_gc_step, 1);
   rb_define_singleton_method(testing_module, "_native_benchmark_intern", _native_benchmark_intern, 4);
   rb_define_singleton_method(testing_module, "_native_test_managed_string_storage_produces_valid_profiles", _native_test_managed_string_storage_produces_valid_profiles, 0);
-  rb_define_singleton_method(testing_module, "_native_commit_pending_heap_recordings", _native_commit_pending_heap_recordings, 1);
+  rb_define_singleton_method(testing_module, "_native_commit_heap_recordings", _native_commit_heap_recordings, 1);
 
   ok_symbol = ID2SYM(rb_intern_const("ok"));
   error_symbol = ID2SYM(rb_intern_const("error"));
@@ -1165,7 +1165,7 @@ static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE
   return rb_ary_new_from_args(2, encoded_pprof_1, encoded_pprof_2);
 }
 
-static VALUE _native_commit_pending_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+static VALUE _native_commit_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 

--- a/ext/datadog_profiling_native_extension/stack_recorder.c
+++ b/ext/datadog_profiling_native_extension/stack_recorder.c
@@ -261,7 +261,7 @@ static VALUE build_profile_stats(profile_slot *slot, long serialization_time_ns,
 static VALUE _native_is_object_recorded(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE record_id);
 static VALUE _native_record_id_for(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE obj);
 static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
-static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
+static VALUE _native_recorder_heap_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
 static VALUE _native_benchmark_intern(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance, VALUE string, VALUE times, VALUE use_all);
 static VALUE _native_test_managed_string_storage_produces_valid_profiles(DDTRACE_UNUSED VALUE _self);
 static VALUE _native_commit_heap_recordings(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance);
@@ -299,7 +299,7 @@ void stack_recorder_init(VALUE profiling_module) {
   rb_define_singleton_method(testing_module, "_native_is_object_recorded?", _native_is_object_recorded, 2);
   rb_define_singleton_method(testing_module, "_native_record_id_for", _native_record_id_for, 2);
   rb_define_singleton_method(testing_module, "_native_heap_recorder_reset_last_update", _native_heap_recorder_reset_last_update, 1);
-  rb_define_singleton_method(testing_module, "_native_recorder_after_gc_step", _native_recorder_after_gc_step, 1);
+  rb_define_singleton_method(testing_module, "_native_recorder_heap_update", _native_recorder_heap_update, 1);
   rb_define_singleton_method(testing_module, "_native_benchmark_intern", _native_benchmark_intern, 4);
   rb_define_singleton_method(testing_module, "_native_test_managed_string_storage_produces_valid_profiles", _native_test_managed_string_storage_produces_valid_profiles, 0);
   rb_define_singleton_method(testing_module, "_native_commit_heap_recordings", _native_commit_heap_recordings, 1);
@@ -687,7 +687,7 @@ void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_
   }
 }
 
-void recorder_after_gc_step(VALUE recorder_instance) {
+void recorder_heap_update_may_lose_gvl(VALUE recorder_instance) {
   stack_recorder_state *state;
   TypedData_Get_Struct(recorder_instance, stack_recorder_state, &stack_recorder_typed_data, state);
 
@@ -1054,8 +1054,8 @@ static VALUE _native_heap_recorder_reset_last_update(DDTRACE_UNUSED VALUE _self,
   return Qtrue;
 }
 
-static VALUE _native_recorder_after_gc_step(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
-  recorder_after_gc_step(recorder_instance);
+static VALUE _native_recorder_heap_update(DDTRACE_UNUSED VALUE _self, VALUE recorder_instance) {
+  recorder_heap_update_may_lose_gvl(recorder_instance);
   return Qtrue;
 }
 

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -4,13 +4,22 @@
 #include <ruby.h>
 
 typedef struct {
+  // In: The object being allocated, and its class. (Its weight is the `alloc_samples` in `sample_values` below.)
+  VALUE new_object;
+  ddog_CharSlice alloc_class;
+  // Out: Set by `record_sample` to whether a `recorder_commit_heap_recordings_may_lose_gvl` callback is needed
+  bool out_needs_commit;
+} heap_sample_values;
+
+typedef struct {
   int64_t cpu_time_ns;
   int64_t wall_time_ns;
   uint32_t cpu_or_wall_samples;
   uint32_t alloc_samples;
   uint32_t alloc_samples_unscaled;
-  bool heap_sample;
   int64_t timeline_wall_time_ns;
+  // When not NULL, this sample also gets recorded for heap profiling
+  heap_sample_values *heap_sample;
 } sample_values;
 
 typedef struct {
@@ -26,7 +35,6 @@ typedef struct {
 
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
-__attribute__((warn_unused_result)) bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class);
 void recorder_commit_heap_recordings_may_lose_gvl(VALUE recorder_instance);
 void recorder_heap_update_may_lose_gvl(VALUE recorder_instance);
 void recorder_install_on_serialize(VALUE recorder_instance, VALUE thread_context_collector_instance);

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -28,6 +28,6 @@ void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, 
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
 __attribute__((warn_unused_result)) bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class);
 void recorder_commit_heap_recordings_may_lose_gvl(VALUE recorder_instance);
-void recorder_after_gc_step(VALUE recorder_instance);
+void recorder_heap_update_may_lose_gvl(VALUE recorder_instance);
 void recorder_install_on_serialize(VALUE recorder_instance, VALUE thread_context_collector_instance);
 VALUE enforce_recorder_instance(VALUE object);

--- a/ext/datadog_profiling_native_extension/stack_recorder.h
+++ b/ext/datadog_profiling_native_extension/stack_recorder.h
@@ -27,7 +27,7 @@ typedef struct {
 void record_sample(VALUE recorder_instance, ddog_prof_Slice_Location locations, sample_values values, sample_labels labels);
 void record_endpoint(VALUE recorder_instance, uint64_t local_root_span_id, ddog_CharSlice endpoint);
 __attribute__((warn_unused_result)) bool track_object(VALUE recorder_instance, VALUE new_object, unsigned int sample_weight, ddog_CharSlice alloc_class);
-void recorder_after_sample(VALUE recorder_instance);
+void recorder_commit_heap_recordings_may_lose_gvl(VALUE recorder_instance);
 void recorder_after_gc_step(VALUE recorder_instance);
 void recorder_install_on_serialize(VALUE recorder_instance, VALUE thread_context_collector_instance);
 VALUE enforce_recorder_instance(VALUE object);

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -981,7 +981,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           eval("proc { def self.foo; rand; end; foo }.call", binding, __FILE__, __LINE__)
         end
 
-        # Internal objects are skipped by the heap profiler (see `start_heap_allocation_recording()`) because tracking
+        # Internal objects are skipped by the heap profiler (see
+        # `heap_recorder_record_allocation_with_rb_protect()`) because tracking
         # them would mean adding them to a `ObjectSpace::WeakMap`, which is not safe. They are still allocation
         # sampled, as that is safe and useful.
         it "records them as allocation samples but never as heap samples" do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -982,7 +982,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         end
 
         # Internal objects are skipped by the heap profiler (see
-        # `heap_recorder_record_allocation_with_rb_protect()`) because tracking
+        # `heap_recorder_record_allocation()`) because tracking
         # them would mean adding them to a `ObjectSpace::WeakMap`, which is not safe. They are still allocation
         # sampled, as that is safe and useful.
         it "records them as allocation samples but never as heap samples" do

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1255,6 +1255,58 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         expect(cpu_time_ns).to be <= elapsed_ns
       end
     end
+
+    # This is a simplified end-to-end test; the ThreadContext has all the variants for otel gems, but
+    # here we're only testing if `thread_context_collector_resolve_otel_span_key_may_lose_gvl` is getting called
+    # correctly
+    context "when a thread has an active otel span" do
+      before do
+        require "opentelemetry/sdk"
+        require "opentelemetry-exporter-otlp"
+      rescue LoadError
+        skip "Test requires the opentelemetry-sdk and opentelemetry-exporter-otlp gems"
+      end
+
+      let(:thread_context_collector) { build_thread_context_collector(recorder, otel_context_enabled: :only) }
+      let(:otel_tracer) do
+        OpenTelemetry::SDK.configure
+        OpenTelemetry.tracer_provider.tracer("datadog-profiling-test")
+      end
+      let(:ready_queue) { Queue.new }
+      let(:background_thread) do
+        Thread.new(ready_queue, otel_tracer) do |ready_queue, otel_tracer|
+          otel_tracer.in_span("profiler.test") do |span|
+            @otel_span_id = span.context.span_id.unpack1("Q>").to_i
+            ready_queue << true
+            sleep
+          end
+        end
+      end
+
+      after do
+        unless RSpec.current_example.skipped?
+          background_thread.kill
+          background_thread.join
+          OpenTelemetry.tracer_provider.shutdown
+        end
+      end
+
+      it "includes the otel span ids in the samples for that thread" do
+        allow(OpenTelemetry.logger).to receive(:error) # Silence "unable to export spans", we have no otlp endpoint
+
+        background_thread
+        ready_queue.pop
+
+        start
+
+        sample = try_wait_until do
+          samples_for_thread(samples_from_pprof(recorder.serialize!), background_thread)
+            .find { |it| it.labels.key?(:"span id") }
+        end
+
+        expect(sample.labels).to include("span id": @otel_span_id, "local root span id": @otel_span_id)
+      end
+    end
   end
 
   describe "Ractor safety" do

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_on_gvl_released(thread)
   end
 
-  def sample_after_gvl_running(thread, allow_exception: false)
-    described_class::Testing._native_sample_after_gvl_running(thread_context_collector, thread, allow_exception)
+  def sample_after_gvl_running(thread)
+    described_class::Testing._native_sample_after_gvl_running(thread_context_collector, thread)
   end
 
   def thread_list
@@ -565,6 +565,13 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
               end
             end
 
+            before do
+              # The otel span key is only lazily extracted after the first sample, so we take that first sample and
+              # throw it away to give it the opportunity to initialize.
+              sample
+              recorder.serialize!
+            end
+
             it 'includes "local root span id" and "span id" labels in the samples' do
               sample
 
@@ -730,6 +737,17 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
               end
             end
 
+            let(:otel_span_key_warmup) { true }
+
+            before do
+              # The otel span key is only lazily extracted after the first sample, so we take that first sample and
+              # throw it away to give it the opportunity to initialize.
+              if otel_span_key_warmup
+                sample
+                recorder.serialize!
+              end
+            end
+
             after do
               OpenTelemetry.tracer_provider.shutdown
             end
@@ -754,6 +772,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
             end
 
             describe "reading CURRENT_SPAN_KEY into otel_current_span_key" do
+              let(:otel_span_key_warmup) { false }
+
               let!(:ran_log) { [] }
 
               let(:setup_failure) do
@@ -775,29 +795,9 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
                 after { expect(ran_log).to eq [:ran_code] }
 
                 it "does not leave the exception pending" do
-                  sample(allow_exception: true)
+                  sample
 
                   expect($!).to be nil
-                end
-
-                it 'omits the "local root span id" and "span id" labels in the sample' do
-                  sample(allow_exception: true)
-
-                  expect(t1_sample.labels.keys).to_not include(:"local root span id", :"span id")
-                end
-              end
-
-              context "during allocation sampling" do
-                it "does not try to read the CURRENT_SPAN_KEY" do
-                  allow(OpenTelemetry.logger).to receive(:error)
-
-                  otel_tracer.in_span("profiler.test") do |_span|
-                    setup_failure
-
-                    sample_allocation(weight: 1)
-                  end
-
-                  expect(ran_log).to eq []
                 end
               end
             end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -791,13 +791,13 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
               end
 
               context "when an exception is raised" do
-                before { setup_failure }
-                after { expect(ran_log).to eq [:ran_code] }
-
                 it "does not leave the exception pending" do
+                  setup_failure
+
                   sample
 
                   expect($!).to be nil
+                  expect(ran_log).to eq [:ran_code]
                 end
               end
             end

--- a/spec/datadog/profiling/collectors/thread_context_spec.rb
+++ b/spec/datadog/profiling/collectors/thread_context_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Datadog::Profiling::Collectors::ThreadContext do
     described_class::Testing._native_on_gc_finish(thread_context_collector)
   end
 
-  def sample_after_gc(allow_exception: false)
-    described_class::Testing._native_sample_after_gc(thread_context_collector, allow_exception)
+  def sample_after_gc
+    described_class::Testing._native_sample_after_gc(thread_context_collector)
   end
 
   def sample_allocation(weight:, new_object: Object.new)

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -371,7 +371,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           "wall-time" => 789,
           "alloc-samples" => sample_rate,
           "timeline" => 42,
-          "heap_sample" => true,
         }
       end
       let(:labels) { {"label_a" => "value_a", "label_b" => "value_b", "state" => "unknown"}.to_a }
@@ -384,10 +383,10 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
       # Returns the record id the heap recorder is using to track `obj`, or nil if the allocation wasn't sampled
       def sample_allocation(obj)
-        # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
-        described_class::Testing._native_track_object(stack_recorder, obj, sample_rate, obj.class.name)
-        Datadog::Profiling::Collectors::Stack::Testing
-          ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
+        Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+          Thread.current, stack_recorder, metric_values, labels, numeric_labels,
+          heap_sample: {new_object: obj, alloc_class: obj.class.name},
+        )
         # Heap recordings are deferred and need to be committed after the sample is recorded
         described_class::Testing._native_commit_heap_recordings(stack_recorder)
         described_class::Testing._native_record_id_for(stack_recorder, obj)
@@ -551,8 +550,6 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           # for each profile-type there in.
           expected_summed_values = {"heap-live-samples": 0, "heap-live-size": 0, "alloc-samples-unscaled": 0}
           metric_values.each_pair do |k, v|
-            next if k == "heap_sample" # This is not a metric, ignore it
-
             expected_summed_values[k.to_sym] = v * @num_allocations
           end
 
@@ -684,14 +681,21 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           end
         end
 
-        # NOTE: This is a regression test that exceptions in end_heap_allocation_recording_with_rb_protect are safely
-        # handled by the stack_recorder.
+        # NOTE: This is a regression test that exceptions raised by the heap recorder while recording a sample are
+        # safely handled by the stack_recorder.
         context "when the heap sampler raises an exception during _native_sample" do
+          before { described_class::Testing._native_heap_recorder_exhaust_record_ids(stack_recorder) }
+
+          def sample_allocation_expecting_failure
+            Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+              Thread.current, stack_recorder, metric_values, labels, numeric_labels,
+              heap_sample: {new_object: Object.new, alloc_class: "Object"},
+            )
+          end
+
           it "propagates the exception" do
-            expect do
-              Datadog::Profiling::Collectors::Stack::Testing
-                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
-            end.to raise_error(::RuntimeError, include("Ended a heap recording"))
+            expect { sample_allocation_expecting_failure }
+              .to raise_error(::RuntimeError, include("Exhausted usable record_ids"))
           end
 
           it "does not keep the active slot mutex locked" do
@@ -700,8 +704,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             expect(slot_two_mutex_locked?).to be true
 
             begin
-              Datadog::Profiling::Collectors::Stack::Testing
-                ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
+              sample_allocation_expecting_failure
             rescue # rubocop:disable Lint/SuppressedException
             end
 
@@ -716,16 +719,17 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             described_class::Testing._native_debug_heap_recorder(stack_recorder).to_h.dig(:state, :pending_recordings_count) > 0
           end
 
-          def track_object_without_commit(obj)
-            described_class::Testing._native_track_object(stack_recorder, obj, sample_rate, obj.class.name)
-            Datadog::Profiling::Collectors::Stack::Testing
-              ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
+          def sample_allocation_without_commit(obj)
+            Datadog::Profiling::Collectors::Stack::Testing._native_sample(
+              Thread.current, stack_recorder, metric_values, labels, numeric_labels,
+              heap_sample: {new_object: obj, alloc_class: obj.class.name},
+            )
           end
 
           it "clears pending recordings after committing" do
             test_object = Object.new
 
-            track_object_without_commit(test_object)
+            sample_allocation_without_commit(test_object)
 
             expect(has_pending_recordings?).to be true
 
@@ -737,7 +741,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           it "clears all pending recordings after multiple allocations" do
             3.times do
               test_object = Object.new
-              track_object_without_commit(test_object)
+              sample_allocation_without_commit(test_object)
             end
 
             expect(has_pending_recordings?).to be true
@@ -1052,10 +1056,9 @@ RSpec.describe Datadog::Profiling::StackRecorder do
       end
 
       def sample_allocation(obj)
-        # Heap sampling currently requires this 2-step process to first pass data about the allocated object...
-        described_class::Testing._native_track_object(stack_recorder, obj, 1, obj.class.name)
         Datadog::Profiling::Collectors::Stack::Testing._native_sample(
-          Thread.current, stack_recorder, {"alloc-samples" => 1, "heap_sample" => true}, [], [],
+          Thread.current, stack_recorder, {"alloc-samples" => 1}, [], [],
+          heap_sample: {new_object: obj, alloc_class: obj.class.name},
         )
         # Heap recordings are deferred and need to be committed after the sample is recorded
         described_class::Testing._native_commit_heap_recordings(stack_recorder)

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
         Datadog::Profiling::Collectors::Stack::Testing
           ._native_sample(Thread.current, stack_recorder, metric_values, labels, numeric_labels)
         # Heap recordings are deferred and need to be committed after the sample is recorded
-        described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
+        described_class::Testing._native_commit_heap_recordings(stack_recorder)
         described_class::Testing._native_record_id_for(stack_recorder, obj)
       end
 
@@ -729,7 +729,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             expect(has_pending_recordings?).to be true
 
-            described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
+            described_class::Testing._native_commit_heap_recordings(stack_recorder)
 
             expect(has_pending_recordings?).to be false
           end
@@ -742,7 +742,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
             expect(has_pending_recordings?).to be true
 
-            described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
+            described_class::Testing._native_commit_heap_recordings(stack_recorder)
 
             expect(has_pending_recordings?).to be false
           end
@@ -1058,7 +1058,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           Thread.current, stack_recorder, {"alloc-samples" => 1, "heap_sample" => true}, [], [],
         )
         # Heap recordings are deferred and need to be committed after the sample is recorded
-        described_class::Testing._native_commit_pending_heap_recordings(stack_recorder)
+        described_class::Testing._native_commit_heap_recordings(stack_recorder)
       end
 
       it "includes heap recorder snapshot" do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Datadog::Profiling::StackRecorder do
     described_class::Testing._native_is_object_recorded?(stack_recorder, record_id)
   end
 
-  def recorder_after_gc_step
-    described_class::Testing._native_recorder_after_gc_step(stack_recorder)
+  def recorder_heap_update
+    described_class::Testing._native_recorder_heap_update(stack_recorder)
   end
 
   describe "#initialize" do
@@ -748,7 +748,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           end
         end
 
-        describe "#recorder_after_gc_step" do
+        describe "#recorder_heap_update" do
           def sample_and_clear
             # The object is allocated and sampled on a separate thread which we immediately join. Once that thread
             # is gone, so are its machine stack and registers, so there is nowhere left for a stale reference to
@@ -778,7 +778,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
               # Every object is still being tracked at this point
               expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
 
-              recorder_after_gc_step
+              recorder_heap_update
 
               # Young objects should no longer be tracked, but older objects are still kept
               expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, false, false]
@@ -802,7 +802,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
                 expect do
                   described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
-                  recorder_after_gc_step
+                  recorder_heap_update
                 end.to_not change { is_object_recorded?(test_record_id) }.from(true)
 
                 described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
@@ -810,7 +810,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
                 # Sanity: after serialization finishes, we can finally clear it
                 expect do
                   described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
-                  recorder_after_gc_step
+                  recorder_heap_update
                 end.to change { is_object_recorded?(test_record_id) }.from(true).to(false)
               end
             end
@@ -820,11 +820,11 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
               test_record_id_1 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
+              expect { recorder_heap_update }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
 
               test_record_id_2 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
+              expect { recorder_heap_update }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
             end
 
             it "does not apply the minimum time between heap updates when serializing" do
@@ -832,11 +832,11 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
               test_record_id_1 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
+              expect { recorder_heap_update }.to change { is_object_recorded?(test_record_id_1) }.from(true).to(false)
 
               test_record_id_2 = sample_and_clear
 
-              expect { recorder_after_gc_step }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
+              expect { recorder_heap_update }.to_not change { is_object_recorded?(test_record_id_2) }.from(true)
 
               expect { serialize }.to change { is_object_recorded?(test_record_id_2) }.from(true).to(false)
             end
@@ -851,7 +851,7 @@ RSpec.describe Datadog::Profiling::StackRecorder do
               # Every object is still being tracked at this point
               expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]
 
-              recorder_after_gc_step
+              recorder_heap_update
 
               # No change -- all objects are still being tracked
               expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [true, true, true, true]


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a longstanding issue with the `during_sample` flag being innacurate if something released the GVL while `during_sample == true`.

This was bad because `during_sample` is not supposed to behave in a re-entrant way, and actually could leave to clobbering, where:

* Code path A sets the flag by calling `during_sample_enter` and releases GVL (often the heap profiler)
* Code path B comes in and calls `during_sample_enter` AGAIN + `during_sample_exit`, flag gets reset back to `false`
* Code path A is still running and it looks like it should have `during_sample == true` still but it doesn't anymore

We uncovered this issue while working on https://github.com/DataDog/dd-trace-rb/pull/6245 and https://github.com/DataDog/dd-trace-rb/pull/6244 .

This PR fixes the issue by:

1. Improving the documentation to clearly state that it MUST NOT be held across a GVL release (thus making it clear to both humans and agents what's expected and when we can break such expectations)
2. Fixing all three issues where we could lose the GVL while `during_sample == true`: two in the heap profiler (updating after a GC and committing pending recordings) + one in the thread context (initializing `get_otel_current_span_key`)

Along the way, I also tried to rename a few functions to make it clear that they may lose the GVL, and fixed a potential issue with the `updating` flag for the heap recorder.

**Motivation:**

While the fix in https://github.com/DataDog/dd-trace-rb/pull/6245 fixes once consequence of getting `during_sample` wrong, this PR fixes our architecture and assumptions to make sure that we can trust `during_sample` and what it means.

**Change log entry**

None. (This was all internal, the visible fixes were the other PRs mentioned)

**Additional Notes:**

This PR is missing a few tidbits:

* Now that we fixed `during_sample` we can finally make calling `during_sample_enter` with the flag already being true an error

* I plan to add some testing using `GC.stress`, as that seemed to be quite successful in triggering the issue in https://github.com/DataDog/dd-trace-rb/pull/6245 and https://github.com/DataDog/dd-trace-rb/pull/6242 .

I plan to open a follow-up PR with these, yet this PR/branch was already getting quite meaty so I decided to separate these changes into a follow-up PR.

I've worked on this PR as small self-contained steps, so reviewing commit-by-commit might be easier than trying to take in the whole diff at once.

**How to test the change?**

In a lot of the cases here, our existing code coverage is enough. There's gaps (see "additional notes") so those extra tests we could add will come in that latter PR.