### PR TITLE
Pin images-rb trust policy back to refs/heads/main

### DIFF
--- a/.github/chainguard/images-rb.notify-consumers.sts.yaml
+++ b/.github/chainguard/images-rb.notify-consumers.sts.yaml
@@ -1,13 +1,16 @@
 issuer: https://token.actions.githubusercontent.com
 
-# Caller: images-rb's notify-consumers.yml. Any branch, since it can be
-# manually dispatched pre-merge to send an early pin-update.
-subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/.+"
+# Caller: images-rb's notify-consumers.yml. Pinned to main so only the
+# reviewed workflow definition on main can mint this contents:write token --
+# do not relax to another ref pattern. notify-consumers.yml is only ever
+# intended to run from main (manual dispatch is documented as `--ref main`),
+# so nothing is lost by pinning here.
+subject_pattern: "repo:DataDog/images-rb:ref:refs/heads/main"
 
 claim_pattern:
   event_name: workflow_run|workflow_dispatch
   repository: DataDog/images-rb
-  job_workflow_ref: DataDog/images-rb/\.github/workflows/notify-consumers\.yml@refs/heads/.+
+  job_workflow_ref: DataDog/images-rb/\.github/workflows/notify-consumers\.yml@refs/heads/main
 
 permissions:
   contents: write


### PR DESCRIPTION
**What does this PR do?**
Pins `images-rb.notify-consumers.sts.yaml`'s OIDC claims back to `refs/heads/main`, reverting the `refs/heads/.+` wildcard from 0437367e.

**Motivation:**
The wildcard lets any branch in images-rb mint a `contents:write` token here. The wildcard was meant to support pre-merge manual dispatch, but images-rb's `notify-consumers.yml` only documents `--ref main` dispatch, so nothing is lost by pinning back.

**Change log entry**
None/No

**Additional Notes:**
No images-rb change needed — pre-merge image testing is already covered by its per-commit tags, built on every branch push.

**How to test the change?**
Config-only change; validated by confirming notify-consumers.yml's only supported invocations (main workflow_run, documented `--ref main` dispatch) still satisfy the pinned pattern.