### PR TITLE
Skip flaky "closes tracer file descriptors" spec

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Datadog integration" do
       }x.freeze
       # standard:enable Lint/ConstantDefinitionInBlock:
 
-      it "closes tracer file descriptors" do
+      it "closes tracer file descriptors", skip: "Flaky: intermittently fails in CI with leaked file descriptors, cause not yet identified" do
         before_open_file_descriptors = open_file_descriptors
 
         start_tracer


### PR DESCRIPTION
**What does this PR do?**
Skips the `"closes tracer file descriptors"` spec.

**Motivation:**
Flaky in CI with unexplained leaked file descriptors, e.g. https://github.com/DataDog/dd-trace-rb/actions/runs/33800192164

**Change log entry**
None.

**Additional Notes:**
Doesn't fix the underlying leak (if any); just stops the noise.

**How to test the change?**
N/A — test-only change.