### PR TITLE
Suppress GHSA-rmxg-5p3r-j6hh for pinned graphql appraisal versions

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -113,3 +113,22 @@ ignore_gem_versions:
   - gem: rack-contrib
     version: 1.8.0
     reason: "rack-contrib >= 2.0.0 (fixed for CVE-2024-35231) requires Rack::MediaType, unavailable before Rack 2.0; rack_1 appraisal intentionally tests Rack 1.x"
+
+  - gem: graphql
+    version: 1.13.25
+    reason: "Ceiling of graphql ~> 1.13.0 constraint in graphql-1.13 appraisal; intentionally tests old graphql major version, no fixed 1.13.x release exists for GHSA-rmxg-5p3r-j6hh"
+  - gem: graphql
+    version: 2.0.32
+    reason: "Ceiling of graphql ~> 2.0.0 constraint in graphql-2.0 appraisal; intentionally tests old graphql minor version, no fixed 2.0.x release exists for GHSA-rmxg-5p3r-j6hh"
+  - gem: graphql
+    version: 2.1.15
+    reason: "Ceiling of graphql ~> 2.1.0 constraint in graphql-2.1 appraisal; intentionally tests old graphql minor version, no fixed 2.1.x release exists for GHSA-rmxg-5p3r-j6hh"
+  - gem: graphql
+    version: 2.2.17
+    reason: "Ceiling of graphql ~> 2.2.0 constraint in graphql-2.2 appraisal; intentionally tests old graphql minor version, no fixed 2.2.x release exists for GHSA-rmxg-5p3r-j6hh"
+  - gem: graphql
+    version: 2.3.22
+    reason: "Ceiling of graphql ~> 2.3.0 constraint in graphql-2.3 appraisal; intentionally tests old graphql minor version, no fixed 2.3.x release exists for GHSA-rmxg-5p3r-j6hh"
+  - gem: graphql
+    version: 2.3.23
+    reason: "Ceiling of graphql ~> 2.3.0 constraint in graphql-2.3 appraisal; intentionally tests old graphql minor version, no fixed 2.3.x release exists for GHSA-rmxg-5p3r-j6hh"


### PR DESCRIPTION
**What does this PR do?**
Adds `ignore_gem_versions` entries in `.bundler-audit.yml` for the graphql versions pinned by the `graphql-{1.13,2.0,2.1,2.2,2.3}` appraisals, suppressing the `GHSA-rmxg-5p3r-j6hh` advisory for those exact gem+version pairs.

**Motivation:**
`bundle exec rake dependency:audit` started flagging `GHSA-rmxg-5p3r-j6hh` across all 25 graphql lockfiles in the test matrix. The fix for this advisory only landed upstream in graphql-ruby 2.6.9, but the affected appraisals intentionally pin older graphql majors/minors (`~> 1.13.0`, `~> 2.0.0`, etc.) for backward-compatibility test coverage, so they can't be bumped to pick up the fix.

**Change log entry**
None.

**Additional Notes:**
None.

**How to test the change?**
Ran `bundle exec rake dependency:audit`, which now reports no high/critical advisories.