### PR TITLE
Fix flaky `#recorder_heap_update` specs when Ruby keeps an object alive

### DIFF
--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -808,14 +808,18 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
                 described_class::Testing._native_start_fake_slow_heap_serialization(stack_recorder)
 
-                test_record_id = sample_and_clear
+                # `ensure` because `sample_and_clear` can `skip` out of the example, and we don't want to leave the
+                # fake serialization dangling when it does
+                begin
+                  test_record_id = sample_and_clear
 
-                expect do
-                  described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
-                  recorder_heap_update
-                end.to_not change { is_object_recorded?(test_record_id) }.from(true)
-
-                described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
+                  expect do
+                    described_class::Testing._native_heap_recorder_reset_last_update(stack_recorder)
+                    recorder_heap_update
+                  end.to_not change { is_object_recorded?(test_record_id) }.from(true)
+                ensure
+                  described_class::Testing._native_end_fake_slow_heap_serialization(stack_recorder)
+                end
 
                 # Sanity: after serialization finishes, we can finally clear it
                 expect do

--- a/spec/datadog/profiling/stack_recorder_spec.rb
+++ b/spec/datadog/profiling/stack_recorder_spec.rb
@@ -752,13 +752,30 @@ RSpec.describe Datadog::Profiling::StackRecorder do
             # Doing this on the main thread instead made these examples flaky on CI: the object would survive the
             # GC below and the recorder would (correctly!) keep reporting it. That's the same class of problem the
             # enclosing `before` documents, see https://bugs.ruby-lang.org/issues/19460.
-            record_id = Thread.new { sample_allocation(Object.new) }.value
+            #
+            # That's still not airtight, though: the conservative garbage collector also scans the main thread, and a
+            # stale value there that happens to look like a pointer to our object keeps the object alive. While that
+            # happens the recorder is right to keep reporting the object, so there's nothing left for these examples
+            # to check. We record a weak reference of our own so we can ask Ruby whether the object is really gone and
+            # bail out instead of flaking. (Seen on CI as `[true, false, false, false]` for the oldest object.)
+            record_id = Thread.new do
+              object = Object.new
+              id = sample_allocation(object)
+              @sampled_objects[id] = object
+              id
+            end.value
             GC.start
+
+            skip "Ruby's conservative GC kept the sampled object alive" unless @sampled_objects[record_id].nil?
+
             record_id
           end
 
           before do
             GC.disable
+
+            # Weak references to the objects tracked below, so we can check whether Ruby really collected them
+            @sampled_objects = ObjectSpace::WeakMap.new
 
             @record_ids = Array.new(4) { sample_and_clear }
           end
@@ -779,10 +796,9 @@ RSpec.describe Datadog::Profiling::StackRecorder do
 
               stack_recorder.serialize
 
-              GC.enable
-              GC.start
-
-              # Older objects are only cleared at serialization time
+              # Older objects are only cleared at serialization time. (No `GC.start` needed here: records are only
+              # ever dropped by a heap recorder update, and `sample_and_clear` already made sure Ruby collected the
+              # objects.)
               expect(@record_ids.map { |it| is_object_recorded?(it) }).to eq [false, false, false, false]
             end
 


### PR DESCRIPTION
Fixes https://github.com/DataDog/ruby-guild/issues/323

This is not ideal but not sure what we can do.
This PR skips if the conservative GC keeps the object alive unexpectedly.
An alternative would be "do nothing since it should be a very rare transient", but not sure that's OK and unclear what's the frequency of it at this point.

I guess let's wait a bit and if it happens frequently enough let's merge this or some other fix, and if not, good as-is.

---

These examples need the objects they sample to actually be garbage collected: the heap recorder only drops a record once Ruby reports the object as gone. Allocating and sampling on a joined thread removed the child thread's machine stack and registers as hiding places for a stale reference, but not the main thread's -- Ruby's conservative garbage collector still occasionally decides one of these objects is reachable.

We saw this on CI (macOS, Ruby 3.3) as

    expected: [false, false, false, false]
         got: [true, false, false, false]

with the heap recorder debug dump confirming the full update ran and skipped nothing, so the weak reference for the oldest object was still live at serialization time and the recorder was right to keep reporting it. The object was only collected by the `GC.start` that followed.

Have `sample_and_clear` register a weak reference of its own, so the examples can tell "Ruby kept the object alive" apart from "the recorder failed to drop the record" and skip rather than fail in the former case.

Also drop the `GC.enable`/`GC.start` between `serialize` and the last expectation: records are only ever removed by a heap recorder update, so those lines could not affect the result, and without them the expectation shows that serialization is what cleared the older objects.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

**Motivation:**
<!-- What inspired you to submit this pull request? -->

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
