### PR TITLE
Enable auto-merge on auto-generated PRs

### DIFF
--- a/.github/actions/enable-auto-merge/action.yml
+++ b/.github/actions/enable-auto-merge/action.yml
@@ -1,0 +1,35 @@
+name: 'Enable auto-merge'
+
+description: >-
+  Enables GitHub auto-merge on a pull request, using a merge commit by default.
+  Best-effort: auto-merge can be switched off at the repo or org level, so on
+  failure this warns instead of failing the run, leaving the pull request open
+  for a manual merge.
+
+inputs:
+  token:
+    description: 'Token with pull_requests:write.'
+    required: true
+  pull-request-number:
+    description: 'Pull request to enable auto-merge on. Empty is a no-op.'
+    required: false
+    default: ''
+  merge-method:
+    description: 'Merge method: merge, squash, or rebase.'
+    required: false
+    default: 'merge'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Enable auto-merge
+      if: ${{ inputs.pull-request-number != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR: ${{ inputs.pull-request-number }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: |
+        if ! gh pr merge --auto "--$MERGE_METHOD" "$PR"; then
+          echo "::warning::Could not enable auto-merge for PR #$PR; leaving it for a manual merge"
+        fi

--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -49,6 +49,9 @@ outputs:
   commit-hash:
     description: 'Hash of the created commit, empty when nothing changed.'
     value: ${{ steps.commit.outputs.commit-hash }}
+  pull-request-number:
+    description: 'Number of the created or updated pull request, empty when nothing changed.'
+    value: ${{ steps.pr.outputs.pull-request-number }}
 
 runs:
   using: "composite"
@@ -182,6 +185,7 @@ runs:
     # on name alone: a fork PR sharing the branch name would otherwise be edited
     # in place of the one this action needs to open.
     - name: Create or update pull request
+      id: pr
       if: steps.stage.outputs.changed == 'true'
       shell: bash
       env:
@@ -216,3 +220,11 @@ runs:
           gh pr create --repo "$REPO" --head "$BRANCH" --base "$BASE" \
             --title "$TITLE" --body "$BODY" "${args[@]/--add-label/--label}"
         fi
+
+        # `gh pr create` has no --json flag, so rather than parse its free
+        # text, resolve the number with the same structured query that chose
+        # between editing and creating above.
+        pr_number="$(gh pr list --repo "$REPO" --head "$BRANCH" --base "$BASE" --state open \
+          --json number,headRepositoryOwner \
+          --jq "[.[] | select(.headRepositoryOwner.login == \"${REPO%%/*}\"")] | .[0].number // empty")"
+        echo "pull-request-number=$pr_number" >> "$GITHUB_OUTPUT"

--- a/.github/actions/signed-commit-pr/action.yml
+++ b/.github/actions/signed-commit-pr/action.yml
@@ -226,5 +226,5 @@ runs:
         # between editing and creating above.
         pr_number="$(gh pr list --repo "$REPO" --head "$BRANCH" --base "$BASE" --state open \
           --json number,headRepositoryOwner \
-          --jq "[.[] | select(.headRepositoryOwner.login == \"${REPO%%/*}\"")] | .[0].number // empty")"
+          --jq "[.[] | select(.headRepositoryOwner.login == \"${REPO%%/*}\")] | .[0].number // empty")"
         echo "pull-request-number=$pr_number" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bump-gem-version.yml
+++ b/.github/workflows/bump-gem-version.yml
@@ -67,6 +67,7 @@ jobs:
         run: cp .github/forced-tests-list.cfg.template .github/forced-tests-list.cfg
 
       - name: Create Pull Request
+        id: cpr
         uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -91,3 +92,9 @@ jobs:
             - Source commit: ${{ github.event.client_payload.source_commit || 'N/A' }}
 
             Please review the changes and merge when ready
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -392,6 +392,7 @@ jobs:
           fetch-depth: 0
       - env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        id: pr
         run: |
           JOB_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TEMP_BRANCH="update-document-v${GEM_VERSION}"
@@ -406,3 +407,16 @@ jobs:
             --title "Update document v${GEM_VERSION}" \
           --body "This is an auto-generated PR to update documentation from [here](${JOB_URL}). Please merge (with a merge commit) when ready.\n\nTo resolve conflicts:\n\`\`\`bash\ngit merge release\ngit checkout --ours .\`\`\`." \
             --label "docs"
+
+          # `gh pr create` has no --json flag, so resolve the number via a
+          # structured lookup rather than parsing its free-text output.
+          echo "pull-request-number=$(gh pr list \
+            --head "${TEMP_BRANCH}" --base release --state open \
+            --json number,headRepositoryOwner \
+            --jq "[.[] | select(.headRepositoryOwner.login == \"${GITHUB_REPOSITORY%%/*}\")] | .[0].number // empty")" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.pr.outputs.pull-request-number }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -65,6 +65,7 @@ jobs:
         run: bundle exec ruby .github/scripts/update_supported_versions.rb
 
       - name: Create release Pull Request
+        id: cpr
         uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -88,3 +89,9 @@ jobs:
             version, and lockfiles. Review and merge to proceed with publishing.
 
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -90,3 +90,9 @@ jobs:
             - Source run: ${{ github.event.client_payload.source_run_url }}
 
             Please review the changes and merge when ready.
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-latest-dependency.yml
+++ b/.github/workflows/update-latest-dependency.yml
@@ -96,6 +96,7 @@ jobs:
           policy: self.update-latest-dependency
 
       - name: Create Pull Request
+        id: cpr
         uses: ./.github/actions/signed-commit-pr
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -109,3 +110,9 @@ jobs:
             _This is an auto-generated PR from [here](https://github.com/DataDog/dd-trace-rb/blob/master/.github/workflows/update-latest-dependency.yml), which creates a pull request that will be continually updated with new changes until it is merged or closed)_
 
             The PR updates latest versions of defined dependencies. Please review the changes and merge when ready.
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-system-tests.yml
+++ b/.github/workflows/update-system-tests.yml
@@ -116,3 +116,9 @@ jobs:
             None.
 
             Please review the changes and merge when ready.
+
+      - name: Enable auto-merge
+        uses: ./.github/actions/enable-auto-merge
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
**What does this PR do?**
Adds a shared `enable-auto-merge` composite action, called from all six PR-creating workflows: `update-images`, `update-system-tests`, `update-latest-dependency`, `bump-gem-version`, `release-prep`, and `publish`'s `update-release-branch`. `signed-commit-pr` gains a structured `pull-request-number` output to feed it.

**Motivation**
Auto-generated PRs should merge themselves once the required approval and checks pass, instead of needing a maintainer to come back and click merge.

**Change log entry**
None.

**Additional Notes:**
- Best-effort: if auto-merge is unavailable (e.g. switched off at the repo level), the action warns and exits green, leaving the PR for a manual merge.
- An empty `pull-request-number` input is a no-op; the guard lives in the action, not the callers.
- The `update-release-branch` PR targets `release`, which requires no reviews or checks, so it merges immediately; all `master`-targeting PRs wait for the required approval and checks.
- Composite action scripts are not shellchecked by `actionlint`; all touched run blocks were verified directly with `bash -n` and `shellcheck`.

**How to test the change?**
Internal CI change; `yamllint --strict` and `actionlint` pass on all touched files. No gem code changed.
