### PR TITLE
Pin test agent to the image with the forwarded-response fix

### DIFF
--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -129,7 +129,7 @@ jobs:
         TEST_DATADOG_INTEGRATION: "1"
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby
@@ -216,7 +216,7 @@ jobs:
       options: --link mongodb:mongodb_secondary
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -129,7 +129,9 @@ jobs:
         TEST_DATADOG_INTEGRATION: "1"
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
+        # Pinned by digest for https://github.com/DataDog/dd-apm-test-agent/pull/410
+        # Switch to the v1.66.0 tag once it is released.
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent@sha256:67a560e0dbd928534e6d680362a5407d382acc263cb976c4a7a294070abfba26
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby
@@ -216,7 +218,9 @@ jobs:
       options: --link mongodb:mongodb_secondary
     services:
       agent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
+        # Pinned by digest for https://github.com/DataDog/dd-apm-test-agent/pull/410
+        # Switch to the v1.66.0 tag once it is released.
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent@sha256:67a560e0dbd928534e6d680362a5407d382acc263cb976c4a7a294070abfba26
         env:
           LOG_LEVEL: DEBUG
           TRACE_LANGUAGE: ruby

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,6 @@ Ruby idioms:
 # Gotchas
 
 - Pipe `rspec` and `rake test:*` output through `2>&1 | tee /tmp/full_rspec.log | grep -E 'Pending:|Failures:|Finished' -A 99` for concise but complete results.
-- Transport noise (`Internal error during Datadog::Tracing::Transport::HTTP::Client request`) is expected unless debugging transport logic.
 - Thread leaks: use `rspec --seed <N>` and inspect `docs/DevelopmentGuide.md#ensuring-tests-dont-leak-resources`.
 - `docker compose run` failures: run `docker compose pull` before retrying.
 - `ProbeNotifierWorker#flush` blocks until queues are empty; never add `sleep` after it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,10 +193,13 @@ services:
       - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
       - "127.0.0.1:${OTLP_GRPC_PORT}:4317"
       - "127.0.0.1:${OTLP_HTTP_PORT}:4318"
+    depends_on:
+      - ddagent
     env_file: ./.env
     environment:
       - LOG_LEVEL=DEBUG
       - TRACE_LANGUAGE=ruby
+      - DD_TRACE_AGENT_URL=http://${DD_REAL_AGENT_HOST}:${DD_REAL_AGENT_PORT}
       - PORT=${DD_TRACE_AGENT_PORT}
       - OTLP_GRPC_PORT=${OTLP_GRPC_PORT}
       - OTLP_HTTP_PORT=${OTLP_HTTP_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,13 +191,10 @@ services:
       - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
       - "127.0.0.1:${OTLP_GRPC_PORT}:4317"
       - "127.0.0.1:${OTLP_HTTP_PORT}:4318"
-    depends_on:
-      - ddagent
     env_file: ./.env
     environment:
       - LOG_LEVEL=DEBUG
       - TRACE_LANGUAGE=ruby
-      - DD_TRACE_AGENT_URL=http://${DD_REAL_AGENT_HOST}:${DD_REAL_AGENT_PORT}
       - PORT=${DD_TRACE_AGENT_PORT}
       - OTLP_GRPC_PORT=${OTLP_GRPC_PORT}
       - OTLP_HTTP_PORT=${OTLP_HTTP_PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
       - ddagent_var_run:/var/run/datadog
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.37.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
     ports:
       - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
       - "127.0.0.1:${OTLP_GRPC_PORT}:4317"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,9 @@ services:
       - ddagent_var_run:/var/run/datadog
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.65.0
+    # Pinned by digest for https://github.com/DataDog/dd-apm-test-agent/pull/410
+    # Switch to the v1.66.0 tag once it is released.
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent@sha256:67a560e0dbd928534e6d680362a5407d382acc263cb976c4a7a294070abfba26
     ports:
       - "127.0.0.1:${DD_TRACE_AGENT_PORT}:9126"
       - "127.0.0.1:${OTLP_GRPC_PORT}:4317"


### PR DESCRIPTION
**What does this PR do?**

Pins the test agent by digest to a build containing https://github.com/DataDog/dd-apm-test-agent/pull/410, in Docker Compose and CI.

**Motivation:**

Every spec that flushes a trace pays for a bug in the test agent. It re-serializes forwarded trace responses while relaying the real agent's `Content-Length`, so the body arrives truncated and the tracer cannot parse it. On `rake test:pg` that is 2,162 failures across 2,215 examples - roughly one per example:

```
Internal error during Datadog::Tracing::Transport::HTTP::Client request.
Cause: JSON::ParserError: unexpected end of input, expected closing "
```

This costs us three ways:

- **Slow.** Each failed flush blocks 24-38 ms on a round-trip. `test:pg` takes 76-107 s instead of ~24 s. The test agent backs every job in the matrix, so the tax is paid across the board, not just here.
- **Token cost.** The log is 288,348 tokens (o200k_base), 99.7% of it this one error at ~133 tokens a line. That overflows a 200K context window on a single task, so any agent reading CI output either truncates it or pays to ingest a quarter-million tokens of the same message. After the fix: 787 tokens.
- **Normalized breakage.** The noise was common enough that `AGENTS.md` told readers to expect transport errors. A permanently red signal is one nobody reads, and it hides the transport failures that do matter.

PR #410 recomputes `Content-Length` and fixes it at the source. It is not in v1.65.0, so the pin is a digest until v1.66.0 is released.

**Change log entry**

None.

**Additional Notes:**

`rake test:pg`, Ruby 4.0, local:

| | before | after | Reduction |
|---|---|---|---|
| Wall time | 76-107 s | ~24 s | 69-78% |
| Log tokens (o200k_base) | 288,348 | 787 | 99.7% |
| Output size | 930 KB | 4.8 KB | 99.5% |
| Output lines | 2,213 | 54 | 97.6% |
| Transport error lines | 2,162 | 0 | 100% |
| Examples / failures | 2215 / 0 | 2215 / 0 | - |

Wall time fluctuated quite a lot based on local condition, but generally it is faster, CI figures will differ. Same examples pass either way, so the whole delta is overhead.

The `AGENTS.md` gotcha calling this transport noise expected is dropped, since it described the symptom of this bug rather than normal behavior.

**How to test the change?**

`bundle exec rake test:pg` - 2215 examples, 0 failures, zero parse errors.
