### PR TITLE
ci: add health checks to mysql/postgres/redis unit-test services

### DIFF
--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -145,14 +145,29 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_PASSWORD: mysql
           MYSQL_USER: mysql
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
       postgres:
         image: ghcr.io/datadog/images-rb/services/postgres:9.6
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
       redis:
         image: ghcr.io/datadog/images-rb/services/redis:6.2
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
**What does this PR do?**

Adds `--health-cmd` gating to the `mysql`, `postgres`, and `redis` service containers in the `build-test-standard` unit-test job (`.github/workflows/_unit_test.yml`).

**Motivation:**

Only `elasticsearch` declared a health check. Without `--health-cmd`, GitHub Actions starts the DB containers and proceeds immediately, so steps can begin before a database accepts connections and unhealthy containers go undetected. A transient MySQL blip then cascades into hundreds of failures across `spec:appsec:rails` (every example reinitializes the app and opens a connection). Gating on service health makes the job wait for readiness and fail fast at "Initialize containers" with a clear signal.

**Change log entry**

None.

**Additional Notes:**

Draft to observe CI behavior. Test-side connection retry (a separate, higher-risk change) is intentionally out of scope.

**How to test the change?**

CI on this PR exercises the changed job. Verify `build-test-standard` waits on service health and that DB-backed suites (e.g. `spec:appsec:rails`) run green.
