### PR TITLE
remote config: type parsed JSON as Datadog::Helpers::json

### DIFF
--- a/lib/datadog/core/remote/configuration/digest.rb
+++ b/lib/datadog/core/remote/configuration/digest.rb
@@ -10,7 +10,11 @@ module Datadog
         class DigestList < Array
           class << self
             def parse(hash)
-              new.concat(hash.map { |type, hexdigest| Digest.new(type, hexdigest) })
+              new.concat(hash.map do |type, hexdigest|
+                raise TypeError, "hexdigest must be a String, got #{hexdigest.class}" unless hexdigest.is_a?(::String)
+
+                Digest.new(type, hexdigest)
+              end)
             end
           end
 

--- a/lib/datadog/core/remote/configuration/target.rb
+++ b/lib/datadog/core/remote/configuration/target.rb
@@ -12,14 +12,18 @@ module Datadog
           class << self
             def parse(hash)
               signed = hash.fetch("signed")
+              raise TypeError, "signed must be a Hash, got #{signed.class}" unless signed.is_a?(Hash)
+
               # Note that the +dig+ call permits +hash['signed']+ to be
               # missing the +custom+ subtree entirely.
               # Previously the subtree was required but +opaque_backend_state+
               # could still be missing (and obtained here as nil).
               opaque_backend_state = signed.dig("custom", "opaque_backend_state")
+              opaque_backend_state = opaque_backend_state.is_a?(String) ? opaque_backend_state : nil
               # The version appears to be optional to the rest of this class,
               # and we have tests that do not provide it.
               version = signed["version"]
+              version = version.is_a?(Integer) ? version : nil
 
               map = new
 
@@ -28,8 +32,12 @@ module Datadog
                 @version = version
               end
 
-              signed.fetch("targets").each_with_object(map) do |(p, t), m|
+              targets = signed.fetch("targets")
+              raise TypeError, "targets must be a Hash, got #{targets.class}" unless targets.is_a?(Hash)
+
+              targets.each_with_object(map) do |(p, t), m|
                 path = Configuration::Path.parse(p)
+                raise TypeError, "target must be a Hash, got #{t.class}" unless t.is_a?(Hash)
                 target = Configuration::Target.parse(t)
 
                 m[path] = target
@@ -54,8 +62,14 @@ module Datadog
           class << self
             def parse(hash)
               length = Integer(hash.fetch("length"))
-              digests = Configuration::DigestList.parse(hash.fetch("hashes"))
+              raise TypeError, "target length is required" unless length.is_a?(Integer)
+
+              hashes = hash.fetch("hashes")
+              raise TypeError, "hashes must be a Hash, got #{hashes.class}" unless hashes.is_a?(Hash)
+              digests = Configuration::DigestList.parse(hashes)
+
               version = Integer(hash.dig("custom", "v"))
+              raise TypeError, "target version (custom.v) is required" unless version.is_a?(Integer)
 
               new(digests: digests, length: length, version: version)
             end

--- a/lib/datadog/di/remote.rb
+++ b/lib/datadog/di/remote.rb
@@ -292,6 +292,8 @@ module Datadog
           # TODO test exception capture
           probe_spec = parse_content(previous_content)
           probe_id = probe_spec.fetch("id")
+          raise TypeError, "probe id must be a String, got #{probe_id.class}" unless probe_id.is_a?(String)
+
           component.probe_manager.remove_probe(probe_id)
         rescue Exception => exc # standard:disable Lint/RescueException
           Datadog::DI.reraise_if_fatal(exc)

--- a/lib/datadog/tracing/remote.rb
+++ b/lib/datadog/tracing/remote.rb
@@ -219,6 +219,9 @@ module Datadog
           end
 
           if (di_enabled = lib_config["dynamic_instrumentation_enabled"]) != nil # rubocop:disable Style/NonNilCheck
+            # Coerce to a boolean so the value matches the handle_rc_enablement
+            # contract regardless of the JSON type the backend sent.
+            di_enabled = di_enabled ? true : false
             # repository is forwarded so that an enable signal can reconcile DI
             # against probes delivered in an earlier poll while DI was stopped
             # (see Datadog::DI::Remote.handle_rc_enablement).

--- a/sig/datadog/appsec/remote.rbs
+++ b/sig/datadog/appsec/remote.rbs
@@ -58,7 +58,7 @@ module Datadog
 
       def self.remote_features_enabled?: () -> bool
 
-      def self.parse_content: (Datadog::Core::Remote::Configuration::Content content) -> ::Hash[::String, untyped]
+      def self.parse_content: (Datadog::Core::Remote::Configuration::Content content) -> ::Hash[::String, Datadog::Helpers::json]
     end
   end
 end

--- a/sig/datadog/core/remote/configuration/digest.rbs
+++ b/sig/datadog/core/remote/configuration/digest.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Remote
       class Configuration
         class DigestList < Array[Digest]
-          def self.parse: (::Hash[::String, untyped] hash) -> DigestList
+          def self.parse: (::Hash[::String, Datadog::Helpers::json] hash) -> DigestList
 
           def check: (Datadog::Core::Remote::Configuration::Content content) -> bool
         end

--- a/sig/datadog/core/remote/configuration/target.rbs
+++ b/sig/datadog/core/remote/configuration/target.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Remote
       class Configuration
         class TargetMap < Hash[Configuration::Path, Configuration::Target]
-          def self.parse: (::Hash[::String, untyped] hash) -> TargetMap
+          def self.parse: (::Hash[::String, Datadog::Helpers::json] hash) -> TargetMap
 
           attr_reader opaque_backend_state: ::String?
 
@@ -20,7 +20,7 @@ module Datadog
 
           attr_reader version: Integer
 
-          def self.parse: (::Hash[::String, untyped] hash) -> Target
+          def self.parse: (::Hash[::String, Datadog::Helpers::json] hash) -> Target
 
           def initialize: (digests: DigestList, length: ::Integer, version: Integer) -> void
 

--- a/sig/datadog/di/remote.rbs
+++ b/sig/datadog/di/remote.rbs
@@ -19,7 +19,7 @@ module Datadog
 
       private
 
-      def self.parse_content: (Core::Remote::Configuration::Content content) -> Hash[String, untyped]
+      def self.parse_content: (Core::Remote::Configuration::Content content) -> Hash[String, Datadog::Helpers::json]
 
       def self.replay_current_probes: (Core::Remote::Configuration::Repository repository, Component component) -> void
       def self.probe_known?: (untyped probe_id, Component component) -> bool

--- a/sig/datadog/tracing/remote.rbs
+++ b/sig/datadog/tracing/remote.rbs
@@ -10,15 +10,14 @@ module Datadog
 
       def self.capabilities: () -> ::Array[::Integer]
 
-      # config and lib_config are parsed JSON of a backend-defined shape, so their
-      # element types are genuinely untyped (not yet modelled by a schema).
+      # config and lib_config are parsed JSON of a backend-defined shape.
       def self.merge_and_apply_configs: (Core::Remote::Configuration::Repository repository) -> void
 
-      def self.config_matches?: (::Hash[::String, untyped] config, ::String? service, ::String? env) -> bool
+      def self.config_matches?: (::Hash[::String, Datadog::Helpers::json] config, ::String? service, ::String? env) -> bool
 
-      def self.config_priority: (::Hash[::String, untyped] config) -> ::Integer
+      def self.config_priority: (::Hash[::String, Datadog::Helpers::json] config) -> ::Integer
 
-      def self.merge_lib_configs: (::Array[::Hash[::String, untyped]] configs_most_specific_first) -> ::Hash[::String, untyped]
+      def self.merge_lib_configs: (::Array[::Hash[::String, Datadog::Helpers::json]] configs_most_specific_first) -> ::Hash[::String, untyped]
 
       def self.apply_lib_config: (::Hash[::String, untyped] lib_config, Core::Remote::Configuration::Repository? repository) -> void
 
@@ -28,7 +27,7 @@ module Datadog
 
       private
 
-      def self.parse_content: (Core::Remote::Configuration::Content content) -> ::Hash[::String, untyped]
+      def self.parse_content: (Core::Remote::Configuration::Content content) -> ::Hash[::String, Datadog::Helpers::json]
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

Types `untyped` in RC payloads.

This typing exposed lack of runtime verification prior to digging into the payloads, which this PR also adds.

**Motivation:**

100% typing of the codebase

**Change log entry**

None. 

**Additional Notes:**

This PR will be updated after #6234 is merged since the latter touches the same code.

**How to test the change?**

Existing CI