### PR TITLE
Reproduce flaky: closes tracer file descriptors

### DIFF
--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -55,6 +55,38 @@ RSpec.describe "Datadog integration" do
         nil
       end
 
+      # Classify a leaked socket fd by inode into AF_UNIX/TCP/UDP with peer
+      # info, by reading /proc/net/{unix,tcp,tcp6,udp,udp6}. Returns a
+      # short string for the failure message so CI identifies the source.
+      def classify_socket(fd_path)
+        target = File.readlink(fd_path)
+        unless target =~ /socket:\[(\d+)\]/
+          return "#{fd_path} -> #{target} (not a socket)"
+        end
+        inode = $1
+        begin
+          File.readlines("/proc/net/unix").each do |line|
+            cols = line.split
+            return "AF_UNIX path=#{cols[7..].join(' ')}" if cols[6] == inode
+          end
+        rescue SystemCallError
+          nil
+        end
+        for proto in %w[tcp tcp6 udp udp6]
+          begin
+            File.readlines("/proc/net/#{proto}").each do |line|
+              cols = line.split
+              return "#{proto.upcase} local=#{cols[1]} remote=#{cols[2]} st=#{cols[3]}" if cols.last == inode
+            end
+          rescue SystemCallError
+            nil
+          end
+        end
+        "socket inode=#{inode} (unclassified)"
+      rescue SystemCallError
+        "#{fd_path} (unreadable)"
+      end
+
       # On JRuby, there are file descriptors opened that resolve to these
       # paths via File.readlink:
       #
@@ -88,13 +120,26 @@ RSpec.describe "Datadog integration" do
       }x.freeze
       # standard:enable Lint/ConstantDefinitionInBlock:
 
-      it "closes tracer file descriptors", skip: "Flaky: intermittently fails in CI with leaked file descriptors, cause not yet identified" do
+      it "closes tracer file descriptors" do
         before_open_file_descriptors = open_file_descriptors
 
-        start_tracer
-        wait_for_tracer_sent
-
-        shutdown
+        # Reproducer: repeat the configure/trace/flush/shutdown cycle to widen
+        # the race window that intermittently leaks sockets in CI (~1/80 per
+        # cycle). 100 cycles give ~70% probability of surfacing the leak in a
+        # single run. Each iteration resets and rebuilds components so the
+        # transport's success counter starts at zero and wait_for_tracer_sent
+        # actually waits for a real flush.
+        #
+        # Calls Datadog::Tracing.trace and Datadog.shutdown! directly (not the
+        # `start_tracer` let / `shutdown` subject) because those are memoized
+        # per example and would only run once across the loop.
+        100.times do
+          Datadog.send(:reset!)
+          Datadog.configure { |c| }
+          Datadog::Tracing.trace("test.op") {}
+          wait_for_tracer_sent
+          Datadog.shutdown!
+        end
 
         after_open_file_descriptors = open_file_descriptors
 
@@ -141,9 +186,11 @@ RSpec.describe "Datadog integration" do
             # from time to time.
             be_empty,
             lambda {
+              classification = new_file_descriptors.keys.map { |k| "  #{k}: #{classify_socket(k)}" }.join("\n")
               "Open fds before (#{before_open_file_descriptors.size}): #{before_open_file_descriptors}\n" \
               "Open fds after (#{after_open_file_descriptors.size}):  #{after_open_file_descriptors}\n" \
-              "New fds (#{new_file_descriptors.size}): #{new_file_descriptors}"
+              "New fds (#{new_file_descriptors.size}): #{new_file_descriptors}\n" \
+              "Classification:\n#{classification}"
             }
           )
       end

--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -123,23 +123,10 @@ RSpec.describe "Datadog integration" do
       it "closes tracer file descriptors" do
         before_open_file_descriptors = open_file_descriptors
 
-        # Reproducer: repeat the configure/trace/flush/shutdown cycle to widen
-        # the race window that intermittently leaks sockets in CI (~1/80 per
-        # cycle). 100 cycles give ~70% probability of surfacing the leak in a
-        # single run. Each iteration resets and rebuilds components so the
-        # transport's success counter starts at zero and wait_for_tracer_sent
-        # actually waits for a real flush.
-        #
-        # Calls Datadog::Tracing.trace and Datadog.shutdown! directly (not the
-        # `start_tracer` let / `shutdown` subject) because those are memoized
-        # per example and would only run once across the loop.
-        100.times do
-          Datadog.send(:reset!)
-          Datadog.configure { |c| }
-          Datadog::Tracing.trace("test.op") {}
-          wait_for_tracer_sent
-          Datadog.shutdown!
-        end
+        start_tracer
+        wait_for_tracer_sent
+
+        shutdown
 
         after_open_file_descriptors = open_file_descriptors
 

--- a/spec/datadog/integration_spec.rb
+++ b/spec/datadog/integration_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Datadog integration" do
         begin
           File.readlines("/proc/net/unix").each do |line|
             cols = line.split
-            return "AF_UNIX path=#{cols[7..].join(' ')}" if cols[6] == inode
+            return "AF_UNIX path=#{cols[7..-1].join(' ')}" if cols[6] == inode
           end
         rescue SystemCallError
           nil


### PR DESCRIPTION
**What does this PR do?**

Reproducer for the flaky test `spec/datadog/integration_spec.rb:123` (`Datadog integration graceful shutdown for file descriptors closes tracer file descriptors`). It unskips the spec (currently skipped by [#6281](https://github.com/DataDog/dd-trace-rb/pull/6281)) and adds socket classification (AF_UNIX/TCP/UDP + peer) to the failure message so CI identifies the leak source when it reproduces.

**Do not merge** — this PR exists for CI validation only.

**Motivation:**

Flaky test [`Ruby 3.4 / build & test (standard) [0]` on run 33800192164](https://github.com/DataDog/dd-trace-rb/actions/runs/33800192164) (scheduled master, 2026-09-03). The same job ran the suite twice: seed 2008 passed (0 failures), seed 26922 failed on this test only. All other Ruby versions passed in the same run. [#6281](https://github.com/DataDog/dd-trace-rb/pull/6281) skipped the test with "cause not yet identified"; no tracking issue exists.

The captured CI failure leaks exactly 2 sockets that survive `Datadog.shutdown!`:
```
New fds (2): {"/dev/fd/10" => socket:[40483], "/dev/fd/12" => socket:[40481]}
```

**Hypothesis (revised):** The leak is **cross-test**, not in-test. The CI "before" snapshot already had sockets (fds 9, 11) leaked by *prior* tests that survived `Datadog.send(:reset!)`. The FD test observes leftover sockets from earlier tests; it does not create them. An in-example 100× loop starts each iteration from a clean baseline and cleans up, so it never accumulates the cross-test pollution — confirmed by 16/16 CI trials passing with the loop (the leak did not fire). The full-suite CI run is therefore the reproducer; the classification in the failure message identifies the leaked socket source when it fires.

Rejected hypotheses (with evidence): crashtracker socketpair (`strace` shows `ddog_crasht_init` does 0 fork/exec/socketpair in libdatadog 40.0.0); `agent_info.fetch`/trace flush leaks (0 leaked in direct diag); failed/slow connection leaks (0 leaked against a dead port); crashtracker reconfigure accumulation (0 sockets across 10 rebuild cycles); health_metrics statsd UDP socket (lazy open + disabled); telemetry/remote/data_streams/appsec/profiling/DI (all disabled in CI); cumulative `stats.success` (per-instance, resets on rebuild); in-example 100× loop (16/16 CI trials passed — leak is cross-test, not in-test).

**Reproducer technique:** Unskip the test and add socket classification (AF_UNIX path / TCP peer / UDP peer) to the failure message by reading `/proc/net/{unix,tcp,tcp6,udp,udp6}`. The full `spec:main` suite run is the reproducer — the leak fires when prior tests leave sockets that survive `reset!`, and the classification identifies the source.

**Platform-specific:** The leak is CI-only (does not reproduce locally across isolated runs, full `spec:main` runs with the exact CI gemfile + seed, or 100-cycle loops). Per the flaky-test investigation skill, a platform-specific reproducer is pushed to the target platform's CI as the validation environment.

**Change log entry**

None.

**How to test the change?**

CI should show the test failing intermittently with a `Classification:` section in the failure message identifying the leaked sockets. The flake is ~1/80 CI runs, so multiple runs may be needed to reproduce. If CI passes consistently, the leak requires conditions not captured by the standard suite ordering.