### PR TITLE
feat(openfeature): add agentless configuration delivery

### DIFF
--- a/lib/datadog/open_feature/agentless/configuration_source.rb
+++ b/lib/datadog/open_feature/agentless/configuration_source.rb
@@ -57,8 +57,8 @@ module Datadog
           @apply = apply
           @logger = logger
           @poll_interval_seconds = poll_interval_seconds
-          @random = random
-          @retry_wait = retry_wait || method(:wait_for_retry)
+          @random = random || -> { Kernel.rand }
+          @retry_wait = retry_wait || ->(delay) { wait_for_retry(delay) }
           @etag = nil
           @warned = {}
           @lifecycle_mutex = Mutex.new
@@ -140,7 +140,7 @@ module Datadog
           else
             clamp(@poll_interval_seconds / 3.0, SECOND_RETRY_MIN_SECONDS, SECOND_RETRY_MAX_SECONDS)
           end
-          random = @random ? @random.call : Kernel.rand
+          random = @random.call
           jitter = 1 - RETRY_JITTER + (random * RETRY_JITTER * 2)
           [1.0, base * jitter].max
         end
@@ -150,7 +150,7 @@ module Datadog
         end
 
         def wait_before_retry(delay)
-          @retry_wait ? @retry_wait.call(delay) : wait_for_retry(delay)
+          @retry_wait.call(delay)
         end
 
         def wait_for_retry(delay)
@@ -190,8 +190,8 @@ module Datadog
           end
 
           @apply.call(configuration)
-          @etag = response.etag.to_s.strip
-          @etag = nil if @etag.empty?
+          etag = response.etag.to_s.strip
+          @etag = etag.empty? ? nil : etag
         rescue EvaluationEngine::ReconfigurationError => error
           warn_once(:application) do
             @logger.warn("Feature Flags agentless UFC payload could not be applied: #{error.class}: #{error.message}")

--- a/lib/datadog/open_feature/agentless/configuration_source.rb
+++ b/lib/datadog/open_feature/agentless/configuration_source.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require_relative "../../core/workers/polling"
+require_relative "../evaluation_engine"
+require_relative "parser"
+require_relative "transport"
+
+module Datadog
+  module OpenFeature
+    module Agentless
+      # Polls the agentless endpoint and applies accepted configuration.
+      class ConfigurationSource
+        MAX_ATTEMPTS = 3
+        FIRST_RETRY_MIN_SECONDS = 2.0
+        FIRST_RETRY_MAX_SECONDS = 10.0
+        SECOND_RETRY_MIN_SECONDS = 5.0
+        SECOND_RETRY_MAX_SECONDS = 30.0
+        RETRY_JITTER = 0.2
+
+        include Core::Workers::Polling
+
+        attr_reader :etag
+
+        def self.build(settings, endpoint:, apply:, logger: Datadog.logger)
+          api_key = settings.api_key.to_s.strip
+          if endpoint.managed? && api_key.empty?
+            logger.warn("Feature Flags agentless delivery requires DD_API_KEY; agentless delivery is disabled")
+            return
+          end
+
+          new(
+            endpoint: endpoint,
+            api_key: api_key.empty? ? nil : api_key,
+            poll_interval_seconds: settings.open_feature.agentless_poll_interval_seconds,
+            request_timeout_seconds: settings.open_feature.agentless_request_timeout_seconds,
+            apply: apply,
+            logger: logger,
+          )
+        end
+
+        def initialize(
+          endpoint:,
+          api_key:,
+          poll_interval_seconds:,
+          request_timeout_seconds:,
+          apply:,
+          logger:,
+          transport: nil,
+          random: nil,
+          retry_wait: nil
+        )
+          @transport = transport || Transport.new(
+            endpoint: endpoint,
+            api_key: api_key,
+            timeout_seconds: request_timeout_seconds,
+          )
+          @apply = apply
+          @logger = logger
+          @poll_interval_seconds = poll_interval_seconds
+          @random = random
+          @retry_wait = retry_wait || method(:wait_for_retry)
+          @etag = nil
+          @warned = {}
+          @lifecycle_mutex = Mutex.new
+          @started = false
+          @stopped = false
+
+          self.enabled = true
+          self.fork_policy = Core::Workers::Async::Thread::FORK_POLICY_RESTART
+          self.loop_base_interval = poll_interval_seconds
+        end
+
+        def start
+          @lifecycle_mutex.synchronize do
+            return false if @stopped
+            return true if @started && !forked?
+
+            perform
+            @started = true
+          end
+
+          true
+        end
+
+        def stop
+          @lifecycle_mutex.synchronize do
+            return false if @stopped
+
+            @stopped = true
+            self.enabled = false
+          end
+
+          super(true)
+          true
+        end
+
+        def perform
+          poll
+        end
+
+        def poll
+          attempt = 1
+
+          while attempt <= MAX_ATTEMPTS
+            return if stopped?
+
+            response = @transport.get(@etag)
+            unless retryable?(response)
+              apply_response(response)
+              return
+            end
+
+            if attempt == MAX_ATTEMPTS
+              warn_failure(response, attempt)
+              return
+            end
+
+            return if wait_before_retry(retry_delay(attempt))
+
+            attempt += 1
+          end
+        end
+
+        private
+
+        def stopped?
+          @lifecycle_mutex.synchronize { @stopped }
+        end
+
+        def retryable?(response)
+          status = response.status
+          return true unless status
+
+          status == 408 || status == 429 || status.between?(500, 599)
+        end
+
+        def retry_delay(attempt)
+          base = if attempt == 1
+            clamp(@poll_interval_seconds / 6.0, FIRST_RETRY_MIN_SECONDS, FIRST_RETRY_MAX_SECONDS)
+          else
+            clamp(@poll_interval_seconds / 3.0, SECOND_RETRY_MIN_SECONDS, SECOND_RETRY_MAX_SECONDS)
+          end
+          random = @random ? @random.call : Kernel.rand
+          jitter = 1 - RETRY_JITTER + (random * RETRY_JITTER * 2)
+          [1.0, base * jitter].max
+        end
+
+        def clamp(value, minimum, maximum)
+          value.clamp(minimum, maximum)
+        end
+
+        def wait_before_retry(delay)
+          @retry_wait ? @retry_wait.call(delay) : wait_for_retry(delay)
+        end
+
+        def wait_for_retry(delay)
+          mutex.synchronize do
+            return true if stopped?
+
+            shutdown.wait(mutex, delay)
+          end
+
+          stopped? || !run_loop?
+        end
+
+        def apply_response(response)
+          case response.status
+          when 200
+            apply_configuration(response)
+          when 304
+            nil
+          when 401, 403
+            warn_once(:authentication) do
+              @logger.warn(
+                "Feature Flags agentless endpoint returned HTTP #{response.status}; verify endpoint authentication"
+              )
+            end
+          else
+            warn_failure(response, 1)
+          end
+        end
+
+        def apply_configuration(response)
+          configuration = response.body && Parser.parse(response.body)
+          unless configuration
+            warn_once(:malformed) do
+              @logger.error("Feature Flags agentless endpoint returned malformed UFC payload")
+            end
+            return
+          end
+
+          @apply.call(configuration)
+          @etag = response.etag.to_s.strip
+          @etag = nil if @etag.empty?
+        rescue EvaluationEngine::ReconfigurationError => error
+          warn_once(:application) do
+            @logger.warn("Feature Flags agentless UFC payload could not be applied: #{error.class}: #{error.message}")
+          end
+        end
+
+        def warn_failure(response, attempts)
+          status = response.status
+          category = status ? :http : :request
+          warn_once(category) do
+            if status
+              @logger.warn("Feature Flags agentless endpoint returned HTTP #{status} after #{attempts} attempt(s)")
+            else
+              error_class = response.error ? response.error.class : StandardError
+              @logger.warn("Feature Flags agentless request failed after #{attempts} attempt(s): #{error_class}")
+            end
+          end
+        end
+
+        def warn_once(category)
+          return if @warned[category]
+
+          @warned[category] = true
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/open_feature/agentless/parser.rb
+++ b/lib/datadog/open_feature/agentless/parser.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Datadog
+  module OpenFeature
+    module Agentless
+      # Parses the JSON:API envelope returned by agentless delivery.
+      module Parser
+        RESOURCE_TYPE = "universal-flag-configuration"
+
+        module_function
+
+        def parse(body)
+          payload = JSON.parse(body)
+          return unless payload.is_a?(Hash)
+
+          data = payload["data"]
+          return unless data.is_a?(Hash) && data["type"] == RESOURCE_TYPE
+
+          attributes = data["attributes"]
+          return unless valid_attributes?(attributes)
+
+          JSON.generate(attributes)
+        rescue JSON::ParserError, JSON::GeneratorError, TypeError
+          nil
+        end
+
+        def valid_attributes?(attributes)
+          return false unless attributes.is_a?(Hash)
+
+          environment = attributes["environment"]
+          attributes["format"].is_a?(String) &&
+            attributes["createdAt"].is_a?(String) &&
+            environment.is_a?(Hash) &&
+            environment["name"].is_a?(String) &&
+            attributes["flags"].is_a?(Hash)
+        end
+        private_class_method :valid_attributes?
+      end
+    end
+  end
+end

--- a/lib/datadog/open_feature/agentless/response.rb
+++ b/lib/datadog/open_feature/agentless/response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Datadog
+  module OpenFeature
+    module Agentless
+      # Result of one agentless configuration request.
+      class Response
+        attr_reader :status, :etag, :body, :error
+
+        def initialize(status: nil, etag: nil, body: nil, error: nil)
+          @status = status
+          @etag = etag
+          @body = body
+          @error = error
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/open_feature/agentless/transport.rb
+++ b/lib/datadog/open_feature/agentless/transport.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "stringio"
+require "timeout"
+require "zlib"
+
+require_relative "../../core/environment/identity"
+require_relative "../../core/transport/ext"
+require_relative "response"
+
+module Datadog
+  module OpenFeature
+    module Agentless
+      # HTTP transport for agentless configuration delivery.
+      class Transport
+        def initialize(endpoint:, api_key:, timeout_seconds:)
+          @endpoint = endpoint
+          @api_key = endpoint.managed? ? api_key : nil
+          @timeout_seconds = timeout_seconds
+        end
+
+        def get(etag)
+          request = Net::HTTP::Get.new(@endpoint.uri.request_uri, headers(etag))
+          response = request(request)
+
+          Response.new(
+            status: response.code.to_i,
+            etag: response["ETag"],
+            body: response_body(response),
+          )
+        # Net::HTTP uses several version-specific exception types. None may end
+        # the delivery worker; the poller classifies every transport failure.
+        rescue => error
+          Response.new(error: error)
+        end
+
+        private
+
+        def headers(etag)
+          headers = {
+            "Accept-Encoding" => "gzip",
+            "DD-Client-Library-Language" => Core::Environment::Identity.lang,
+            "DD-Client-Library-Version" => Core::Environment::Identity.gem_datadog_version_semver2,
+            Core::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST => "1",
+          }
+          headers["DD-API-KEY"] = @api_key if @api_key
+          headers["If-None-Match"] = etag if etag
+          headers
+        end
+
+        def request(request)
+          uri = @endpoint.uri
+          http = Net::HTTP.new(uri.host, uri.port, nil)
+          http.use_ssl = uri.scheme == "https"
+          http.open_timeout = @timeout_seconds
+          http.read_timeout = @timeout_seconds
+          http.write_timeout = @timeout_seconds if http.respond_to?(:write_timeout=)
+
+          Timeout.timeout(@timeout_seconds) do
+            http.start { |connection| connection.request(request) }
+          end
+        end
+
+        def response_body(response)
+          body = response.body
+          return body unless response["Content-Encoding"].to_s.strip.casecmp("gzip") == 0
+
+          Zlib::GzipReader.new(StringIO.new(body)).read
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/open_feature/agentless/transport.rb
+++ b/lib/datadog/open_feature/agentless/transport.rb
@@ -70,7 +70,12 @@ module Datadog
           body = response.body.to_s
           return body unless response["Content-Encoding"].to_s.strip.casecmp("gzip") == 0
 
-          Zlib::GzipReader.new(StringIO.new(body)).read.to_s
+          reader = Zlib::GzipReader.new(StringIO.new(body))
+          begin
+            reader.read.to_s
+          ensure
+            reader.close
+          end
         end
       end
     end

--- a/lib/datadog/open_feature/agentless/transport.rb
+++ b/lib/datadog/open_feature/agentless/transport.rb
@@ -44,14 +44,18 @@ module Datadog
             "DD-Client-Library-Version" => Core::Environment::Identity.gem_datadog_version_semver2,
             Core::Transport::Ext::HTTP::HEADER_DD_INTERNAL_UNTRACED_REQUEST => "1",
           }
-          headers["DD-API-KEY"] = @api_key if @api_key
+          api_key = @api_key
+          headers["DD-API-KEY"] = api_key if api_key
           headers["If-None-Match"] = etag if etag
           headers
         end
 
         def request(request)
           uri = @endpoint.uri
-          http = Net::HTTP.new(uri.host, uri.port, nil)
+          host = uri.host
+          raise ArgumentError, "Feature Flags agentless endpoint must have a host" unless host
+
+          http = Net::HTTP.new(host, uri.port, nil)
           http.use_ssl = uri.scheme == "https"
           http.open_timeout = @timeout_seconds
           http.read_timeout = @timeout_seconds
@@ -63,10 +67,10 @@ module Datadog
         end
 
         def response_body(response)
-          body = response.body
+          body = response.body.to_s
           return body unless response["Content-Encoding"].to_s.strip.casecmp("gzip") == 0
 
-          Zlib::GzipReader.new(StringIO.new(body)).read
+          Zlib::GzipReader.new(StringIO.new(body)).read.to_s
         end
       end
     end

--- a/sig/datadog/open_feature/agentless/configuration_source.rbs
+++ b/sig/datadog/open_feature/agentless/configuration_source.rbs
@@ -15,6 +15,9 @@ module Datadog
         RETRY_JITTER: Float
 
         include Core::Workers::Polling
+        # NOTE: Steep does not infer modules included dynamically by Polling.
+        include Core::Workers::Async::Thread
+        include Core::Workers::IntervalLoop
 
         @transport: Transport
 
@@ -24,9 +27,9 @@ module Datadog
 
         @poll_interval_seconds: Integer
 
-        @random: (^() -> Float)?
+        @random: ^() -> Float
 
-        @retry_wait: (^(Float) -> bool)?
+        @retry_wait: ^(Float) -> bool
 
         @etag: String?
 

--- a/sig/datadog/open_feature/agentless/configuration_source.rbs
+++ b/sig/datadog/open_feature/agentless/configuration_source.rbs
@@ -1,0 +1,94 @@
+module Datadog
+  module OpenFeature
+    module Agentless
+      class ConfigurationSource
+        MAX_ATTEMPTS: 3
+
+        FIRST_RETRY_MIN_SECONDS: Float
+
+        FIRST_RETRY_MAX_SECONDS: Float
+
+        SECOND_RETRY_MIN_SECONDS: Float
+
+        SECOND_RETRY_MAX_SECONDS: Float
+
+        RETRY_JITTER: Float
+
+        include Core::Workers::Polling
+
+        @transport: Transport
+
+        @apply: ^(String) -> void
+
+        @logger: Core::Logger
+
+        @poll_interval_seconds: Integer
+
+        @random: (^() -> Float)?
+
+        @retry_wait: (^(Float) -> bool)?
+
+        @etag: String?
+
+        @warned: Hash[Symbol, bool]
+
+        @lifecycle_mutex: Thread::Mutex
+
+        @started: bool
+
+        @stopped: bool
+
+        attr_reader etag: String?
+
+        def self.build: (
+          Core::Configuration::Settings settings,
+          endpoint: Configuration::AgentlessEndpoint,
+          apply: ^(String) -> void,
+          ?logger: Core::Logger
+        ) -> ConfigurationSource?
+
+        def initialize: (
+          endpoint: Configuration::AgentlessEndpoint,
+          api_key: String?,
+          poll_interval_seconds: Integer,
+          request_timeout_seconds: Integer,
+          apply: ^(String) -> void,
+          logger: Core::Logger,
+          ?transport: Transport?,
+          ?random: (^() -> Float)?,
+          ?retry_wait: (^(Float) -> bool)?
+        ) -> void
+
+        def start: () -> bool
+
+        def stop: () -> bool
+
+        def perform: () -> void
+
+        def poll: () -> void
+
+        private
+
+        def stopped?: () -> bool
+
+        def retryable?: (Response response) -> bool
+
+        def retry_delay: (Integer attempt) -> Float
+
+        def clamp: (Float value, Float minimum, Float maximum) -> Float
+
+        def wait_before_retry: (Float delay) -> bool
+
+        def wait_for_retry: (Float delay) -> bool
+
+        def apply_response: (Response response) -> void
+
+        def apply_configuration: (Response response) -> void
+
+        def warn_failure: (Response response, Integer attempts) -> void
+
+        def warn_once: (Symbol category) { () -> void } -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/open_feature/agentless/parser.rbs
+++ b/sig/datadog/open_feature/agentless/parser.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module OpenFeature
+    module Agentless
+      module Parser
+        RESOURCE_TYPE: String
+
+        def self.parse: (String body) -> String?
+
+        private
+
+        def self.valid_attributes?: (Object attributes) -> bool
+      end
+    end
+  end
+end

--- a/sig/datadog/open_feature/agentless/parser.rbs
+++ b/sig/datadog/open_feature/agentless/parser.rbs
@@ -4,11 +4,11 @@ module Datadog
       module Parser
         RESOURCE_TYPE: String
 
-        def self.parse: (String body) -> String?
+        def self?.parse: (String body) -> String?
 
         private
 
-        def self.valid_attributes?: (Object attributes) -> bool
+        def self?.valid_attributes?: (Object attributes) -> bool
       end
     end
   end

--- a/sig/datadog/open_feature/agentless/response.rbs
+++ b/sig/datadog/open_feature/agentless/response.rbs
@@ -1,0 +1,30 @@
+module Datadog
+  module OpenFeature
+    module Agentless
+      class Response
+        @status: Integer?
+
+        @etag: String?
+
+        @body: String?
+
+        @error: Exception?
+
+        attr_reader status: Integer?
+
+        attr_reader etag: String?
+
+        attr_reader body: String?
+
+        attr_reader error: Exception?
+
+        def initialize: (
+          ?status: Integer?,
+          ?etag: String?,
+          ?body: String?,
+          ?error: Exception?
+        ) -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/open_feature/agentless/transport.rbs
+++ b/sig/datadog/open_feature/agentless/transport.rbs
@@ -1,0 +1,29 @@
+module Datadog
+  module OpenFeature
+    module Agentless
+      class Transport
+        @endpoint: Configuration::AgentlessEndpoint
+
+        @api_key: String?
+
+        @timeout_seconds: Integer
+
+        def initialize: (
+          endpoint: Configuration::AgentlessEndpoint,
+          api_key: String?,
+          timeout_seconds: Integer
+        ) -> void
+
+        def get: (String? etag) -> Response
+
+        private
+
+        def headers: (String? etag) -> Hash[String, String]
+
+        def request: (Net::HTTP::Get request) -> Net::HTTPResponse
+
+        def response_body: (Net::HTTPResponse response) -> String
+      end
+    end
+  end
+end

--- a/spec/datadog/open_feature/agentless/configuration_source_spec.rb
+++ b/spec/datadog/open_feature/agentless/configuration_source_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "timeout"
+require "zlib"
+require "datadog/open_feature/configuration/agentless_endpoint"
+require "datadog/open_feature/agentless/configuration_source"
+
+RSpec.describe Datadog::OpenFeature::Agentless::ConfigurationSource do
+  subject(:source) do
+    described_class.new(
+      endpoint: endpoint,
+      api_key: "secret",
+      poll_interval_seconds: 30,
+      request_timeout_seconds: 5,
+      apply: apply,
+      logger: logger,
+      transport: transport,
+      random: -> { 0.5 },
+      retry_wait: retry_wait,
+    )
+  end
+
+  let(:endpoint) do
+    Datadog::OpenFeature::Configuration::AgentlessEndpoint.new(
+      URI("https://example.test/config"),
+      managed: true,
+    )
+  end
+  let(:transport) { instance_double(Datadog::OpenFeature::Agentless::Transport) }
+  let(:logger) { instance_double(Datadog::Core::Logger, warn: nil, error: nil) }
+  let(:apply) { ->(_configuration) {} }
+  let(:retry_wait) { ->(_delay) { false } }
+  let(:attributes) do
+    {
+      "format" => "SERVER",
+      "createdAt" => "2026-09-08T00:00:00Z",
+      "environment" => {"name" => "test"},
+      "flags" => {},
+    }
+  end
+  let(:body) do
+    JSON.generate(
+      "data" => {
+        "type" => "universal-flag-configuration",
+        "attributes" => attributes,
+      },
+    )
+  end
+
+  def response(status:, etag: nil, body: nil, error: nil)
+    Datadog::OpenFeature::Agentless::Response.new(
+      status: status,
+      etag: etag,
+      body: body,
+      error: error,
+    )
+  end
+
+  describe ".build" do
+    let(:settings) { Datadog::Core::Configuration::Settings.new }
+
+    before { settings.api_key = nil }
+
+    it "rejects a managed endpoint without an API key" do
+      expect(logger).to receive(:warn).with(a_string_including("requires DD_API_KEY"))
+
+      expect(described_class.build(settings, endpoint: endpoint, apply: apply, logger: logger)).to be_nil
+    end
+
+    context "with a custom endpoint" do
+      let(:endpoint) do
+        Datadog::OpenFeature::Configuration::AgentlessEndpoint.new(
+          URI("https://example.test/config"),
+          managed: false,
+        )
+      end
+
+      it "does not require an API key" do
+        expect(described_class.build(settings, endpoint: endpoint, apply: apply, logger: logger))
+          .to be_a(described_class)
+      end
+    end
+  end
+
+  describe "#poll" do
+    it "applies a 200 response and advances the ETag" do
+      expect(transport).to receive(:get).with(nil).and_return(response(status: 200, etag: " next ", body: body))
+      expect(apply).to receive(:call).with(JSON.generate(attributes))
+
+      expect { source.poll }.to change(source, :etag).from(nil).to("next")
+    end
+
+    it "sends the accepted ETag on the next poll" do
+      allow(transport).to receive(:get).with(nil).and_return(response(status: 200, etag: "first", body: body))
+      source.poll
+      expect(transport).to receive(:get).with("first").and_return(response(status: 304))
+
+      source.poll
+    end
+
+    it "does not apply a 304 response" do
+      expect(transport).to receive(:get).with(nil).and_return(response(status: 304))
+      expect(apply).not_to receive(:call)
+
+      source.poll
+    end
+
+    it "retries transport errors three times" do
+      error_response = response(status: nil, error: Net::ReadTimeout.new)
+      expect(transport).to receive(:get).with(nil).exactly(3).times.and_return(error_response)
+      expect(logger).to receive(:warn).once.with(a_string_including("after 3 attempt(s): Net::ReadTimeout"))
+
+      source.poll
+    end
+
+    context "when retrying" do
+      let(:retry_delays) { [] }
+      let(:retry_wait) do
+        lambda do |delay|
+          retry_delays << delay
+          false
+        end
+      end
+
+      it "uses interval-derived backoff between attempts" do
+        allow(transport).to receive(:get).and_return(response(status: 500))
+
+        source.poll
+
+        expect(retry_delays).to eq([5.0, 10.0])
+      end
+    end
+
+    [408, 429, 500, 599].each do |status|
+      it "retries HTTP #{status} three times" do
+        status_response = response(status: status)
+        expect(transport).to receive(:get).with(nil).exactly(3).times.and_return(status_response)
+
+        source.poll
+      end
+    end
+
+    it "does not retry a non-retryable status" do
+      expect(transport).to receive(:get).with(nil).once.and_return(response(status: 400))
+
+      source.poll
+    end
+
+    it "reports an authentication failure without retrying" do
+      expect(transport).to receive(:get).with(nil).once.and_return(response(status: 401))
+      expect(logger).to receive(:warn).once.with(a_string_including("verify endpoint authentication"))
+
+      source.poll
+    end
+
+    it "keeps the ETag when the next payload is malformed" do
+      allow(transport).to receive(:get).with(nil).and_return(response(status: 200, etag: "good", body: body))
+      source.poll
+      allow(transport).to receive(:get).with("good").and_return(response(status: 200, etag: "bad", body: "{"))
+
+      expect { 2.times { source.poll } }.not_to change(source, :etag).from("good")
+      expect(logger).to have_received(:error).once.with(a_string_including("malformed UFC payload"))
+    end
+
+    it "keeps the ETag when configuration cannot be applied" do
+      expect(transport).to receive(:get).with(nil).and_return(response(status: 200, etag: "rejected", body: body))
+      allow(apply).to receive(:call).and_raise(Datadog::OpenFeature::EvaluationEngine::ReconfigurationError)
+
+      expect { source.poll }.not_to change(source, :etag).from(nil)
+    end
+  end
+
+  describe "lifecycle" do
+    let(:retry_wait) { nil }
+
+    it "performs no request before start and starts asynchronously once" do
+      requested = SizedQueue.new(1)
+      allow(transport).to receive(:get) do
+        requested.push(true, true)
+        response(status: 304)
+      rescue ThreadError
+        response(status: 304)
+      end
+
+      expect(transport).not_to have_received(:get)
+      expect(source.start).to be(true)
+      expect(source.start).to be(true)
+      Timeout.timeout(1) { requested.pop }
+      expect(source.stop).to be(true)
+      expect(transport).to have_received(:get).once
+    ensure
+      source&.stop
+    end
+
+    it "cannot start after it has stopped" do
+      allow(transport).to receive(:get)
+      expect(source.stop).to be(true)
+
+      expect(source.start).to be(false)
+      expect(transport).not_to have_received(:get)
+    end
+  end
+end

--- a/spec/datadog/open_feature/agentless/configuration_source_spec.rb
+++ b/spec/datadog/open_feature/agentless/configuration_source_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "timeout"
-require "zlib"
 require "datadog/open_feature/configuration/agentless_endpoint"
 require "datadog/open_feature/agentless/configuration_source"
 

--- a/spec/datadog/open_feature/agentless/parser_spec.rb
+++ b/spec/datadog/open_feature/agentless/parser_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "datadog/open_feature/agentless/parser"
+
+RSpec.describe Datadog::OpenFeature::Agentless::Parser do
+  subject(:configuration) { described_class.parse(JSON.generate(payload)) }
+
+  let(:attributes) do
+    {
+      "format" => "SERVER",
+      "createdAt" => "2026-09-08T00:00:00Z",
+      "environment" => {"name" => "test"},
+      "flags" => {},
+    }
+  end
+  let(:payload) do
+    {
+      "data" => {
+        "type" => "universal-flag-configuration",
+        "attributes" => attributes,
+      },
+    }
+  end
+
+  it "returns serialized UFC attributes" do
+    expect(JSON.parse(configuration)).to eq(attributes)
+  end
+
+  shared_examples "an invalid payload" do
+    it { is_expected.to be_nil }
+  end
+
+  context "with malformed JSON" do
+    subject(:configuration) { described_class.parse("{") }
+
+    it_behaves_like "an invalid payload"
+  end
+
+  context "without data" do
+    let(:payload) { {} }
+
+    it_behaves_like "an invalid payload"
+  end
+
+  context "with the wrong resource type" do
+    before { payload["data"]["type"] = "other" }
+
+    it_behaves_like "an invalid payload"
+  end
+
+  %w[format createdAt environment flags].each do |field|
+    context "without #{field}" do
+      before { attributes.delete(field) }
+
+      it_behaves_like "an invalid payload"
+    end
+  end
+
+  context "without the environment name" do
+    before { attributes["environment"] = {} }
+
+    it_behaves_like "an invalid payload"
+  end
+
+  context "when flags is not an object" do
+    before { attributes["flags"] = [] }
+
+    it_behaves_like "an invalid payload"
+  end
+end

--- a/spec/datadog/open_feature/agentless/response_spec.rb
+++ b/spec/datadog/open_feature/agentless/response_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "datadog/open_feature/agentless/response"
+
+RSpec.describe Datadog::OpenFeature::Agentless::Response do
+  subject(:response) do
+    described_class.new(
+      status: 200,
+      etag: "etag",
+      body: "body",
+      error: error,
+    )
+  end
+
+  let(:error) { StandardError.new("failure") }
+
+  it "exposes the request result" do
+    expect(response.status).to eq(200)
+    expect(response.etag).to eq("etag")
+    expect(response.body).to eq("body")
+    expect(response.error).to equal(error)
+  end
+end

--- a/spec/datadog/open_feature/agentless/transport_spec.rb
+++ b/spec/datadog/open_feature/agentless/transport_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "datadog/open_feature/configuration/agentless_endpoint"
+require "datadog/open_feature/agentless/transport"
+
+RSpec.describe Datadog::OpenFeature::Agentless::Transport do
+  subject(:response) { transport.get(etag) }
+
+  let(:transport) do
+    described_class.new(endpoint: endpoint, api_key: "secret", timeout_seconds: 5)
+  end
+  let(:endpoint) do
+    Datadog::OpenFeature::Configuration::AgentlessEndpoint.new(
+      URI("https://example.test/config?dd_env=test"),
+      managed: managed,
+    )
+  end
+  let(:managed) { true }
+  let(:etag) { "previous" }
+
+  around do |example|
+    WebMock.enable!
+    example.run
+  ensure
+    WebMock.disable!
+  end
+
+  before do
+    stub_request(:get, "https://example.test/config?dd_env=test")
+      .to_return(status: 200, body: "configuration", headers: {"ETag" => "next"})
+  end
+
+  it "sends configuration headers and returns the response" do
+    expect(response.status).to eq(200)
+    expect(response.etag).to eq("next")
+    expect(response.body).to eq("configuration")
+    expect(
+      a_request(:get, "https://example.test/config?dd_env=test").with(
+        headers: {
+          "Accept-Encoding" => "gzip",
+          "DD-API-KEY" => "secret",
+          "DD-Client-Library-Language" => "ruby",
+          "DD-Client-Library-Version" => Datadog::Core::Environment::Identity.gem_datadog_version_semver2,
+          "DD-Internal-Untraced-Request" => "1",
+          "If-None-Match" => "previous",
+        },
+      )
+    ).to have_been_made.once
+  end
+
+  context "with a custom endpoint" do
+    let(:managed) { false }
+
+    it "does not send the API key" do
+      response
+
+      expect(
+        a_request(:get, "https://example.test/config?dd_env=test").with do |request|
+          !request.headers.key?("Dd-Api-Key")
+        end
+      ).to have_been_made.once
+    end
+  end
+
+  context "when the request fails" do
+    before do
+      stub_request(:get, "https://example.test/config?dd_env=test").to_raise(Net::ReadTimeout)
+    end
+
+    it "returns the transport error" do
+      expect(response.status).to be_nil
+      expect(response.error).to be_a(Net::ReadTimeout)
+    end
+  end
+
+  context "with a gzip response" do
+    before do
+      compressed = StringIO.new
+      Zlib::GzipWriter.wrap(compressed) { |writer| writer.write("configuration") }
+      stub_request(:get, "https://example.test/config?dd_env=test")
+        .to_return(status: 200, body: compressed.string, headers: {"Content-Encoding" => "gzip"})
+    end
+
+    it "decompresses the response body" do
+      expect(response.body).to eq("configuration")
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**

Adds the agentless Feature Flags configuration source, HTTP transport, response model, and configuration parser. It implements asynchronous polling, bounded requests, retry backoff, conditional requests with ETags, last-known-good configuration retention, fork-safe worker lifecycle, RBS signatures, and focused unit coverage.

**Motivation:**

This is PR 3 of a four-PR stack that splits agentless Feature Flags delivery into focused changes for easier review. The delivery implementation introduced here is intentionally wired into production only by PR 4, and the complete stack will be merged atomically.

**Change log entry**

None.

**Additional Notes:**

> [!IMPORTANT]
> **WE WILL NOT MERGE THIS PR WITHOUT ITS CHILD PR.**
> This PR contains intentionally dead delivery code until PR 4 supplies the production wiring, so it is not independently releasable.

This PR targets PR #6292, and PR 4 will target this PR's branch. We will merge the completed stack from last to first: PR 4 into this PR, this PR into PR #6292, PR #6292 into PR #6291, and finally PR #6291 into `master`.

**How to test the change?**

Run targeted StandardRB checks for `lib/datadog/open_feature/agentless` and `spec/datadog/open_feature/agentless`, then `bundle exec rake lint:frozen_string_literal rbs:stale rbs:missing steep:check`, followed by `bundle exec rake compile && bundle exec rake test:open_feature` on Ruby 3.1 and Ruby 4.0.
