### PR TITLE
Surface RSpec failures as GitHub Actions annotations

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -31,11 +31,6 @@ runs:
       COVERAGE_DIR: coverage/versions/${{ inputs.alias }}/${{ inputs.container-id }}
       CI_TEST_SEED: "${{ github.run_id }}"
 
-  - name: Annotate test failures
-    if: ${{ failure() }}
-    run: bundle exec rake github:annotate_test_failures
-    shell: bash
-
   - name: Display debug info
     if: ${{ !cancelled() }}
     shell: bash

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -31,6 +31,11 @@ runs:
       COVERAGE_DIR: coverage/versions/${{ inputs.alias }}/${{ inputs.container-id }}
       CI_TEST_SEED: "${{ github.run_id }}"
 
+  - name: Annotate test failures
+    if: ${{ failure() }}
+    run: bundle exec rake github:annotate_test_failures
+    shell: bash
+
   - name: Display debug info
     if: ${{ !cancelled() }}
     shell: bash

--- a/.rspec-local.example
+++ b/.rspec-local.example
@@ -1,6 +1,9 @@
 <% require 'digest' %>
 --require spec_helper
 --require ./spec/support/deterministic_junit_formatter
+--require ./spec/support/failures_only_formatter
 --format documentation
 --format DeterministicJunitFormatter
 --out <%= "tmp/rspec/" + Digest::MD5.hexdigest(ENV['BUNDLE_GEMFILE'] + ARGV.join) + ".xml" %>
+--format FailuresOnlyFormatter
+--out tmp/rspec/failures.txt

--- a/.rspec-local.example
+++ b/.rspec-local.example
@@ -6,4 +6,4 @@
 --format DeterministicJunitFormatter
 --out <%= "tmp/rspec/" + Digest::MD5.hexdigest(ENV['BUNDLE_GEMFILE'] + ARGV.join) + ".xml" %>
 --format FailuresOnlyFormatter
---out tmp/rspec/failures.txt
+--out <%= ENV.fetch('RSPEC_FAILURES_FILE', 'tmp/rspec/failures.txt') %>

--- a/spec/support/failures_only_formatter.rb
+++ b/spec/support/failures_only_formatter.rb
@@ -1,0 +1,22 @@
+# Runs alongside other formatters without affecting their output;
+# each formatter only sees the notifications it registers for.
+#
+# Usage in .rspec or via RSPEC_OPTS:
+#   --require ./spec/support/failures_only_formatter
+#   --format FailuresOnlyFormatter
+#   --out failures.txt
+
+require "rspec/core/formatters/base_text_formatter"
+
+class FailuresOnlyFormatter < RSpec::Core::Formatters::BaseTextFormatter
+  RSpec::Core::Formatters.register self, :dump_failures, :dump_summary
+
+  def message(_notification)
+  end
+
+  def dump_pending(_notification)
+  end
+
+  def seed(_notification)
+  end
+end

--- a/spec/support/failures_only_formatter.rb
+++ b/spec/support/failures_only_formatter.rb
@@ -9,7 +9,7 @@
 require "rspec/core/formatters/base_text_formatter"
 
 class FailuresOnlyFormatter < RSpec::Core::Formatters::BaseTextFormatter
-  RSpec::Core::Formatters.register self, :dump_failures, :dump_summary
+  RSpec::Core::Formatters.register self, :dump_failures, :dump_summary, :seed
 
   def message(_notification)
   end
@@ -17,6 +17,16 @@ class FailuresOnlyFormatter < RSpec::Core::Formatters::BaseTextFormatter
   def dump_pending(_notification)
   end
 
-  def seed(_notification)
+  def dump_summary(summary)
+    super
+    @dumped_summary = true
+  end
+
+  # RSpec notifies :seed twice (once before the run starts, once after the
+  # summary); only the second carries the seed actually used.
+  def seed(notification)
+    return unless @dumped_summary
+
+    super
   end
 end

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -141,16 +141,15 @@ namespace :github do
 
     title = escape_annotation("RSpec failure: #{repro_command}")
 
-    if content.bytesize <= annotation_size_threshold
-      body = "#{title}\n\n#{content}"
-      puts "::error title=#{title}::#{escape_annotation(body)}"
-      body
+    summary = if content.bytesize <= annotation_size_threshold
+      content
     else
-      summary = content[/^Failed examples:.*/m] || content
-      body = "#{title}\n\n#{summary}"
-      puts "::error title=#{title}::#{escape_annotation(body)}"
-      body
+      content[/^Failed examples:.*/m] || content
     end
+
+    body = "#{title}\n\n#{summary}"
+    puts "::error title=#{title}::#{escape_annotation(body)}"
+    body
   end
 
   def escape_annotation(text)

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -135,6 +135,8 @@ namespace :github do
     else
       titles = content.scan(/^rspec \S+:\d+ # (.+)$/).map(&:first)
       summary = titles.map { |title| "- #{title}" }.join("\n")
+      seed_line = content[/^Randomized with seed \d+$/]
+      summary = "#{summary}\n\n#{seed_line}" if seed_line
       puts "::error title=RSpec failures (#{titles.length}, see logs for details)::#{escape_annotation(summary)}"
     end
   end

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -120,7 +120,7 @@ namespace :github do
   end
 
   task :annotate_test_failures do
-    file = "tmp/rspec/failures.txt"
+    file = ENV.fetch("RSPEC_FAILURES_FILE", "tmp/rspec/failures.txt")
     next unless File.exist?(file)
 
     content = File.read(file)

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -110,7 +110,13 @@ namespace :github do
       cmd = "bundle exec rake spec:#{task["task"]}'[--seed #{rng.rand(0xFFFF)}]'"
 
       junit_files_before = Dir["tmp/rspec/*.xml"]
-      Bundler.with_unbundled_env { sh(env, cmd) }
+
+      begin
+        Bundler.with_unbundled_env { sh(env, cmd) }
+      rescue RuntimeError
+        raise annotate_test_failures(env, cmd)
+      end
+
       junit_files_after = Dir["tmp/rspec/*.xml"] - junit_files_before
 
       [task["task"], junit_files_after.sum { |file| junit_suite_time(file) }]
@@ -119,25 +125,31 @@ namespace :github do
     report_task_durations(durations)
   end
 
-  task :annotate_test_failures do
+  def annotate_test_failures(env, cmd)
+    env_prefix = env.map { |k, v| "#{k}=#{v}" }.join(" ")
+    repro_command = "#{env_prefix} #{cmd}"
+
     file = ENV.fetch("RSPEC_FAILURES_FILE", "tmp/rspec/failures.txt")
-    next unless File.exist?(file)
+    return "RSpec failure" unless File.exist?(file)
 
     content = File.read(file)
-    next if content.strip.empty?
+    return "RSpec failure" if content.strip.empty?
 
     # GitHub Actions truncates large annotations in the UI; above this size,
     # fall back to failed example titles only.
     annotation_size_threshold = 4096
 
+    title = escape_annotation("RSpec failure: #{repro_command}")
+
     if content.bytesize <= annotation_size_threshold
-      puts "::error title=RSpec failure::#{escape_annotation(content)}"
+      body = "#{title}\n\n#{content}"
+      puts "::error title=#{title}::#{escape_annotation(body)}"
+      body
     else
-      titles = content.scan(/^rspec \S+:\d+ # (.+)$/).map(&:first)
-      summary = titles.map { |title| "- #{title}" }.join("\n")
-      seed_line = content[/^Randomized with seed \d+$/]
-      summary = "#{summary}\n\n#{seed_line}" if seed_line
-      puts "::error title=RSpec failures (#{titles.length}, see logs for details)::#{escape_annotation(summary)}"
+      summary = content[/^Failed examples:.*/m] || content
+      body = "#{title}\n\n#{summary}"
+      puts "::error title=#{title}::#{escape_annotation(body)}"
+      body
     end
   end
 

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -119,6 +119,30 @@ namespace :github do
     report_task_durations(durations)
   end
 
+  task :annotate_test_failures do
+    file = "tmp/rspec/failures.txt"
+    next unless File.exist?(file)
+
+    content = File.read(file)
+    next if content.strip.empty?
+
+    # GitHub Actions truncates large annotations in the UI; above this size,
+    # fall back to failed example titles only.
+    annotation_size_threshold = 4096
+
+    if content.bytesize <= annotation_size_threshold
+      puts "::error title=RSpec failure::#{escape_annotation(content)}"
+    else
+      titles = content.scan(/^rspec \S+:\d+ # (.+)$/).map(&:first)
+      summary = titles.map { |title| "- #{title}" }.join("\n")
+      puts "::error title=RSpec failures (#{titles.length}, see logs for details)::#{escape_annotation(summary)}"
+    end
+  end
+
+  def escape_annotation(text)
+    text.gsub("%", "%25").gsub("\r", "%0D").gsub("\n", "%0A")
+  end
+
   def junit_suite_time(file)
     File.read(file)[/<testsuite\b[^>]*\btime="([\d.]+)"/, 1].to_f
   rescue Errno::ENOENT


### PR DESCRIPTION
**What does this PR do?**
Adds a GitHub Actions annotation with the RSpec failure output on a failed test job.
<img width="1614" height="826" alt="Screenshot 2026-08-31 at 13 48 44" src="https://github.com/user-attachments/assets/f0292b17-9d8f-44af-8d9a-827522ab6cfd" />


**Motivation:**
Today, seeing why a test job failed means scrolling to the bottom of the raw build log. This surfaces the failure directly on the PR and run summary instead.

**Change log entry**
None.

**Additional Notes:**
Large failure output falls back to a list of failed example titles, since GitHub truncates large annotations. The output path is configurable via `RSPEC_FAILURES_FILE`.

**How to test the change?**
Verified locally against real passing/failing specs: failure output, formatter isolation, and the size-based annotation fallback all behave as expected.