### PR TITLE
Always use Datadog::Core::Utils::Time.now

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,6 @@ no external grant needed. No local trigger otherwise.
 
 - Use `Core::Utils::EnumerableCompat.filter_map` instead of `filter_map` for compatibility with Ruby 2.5 and 2.6 (native `filter_map` requires Ruby 2.7+).
 - Use `Datadog::Core::Utils::Time.now` instead of `Time.now` everywhere. The time provider is configurable (for example, for Timecop support), and tests can override it via `Core::Utils::Time.now_provider=`.
-  - Constants initialized at load time, before user configuration, may use `::Time.now` directly; add a comment explaining why (see `lib/datadog/profiling/collectors/info.rb` for an example).
-  - Dynamic Instrumentation probe instrumentation that runs inside customer application methods must use `::Time.now` directly. DI must never invoke customer-provided code during instrumentation.
 
 ## Documentation
 

--- a/lib/datadog/profiling/collectors/info.rb
+++ b/lib/datadog/profiling/collectors/info.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "set"
-require "time"
 require "libdatadog"
+require_relative "../../core/utils/time"
 
 module Datadog
   module Profiling
@@ -71,10 +70,7 @@ module Datadog
         # Instead of trying to figure out real process start time by checking
         # /proc or some other complex/non-portable way, approximate start time
         # by time of requirement of this file.
-        #
-        # Note: this does not use Core::Utils::Time.now because this constant
-        # gets initialized before a user has a chance to configure the library.
-        START_TIME = Time.now.utc.freeze
+        START_TIME = Datadog::Core::Utils::Time.now.utc.freeze
 
         #: () -> ::Hash[::Symbol, untyped]
         def collect_platform_info


### PR DESCRIPTION
* That is no longer configurable (since https://github.com/DataDog/dd-trace-rb/pull/6010) and is the reliable non-monkey-patched current time.

<!--
Check out the
https://github.com/DataDog/dd-trace-rb/blob/master/docs/DevelopmentGuide.md
for guidance on how to set up your development environment,
run the test suite, write new integrations, and more.
-->

**What does this PR do?**
^

**Motivation:**
<!-- What inspired you to submit this pull request? -->
Keep things consistent and simple, this now work reliably so we don't need any exception to the rule anymore.

**Change log entry**
<!--
If you are a Datadog employee:

If this is a customer-visible change, use:
`Yes. A brief summary to be placed into the CHANGELOG.md`
Or opt out with `None/No/Nope`.

This will be the ONLY mention of the change in the release notes;
it should be self-contained and understandable by customers.

If you are not a Datadog employee:

You can skip this section and it will be filled or deleted during PR review.
Please do not remove this section from the PR though.
-->
None

**Additional Notes:**
<!--
If you used AI, have you read and understood what AI wrote?

Anything else we should know when reviewing?
-->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

<!-- Unsure? Have a question? Request a review! -->
