### PR TITLE
Re-enable Ruby 2.7 integration apps jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,11 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: re-enable once the Ruby 2.7 base image can build again; Debian 11
-          # (bullseye) reached EOL and the bullseye-security pool returns 404s.
-          # https://github.com/DataDog/ruby-guild/issues/324
-          # - app: rails-five
-          #   ruby: "2.7"
+          - app: rails-five
+            ruby: "2.7"
           - app: rails-six
             ruby: "3.3"
           - app: rails-seven
@@ -71,11 +68,8 @@ jobs:
             ruby: "3.4"
           - app: sinatra2-modular
             ruby: "3.4"
-          # TODO: re-enable once the Ruby 2.7 base image can build again; Debian 11
-          # (bullseye) reached EOL and the bullseye-security pool returns 404s.
-          # https://github.com/DataDog/ruby-guild/issues/324
-          # - app: hanami
-          #   ruby: "2.7"
+          - app: hanami
+            ruby: "2.7"
           - app: opentelemetry
             ruby: "3.4"
     steps:


### PR DESCRIPTION
**What does this PR do?**
Re-enables the `rails-five (Ruby 2.7)` and `hanami (Ruby 2.7)` integration jobs in `.github/workflows/integration-test.yml`, which were disabled in 6ef48a0015 after Debian 11 (bullseye) reached EOL and the broken `bullseye-security` apt pool stopped the Ruby 2.7 engine image from building.

**Motivation:**
The Ruby 2.7 base image build is fixed, so the temporarily-disabled jobs can restore integration coverage.

The fix lives in https://github.com/DataDog/images-rb/pull/117: the engine images now use the frozen `snapshot.debian.org` sources (the ones the stock `debian:11` base keeps commented in `/etc/apt/sources.list`) with `Acquire::Check-Valid-Until "false"`, both persisting in the published images. The `archive.debian.org` route from DataDog/system-tests#7661 was ruled out there: the archive doesn't host bullseye-security yet, and the image's installed `gpgv` u3 conflicts with the archive's `gnupg` u2. dd-trace-rb picked up the fixed images through the images-rb pin update (a565b531dd, #6310), so no change on this side was needed.

**Change log entry**
Not needed: internal CI change.

**Additional Notes:**
The long-term base image fix is tracked in https://github.com/DataDog/ruby-guild/issues/324.

**How to test the change?**
The re-enabled `rails-five (Ruby 2.7)` and `hanami (Ruby 2.7)` jobs passed on the latest CI run of this PR, on top of the pinned images from #6310.
