### PR TITLE
Memcheck native span link cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -300,6 +300,20 @@ namespace :spec do
   # the fork-heavy ProcessDiscovery specs.
   Rake::Task["spec:native_transport"].enhance([:compile])
 
+  desc "Run native transport cleanup specs with memory leak checking"
+  if Gem.loaded_specs.key?("ruby_memcheck")
+    RubyMemcheck::RSpec::RakeTask.new(:native_transport_memcheck) do |t, args|
+      t.pattern = NATIVE_TRANSPORT_SPECS.join(", ")
+      t.rspec_opts = [*args.to_a, "--tag native_transport_memcheck"].join(" ")
+    end
+    Rake::Task["spec:native_transport_memcheck"].enhance([:compile])
+    Rake::Task["spec:core_with_libdatadog_api_memcheck"].enhance(["spec:native_transport_memcheck"])
+  else
+    task :native_transport_memcheck do
+      raise "Memcheck requires the ruby_memcheck gem to be installed"
+    end
+  end
+
   desc "" # "Explicitly hiding from `rake -T`"
   RSpec::Core::RakeTask.new(:core_with_rails) do |t, args|
     t.pattern = "spec/datadog/core/environment/process_spec.rb," \

--- a/spec/datadog/tracing/transport/native/tracer_span_spec.rb
+++ b/spec/datadog/tracing/transport/native/tracer_span_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Datadog::Tracing::Transport::Native::TracerSpan" do
         GC.start
       end
 
-      it "cleans up partial snapshots when a hash default proc raises, then converts a valid span" do
+      it "cleans up partial snapshots when a hash default proc raises, then converts a valid span", :native_transport_memcheck do
         calls = []
         canonical = {
           trace_id: 1,
@@ -168,7 +168,7 @@ RSpec.describe "Datadog::Tracing::Transport::Native::TracerSpan" do
         GC.start
       end
 
-      it "releases prepared meta_struct storage when links is not an array, then converts a valid span" do
+      it "releases prepared meta_struct storage when links is not an array, then converts a valid span", :native_transport_memcheck do
         span = make_ruby_span
         span.set_metastruct_tag("_dd.stack", {frames: [{file: "app.rb", line: 42}]})
         # The public #links setter has no type enforcement, so a non-Array value


### PR DESCRIPTION
**What does this PR do?**

Runs the two native span-link cleanup paths under Valgrind. A dedicated `spec:native_transport_memcheck` task selects those examples and runs as a separate prerequisite of the existing libdatadog memcheck task.

**Motivation:**

Follow-up to the cleanup-test concern on #6270. The ordinary recovery assertions prove post-failure usability but cannot detect leaked C allocations; this makes allocation release an automated CI invariant without mixing native exporter state into the fork-heavy core spec process.

Tracks [APMSP-3219](https://datadoghq.atlassian.net/browse/APMSP-3219).

**Change log entry**

None.

**Additional Notes:**

Stacked on #6270 (`grl/6129-review-fixes`). AI-assisted implementation was reviewed and tested locally.

**How to test the change?**

- `spec:native_transport_memcheck`: 2 examples, 0 failures under Valgrind
- `spec:native_transport`: 146 examples, 0 failures
- `rake rubocop`: 1,961 files, 0 offences
- `actionlint .github/workflows/test-memory-leaks.yaml`

[APMSP-3219]: https://datadoghq.atlassian.net/browse/APMSP-3219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ