### PR TITLE
[NO-TICKET] Profiling: Avoid nesting inside `handle_sampling_signal`

### DIFF
--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -1283,14 +1283,16 @@ void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
 
   // Since this is not a real signal firing, we need to block SIGPROF delivery on this thread to avoid an actual SIGPROF
   // signal coming in nested and interrupting us on this thread. Thus we respect the invariant of "no nesting" for `handle_sampling_signal`.
-  block_sigprof_signal_handler_from_running_in_current_thread();
+  //
+  // Not needed when `no_signals_workaround_enabled` is set: no SIGPROFs are ever sent in that mode, so there's nothing to mask.
+  if (!state->no_signals_workaround_enabled) block_sigprof_signal_handler_from_running_in_current_thread();
 
   state->stats.simulated_signal_delivery++;
 
   // `handle_sampling_signal` does a few things extra on top of `sample_from_postponed_job` so that's why we don't shortcut here
   handle_sampling_signal(0, NULL, NULL);
 
-  unblock_sigprof_signal_handler_from_running_in_current_thread();
+  if (!state->no_signals_workaround_enabled) unblock_sigprof_signal_handler_from_running_in_current_thread();
 
   return NULL; // Unused
 }

--- a/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
+++ b/ext/datadog_profiling_native_extension/collectors_cpu_and_wall_time_worker.c
@@ -740,6 +740,8 @@ static void handle_sampling_signal(DDTRACE_UNUSED int _signal, DDTRACE_UNUSED si
   // a) we get triggered using SIGPROF, and the docs state a second SIGPROF will not interrupt an existing one (see sigaction docs on sa_mask)
   // b) we validate we are in the thread that has the global VM lock; if a different thread gets a signal, it will return early
   //    because it will not have the global VM lock
+  // c) `simulate_sampling_signal_delivery` calls us directly instead of via a real SIGPROF, and blocks SIGPROF delivery on its
+  //    thread for the duration of that call, so it can't be nested into by a real SIGPROF either
 
   state->stats.signal_handler_enqueued_sample++;
 
@@ -1279,10 +1281,16 @@ void *simulate_sampling_signal_delivery(DDTRACE_UNUSED void *_unused) {
   // This can potentially happen if the CpuAndWallTimeWorker was stopped while the IdleSamplingHelper was trying to execute this action
   if (state == NULL) return NULL;
 
+  // Since this is not a real signal firing, we need to block SIGPROF delivery on this thread to avoid an actual SIGPROF
+  // signal coming in nested and interrupting us on this thread. Thus we respect the invariant of "no nesting" for `handle_sampling_signal`.
+  block_sigprof_signal_handler_from_running_in_current_thread();
+
   state->stats.simulated_signal_delivery++;
 
   // `handle_sampling_signal` does a few things extra on top of `sample_from_postponed_job` so that's why we don't shortcut here
   handle_sampling_signal(0, NULL, NULL);
+
+  unblock_sigprof_signal_handler_from_running_in_current_thread();
 
   return NULL; // Unused
 }


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a rare race I spotted when I was reviewing a PR earlier today: the `handle_sampling_signal` function documents itself as "cannot be nested" but actually the function could be nested if it got called from `simulate_sampling_signal_delivery`.

This is roughtly the (unlikely, but possible) chain of events leading to the issue:

1. Ruby is idle (no thread has GVL)
2. `CpuAndWallTimeWorker` thread in `run_sampling_trigger_loop` sees that no thread has GVL, uses `idle_sampling_helper_request_action(..., grab_gvl_and_sample)` to ask `IdleSamplingThread` to do work, then goes to sleep
3. `IdleSamplingThread` wakes up, grabs GVL, enters `handle_sampling_signal` via `simulate_sampling_signal_delivery`, and in the middle of that...
4. `CpuAndWallTimeWorker` thread wakes up in parallel, sees that there is a thread holding the GVL, and sends it a SIGPROF
5. If we get really unlucky with timing, there will be a call to `handle_sampling_signal` triggered by the SIGPROF that nests inside the existing `handle_sampling_signal`
6. It's unclear if anything bad could happen with the current implementation, but this is at least a footgun...

To fix this issue, the `simulate_sampling_signal_delivery` now actually blocks SIGPROF signals from arriving while it's working, so our assumption holds.

**Motivation:**

Fix rare race inside `handle_sampling_signal`.

**Change log entry**

Yes. Profiling: Fix potential race inside handle_sampling_signal

(I hesitated on if this is changelog-able or not, ended up choosing to do it)

**Additional Notes:**

There may be a bit of redundant work if the race above happens: `handle_sampling_signal` will still run twice whereas presumably it could run only once.

But since this is not expected to be very common, I decided to not do anything about it now.

**How to test the change?**

I didn't have good ideas on how to test it without a lot of noise in the production code... So for now I'm relying on the fact that we do have testing for
`block_sigprof_signal_handler_from_running_in_current_thread`/ `unblock_sigprof_signal_handler_from_running_in_current_thread` doing the correct thing, and our use here of them is very straightforward.