### PR TITLE
Fix flaky heap profiling specs by allocating on a thread we join

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -408,31 +408,21 @@ RSpec.describe Datadog::Profiling::StackRecorder do
           skip "Heap profiling is only supported on Ruby >= 3.1"
         end
 
-        allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash,
-          {"z" => -1, "y" => "-2", "x" => false}, Object.new]
         @num_allocations = 0
-        allocations.each_with_index do |obj, i|
-          introduce_distinct_stacktraces(i, obj)
-          @num_allocations += 1
-          GC.start # Force each allocation to be done in its own GC epoch for interesting GC age labels
-        end
 
-        allocations.clear # The literals in the previous array are now dangling
-        GC.start # And this will clear them, leaving only the non-literals which are still pointed to by the lets
+        # Use the `Thread.new { allocations; nil }.join; GC.start` trick to reliably GC the allocations
+        Thread.new do
+          allocations = [a_string, an_array, "a fearsome interpolated string: #{sample_rate}", (-10..-1).to_a, a_hash,
+            {"z" => -1, "y" => "-2", "x" => false}, Object.new]
+          allocations.each_with_index do |obj, i|
+            introduce_distinct_stacktraces(i, obj)
+            @num_allocations += 1
+            GC.start # Force each allocation to be done in its own GC epoch for interesting GC age labels
+          end
+          nil # to avoid Thread#value to hold onto allocations
+        end.join
 
-        # NOTE: We've witnessed CI flakiness where some no longer referenced allocations may still be seen as alive
-        # after the previous GC.
-        # This might be an instance of the issues described in https://bugs.ruby-lang.org/issues/19460
-        # and https://bugs.ruby-lang.org/issues/19041. We didn't get to the bottom of the
-        # reason but it might be that some machine context/register ends up still pointing to
-        # that last entry and thus manages to get it marked in the first GC.
-        # To reduce the likelihood of this happening we'll:
-        # * Allocate some more stuff and clear again
-        # * Do another GC
-        allocations = ["another fearsome interpolated string: #{sample_rate}", (-20..-10).to_a,
-          {"a" => 1, "b" => "2", "c" => true}, Object.new]
-        allocations.clear
-        GC.start
+        GC.start # This clears the literals above, leaving only the non-literals which are still pointed to by the lets
       end
 
       after do |example|


### PR DESCRIPTION
**What does this PR do?**

TLDR: Use the `Thread.new { allocations; nil }.join; GC.start` trick to reliably GC the allocations
Fixes https://github.com/DataDog/ruby-guild/issues/321

Below is from Claude:

Allocates the heap profiling specs' fixture objects on a thread we join, so the ones no `let` points at get reliably collected before serialization, and drops the now-redundant allocate-some-more-stuff-and-clear-again mitigation.

**Motivation:**

`#serialize heap samples and sizes when enabled contribute to recorded samples stats` failed in CI with `recorded_samples: 257` instead of 256.

`recorded_samples` counts one recorded sample per live heap object, so the extra one is a sampled object that the `before` block dropped but that was still reported as alive. The `before` block already had a NOTE about this: the garbage collector scans machine stacks and registers conservatively, so a leftover slot pointing at one of those objects is enough to keep it alive, and the existing mitigation only lowered the odds.

Once the allocating thread is joined its machine stack and registers are gone, so they can't keep anything alive, and the specs can keep asserting exact object counts.

The thread block has to end in `nil`, otherwise the thread's return value is the `allocations` array and everything in it stays alive for as long as the `Thread` object does — which is the same conservative scanning we're trying to stop depending on. With the thread deliberately kept reachable, `heap_samples.size` goes from 3 to 7.

**Change log entry**

None.

**Additional Notes:**

Dropping the extra mitigation `GC.start` moves `hash_age` in `include accurate object ages` from 5 to a stable 4, still inside its `be_between(4, 5)` — and with more headroom, since a GC out of our control now lands on 5 instead of 6.

**How to test the change?**

`bundle exec rspec spec/datadog/profiling/stack_recorder_spec.rb`, green over 15 consecutive runs on Ruby 4.0.6 and 6 on 3.4.9.

The specs are not loosened by this change: deliberately retaining one of the dropped objects still fails both `contribute to recorded samples stats` and `include the stack and sample counts for the objects still left alive`.
