### PR TITLE
[NO-TICKET] Profiling: Add integration test with GC.stress

### DIFF
--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1210,8 +1210,7 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
     context "GC stress enabled integration test", :memcheck_valgrind_skip do
       before do
         unless ENV["DATADOG_GEM_CI"] == "true"
-          skip "Test is slow so we only run it when " \
-            "DATADOG_GEM_CI env var is true"
+          skip "Test is slow so we only run it with DATADOG_GEM_CI=true"
         end
       end
 
@@ -1227,8 +1226,8 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
         on_failure_proc_called = false
         cpu_and_wall_time_worker # pre-create instances before enabling stress
 
+        GC.stress = true
         begin
-          GC.stress = true
 
           cpu_and_wall_time_worker.start(on_failure_proc: proc { on_failure_proc_called = true })
           cpu_and_wall_time_worker.wait_until_running(timeout_seconds: 30)

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1207,6 +1207,46 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
       end
     end
 
+    context "GC stress enabled integration test", :memcheck_valgrind_skip do
+      before do
+        unless ENV["DATADOG_GEM_CI"] == "true"
+          skip "Test is slow so we only run it when " \
+            "DATADOG_GEM_CI env var is true"
+        end
+      end
+
+      let(:allocation_profiling_enabled) { true }
+      let(:allocation_counting_enabled) { true }
+      let(:heap_profiling_enabled) { RubyVersion.is?(">= 3.1") }
+      let(:gvl_profiling_enabled) { RubyVersion.is?(">= 3.2") }
+      let(:sighandler_sampling_enabled) do
+        !(RubyVersion.is?("< 3.2.5") || RubyVersion.is?(">= 3.3", "< 3.3.4"))
+      end
+
+      it "runs the profiler successfully" do
+        on_failure_proc_called = false
+        cpu_and_wall_time_worker # pre-create instances before enabling stress
+
+        begin
+          GC.stress = true
+
+          cpu_and_wall_time_worker.start(on_failure_proc: proc { on_failure_proc_called = true })
+          cpu_and_wall_time_worker.wait_until_running(timeout_seconds: 30)
+
+          10.times { |i| i.to_s }
+          recorder.serialize!
+          10.times { |i| i.to_s }
+
+          cpu_and_wall_time_worker.stop
+          recorder.serialize!
+        ensure
+          GC.stress = false
+        end
+
+        expect(on_failure_proc_called).to be false
+      end
+    end
+
     context "when the _native_sampling_loop terminates with an exception" do
       it "calls the on_failure_proc" do
         expect(described_class).to receive(:_native_sampling_loop).and_raise(StandardError.new("Simulated error"))

--- a/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
+++ b/spec/datadog/profiling/collectors/cpu_and_wall_time_worker_spec.rb
@@ -1243,7 +1243,14 @@ RSpec.describe Datadog::Profiling::Collectors::CpuAndWallTimeWorker do
           GC.stress = false
         end
 
-        expect(on_failure_proc_called).to be false
+        expect(on_failure_proc_called).to(
+          be(false),
+          -> {
+            failure_exception = cpu_and_wall_time_worker.send(:failure_exception)
+            "Profiler failed to run cleanly, failure_exception: #{failure_exception.inspect}\n" \
+              "#{failure_exception&.backtrace&.join("\n")}"
+          }
+        )
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new "integration" test to the
`cpu_and_wall_time_worker_spec.rb` where we run the profiler for a brief period with all features enabled under Ruby's `GC.stress` setting.

**Motivation:**

In https://github.com/DataDog/dd-trace-rb/pull/6242 and https://github.com/DataDog/dd-trace-rb/pull/6245 we were able to reproduce those bugs using `GC.stress`.

To try to catch possible similar issues in the future, it seemed useful to have an integration test where we ran the profiler with `GC.stress`.

**Change log entry**

None.

**Additional Notes:**

The big downside of `GC.stress` is how slow it makes the test suite. On my workspace, it takes around 20-30s to run just this one new testcase, which is why I've made it only run in CI as I really value quick iteration on our testsuite and having mega-slow tests breaks that.

I also evaluated how feasible it would be to run the entire `cpu_and_wall_time_worker_spec.rb` with `GC.stress` and unfortunately the answer isn't great -- it would take hours AND in particular it would need modifications since we have a bunch of timeouts for cross-thread stuff that would need heavy tweaking.

Ideas on how we could get more coverage without a lot of work are welcome ;)

**How to test the change?**

Validate CI is green and this test passes!